### PR TITLE
Stream batches to processor in asynq runner

### DIFF
--- a/src/olmo_eval/common/progress.py
+++ b/src/olmo_eval/common/progress.py
@@ -75,7 +75,8 @@ class ProgressLogger:
         self.count += n
         now = time.time()
 
-        if now - self.last_log_time >= self.log_interval:
+        # Log at intervals, but skip if at 100% since close() will log final summary
+        if now - self.last_log_time >= self.log_interval and self.count < self.total:
             self._log_progress(now)
             self.last_log_time = now
 

--- a/src/olmo_eval/runners/asynq/processing.py
+++ b/src/olmo_eval/runners/asynq/processing.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import multiprocessing as mp
 from typing import TYPE_CHECKING
 
@@ -209,6 +210,7 @@ async def process_items(
     harness: Harness,
     result_queue: mp.Queue,
     max_concurrency: int | None = None,
+    worker_logger: logging.Logger | None = None,
 ) -> None:
     """Process queue items, batching where possible.
 
@@ -221,8 +223,11 @@ async def process_items(
         harness: Harness instance for execution.
         result_queue: Queue to put results.
         max_concurrency: Maximum concurrent CHAT requests.
+        worker_logger: Logger with worker identification.
     """
     from olmo_eval.common.types import RequestType, SamplingParams
+
+    log = worker_logger or logger
 
     chat_items: list[QueueItem] = []
     batchable_items: list[QueueItem] = []
@@ -244,7 +249,7 @@ async def process_items(
             batches[key].append(item)
 
         progress = ProgressLogger(
-            total=len(batchable_items), desc="Processed", logger=logger, color="green"
+            total=len(batchable_items), desc="Processed", logger=log, color="green"
         )
         for batch in batches.values():
             await process_batch(batch, harness, result_queue)
@@ -256,7 +261,7 @@ async def process_items(
 
         semaphore = asyncio.Semaphore(max_concurrency or len(chat_items))
         progress = ProgressLogger(
-            total=len(chat_items), desc="Processed", logger=logger, color="green"
+            total=len(chat_items), desc="Processed", logger=log, color="green"
         )
 
         async def process(item: QueueItem) -> None:

--- a/src/olmo_eval/runners/asynq/runner.py
+++ b/src/olmo_eval/runners/asynq/runner.py
@@ -26,7 +26,7 @@ from olmo_eval.runners.asynq.preparation import (
     prepare_task_items,
 )
 from olmo_eval.runners.asynq.results import aggregate_results, process_results
-from olmo_eval.runners.asynq.types import DEFAULT_SCORING_CONCURRENCY, QueueItem, TaskTracker
+from olmo_eval.runners.asynq.types import QueueItem, TaskTracker
 from olmo_eval.runners.asynq.workers import inference_worker, scoring_worker
 from olmo_eval.runners.common.base import BaseEvalRunner
 from olmo_eval.runners.common.mixins import RunnerResultsMixin
@@ -187,18 +187,15 @@ class AsyncEvalRunner(RunnerResultsMixin, BaseEvalRunner):
             if self.harness_config.scoring_concurrency:
                 scoring_concurrency = self.harness_config.scoring_concurrency
             elif sandbox_configs_list is not None:
-                # Sandboxes handle concurrency differently - warn user to set explicit value
-                scoring_concurrency = DEFAULT_SCORING_CONCURRENCY
-                runner_logger.warning(
-                    f"Using default scoring_concurrency={scoring_concurrency} with sandboxes. "
-                    "Consider setting harness_config.scoring_concurrency explicitly as "
-                    "sandboxes handle concurrency differently."
-                )
+                # Match sandbox pool size (sum of instances across all configs)
+                sandbox_pool_size = sum(cfg.get("instances", 1) for cfg in sandbox_configs_list)
+                scoring_concurrency = max(1, sandbox_pool_size)
             else:
+                # CPU-bound scoring - use available cores
                 import os
 
                 cpu_count = os.cpu_count() or 4
-                scoring_concurrency = max(1, int(cpu_count * 0.5))
+                scoring_concurrency = max(1, int(cpu_count * 0.75))
 
             runner_logger.info(f"Scoring concurrency: {scoring_concurrency}")
 

--- a/src/olmo_eval/runners/asynq/runner.py
+++ b/src/olmo_eval/runners/asynq/runner.py
@@ -185,9 +185,11 @@ class AsyncEvalRunner(RunnerResultsMixin, BaseEvalRunner):
             scoring_concurrency = (
                 self.harness_config.scoring_concurrency or DEFAULT_SCORING_CONCURRENCY
             )
+            scorer_id = "scorer-0"  # TODO: support multiple scorers
             scorer_proc = ctx.Process(
                 target=scoring_worker,
                 args=(
+                    scorer_id,
                     scoring_queue,
                     scored_queue,
                     total_instances,

--- a/src/olmo_eval/runners/asynq/runner.py
+++ b/src/olmo_eval/runners/asynq/runner.py
@@ -13,7 +13,7 @@ from typing import Any
 from olmo_eval.cli.utils import console
 from olmo_eval.common.configs import expand_tasks
 from olmo_eval.common.constants.infrastructure import BEAKER_RESULT_DIR
-from olmo_eval.common.logging import get_logger, get_worker_id
+from olmo_eval.common.logging import configure_worker_logging, get_logger, get_worker_id
 from olmo_eval.harness.config import HarnessConfig, ProviderConfig
 from olmo_eval.runners.asynq.monitoring import (
     terminate_workers,
@@ -35,6 +35,7 @@ from olmo_eval.runners.processing.utils import compute_task_hash, generate_exper
 from olmo_eval.storage import StorageBackend
 
 logger = get_logger(__name__)
+runner_logger = configure_worker_logging("runner")
 
 
 @dataclass
@@ -141,7 +142,7 @@ class AsyncEvalRunner(RunnerResultsMixin, BaseEvalRunner):
         # Prepare tasks
         expanded_tasks, trackers, items = self._prepare_tasks()
         total_instances = len(items)
-        logger.info(f"Total instances: {total_instances}")
+        runner_logger.info(f"Total instances: {total_instances}")
 
         # Setup multiprocessing
         ctx = mp.get_context("spawn")
@@ -179,12 +180,28 @@ class AsyncEvalRunner(RunnerResultsMixin, BaseEvalRunner):
             scorer_ready = ctx.Event()
 
             workers = self._start_workers(
-                ctx, num_workers, total_gpus, item_queue, result_queue, init_times
+                ctx, num_workers, total_gpus, item_queue, result_queue, init_times, total_instances
             )
 
-            scoring_concurrency = (
-                self.harness_config.scoring_concurrency or DEFAULT_SCORING_CONCURRENCY
-            )
+            # Determine scoring concurrency
+            if self.harness_config.scoring_concurrency:
+                scoring_concurrency = self.harness_config.scoring_concurrency
+            elif sandbox_configs_list is not None:
+                # Sandboxes handle concurrency differently - warn user to set explicit value
+                scoring_concurrency = DEFAULT_SCORING_CONCURRENCY
+                runner_logger.warning(
+                    f"Using default scoring_concurrency={scoring_concurrency} with sandboxes. "
+                    "Consider setting harness_config.scoring_concurrency explicitly as "
+                    "sandboxes handle concurrency differently."
+                )
+            else:
+                import os
+
+                cpu_count = os.cpu_count() or 4
+                scoring_concurrency = max(1, int(cpu_count * 0.5))
+
+            runner_logger.info(f"Scoring concurrency: {scoring_concurrency}")
+
             scorer_id = "scorer-0"  # TODO: support multiple scorers
             scorer_proc = ctx.Process(
                 target=scoring_worker,
@@ -201,15 +218,15 @@ class AsyncEvalRunner(RunnerResultsMixin, BaseEvalRunner):
             scorer_proc.start()
 
             # Wait for workers to initialize
-            logger.info("Waiting for inference workers to initialize...")
+            runner_logger.info("Waiting for inference workers to initialize...")
             wait_for_workers_ready(workers, result_queue, startup_timeout=60.0)
-            logger.info("Inference workers ready")
+            runner_logger.info("Inference workers ready")
 
             # Now wait for scoring worker (runs in parallel with inference worker init)
             if sandbox_configs_list is not None:
-                logger.info("Waiting for scoring worker to initialize...")
+                runner_logger.info("Waiting for scoring worker to initialize...")
                 wait_for_scorer_ready(scorer_proc, scorer_ready, scored_queue, timeout=180.0)
-                logger.info("Scoring worker ready")
+                runner_logger.info("Scoring worker ready")
 
             # Wait for workers to report their init times (also checks for crashes)
             provider_init_seconds = wait_for_init_times(
@@ -403,6 +420,7 @@ class AsyncEvalRunner(RunnerResultsMixin, BaseEvalRunner):
         item_queue: mp.Queue,
         result_queue: mp.Queue,
         init_times: Any,
+        total_instances: int,
     ) -> list[mp.process.BaseProcess]:
         """Start worker processes."""
         workers: list[mp.process.BaseProcess] = []
@@ -422,6 +440,7 @@ class AsyncEvalRunner(RunnerResultsMixin, BaseEvalRunner):
                     item_queue,
                     result_queue,
                     harness_config_dict,
+                    total_instances,
                     init_times,
                     self.output_dir,
                 ),

--- a/src/olmo_eval/runners/asynq/types.py
+++ b/src/olmo_eval/runners/asynq/types.py
@@ -18,6 +18,12 @@ SCORER_FATAL = "__SCORER_FATAL__"
 # Default concurrency for scoring worker
 DEFAULT_SCORING_CONCURRENCY = 8
 
+# Default chunk size for streaming processing (matches typical vLLM max_num_seqs)
+DEFAULT_CHUNK_SIZE = 256
+
+# Timeout for collecting items before processing partial chunk
+DEFAULT_CHUNK_TIMEOUT = 2.0
+
 
 @dataclass
 class QueueItem:
@@ -112,6 +118,9 @@ class ScoredResponse:
 
 
 __all__ = [
+    "DEFAULT_CHUNK_SIZE",
+    "DEFAULT_CHUNK_TIMEOUT",
+    "DEFAULT_SCORING_CONCURRENCY",
     "WORKER_FATAL",
     "SCORER_FATAL",
     "QueueItem",

--- a/src/olmo_eval/runners/asynq/workers.py
+++ b/src/olmo_eval/runners/asynq/workers.py
@@ -8,10 +8,15 @@ import os
 import queue
 import time
 from multiprocessing.synchronize import Event as MPEvent
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from olmo_eval.harness import Harness
 
 from olmo_eval.common.logging import get_logger
 from olmo_eval.runners.asynq.types import (
+    DEFAULT_CHUNK_SIZE,
+    DEFAULT_CHUNK_TIMEOUT,
     DEFAULT_SCORING_CONCURRENCY,
     SCORER_FATAL,
     WORKER_FATAL,
@@ -21,6 +26,55 @@ from olmo_eval.runners.asynq.types import (
 )
 
 logger = get_logger(__name__)
+
+
+async def process_items_streaming(
+    item_queue: mp.Queue[QueueItem | None],
+    harness: Harness,
+    result_queue: mp.Queue[ResultItem],
+    max_concurrency: int | None,
+    chunk_size: int = DEFAULT_CHUNK_SIZE,
+    chunk_timeout: float = DEFAULT_CHUNK_TIMEOUT,
+) -> None:
+    """Process items in chunks for balanced latency and throughput.
+
+    Collects items until chunk_size is reached or chunk_timeout expires,
+    then processes the chunk while continuing to accept new items.
+    This allows processing to start before all items are enqueued.
+
+    Args:
+        item_queue: Queue of QueueItems (None signals shutdown).
+        harness: Harness instance for execution.
+        result_queue: Queue to put ResultItems.
+        max_concurrency: Maximum concurrent requests.
+        chunk_size: Maximum items per chunk (default 256, matches vLLM max_num_seqs).
+        chunk_timeout: Seconds to wait for chunk to fill before processing partial.
+    """
+    import time
+
+    from olmo_eval.runners.asynq.processing import process_items
+
+    while True:
+        items: list[QueueItem] = []
+        deadline = time.time() + chunk_timeout
+
+        # Collect items until chunk is full or timeout
+        while len(items) < chunk_size:
+            remaining = max(0.01, deadline - time.time())
+            try:
+                item = item_queue.get(timeout=remaining)
+                if item is None:
+                    # Poison pill - process remaining items and exit
+                    if items:
+                        await process_items(items, harness, result_queue, max_concurrency)
+                    return
+                items.append(item)
+            except queue.Empty:
+                # Timeout - process what we have
+                break
+
+        if items:
+            await process_items(items, harness, result_queue, max_concurrency)
 
 
 def inference_worker(
@@ -34,8 +88,9 @@ def inference_worker(
 ) -> None:
     """Worker process that initializes a harness and processes items.
 
-    Collects all items from the queue, then processes them with batching
-    for COMPLETION/LOGLIKELIHOOD and async concurrency for CHAT requests.
+    Processes items in streaming chunks for balanced latency and throughput.
+    COMPLETION/LOGLIKELIHOOD requests are batched, CHAT requests use async
+    concurrency.
 
     Args:
         worker_id: Unique worker identifier.
@@ -133,17 +188,7 @@ def inference_worker(
             if harness_config.backend:
                 asyncio.run(harness.backend.initialize(harness_config))
 
-            items: list[QueueItem] = []
-            while True:
-                item = item_queue.get()
-                if item is None:
-                    break
-                items.append(item)
-
-            if items:
-                from olmo_eval.runners.asynq.processing import process_items
-
-                asyncio.run(process_items(items, harness, result_queue, max_concurrency))
+            asyncio.run(process_items_streaming(item_queue, harness, result_queue, max_concurrency))
 
             worker_logger.info("Processing complete")
         finally:
@@ -355,5 +400,6 @@ def scoring_worker(
 
 __all__ = [
     "inference_worker",
+    "process_items_streaming",
     "scoring_worker",
 ]

--- a/src/olmo_eval/runners/asynq/workers.py
+++ b/src/olmo_eval/runners/asynq/workers.py
@@ -35,6 +35,7 @@ async def process_items_streaming(
     result_queue: mp.Queue[ResultItem],
     max_concurrency: int | None,
     worker_logger: logging.Logger,
+    total_instances: int,
     chunk_size: int = DEFAULT_CHUNK_SIZE,
     chunk_timeout: float = DEFAULT_CHUNK_TIMEOUT,
 ) -> None:
@@ -50,14 +51,18 @@ async def process_items_streaming(
         result_queue: Queue to put ResultItems.
         max_concurrency: Maximum concurrent requests.
         worker_logger: Logger with worker identification.
+        total_instances: Total number of instances to process.
         chunk_size: Maximum items per chunk (default 256, matches vLLM max_num_seqs).
         chunk_timeout: Seconds to wait for chunk to fill before processing partial.
     """
+    import math
     import time
 
     from olmo_eval.runners.asynq.processing import process_items
 
+    total_batches = math.ceil(total_instances / chunk_size)
     batch_num = 0
+
     while True:
         items: list[QueueItem] = []
         deadline = time.time() + chunk_timeout
@@ -72,7 +77,7 @@ async def process_items_streaming(
                     if items:
                         batch_num += 1
                         worker_logger.info(
-                            f"Processing final batch {batch_num} ({len(items)} items)"
+                            f"Processing batch {batch_num}/{total_batches} ({len(items)} items)"
                         )
                         await process_items(
                             items, harness, result_queue, max_concurrency, worker_logger
@@ -85,7 +90,7 @@ async def process_items_streaming(
 
         if items:
             batch_num += 1
-            worker_logger.info(f"Processing batch {batch_num} ({len(items)} items)")
+            worker_logger.info(f"Processing batch {batch_num}/{total_batches} ({len(items)} items)")
             await process_items(items, harness, result_queue, max_concurrency, worker_logger)
 
 
@@ -95,6 +100,7 @@ def inference_worker(
     item_queue: mp.Queue,
     result_queue: mp.Queue,
     harness_config_dict: dict[str, Any],
+    total_instances: int,
     init_times: dict[str, float] | None = None,
     output_dir: str | None = None,
 ) -> None:
@@ -110,6 +116,7 @@ def inference_worker(
         item_queue: Queue of QueueItems (None signals shutdown).
         result_queue: Queue to put ResultItems.
         harness_config_dict: Serialized HarnessConfig.
+        total_instances: Total number of instances to process.
         init_times: Optional shared dict for tracking initialization times.
         output_dir: Output directory for persisting logs (e.g., vLLM server logs).
     """
@@ -200,10 +207,15 @@ def inference_worker(
             if harness_config.backend:
                 asyncio.run(harness.backend.initialize(harness_config))
 
-            worker_logger.info("Processing worker ready")
+            worker_logger.info("Inference worker ready")
             asyncio.run(
                 process_items_streaming(
-                    item_queue, harness, result_queue, max_concurrency, worker_logger
+                    item_queue,
+                    harness,
+                    result_queue,
+                    max_concurrency,
+                    worker_logger,
+                    total_instances,
                 )
             )
 

--- a/src/olmo_eval/runners/asynq/workers.py
+++ b/src/olmo_eval/runners/asynq/workers.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import multiprocessing as mp
 import os
 import queue
@@ -33,6 +34,7 @@ async def process_items_streaming(
     harness: Harness,
     result_queue: mp.Queue[ResultItem],
     max_concurrency: int | None,
+    worker_logger: logging.Logger,
     chunk_size: int = DEFAULT_CHUNK_SIZE,
     chunk_timeout: float = DEFAULT_CHUNK_TIMEOUT,
 ) -> None:
@@ -47,6 +49,7 @@ async def process_items_streaming(
         harness: Harness instance for execution.
         result_queue: Queue to put ResultItems.
         max_concurrency: Maximum concurrent requests.
+        worker_logger: Logger with worker identification.
         chunk_size: Maximum items per chunk (default 256, matches vLLM max_num_seqs).
         chunk_timeout: Seconds to wait for chunk to fill before processing partial.
     """
@@ -54,6 +57,7 @@ async def process_items_streaming(
 
     from olmo_eval.runners.asynq.processing import process_items
 
+    batch_num = 0
     while True:
         items: list[QueueItem] = []
         deadline = time.time() + chunk_timeout
@@ -66,7 +70,13 @@ async def process_items_streaming(
                 if item is None:
                     # Poison pill - process remaining items and exit
                     if items:
-                        await process_items(items, harness, result_queue, max_concurrency)
+                        batch_num += 1
+                        worker_logger.info(
+                            f"Processing final batch {batch_num} ({len(items)} items)"
+                        )
+                        await process_items(
+                            items, harness, result_queue, max_concurrency, worker_logger
+                        )
                     return
                 items.append(item)
             except queue.Empty:
@@ -74,7 +84,9 @@ async def process_items_streaming(
                 break
 
         if items:
-            await process_items(items, harness, result_queue, max_concurrency)
+            batch_num += 1
+            worker_logger.info(f"Processing batch {batch_num} ({len(items)} items)")
+            await process_items(items, harness, result_queue, max_concurrency, worker_logger)
 
 
 def inference_worker(
@@ -188,7 +200,12 @@ def inference_worker(
             if harness_config.backend:
                 asyncio.run(harness.backend.initialize(harness_config))
 
-            asyncio.run(process_items_streaming(item_queue, harness, result_queue, max_concurrency))
+            worker_logger.info("Processing worker ready")
+            asyncio.run(
+                process_items_streaming(
+                    item_queue, harness, result_queue, max_concurrency, worker_logger
+                )
+            )
 
             worker_logger.info("Processing complete")
         finally:
@@ -219,6 +236,7 @@ def inference_worker(
 
 
 def scoring_worker(
+    worker_id: str,
     scoring_queue: mp.Queue,
     scored_queue: mp.Queue,
     total_instances: int,
@@ -235,6 +253,7 @@ def scoring_worker(
     similar to how inference_worker manages provider lifecycle.
 
     Args:
+        worker_id: Unique worker identifier (e.g., "scorer-0").
         scoring_queue: Queue of ScoringItems (None signals shutdown).
         scored_queue: Queue to put ScoredResponses.
         total_instances: Total number of instances to score (for progress).
@@ -244,9 +263,10 @@ def scoring_worker(
     """
     import sys
 
-    from olmo_eval.common.logging import configure_logging
+    from olmo_eval.common.logging import configure_logging, configure_worker_logging
 
     configure_logging()
+    worker_logger = configure_worker_logging(worker_id)
 
     from olmo_eval.common.execution import ScoringContext
     from olmo_eval.common.progress import ProgressLogger
@@ -269,7 +289,7 @@ def scoring_worker(
                     scored=scored,
                 )
             except Exception as e:
-                logger.warning(f"Failed to score {item.spec}[{item.instance_idx}]: {e}")
+                worker_logger.warning(f"Failed to score {item.spec}[{item.instance_idx}]: {e}")
                 return ScoredResponse(
                     spec=item.spec,
                     instance_idx=item.instance_idx,
@@ -308,7 +328,7 @@ def scoring_worker(
                             progress = ProgressLogger(
                                 total=total_instances,
                                 desc="Scored",
-                                logger=logger,
+                                logger=worker_logger,
                                 color="blue",
                             )
                         await process_batch(batch, scoring_context, progress)
@@ -322,7 +342,7 @@ def scoring_worker(
                             progress = ProgressLogger(
                                 total=total_instances,
                                 desc="Scored",
-                                logger=logger,
+                                logger=worker_logger,
                                 color="blue",
                             )
                         await process_batch(batch, scoring_context, progress)
@@ -330,8 +350,9 @@ def scoring_worker(
 
                 # Create progress logger on first item
                 if progress is None:
+                    worker_logger.info("Starting scoring")
                     progress = ProgressLogger(
-                        total=total_instances, desc="Scored", logger=logger, color="blue"
+                        total=total_instances, desc="Scored", logger=worker_logger, color="blue"
                     )
 
                 batch.append(item)
@@ -350,14 +371,16 @@ def scoring_worker(
             from olmo_eval.harness.sandbox import SandboxConfig, SandboxManager
 
             sandbox_configs = [SandboxConfig.from_dict(d) for d in sandbox_configs_list]
-            logger.info(f"Initializing sandbox manager with {len(sandbox_configs)} config(s)...")
+            worker_logger.info(
+                f"Initializing sandbox manager with {len(sandbox_configs)} config(s)..."
+            )
             sandbox_manager = SandboxManager(sandbox_configs, owner="scorer")
 
             # Start sandbox synchronously using asyncio
             try:
                 asyncio.run(sandbox_manager.start())
             except Exception as e:
-                logger.error(f"Failed to start sandbox: {e}")
+                worker_logger.error(f"Failed to start sandbox: {e}")
                 scored_queue.put(
                     ScoredResponse(
                         spec=SCORER_FATAL,
@@ -371,6 +394,7 @@ def scoring_worker(
             scoring_context = ScoringContext(execution_env=sandbox_manager)
 
         # Signal that worker is ready
+        worker_logger.info("Scorer ready")
         if ready_event is not None:
             ready_event.set()
 
@@ -378,7 +402,7 @@ def scoring_worker(
         asyncio.run(run_scoring_loop())
 
     except Exception as e:
-        logger.error(f"Scoring worker failed: {e}")
+        worker_logger.error(f"Scoring worker failed: {e}")
         # Signal fatal error via the scored queue
         scored_queue.put(
             ScoredResponse(
@@ -395,7 +419,7 @@ def scoring_worker(
             try:
                 asyncio.run(sandbox_manager.stop())
             except Exception as e:
-                logger.warning(f"Failed to stop sandbox: {e}")
+                worker_logger.warning(f"Failed to stop sandbox: {e}")
 
 
 __all__ = [


### PR DESCRIPTION
The async loop for processing was eager and lacked good telemetry so I've made this more flexible and added batching to processing (tunable) along with better logging for the scoring worker(s).

```
2026-02-19T21:54:11.418Z 2026-02-19 21:54:11 [INFO] [scorer-0] Scored      3841/5000 ( 77%) at 4.5 items/sec
2026-02-19T21:54:22.543Z 2026-02-19 21:54:22 [INFO] [Olmo-3-1025-7B-w0] Processed    256/256 (100%) in 53.1s (4.8 items/sec)
2026-02-19T21:54:22.551Z 2026-02-19 21:54:22 [INFO] [Olmo-3-1025-7B-w0] Processing batch 18/20 (256 items)
2026-02-19T21:55:04.037Z 2026-02-19 21:55:04 [INFO] [scorer-0] Scored      4097/5000 ( 82%) at 4.5 items/sec
2026-02-19T21:55:18.331Z 2026-02-19 21:55:18 [INFO] [Olmo-3-1025-7B-w0] Processed    256/256 (100%) in 55.8s (4.6 items/sec)
2026-02-19T21:55:18.340Z 2026-02-19 21:55:18 [INFO] [Olmo-3-1025-7B-w0] Processing batch 19/20 (256 items)
2026-02-19T21:56:04.672Z 2026-02-19 21:56:04 [INFO] [scorer-0] Scored      4353/5000 ( 87%) at 4.5 items/sec
2026-02-19T21:56:10.665Z 2026-02-19 21:56:10 [INFO] [Olmo-3-1025-7B-w0] Processed    256/256 (100%) in 52.3s (4.9 items/sec)
2026-02-19T21:56:10.675Z 2026-02-19 21:56:10 [INFO] [Olmo-3-1025-7B-w0] Processing batch 20/20 (136 items)
2026-02-19T21:56:38.315Z 2026-02-19 21:56:38 [INFO] [Olmo-3-1025-7B-w0] Processed    136/136 (100%) in 27.6s (4.9 items/sec)
2026-02-19T21:56:38.318Z 2026-02-19 21:56:38 [INFO] [Olmo-3-1025-7B-w0] Processing complete
2026-02-19T21:56:51.867Z 2026-02-19 21:56:51 [INFO] [scorer-0] Scored      4609/5000 ( 92%) at 4.5 items/sec
2026-02-19T21:57:12.476Z 2026-02-19 21:57:12 [INFO] [scorer-0] Scored      4865/5000 ( 97%) at 4.7 items/sec
```