### PR TITLE
val and test and also non-deconned data

### DIFF
--- a/configs/task_sets/eval_suite_ppl_test_v3.libsonnet
+++ b/configs/task_sets/eval_suite_ppl_test_v3.libsonnet
@@ -8,7 +8,7 @@ local common_kwargs = {
         detailed_output: true,
     },
     prediction_kwargs: {
-        split: "validation",
+        split: "test",
         model_max_length: task_utils.model_max_length,
     }
 };
@@ -21,7 +21,7 @@ local create_task_kwargs(task_names) = [
     {
         task_kwargs: {
             task_rename: "ppl_" + task_name,
-            files: [data_dir + "/" + task_name + "/val"]
+            files: [data_dir + "/" + task_name + "/test"]
         }
     }
     for task_name in task_names

--- a/configs/task_sets/eval_suite_ppl_test_v3_not_deconned.libsonnet
+++ b/configs/task_sets/eval_suite_ppl_test_v3_not_deconned.libsonnet
@@ -15,7 +15,7 @@ local common_kwargs = {
 
 // TODO: refactor catwalk's Perplexity task so that it actually uses the s3 path.
 // until then, let the path be present in nfs ($EVAL_DATA_PATH).
-local data_dir = "olmo-ppl-val-v3-not-deconned/";
+local data_dir = "v3_not_deconned/";
 
 local create_task_kwargs(task_names) = [
     {

--- a/configs/task_sets/eval_suite_ppl_test_v3_not_deconned.libsonnet
+++ b/configs/task_sets/eval_suite_ppl_test_v3_not_deconned.libsonnet
@@ -8,20 +8,20 @@ local common_kwargs = {
         detailed_output: true,
     },
     prediction_kwargs: {
-        split: "validation",
+        split: "test",
         model_max_length: task_utils.model_max_length,
     }
 };
 
 // TODO: refactor catwalk's Perplexity task so that it actually uses the s3 path.
 // until then, let the path be present in nfs ($EVAL_DATA_PATH).
-local data_dir = "olmo-ppl-val-v3/";
+local data_dir = "olmo-ppl-val-v3-not-deconned/";
 
 local create_task_kwargs(task_names) = [
     {
         task_kwargs: {
             task_rename: "ppl_" + task_name,
-            files: [data_dir + "/" + task_name + "/val"]
+            files: [data_dir + "/" + task_name + "/test"]
         }
     }
     for task_name in task_names
@@ -45,7 +45,8 @@ local task_dicts = create_task_kwargs(
     "redpajama",
     "falcon-refinedweb",
     "dolma-v1_5",
-    "dolma_100_subreddits"
+    "dolma_100_subreddits",
+    "dolma_100_programing_languages"
     ]
 );
 

--- a/configs/task_sets/eval_suite_ppl_val_v3_not_deconned.libsonnet
+++ b/configs/task_sets/eval_suite_ppl_val_v3_not_deconned.libsonnet
@@ -15,7 +15,7 @@ local common_kwargs = {
 
 // TODO: refactor catwalk's Perplexity task so that it actually uses the s3 path.
 // until then, let the path be present in nfs ($EVAL_DATA_PATH).
-local data_dir = "olmo-ppl-val-v3-not-deconned/";
+local data_dir = "v3_not_deconned/";
 
 local create_task_kwargs(task_names) = [
     {

--- a/configs/task_sets/eval_suite_ppl_val_v3_not_deconned.libsonnet
+++ b/configs/task_sets/eval_suite_ppl_val_v3_not_deconned.libsonnet
@@ -15,7 +15,7 @@ local common_kwargs = {
 
 // TODO: refactor catwalk's Perplexity task so that it actually uses the s3 path.
 // until then, let the path be present in nfs ($EVAL_DATA_PATH).
-local data_dir = "olmo-ppl-val-v3/";
+local data_dir = "olmo-ppl-val-v3-not-deconned/";
 
 local create_task_kwargs(task_names) = [
     {
@@ -45,7 +45,8 @@ local task_dicts = create_task_kwargs(
     "redpajama",
     "falcon-refinedweb",
     "dolma-v1_5",
-    "dolma_100_subreddits"
+    "dolma_100_subreddits",
+    "dolma_100_programing_languages"
     ]
 );
 


### PR DESCRIPTION
Added some configurations for the rest of the perplexity suite: the test set and and then also the full version of the perplexity suite v3 that also includes non decontaminated stack data.

The non-deconned versions here will also need to be added to `/net/nfs.cirrascale/allennlp/akshitab/eval_data`, @AkshitaB, please :D The data can be found at `s3://ai2-llm/eval-data/perplexity/v3_not_deconned/`