### PR TITLE
Add text-only LAB-Bench evals

### DIFF
--- a/src/olmo_eval/common/formatters.py
+++ b/src/olmo_eval/common/formatters.py
@@ -126,7 +126,7 @@ class MultipleChoiceFormatter(Formatter):
 
     @property
     def request_type(self) -> RequestType:
-        return RequestType.COMPLETION
+        return RequestType.LOGLIKELIHOOD
 
     def format(
         self,

--- a/src/olmo_eval/evals/suites/biology.py
+++ b/src/olmo_eval/evals/suites/biology.py
@@ -6,15 +6,29 @@ from olmo_eval.evals.suites.registry import make_suite
 # LAB-Bench Suite
 # =============================================================================
 
+_LAB_BENCH_TASKS = (
+    "lab_bench_litqa2",
+    "lab_bench_dbqa",
+    "lab_bench_seqqa",
+    "lab_bench_protocolqa",
+    "lab_bench_suppqa",
+    "lab_bench_cloning_scenarios",
+)
+
 LAB_BENCH = make_suite(
     "lab_bench",
-    (
-        "lab_bench_litqa2",
-        "lab_bench_dbqa",
-        "lab_bench_seqqa",
-        "lab_bench_protocolqa",
-        "lab_bench_suppqa",
-        "lab_bench_cloning_scenarios",
-    ),
+    _LAB_BENCH_TASKS,
     description="LAB-Bench biology research benchmark (futurehouse/lab-bench)",
+)
+
+LAB_BENCH_MC = make_suite(
+    "lab_bench:mc",
+    tuple(f"{t}:mc" for t in _LAB_BENCH_TASKS),
+    description="LAB-Bench with logprob-based MC scoring",
+)
+
+LAB_BENCH_BPB = make_suite(
+    "lab_bench:bpb",
+    tuple(f"{t}:bpb" for t in _LAB_BENCH_TASKS),
+    description="LAB-Bench with bits-per-byte evaluation",
 )

--- a/src/olmo_eval/evals/suites/biology.py
+++ b/src/olmo_eval/evals/suites/biology.py
@@ -8,6 +8,13 @@ from olmo_eval.evals.suites.registry import make_suite
 
 LAB_BENCH = make_suite(
     "lab_bench",
-    ("lab_bench_litqa2",),
+    (
+        "lab_bench_litqa2",
+        "lab_bench_dbqa",
+        "lab_bench_seqqa",
+        "lab_bench_protocolqa",
+        "lab_bench_suppqa",
+        "lab_bench_cloning_scenarios",
+    ),
     description="LAB-Bench biology research benchmark (futurehouse/lab-bench)",
 )

--- a/src/olmo_eval/evals/suites/biology.py
+++ b/src/olmo_eval/evals/suites/biology.py
@@ -1,0 +1,13 @@
+"""Biology evaluation suite."""
+
+from olmo_eval.evals.suites.registry import make_suite
+
+# =============================================================================
+# LAB-Bench Suite
+# =============================================================================
+
+LAB_BENCH = make_suite(
+    "lab_bench",
+    ("lab_bench_litqa2",),
+    description="LAB-Bench biology research benchmark (futurehouse/lab-bench)",
+)

--- a/src/olmo_eval/evals/tasks/lab_bench.py
+++ b/src/olmo_eval/evals/tasks/lab_bench.py
@@ -163,6 +163,33 @@ class LabBenchTask(Task):
             messages=({"role": "user", "content": instance.question},),
         )
 
+    def _extract_answers(self, responses: Sequence[Response]) -> None:
+        """Extract answers, with argmax for logprob-based MC scoring."""
+        for response in responses:
+            if (
+                response.request.request_type == RequestType.LOGLIKELIHOOD
+                and len(response.outputs) > 1
+            ):
+                # MC logprob mode: pick the continuation with highest logprob
+                best_idx = 0
+                best_logprob = float("-inf")
+                for i, output in enumerate(response.outputs):
+                    logprob = (
+                        output.metadata.get("total_logprob", float("-inf"))
+                        if output.metadata
+                        else float("-inf")
+                    )
+                    if logprob > best_logprob:
+                        best_logprob = logprob
+                        best_idx = i
+                letter = chr(ord("A") + best_idx)
+                for output in response.outputs:
+                    output.extracted_answer = letter
+            else:
+                # Chat mode: parse "ANSWER: X" from generated text
+                for output in response.outputs:
+                    output.extracted_answer = self.extract_answer(output)
+
     def extract_answer(self, output: LMOutput) -> str | None:
         """Extract the last ``ANSWER: X`` letter from model output."""
         matches = list(_ANSWER_PATTERN.finditer(output.text))
@@ -178,6 +205,15 @@ End your response with "ANSWER: X" where X is the letter of your chosen answer."
 _DEFAULT_ACCURACY = AccuracyMetric(scorer=MultipleChoiceScorer)
 _DEFAULT_METRICS = (_DEFAULT_ACCURACY, PrecisionMetric(), CoverageMetric())
 _DEFAULT_SAMPLING = SamplingParams(temperature=0.0, max_tokens=1024)
+
+
+@dataclass(slots=True)
+class _MCLogprobFormatter(MultipleChoiceFormatter):
+    """MultipleChoiceFormatter that routes to logprobs instead of generation."""
+
+    @property
+    def request_type(self) -> RequestType:
+        return RequestType.LOGLIKELIHOOD
 
 
 # =============================================================================
@@ -244,7 +280,7 @@ for _task in _ALL_TASKS:
     register_variant(
         _task,
         "mc",
-        formatter=MultipleChoiceFormatter(),
+        formatter=_MCLogprobFormatter(),
         metrics=_DEFAULT_METRICS,
     )
     register_variant(

--- a/src/olmo_eval/evals/tasks/lab_bench.py
+++ b/src/olmo_eval/evals/tasks/lab_bench.py
@@ -33,6 +33,7 @@ from olmo_eval.common.types import (
     RequestType,
     Response,
     SamplingParams,
+    Split,
 )
 from olmo_eval.data import DataLoader, DataSource
 from olmo_eval.evals.tasks.common import Task, register, register_variant
@@ -78,6 +79,9 @@ class LabBenchTask(Task):
     Handles the shared pattern: combine `ideal` + `distractors` into shuffled
     choices, extract letter answers from model output.
     """
+
+    # LAB-Bench only publishes a "train" split on HuggingFace
+    split = Split.TRAIN
 
     @property
     def instances(self) -> Iterator[Instance]:
@@ -178,7 +182,7 @@ for _name, _subset in _STANDARD_SUBTASKS.items():
         _subset,
         (LabBenchTask,),
         {
-            "data_source": DataSource(path="futurehouse/lab-bench", subset=_subset, split="train"),
+            "data_source": DataSource(path="futurehouse/lab-bench", subset=_subset),
             "formatter": MCQAChatFormatter(system_prompt=_SYSTEM_PROMPT),
             "metrics": _DEFAULT_METRICS,
             "sampling_params": _DEFAULT_SAMPLING,
@@ -195,7 +199,7 @@ class LabBenchProtocolQA(LabBenchTask):
     "the listed protocol" which is stored in a separate dataset field.
     """
 
-    data_source = DataSource(path="futurehouse/lab-bench", subset="ProtocolQA", split="train")
+    data_source = DataSource(path="futurehouse/lab-bench", subset="ProtocolQA")
     formatter = MCQAChatFormatter(system_prompt=_SYSTEM_PROMPT)
     metrics = _DEFAULT_METRICS
     sampling_params = _DEFAULT_SAMPLING

--- a/src/olmo_eval/evals/tasks/lab_bench.py
+++ b/src/olmo_eval/evals/tasks/lab_bench.py
@@ -99,6 +99,21 @@ class LabBenchTask(Task):
     # LAB-Bench only publishes a "train" split on HuggingFace
     split = Split.TRAIN
 
+    def __init_subclass__(cls, subset: str | None = None, **kwargs):
+        super().__init_subclass__(**kwargs)
+        if subset is None:
+            return
+        snake = re.sub(r"([a-z])([A-Z][a-z])", r"\1_\2", subset).lower()
+        name = f"lab_bench_{snake}"
+        cls.data_source = DataSource(path="futurehouse/lab-bench", subset=subset)
+        cls.formatter = MCQAChatFormatter(system_prompt=_SYSTEM_PROMPT)
+        cls.metrics = _DEFAULT_METRICS
+        cls.primary_metric = _DEFAULT_ACCURACY
+        cls.sampling_params = _DEFAULT_SAMPLING
+        register(name)(cls)
+        register_variant(name, "mc", formatter=MultipleChoiceFormatter(), metrics=_DEFAULT_METRICS)
+        register_variant(name, "bpb", formatter=PPLFormatter(), metrics=(BPBMetric(),))
+
     @property
     def instances(self) -> Iterator[Instance]:
         if self._instances_cache is None:
@@ -207,60 +222,28 @@ _DEFAULT_METRICS = (_DEFAULT_ACCURACY, PrecisionMetric(), CoverageMetric())
 _DEFAULT_SAMPLING = SamplingParams(temperature=0.0, max_tokens=1024)
 
 
-@dataclass(slots=True)
-class _MCLogprobFormatter(MultipleChoiceFormatter):
-    """MultipleChoiceFormatter that routes to logprobs instead of generation."""
-
-    @property
-    def request_type(self) -> RequestType:
-        return RequestType.LOGLIKELIHOOD
-
-
 # =============================================================================
 # Task Registrations
 # =============================================================================
 
 
-# Subtasks that use LabBenchTask directly (question field is self-contained)
-_STANDARD_SUBTASKS: dict[str, str] = {
-    "lab_bench_litqa2": "LitQA2",
-    "lab_bench_dbqa": "DbQA",
-    "lab_bench_seqqa": "SeqQA",
-    "lab_bench_suppqa": "SuppQA",
-    "lab_bench_cloning_scenarios": "CloningScenarios",
-}
-
-for _name, _subset in _STANDARD_SUBTASKS.items():
-    _cls = type(
-        _subset,
-        (LabBenchTask,),
-        {
-            "__module__": __name__,
-            "__qualname__": _subset,
-            "data_source": DataSource(path="futurehouse/lab-bench", subset=_subset),
-            "formatter": MCQAChatFormatter(system_prompt=_SYSTEM_PROMPT),
-            "metrics": _DEFAULT_METRICS,
-            "primary_metric": _DEFAULT_ACCURACY,
-            "sampling_params": _DEFAULT_SAMPLING,
-        },
-    )
-    globals()[_subset] = _cls  # Make picklable by storing in module namespace
-    register(_name)(_cls)
+class LitQA2(LabBenchTask, subset="LitQA2"): ...
 
 
-@register("lab_bench_protocolqa")
-class LabBenchProtocolQA(LabBenchTask):
-    """ProtocolQA: Lab protocol question answering from LAB-Bench.
+class DbQA(LabBenchTask, subset="DbQA"): ...
 
-    Prepends the protocol text to the question, since questions reference
-    "the listed protocol" which is stored in a separate dataset field.
-    """
 
-    data_source = DataSource(path="futurehouse/lab-bench", subset="ProtocolQA")
-    formatter = MCQAChatFormatter(system_prompt=_SYSTEM_PROMPT)
-    metrics = _DEFAULT_METRICS
-    primary_metric = _DEFAULT_ACCURACY
-    sampling_params = _DEFAULT_SAMPLING
+class SeqQA(LabBenchTask, subset="SeqQA"): ...
+
+
+class SuppQA(LabBenchTask, subset="SuppQA"): ...
+
+
+class CloningScenarios(LabBenchTask, subset="CloningScenarios"): ...
+
+
+class ProtocolQA(LabBenchTask, subset="ProtocolQA"):
+    """Prepends the protocol text to the question."""
 
     def process_doc(self, doc: dict[str, Any], index: int = 0) -> Instance | None:
         protocol = doc.get("protocol", "")
@@ -268,24 +251,3 @@ class LabBenchProtocolQA(LabBenchTask):
             question = doc.get("question", "")
             doc = {**doc, "question": f"Protocol:\n{protocol}\n\nQuestion: {question}"}
         return super().process_doc(doc, index)
-
-
-# =============================================================================
-# Variant Registrations
-# =============================================================================
-
-_ALL_TASKS = (*_STANDARD_SUBTASKS, "lab_bench_protocolqa")
-
-for _task in _ALL_TASKS:
-    register_variant(
-        _task,
-        "mc",
-        formatter=_MCLogprobFormatter(),
-        metrics=_DEFAULT_METRICS,
-    )
-    register_variant(
-        _task,
-        "bpb",
-        formatter=PPLFormatter(),
-        metrics=(BPBMetric(),),
-    )

--- a/src/olmo_eval/evals/tasks/lab_bench.py
+++ b/src/olmo_eval/evals/tasks/lab_bench.py
@@ -1,17 +1,18 @@
 """LAB-Bench evaluation tasks.
 
 LAB-Bench (futurehouse/lab-bench) is a biology research benchmark with 8 subtasks.
-This module implements the text-only subtasks, starting with LitQA2.
+This module implements the 6 text-only subtasks. The 2 image-based subtasks
+(FigQA, TableQA) are deferred until the framework supports multimodal inputs.
 
-Usage:
-    # Chat-based generation (default)
-    olmo-eval run -m llama3.1-8b -t lab_bench_litqa2
+Subtasks:
+    lab_bench_litqa2            LitQA2 — literature-based QA (199 questions)
+    lab_bench_dbqa              DbQA — biological database QA (520 questions)
+    lab_bench_seqqa             SeqQA — DNA/protein sequence analysis (600 questions)
+    lab_bench_protocolqa        ProtocolQA — lab protocol QA (108 questions)
+    lab_bench_suppqa            SuppQA — supplementary material QA (82 questions)
+    lab_bench_cloning_scenarios CloningScenarios — molecular cloning (33 questions)
 
-    # Logprob-based multiple choice
-    olmo-eval run -m llama3.1-8b -t lab_bench_litqa2:mc
-
-    # Bits-per-byte perplexity
-    olmo-eval run -m llama3.1-8b -t lab_bench_litqa2:bpb
+Each task supports :mc (logprob-based) and :bpb (bits-per-byte) variants.
 """
 
 from __future__ import annotations
@@ -45,11 +46,11 @@ _REFUSE_CHOICE = "Insufficient information to answer the question"
 
 @dataclass(frozen=True, slots=True)
 class PrecisionMetric(Metric):
-    """Accuracy excluding abstentions (correct / non-abstained).
+    """Accuracy excluding refusals (correct / non-refused).
 
     Matches the "precision" metric from the LAB-Bench evaluation protocol.
-    A response is an abstention if the model chose the refuse option
-    (identified by `unsure_idx` in instance metadata).
+    A response is a refusal if the model chose the refuse option
+    (identified by `refuse_idx` in instance metadata).
     """
 
     name: str = "precision"
@@ -62,12 +63,10 @@ class PrecisionMetric(Metric):
         committed = 0
         correct = 0.0
         for r in responses:
-            unsure_idx = r.instance.metadata.get("unsure_idx")
-            if unsure_idx is not None:
-                unsure_letter = chr(ord("A") + unsure_idx)
-                extracted = r.outputs[0].extracted_answer if r.outputs else None
-                if extracted is not None and str(extracted).strip().upper() == unsure_letter:
-                    continue
+            refuse_letter = chr(ord("A") + r.instance.metadata["refuse_idx"])
+            extracted = r.outputs[0].extracted_answer if r.outputs else None
+            if extracted is not None and extracted.strip().upper() == refuse_letter:
+                continue
             committed += 1
             correct += r.scores.get(scorer_name, 0.0)
         return correct / committed if committed > 0 else 0.0
@@ -104,33 +103,24 @@ class LabBenchTask(Task):
         # Build choices: ideal + distractors (deduplicate in case ideal appears in distractors)
         choices = [ideal] + [d for d in distractors if d != ideal]
 
-        # Inject abstention option if not already present (the HF dataset omits it,
-        # but the LAB-Bench evaluation protocol includes it)
-        if not any("insufficient" in c.lower() for c in choices):
-            choices.append(_REFUSE_CHOICE)
+        # Inject refuse option per the LAB-Bench evaluation protocol
+        choices.append(_REFUSE_CHOICE)
 
         # Deterministic per-question shuffle
         rng = random.Random(f"{self.config.seed}:{index}")
         rng.shuffle(choices)
 
-        # Find where the ideal and refuse options landed after shuffle
         gold_idx = choices.index(ideal)
         gold_letter = chr(ord("A") + gold_idx)
-
-        # Find the refuse option index (may not exist if one was already in distractors)
-        try:
-            unsure_idx = choices.index(_REFUSE_CHOICE)
-        except ValueError:
-            unsure_idx = None
+        refuse_idx = choices.index(_REFUSE_CHOICE)
 
         metadata: dict[str, Any] = {
             "id": doc.get("id", f"lab_bench_{index}"),
             "index": index,
             "gold_idx": gold_idx,
             "gold_text": ideal,
+            "refuse_idx": refuse_idx,
         }
-        if unsure_idx is not None:
-            metadata["unsure_idx"] = unsure_idx
 
         return Instance(
             question=question,
@@ -154,55 +144,86 @@ class LabBenchTask(Task):
         )
 
     def extract_answer(self, output: LMOutput) -> str | None:
-        """Extract a letter answer from model output.
-
-        Looks for the "ANSWER: X" pattern that the system prompt requests.
-        Returns None if the model doesn't follow the expected format.
-        """
-        text = output.text.strip()
-        if not text:
-            return None
-
-        matches = list(_ANSWER_PATTERN.finditer(text))
-        if matches:
-            return matches[-1].group(1).upper()
-
-        return None
+        """Extract the last ``ANSWER: X`` letter from model output."""
+        matches = list(_ANSWER_PATTERN.finditer(output.text))
+        return matches[-1].group(1).upper() if matches else None
 
 
-LITQA2_SYSTEM_PROMPT = """\
+_SYSTEM_PROMPT = """\
 You are a scientific research assistant. Answer the following multiple choice \
 question by reasoning through the options and selecting the best answer.
 
 End your response with "ANSWER: X" where X is the letter of your chosen answer."""
 
+_DEFAULT_METRICS = (AccuracyMetric(scorer=MultipleChoiceScorer), PrecisionMetric())
+_DEFAULT_SAMPLING = SamplingParams(temperature=0.0, max_tokens=1024)
 
-@register("lab_bench_litqa2")
-class LabBenchLitQA2(LabBenchTask):
-    """LitQA2: Literature-based question answering from LAB-Bench."""
 
-    data_source = DataSource(path="futurehouse/lab-bench", subset="LitQA2", split="train")
-    formatter = MCQAChatFormatter(system_prompt=LITQA2_SYSTEM_PROMPT)
-    metrics = (AccuracyMetric(scorer=MultipleChoiceScorer), PrecisionMetric())
-    sampling_params = SamplingParams(temperature=0.0, max_tokens=1024)
+# =============================================================================
+# Task Registrations
+# =============================================================================
+
+
+# Subtasks that use LabBenchTask directly (question field is self-contained)
+_STANDARD_SUBTASKS: dict[str, str] = {
+    "lab_bench_litqa2": "LitQA2",
+    "lab_bench_dbqa": "DbQA",
+    "lab_bench_seqqa": "SeqQA",
+    "lab_bench_suppqa": "SuppQA",
+    "lab_bench_cloning_scenarios": "CloningScenarios",
+}
+
+for _name, _subset in _STANDARD_SUBTASKS.items():
+    _cls = type(
+        _subset,
+        (LabBenchTask,),
+        {
+            "data_source": DataSource(path="futurehouse/lab-bench", subset=_subset, split="train"),
+            "formatter": MCQAChatFormatter(system_prompt=_SYSTEM_PROMPT),
+            "metrics": _DEFAULT_METRICS,
+            "sampling_params": _DEFAULT_SAMPLING,
+        },
+    )
+    register(_name)(_cls)
+
+
+@register("lab_bench_protocolqa")
+class LabBenchProtocolQA(LabBenchTask):
+    """ProtocolQA: Lab protocol question answering from LAB-Bench.
+
+    Prepends the protocol text to the question, since questions reference
+    "the listed protocol" which is stored in a separate dataset field.
+    """
+
+    data_source = DataSource(path="futurehouse/lab-bench", subset="ProtocolQA", split="train")
+    formatter = MCQAChatFormatter(system_prompt=_SYSTEM_PROMPT)
+    metrics = _DEFAULT_METRICS
+    sampling_params = _DEFAULT_SAMPLING
+
+    def process_doc(self, doc: dict[str, Any], index: int = 0) -> Instance | None:
+        protocol = doc.get("protocol", "")
+        if protocol:
+            question = doc.get("question", "")
+            doc = {**doc, "question": f"Protocol:\n{protocol}\n\nQuestion: {question}"}
+        return super().process_doc(doc, index)
 
 
 # =============================================================================
 # Variant Registrations
 # =============================================================================
 
-# Logprob-based multiple choice
-register_variant(
-    "lab_bench_litqa2",
-    "mc",
-    formatter=MultipleChoiceFormatter(),
-    metrics=(AccuracyMetric(scorer=MultipleChoiceScorer), PrecisionMetric()),
-)
+_ALL_TASKS = (*_STANDARD_SUBTASKS, "lab_bench_protocolqa")
 
-# Bits-per-byte perplexity
-register_variant(
-    "lab_bench_litqa2",
-    "bpb",
-    formatter=PPLFormatter(),
-    metrics=(BPBMetric(),),
-)
+for _task in _ALL_TASKS:
+    register_variant(
+        _task,
+        "mc",
+        formatter=MultipleChoiceFormatter(),
+        metrics=_DEFAULT_METRICS,
+    )
+    register_variant(
+        _task,
+        "bpb",
+        formatter=PPLFormatter(),
+        metrics=(BPBMetric(),),
+    )

--- a/src/olmo_eval/evals/tasks/lab_bench.py
+++ b/src/olmo_eval/evals/tasks/lab_bench.py
@@ -159,7 +159,8 @@ question by reasoning through the options and selecting the best answer.
 
 End your response with "ANSWER: X" where X is the letter of your chosen answer."""
 
-_DEFAULT_METRICS = (AccuracyMetric(scorer=MultipleChoiceScorer), PrecisionMetric())
+_DEFAULT_ACCURACY = AccuracyMetric(scorer=MultipleChoiceScorer)
+_DEFAULT_METRICS = (_DEFAULT_ACCURACY, PrecisionMetric())
 _DEFAULT_SAMPLING = SamplingParams(temperature=0.0, max_tokens=1024)
 
 
@@ -185,6 +186,7 @@ for _name, _subset in _STANDARD_SUBTASKS.items():
             "data_source": DataSource(path="futurehouse/lab-bench", subset=_subset),
             "formatter": MCQAChatFormatter(system_prompt=_SYSTEM_PROMPT),
             "metrics": _DEFAULT_METRICS,
+            "primary_metric": _DEFAULT_ACCURACY,
             "sampling_params": _DEFAULT_SAMPLING,
         },
     )
@@ -202,6 +204,7 @@ class LabBenchProtocolQA(LabBenchTask):
     data_source = DataSource(path="futurehouse/lab-bench", subset="ProtocolQA")
     formatter = MCQAChatFormatter(system_prompt=_SYSTEM_PROMPT)
     metrics = _DEFAULT_METRICS
+    primary_metric = _DEFAULT_ACCURACY
     sampling_params = _DEFAULT_SAMPLING
 
     def process_doc(self, doc: dict[str, Any], index: int = 0) -> Instance | None:

--- a/src/olmo_eval/evals/tasks/lab_bench.py
+++ b/src/olmo_eval/evals/tasks/lab_bench.py
@@ -1,0 +1,208 @@
+"""LAB-Bench evaluation tasks.
+
+LAB-Bench (futurehouse/lab-bench) is a biology research benchmark with 8 subtasks.
+This module implements the text-only subtasks, starting with LitQA2.
+
+Usage:
+    # Chat-based generation (default)
+    olmo-eval run -m llama3.1-8b -t lab_bench_litqa2
+
+    # Logprob-based multiple choice
+    olmo-eval run -m llama3.1-8b -t lab_bench_litqa2:mc
+
+    # Bits-per-byte perplexity
+    olmo-eval run -m llama3.1-8b -t lab_bench_litqa2:bpb
+"""
+
+from __future__ import annotations
+
+import random
+import re
+from collections.abc import Iterator, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from olmo_eval.common.formatters import MCQAChatFormatter, MultipleChoiceFormatter, PPLFormatter
+from olmo_eval.common.metrics import AccuracyMetric, BPBMetric, Metric
+from olmo_eval.common.scorers import MultipleChoiceScorer, Scorer
+from olmo_eval.common.types import (
+    Instance,
+    LMOutput,
+    LMRequest,
+    RequestType,
+    Response,
+    SamplingParams,
+)
+from olmo_eval.data import DataLoader, DataSource
+from olmo_eval.evals.tasks.common import Task, register, register_variant
+
+# Regex for "ANSWER: X" pattern (case-insensitive)
+_ANSWER_PATTERN = re.compile(r"ANSWER\s*:\s*([A-Z])", re.IGNORECASE)
+
+# Matches REFUSE_CHOICE from the official LAB-Bench evaluation code
+_REFUSE_CHOICE = "Insufficient information to answer the question"
+
+
+@dataclass(frozen=True, slots=True)
+class PrecisionMetric(Metric):
+    """Accuracy excluding abstentions (correct / non-abstained).
+
+    Matches the "precision" metric from the LAB-Bench evaluation protocol.
+    A response is an abstention if the model chose the refuse option
+    (identified by `unsure_idx` in instance metadata).
+    """
+
+    name: str = "precision"
+    scorer: type[Scorer] = MultipleChoiceScorer
+
+    def compute(self, responses: Sequence[Response]) -> float:
+        if not responses:
+            return 0.0
+        scorer_name = self.scorer().name
+        committed = 0
+        correct = 0.0
+        for r in responses:
+            unsure_idx = r.instance.metadata.get("unsure_idx")
+            if unsure_idx is not None:
+                unsure_letter = chr(ord("A") + unsure_idx)
+                extracted = r.outputs[0].extracted_answer if r.outputs else None
+                if extracted is not None and str(extracted).strip().upper() == unsure_letter:
+                    continue
+            committed += 1
+            correct += r.scores.get(scorer_name, 0.0)
+        return correct / committed if committed > 0 else 0.0
+
+
+class LabBenchTask(Task):
+    """Base class for text-only LAB-Bench subtasks.
+
+    Handles the shared pattern: combine `ideal` + `distractors` into shuffled
+    choices, extract letter answers from model output.
+    """
+
+    @property
+    def instances(self) -> Iterator[Instance]:
+        if self._instances_cache is None:
+            self._instances_cache = []
+            loader = DataLoader()
+            source = self.config.get_data_source()
+            for idx, doc in enumerate(loader.load(source)):
+                instance = self.process_doc(doc, idx)
+                if instance is not None:
+                    self._instances_cache.append(instance)
+        yield from self._instances_cache
+
+    def process_doc(self, doc: dict[str, Any], index: int = 0) -> Instance | None:
+        """Convert a LAB-Bench document to an Instance with shuffled choices."""
+        question = doc.get("question", "")
+        ideal = doc.get("ideal", "")
+        distractors = doc.get("distractors", [])
+
+        if not question or not ideal:
+            return None
+
+        # Build choices: ideal + distractors (deduplicate in case ideal appears in distractors)
+        choices = [ideal] + [d for d in distractors if d != ideal]
+
+        # Inject abstention option if not already present (the HF dataset omits it,
+        # but the LAB-Bench evaluation protocol includes it)
+        if not any("insufficient" in c.lower() for c in choices):
+            choices.append(_REFUSE_CHOICE)
+
+        # Deterministic per-question shuffle
+        rng = random.Random(f"{self.config.seed}:{index}")
+        rng.shuffle(choices)
+
+        # Find where the ideal and refuse options landed after shuffle
+        gold_idx = choices.index(ideal)
+        gold_letter = chr(ord("A") + gold_idx)
+
+        # Find the refuse option index (may not exist if one was already in distractors)
+        try:
+            unsure_idx = choices.index(_REFUSE_CHOICE)
+        except ValueError:
+            unsure_idx = None
+
+        metadata: dict[str, Any] = {
+            "id": doc.get("id", f"lab_bench_{index}"),
+            "index": index,
+            "gold_idx": gold_idx,
+            "gold_text": ideal,
+        }
+        if unsure_idx is not None:
+            metadata["unsure_idx"] = unsure_idx
+
+        return Instance(
+            question=question,
+            gold_answer=gold_letter,
+            choices=tuple(choices),
+            metadata=metadata,
+        )
+
+    @property
+    def request_type(self) -> RequestType:
+        if self.config.formatter is not None:
+            return self.config.formatter.request_type
+        return RequestType.CHAT
+
+    def format_request(self, instance: Instance) -> LMRequest:
+        if self.config.formatter is not None:
+            return self.config.formatter.format(instance, self.get_fewshot())
+        return LMRequest(
+            request_type=RequestType.CHAT,
+            messages=({"role": "user", "content": instance.question},),
+        )
+
+    def extract_answer(self, output: LMOutput) -> str | None:
+        """Extract a letter answer from model output.
+
+        Looks for the "ANSWER: X" pattern that the system prompt requests.
+        Returns None if the model doesn't follow the expected format.
+        """
+        text = output.text.strip()
+        if not text:
+            return None
+
+        matches = list(_ANSWER_PATTERN.finditer(text))
+        if matches:
+            return matches[-1].group(1).upper()
+
+        return None
+
+
+LITQA2_SYSTEM_PROMPT = """\
+You are a scientific research assistant. Answer the following multiple choice \
+question by reasoning through the options and selecting the best answer.
+
+End your response with "ANSWER: X" where X is the letter of your chosen answer."""
+
+
+@register("lab_bench_litqa2")
+class LabBenchLitQA2(LabBenchTask):
+    """LitQA2: Literature-based question answering from LAB-Bench."""
+
+    data_source = DataSource(path="futurehouse/lab-bench", subset="LitQA2", split="train")
+    formatter = MCQAChatFormatter(system_prompt=LITQA2_SYSTEM_PROMPT)
+    metrics = (AccuracyMetric(scorer=MultipleChoiceScorer), PrecisionMetric())
+    sampling_params = SamplingParams(temperature=0.0, max_tokens=1024)
+
+
+# =============================================================================
+# Variant Registrations
+# =============================================================================
+
+# Logprob-based multiple choice
+register_variant(
+    "lab_bench_litqa2",
+    "mc",
+    formatter=MultipleChoiceFormatter(),
+    metrics=(AccuracyMetric(scorer=MultipleChoiceScorer), PrecisionMetric()),
+)
+
+# Bits-per-byte perplexity
+register_variant(
+    "lab_bench_litqa2",
+    "bpb",
+    formatter=PPLFormatter(),
+    metrics=(BPBMetric(),),
+)

--- a/src/olmo_eval/evals/tasks/lab_bench.py
+++ b/src/olmo_eval/evals/tasks/lab_bench.py
@@ -45,13 +45,18 @@ _ANSWER_PATTERN = re.compile(r"ANSWER\s*:\s*([A-Z])", re.IGNORECASE)
 _REFUSE_CHOICE = "Insufficient information to answer the question"
 
 
+def _is_refusal(r: Response) -> bool:
+    """Check if a response chose the refuse option."""
+    refuse_letter = chr(ord("A") + r.instance.metadata["refuse_idx"])
+    extracted = r.outputs[0].extracted_answer if r.outputs else None
+    return extracted is not None and extracted.strip().upper() == refuse_letter
+
+
 @dataclass(frozen=True, slots=True)
 class PrecisionMetric(Metric):
     """Accuracy excluding refusals (correct / non-refused).
 
     Matches the "precision" metric from the LAB-Bench evaluation protocol.
-    A response is a refusal if the model chose the refuse option
-    (identified by `refuse_idx` in instance metadata).
     """
 
     name: str = "precision"
@@ -61,16 +66,27 @@ class PrecisionMetric(Metric):
         if not responses:
             return 0.0
         scorer_name = self.scorer().name
-        committed = 0
-        correct = 0.0
-        for r in responses:
-            refuse_letter = chr(ord("A") + r.instance.metadata["refuse_idx"])
-            extracted = r.outputs[0].extracted_answer if r.outputs else None
-            if extracted is not None and extracted.strip().upper() == refuse_letter:
-                continue
-            committed += 1
-            correct += r.scores.get(scorer_name, 0.0)
-        return correct / committed if committed > 0 else 0.0
+        committed = [r for r in responses if not _is_refusal(r)]
+        if not committed:
+            return 0.0
+        return sum(r.scores.get(scorer_name, 0.0) for r in committed) / len(committed)
+
+
+@dataclass(frozen=True, slots=True)
+class CoverageMetric(Metric):
+    """Fraction of responses where the model committed (did not refuse).
+
+    Matches the "coverage" metric from the LAB-Bench evaluation protocol.
+    """
+
+    name: str = "coverage"
+    scorer: type[Scorer] = MultipleChoiceScorer
+
+    def compute(self, responses: Sequence[Response]) -> float:
+        if not responses:
+            return 0.0
+        committed = sum(1 for r in responses if not _is_refusal(r))
+        return committed / len(responses)
 
 
 class LabBenchTask(Task):
@@ -160,7 +176,7 @@ question by reasoning through the options and selecting the best answer.
 End your response with "ANSWER: X" where X is the letter of your chosen answer."""
 
 _DEFAULT_ACCURACY = AccuracyMetric(scorer=MultipleChoiceScorer)
-_DEFAULT_METRICS = (_DEFAULT_ACCURACY, PrecisionMetric())
+_DEFAULT_METRICS = (_DEFAULT_ACCURACY, PrecisionMetric(), CoverageMetric())
 _DEFAULT_SAMPLING = SamplingParams(temperature=0.0, max_tokens=1024)
 
 

--- a/src/olmo_eval/evals/tasks/lab_bench.py
+++ b/src/olmo_eval/evals/tasks/lab_bench.py
@@ -183,6 +183,8 @@ for _name, _subset in _STANDARD_SUBTASKS.items():
         _subset,
         (LabBenchTask,),
         {
+            "__module__": __name__,
+            "__qualname__": _subset,
             "data_source": DataSource(path="futurehouse/lab-bench", subset=_subset),
             "formatter": MCQAChatFormatter(system_prompt=_SYSTEM_PROMPT),
             "metrics": _DEFAULT_METRICS,
@@ -190,6 +192,7 @@ for _name, _subset in _STANDARD_SUBTASKS.items():
             "sampling_params": _DEFAULT_SAMPLING,
         },
     )
+    globals()[_subset] = _cls  # Make picklable by storing in module namespace
     register(_name)(_cls)
 
 

--- a/tests/core/test_formatters.py
+++ b/tests/core/test_formatters.py
@@ -160,7 +160,7 @@ class TestMultipleChoiceFormatter:
 
         request = formatter.format(instance)
 
-        assert request.request_type == RequestType.COMPLETION
+        assert request.request_type == RequestType.LOGLIKELIHOOD
         # Default behavior includes labeled choices in prompt
         assert "What color is the sky?" in request.prompt
         assert "A. Red" in request.prompt
@@ -179,7 +179,7 @@ class TestMultipleChoiceFormatter:
 
         request = formatter.format(instance)
 
-        assert request.request_type == RequestType.COMPLETION
+        assert request.request_type == RequestType.LOGLIKELIHOOD
         assert request.prompt == "What color is the sky?"
         assert request.continuations == ("Red", "Blue", "Green")
 

--- a/tests/evals/tasks/test_lab_bench.py
+++ b/tests/evals/tasks/test_lab_bench.py
@@ -230,7 +230,7 @@ class TestFormatRequest:
             metadata={"gold_idx": 0, "gold_text": "Kinase A"},
         )
         request = task.format_request(instance)
-        assert request.request_type == RequestType.COMPLETION
+        assert request.request_type == RequestType.LOGLIKELIHOOD
         assert request.continuations is not None
         assert len(request.continuations) == 2
 

--- a/tests/evals/tasks/test_lab_bench.py
+++ b/tests/evals/tasks/test_lab_bench.py
@@ -13,22 +13,36 @@ def _setup_registry():
     import olmo_eval.evals.tasks  # noqa: F401
 
 
+_ALL_TASKS = (
+    "lab_bench_litqa2",
+    "lab_bench_dbqa",
+    "lab_bench_seqqa",
+    "lab_bench_protocolqa",
+    "lab_bench_suppqa",
+    "lab_bench_cloning_scenarios",
+)
+
+
 class TestLabBenchRegistration:
     """Tests for LAB-Bench task registration."""
 
-    def test_litqa2_registered(self):
-        assert "lab_bench_litqa2" in list_tasks()
+    @pytest.mark.parametrize("task_name", _ALL_TASKS)
+    def test_task_registered(self, task_name):
+        assert task_name in list_tasks()
 
-    def test_get_litqa2(self):
-        task = get_task("lab_bench_litqa2")
-        assert task.config.name == "lab_bench_litqa2"
+    @pytest.mark.parametrize("task_name", _ALL_TASKS)
+    def test_get_task(self, task_name):
+        task = get_task(task_name)
+        assert task.config.name == task_name
 
-    def test_litqa2_mc_variant(self):
-        task = get_task("lab_bench_litqa2:mc")
+    @pytest.mark.parametrize("task_name", _ALL_TASKS)
+    def test_mc_variant(self, task_name):
+        task = get_task(f"{task_name}:mc")
         assert task is not None
 
-    def test_litqa2_bpb_variant(self):
-        task = get_task("lab_bench_litqa2:bpb")
+    @pytest.mark.parametrize("task_name", _ALL_TASKS)
+    def test_bpb_variant(self, task_name):
+        task = get_task(f"{task_name}:bpb")
         assert task is not None
 
 
@@ -43,17 +57,17 @@ class TestProcessDoc:
         doc = {
             "question": "What enzyme catalyzes X?",
             "ideal": "Kinase A",
-            "distractors": ["Kinase B", "Kinase C", "Insufficient information"],
+            "distractors": ["Kinase B", "Kinase C"],
         }
         instance = task.process_doc(doc, index=0)
 
         assert instance is not None
         assert instance.question == "What enzyme catalyzes X?"
-        assert len(instance.choices) == 4
+        assert len(instance.choices) == 4  # ideal + 2 distractors + refuse
         assert "Kinase A" in instance.choices
         assert "Kinase B" in instance.choices
         assert "Kinase C" in instance.choices
-        assert "Insufficient information" in instance.choices
+        assert "Insufficient information to answer the question" in instance.choices
 
     def test_gold_letter_points_to_ideal(self, task):
         doc = {
@@ -88,27 +102,6 @@ class TestProcessDoc:
         inst1 = task.process_doc(doc, index=1)
         assert inst0.choices != inst1.choices
 
-    def test_injects_insufficient_info_option(self, task):
-        doc = {
-            "question": "Q?",
-            "ideal": "Answer",
-            "distractors": ["Wrong 1", "Wrong 2"],
-        }
-        instance = task.process_doc(doc, index=0)
-        assert any("insufficient" in c.lower() for c in instance.choices)
-        assert len(instance.choices) == 4  # ideal + 2 distractors + injected
-
-    def test_skips_injection_when_already_present(self, task):
-        doc = {
-            "question": "Q?",
-            "ideal": "Answer",
-            "distractors": ["Wrong", "Insufficient information to answer"],
-        }
-        instance = task.process_doc(doc, index=0)
-        insuff_count = sum(1 for c in instance.choices if "insufficient" in c.lower())
-        assert insuff_count == 1
-        assert len(instance.choices) == 3  # ideal + 2 distractors, no injection
-
     def test_deduplicates_ideal_in_distractors(self, task):
         doc = {
             "question": "Q?",
@@ -117,7 +110,7 @@ class TestProcessDoc:
         }
         instance = task.process_doc(doc, index=0)
         assert instance.choices.count("Same") == 1
-        assert len(instance.choices) == 3  # deduped ideal + 1 distractor + injected
+        assert len(instance.choices) == 3  # "Same" + "Different" + refuse option
 
     def test_metadata_contains_gold_idx_and_text(self, task):
         doc = {
@@ -129,15 +122,15 @@ class TestProcessDoc:
         assert "gold_idx" in instance.metadata
         assert instance.metadata["gold_text"] == "The right answer"
 
-    def test_metadata_contains_unsure_idx(self, task):
+    def test_metadata_contains_refuse_idx(self, task):
         doc = {
             "question": "Q?",
             "ideal": "Answer",
             "distractors": ["Wrong 1", "Wrong 2"],
         }
         instance = task.process_doc(doc, index=0)
-        unsure_idx = instance.metadata["unsure_idx"]
-        assert instance.choices[unsure_idx] == "Insufficient information to answer the question"
+        refuse_idx = instance.metadata["refuse_idx"]
+        assert instance.choices[refuse_idx] == "Insufficient information to answer the question"
 
     def test_skip_missing_question(self, task):
         doc = {"question": "", "ideal": "Answer", "distractors": ["D1"]}
@@ -146,6 +139,35 @@ class TestProcessDoc:
     def test_skip_missing_ideal(self, task):
         doc = {"question": "Q?", "ideal": "", "distractors": ["D1"]}
         assert task.process_doc(doc, index=0) is None
+
+
+class TestProtocolQAProcessDoc:
+    """Tests for ProtocolQA protocol injection."""
+
+    @pytest.fixture
+    def task(self):
+        return get_task("lab_bench_protocolqa")
+
+    def test_protocol_prepended_to_question(self, task):
+        doc = {
+            "question": "What went wrong?",
+            "ideal": "Step 3 was skipped",
+            "distractors": ["Step 1 was skipped"],
+            "protocol": "Step 1: Mix reagents\nStep 2: Incubate\nStep 3: Centrifuge",
+        }
+        instance = task.process_doc(doc, index=0)
+        assert "Protocol:" in instance.question
+        assert "Step 1: Mix reagents" in instance.question
+        assert "Question: What went wrong?" in instance.question
+
+    def test_missing_protocol_uses_question_only(self, task):
+        doc = {
+            "question": "What went wrong?",
+            "ideal": "Unknown",
+            "distractors": ["Nothing"],
+        }
+        instance = task.process_doc(doc, index=0)
+        assert instance.question == "What went wrong?"
 
 
 class TestExtractAnswer:
@@ -214,24 +236,21 @@ class TestFormatRequest:
 
 
 class TestPrecisionMetric:
-    """Tests for PrecisionMetric (accuracy excluding abstentions)."""
+    """Tests for PrecisionMetric (accuracy excluding refusals)."""
 
     @pytest.fixture
     def metric(self):
         return PrecisionMetric()
 
     def _make_response(
-        self, gold: str, extracted: str, score: float, unsure_idx: int | None = None
+        self, gold: str, extracted: str, score: float, refuse_idx: int = 2
     ) -> Response:
-        metadata: dict = {"gold_idx": 0, "gold_text": "Answer"}
-        if unsure_idx is not None:
-            metadata["unsure_idx"] = unsure_idx
         return Response(
             instance=Instance(
                 question="Q?",
                 gold_answer=gold,
                 choices=("A", "B", "C"),
-                metadata=metadata,
+                metadata={"gold_idx": 0, "gold_text": "Answer", "refuse_idx": refuse_idx},
             ),
             request=LMRequest(request_type=RequestType.CHAT, messages=()),
             outputs=[LMOutput(text="", extracted_answer=extracted)],
@@ -239,37 +258,29 @@ class TestPrecisionMetric:
         )
 
     def test_all_committed(self, metric):
-        """No abstentions: precision == accuracy."""
+        """No refusals: precision == accuracy."""
         responses = [
-            self._make_response("A", "A", 1.0, unsure_idx=2),
-            self._make_response("A", "B", 0.0, unsure_idx=2),
+            self._make_response("A", "A", 1.0),
+            self._make_response("A", "B", 0.0),
         ]
         assert metric.compute(responses) == pytest.approx(0.5)
 
-    def test_abstention_excluded(self, metric):
-        """Abstained response excluded from denominator."""
+    def test_refusal_excluded(self, metric):
+        """Refused response excluded from denominator."""
         responses = [
-            self._make_response("A", "A", 1.0, unsure_idx=2),  # correct
-            self._make_response("A", "C", 0.0, unsure_idx=2),  # abstained (chose C = unsure)
+            self._make_response("A", "A", 1.0),  # correct
+            self._make_response("A", "C", 0.0),  # refused (chose C = refuse option)
         ]
         # Only 1 committed response, and it's correct
         assert metric.compute(responses) == pytest.approx(1.0)
 
-    def test_all_abstained(self, metric):
-        """All responses abstained: returns 0.0."""
+    def test_all_refused(self, metric):
+        """All responses refused: returns 0.0."""
         responses = [
-            self._make_response("A", "C", 0.0, unsure_idx=2),
-            self._make_response("A", "C", 0.0, unsure_idx=2),
+            self._make_response("A", "C", 0.0),
+            self._make_response("A", "C", 0.0),
         ]
         assert metric.compute(responses) == pytest.approx(0.0)
 
     def test_empty_responses(self, metric):
         assert metric.compute([]) == pytest.approx(0.0)
-
-    def test_no_unsure_idx_in_metadata(self, metric):
-        """When unsure_idx is absent, all responses count as committed."""
-        responses = [
-            self._make_response("A", "A", 1.0, unsure_idx=None),
-            self._make_response("A", "B", 0.0, unsure_idx=None),
-        ]
-        assert metric.compute(responses) == pytest.approx(0.5)

--- a/tests/evals/tasks/test_lab_bench.py
+++ b/tests/evals/tasks/test_lab_bench.py
@@ -1,0 +1,275 @@
+"""Tests for LAB-Bench task logic."""
+
+import pytest
+
+from olmo_eval.common.scorers import MultipleChoiceScorer
+from olmo_eval.common.types import Instance, LMOutput, LMRequest, RequestType, Response
+from olmo_eval.evals.tasks.common import get_task, list_tasks
+from olmo_eval.evals.tasks.lab_bench import PrecisionMetric
+
+
+@pytest.fixture(autouse=True)
+def _setup_registry():
+    import olmo_eval.evals.tasks  # noqa: F401
+
+
+class TestLabBenchRegistration:
+    """Tests for LAB-Bench task registration."""
+
+    def test_litqa2_registered(self):
+        assert "lab_bench_litqa2" in list_tasks()
+
+    def test_get_litqa2(self):
+        task = get_task("lab_bench_litqa2")
+        assert task.config.name == "lab_bench_litqa2"
+
+    def test_litqa2_mc_variant(self):
+        task = get_task("lab_bench_litqa2:mc")
+        assert task is not None
+
+    def test_litqa2_bpb_variant(self):
+        task = get_task("lab_bench_litqa2:bpb")
+        assert task is not None
+
+
+class TestProcessDoc:
+    """Tests for LabBenchTask.process_doc."""
+
+    @pytest.fixture
+    def task(self):
+        return get_task("lab_bench_litqa2")
+
+    def test_basic_conversion(self, task):
+        doc = {
+            "question": "What enzyme catalyzes X?",
+            "ideal": "Kinase A",
+            "distractors": ["Kinase B", "Kinase C", "Insufficient information"],
+        }
+        instance = task.process_doc(doc, index=0)
+
+        assert instance is not None
+        assert instance.question == "What enzyme catalyzes X?"
+        assert len(instance.choices) == 4
+        assert "Kinase A" in instance.choices
+        assert "Kinase B" in instance.choices
+        assert "Kinase C" in instance.choices
+        assert "Insufficient information" in instance.choices
+
+    def test_gold_letter_points_to_ideal(self, task):
+        doc = {
+            "question": "What is the answer?",
+            "ideal": "Correct answer",
+            "distractors": ["Wrong 1", "Wrong 2"],
+        }
+        instance = task.process_doc(doc, index=42)
+
+        gold_idx = instance.metadata["gold_idx"]
+        assert instance.choices[gold_idx] == "Correct answer"
+        assert instance.gold_answer == chr(ord("A") + gold_idx)
+
+    def test_shuffle_determinism(self, task):
+        doc = {
+            "question": "Q?",
+            "ideal": "Ideal",
+            "distractors": ["D1", "D2", "D3"],
+        }
+        inst1 = task.process_doc(doc, index=7)
+        inst2 = task.process_doc(doc, index=7)
+        assert inst1.choices == inst2.choices
+        assert inst1.gold_answer == inst2.gold_answer
+
+    def test_different_indices_produce_different_shuffles(self, task):
+        doc = {
+            "question": "Q?",
+            "ideal": "Ideal",
+            "distractors": ["D1", "D2", "D3", "D4", "D5"],
+        }
+        inst0 = task.process_doc(doc, index=0)
+        inst1 = task.process_doc(doc, index=1)
+        assert inst0.choices != inst1.choices
+
+    def test_injects_insufficient_info_option(self, task):
+        doc = {
+            "question": "Q?",
+            "ideal": "Answer",
+            "distractors": ["Wrong 1", "Wrong 2"],
+        }
+        instance = task.process_doc(doc, index=0)
+        assert any("insufficient" in c.lower() for c in instance.choices)
+        assert len(instance.choices) == 4  # ideal + 2 distractors + injected
+
+    def test_skips_injection_when_already_present(self, task):
+        doc = {
+            "question": "Q?",
+            "ideal": "Answer",
+            "distractors": ["Wrong", "Insufficient information to answer"],
+        }
+        instance = task.process_doc(doc, index=0)
+        insuff_count = sum(1 for c in instance.choices if "insufficient" in c.lower())
+        assert insuff_count == 1
+        assert len(instance.choices) == 3  # ideal + 2 distractors, no injection
+
+    def test_deduplicates_ideal_in_distractors(self, task):
+        doc = {
+            "question": "Q?",
+            "ideal": "Same",
+            "distractors": ["Same", "Different"],
+        }
+        instance = task.process_doc(doc, index=0)
+        assert instance.choices.count("Same") == 1
+        assert len(instance.choices) == 3  # deduped ideal + 1 distractor + injected
+
+    def test_metadata_contains_gold_idx_and_text(self, task):
+        doc = {
+            "question": "Q?",
+            "ideal": "The right answer",
+            "distractors": ["Wrong"],
+        }
+        instance = task.process_doc(doc, index=0)
+        assert "gold_idx" in instance.metadata
+        assert instance.metadata["gold_text"] == "The right answer"
+
+    def test_metadata_contains_unsure_idx(self, task):
+        doc = {
+            "question": "Q?",
+            "ideal": "Answer",
+            "distractors": ["Wrong 1", "Wrong 2"],
+        }
+        instance = task.process_doc(doc, index=0)
+        unsure_idx = instance.metadata["unsure_idx"]
+        assert instance.choices[unsure_idx] == "Insufficient information to answer the question"
+
+    def test_skip_missing_question(self, task):
+        doc = {"question": "", "ideal": "Answer", "distractors": ["D1"]}
+        assert task.process_doc(doc, index=0) is None
+
+    def test_skip_missing_ideal(self, task):
+        doc = {"question": "Q?", "ideal": "", "distractors": ["D1"]}
+        assert task.process_doc(doc, index=0) is None
+
+
+class TestExtractAnswer:
+    """Tests for LabBenchTask.extract_answer."""
+
+    @pytest.fixture
+    def task(self):
+        return get_task("lab_bench_litqa2")
+
+    def test_answer_pattern(self, task):
+        output = LMOutput(text="The answer is clearly B because...\nANSWER: B")
+        assert task.extract_answer(output) == "B"
+
+    def test_answer_pattern_lowercase(self, task):
+        output = LMOutput(text="answer: c")
+        assert task.extract_answer(output) == "C"
+
+    def test_answer_pattern_no_space(self, task):
+        output = LMOutput(text="ANSWER:A")
+        assert task.extract_answer(output) == "A"
+
+    def test_last_answer_pattern_wins(self, task):
+        output = LMOutput(text="ANSWER: A\nWait, actually ANSWER: C")
+        assert task.extract_answer(output) == "C"
+
+    def test_no_answer_pattern_returns_none(self, task):
+        output = LMOutput(text="I think the answer is B")
+        assert task.extract_answer(output) is None
+
+    def test_empty_output(self, task):
+        output = LMOutput(text="")
+        assert task.extract_answer(output) is None
+
+    def test_whitespace_only(self, task):
+        output = LMOutput(text="   ")
+        assert task.extract_answer(output) is None
+
+
+class TestFormatRequest:
+    """Tests for format_request delegation."""
+
+    def test_chat_format(self):
+        task = get_task("lab_bench_litqa2")
+        instance = Instance(
+            question="What enzyme?",
+            gold_answer="A",
+            choices=("Kinase A", "Kinase B"),
+            metadata={"gold_idx": 0, "gold_text": "Kinase A"},
+        )
+        request = task.format_request(instance)
+        assert request.request_type == RequestType.CHAT
+        assert any("Kinase A" in m["content"] for m in request.messages if m["role"] == "user")
+
+    def test_mc_format(self):
+        task = get_task("lab_bench_litqa2:mc")
+        instance = Instance(
+            question="What enzyme?",
+            gold_answer="A",
+            choices=("Kinase A", "Kinase B"),
+            metadata={"gold_idx": 0, "gold_text": "Kinase A"},
+        )
+        request = task.format_request(instance)
+        assert request.request_type == RequestType.COMPLETION
+        assert request.continuations is not None
+        assert len(request.continuations) == 2
+
+
+class TestPrecisionMetric:
+    """Tests for PrecisionMetric (accuracy excluding abstentions)."""
+
+    @pytest.fixture
+    def metric(self):
+        return PrecisionMetric()
+
+    def _make_response(
+        self, gold: str, extracted: str, score: float, unsure_idx: int | None = None
+    ) -> Response:
+        metadata: dict = {"gold_idx": 0, "gold_text": "Answer"}
+        if unsure_idx is not None:
+            metadata["unsure_idx"] = unsure_idx
+        return Response(
+            instance=Instance(
+                question="Q?",
+                gold_answer=gold,
+                choices=("A", "B", "C"),
+                metadata=metadata,
+            ),
+            request=LMRequest(request_type=RequestType.CHAT, messages=()),
+            outputs=[LMOutput(text="", extracted_answer=extracted)],
+            scores={MultipleChoiceScorer().name: score},
+        )
+
+    def test_all_committed(self, metric):
+        """No abstentions: precision == accuracy."""
+        responses = [
+            self._make_response("A", "A", 1.0, unsure_idx=2),
+            self._make_response("A", "B", 0.0, unsure_idx=2),
+        ]
+        assert metric.compute(responses) == pytest.approx(0.5)
+
+    def test_abstention_excluded(self, metric):
+        """Abstained response excluded from denominator."""
+        responses = [
+            self._make_response("A", "A", 1.0, unsure_idx=2),  # correct
+            self._make_response("A", "C", 0.0, unsure_idx=2),  # abstained (chose C = unsure)
+        ]
+        # Only 1 committed response, and it's correct
+        assert metric.compute(responses) == pytest.approx(1.0)
+
+    def test_all_abstained(self, metric):
+        """All responses abstained: returns 0.0."""
+        responses = [
+            self._make_response("A", "C", 0.0, unsure_idx=2),
+            self._make_response("A", "C", 0.0, unsure_idx=2),
+        ]
+        assert metric.compute(responses) == pytest.approx(0.0)
+
+    def test_empty_responses(self, metric):
+        assert metric.compute([]) == pytest.approx(0.0)
+
+    def test_no_unsure_idx_in_metadata(self, metric):
+        """When unsure_idx is absent, all responses count as committed."""
+        responses = [
+            self._make_response("A", "A", 1.0, unsure_idx=None),
+            self._make_response("A", "B", 0.0, unsure_idx=None),
+        ]
+        assert metric.compute(responses) == pytest.approx(0.5)

--- a/tests/evals/tasks/test_lab_bench.py
+++ b/tests/evals/tasks/test_lab_bench.py
@@ -5,7 +5,7 @@ import pytest
 from olmo_eval.common.scorers import MultipleChoiceScorer
 from olmo_eval.common.types import Instance, LMOutput, LMRequest, RequestType, Response
 from olmo_eval.evals.tasks.common import get_task, list_tasks
-from olmo_eval.evals.tasks.lab_bench import PrecisionMetric
+from olmo_eval.evals.tasks.lab_bench import CoverageMetric, PrecisionMetric
 
 
 @pytest.fixture(autouse=True)
@@ -276,6 +276,53 @@ class TestPrecisionMetric:
 
     def test_all_refused(self, metric):
         """All responses refused: returns 0.0."""
+        responses = [
+            self._make_response("A", "C", 0.0),
+            self._make_response("A", "C", 0.0),
+        ]
+        assert metric.compute(responses) == pytest.approx(0.0)
+
+    def test_empty_responses(self, metric):
+        assert metric.compute([]) == pytest.approx(0.0)
+
+
+class TestCoverageMetric:
+    """Tests for CoverageMetric (fraction of non-refused responses)."""
+
+    @pytest.fixture
+    def metric(self):
+        return CoverageMetric()
+
+    def _make_response(
+        self, gold: str, extracted: str, score: float, refuse_idx: int = 2
+    ) -> Response:
+        return Response(
+            instance=Instance(
+                question="Q?",
+                gold_answer=gold,
+                choices=("A", "B", "C"),
+                metadata={"gold_idx": 0, "gold_text": "Answer", "refuse_idx": refuse_idx},
+            ),
+            request=LMRequest(request_type=RequestType.CHAT, messages=()),
+            outputs=[LMOutput(text="", extracted_answer=extracted)],
+            scores={MultipleChoiceScorer().name: score},
+        )
+
+    def test_all_committed(self, metric):
+        responses = [
+            self._make_response("A", "A", 1.0),
+            self._make_response("A", "B", 0.0),
+        ]
+        assert metric.compute(responses) == pytest.approx(1.0)
+
+    def test_some_refused(self, metric):
+        responses = [
+            self._make_response("A", "A", 1.0),  # committed
+            self._make_response("A", "C", 0.0),  # refused
+        ]
+        assert metric.compute(responses) == pytest.approx(0.5)
+
+    def test_all_refused(self, metric):
         responses = [
             self._make_response("A", "C", 0.0),
             self._make_response("A", "C", 0.0),


### PR DESCRIPTION
## Description

Add the 6 text-only [LAB-Bench](https://huggingface.co/datasets/futurehouse/lab-bench) evaluation subtasks. I punted on the 2 image-based subtasks (FigQA, TableQA) for now.

Files added:
  - `src/olmo_eval/evals/tasks/lab_bench.py` — task implementations, base class, precision metric
  - `src/olmo_eval/evals/suites/biology.py` — suite registration, more bio tasks to come
  - `tests/evals/tasks/test_lab_bench.py` — lots of unit tests

Main additions:
  - LabBenchTask base class for text-only LAB-Bench subtasks (which are all multiple choice). This class handles combining ideal + distractor answers into deterministically A,B,C,D style multiple choices, injecting an additional "refuse to answer" option, and extracting single letter answers from `ANSWER: X` patterns
  - PrecisionMetric — accuracy excluding refusals (correct / non-refused), matching the [precision metric from LAB-Bench](https://github.com/Future-House/LAB-Bench/blob/998a8e0a40cf116c80e1b0e7a805ebb5fb9fa838/labbench/evaluator.py#L128)
  - 6 registered tasks, each with :mc (logprob-based) and :bpb (bits-per-byte) variants:
    - lab_bench_litqa2 — literature-based QA (199 questions)
    - lab_bench_dbqa — biological database QA (520 questions)
    - lab_bench_seqqa — DNA/protein sequence analysis (600 questions)
    - lab_bench_protocolqa — lab protocol QA (108 questions, prepends protocol context)
    - lab_bench_suppqa — supplementary material QA (82 questions)
    - lab_bench_cloning_scenarios — molecular cloning (33 questions)
  - lab_bench suite in `biology.py`

## Type of Change

<!-- Put an `x` in all the boxes that apply -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Testing

<!-- Describe how you tested your changes -->

- [x] Unit tests pass locally (`pytest tests/ --ignore=tests/integration/`)
- [ ] Integration tests pass (if applicable)
- [x] New tests added for new functionality

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published
