### PR TITLE
hf_olmo via ssh

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ dev = [
     "packaging"
 ]
 olmo = [
-    "hf_olmo @ git+https://github.com/allenai/LLM.git@main#subdirectory=hf_olmo",
+    "hf_olmo @ git+ssh://github.com/allenai/LLM.git@main#subdirectory=hf_olmo",
     "omegaconf"
 ]
 


### PR DESCRIPTION
Uses ssh rather than https to load hf_olmo as https auth seems to be deprecated.