### PR TITLE
Naive AstaBench ScholarQA-CS2 addition

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,6 +149,8 @@ select = [
 "tests/**/fixtures.py" = ["E501"]
 # Long URLs in model configs
 "src/olmo_eval/common/constants/models.py" = ["E501"]
+# Verbatim prompt templates from asta-bench reference implementation
+"src/olmo_eval/evals/tasks/astabench_sqa.py" = ["E501"]
 
 [tool.ruff.format]
 docstring-code-format = true

--- a/src/olmo_eval/common/scorers/llm_judge.py
+++ b/src/olmo_eval/common/scorers/llm_judge.py
@@ -14,7 +14,7 @@ from olmo_eval.common.scorers.base import Scorer
 from olmo_eval.common.types import Instance, LMOutput
 
 # Type for judge function: takes prompt, returns judge response
-JudgeFn = Callable[[str], str]
+JudgeFn = Callable[..., str]
 
 # Rubric-based judge prompt template
 RUBRIC_JUDGE_PROMPT_TEMPLATE = """\
@@ -54,7 +54,10 @@ SimpleQAGrade = Literal["CORRECT", "INCORRECT", "NOT_ATTEMPTED"]
 
 
 def build_openai_judge_fn(
-    model: str = "gpt-4o-mini", scorer_name: str = "LLMJudgeScorer"
+    model: str = "gpt-4o-mini",
+    scorer_name: str = "LLMJudgeScorer",
+    max_tokens: int = 10,
+    temperature: float = 0.0,
 ) -> JudgeFn:
     """Build a lazy judge function using OpenAI API.
 
@@ -62,16 +65,21 @@ def build_openai_judge_fn(
     This allows scorers to be instantiated before the environment variable is set
     (e.g., in Beaker jobs where secrets are injected at runtime).
 
+    The function accepts either a plain string prompt (sent as a user message) or
+    can be called with a system_prompt keyword argument for system+user message pairs.
+
     Args:
         model: OpenAI model to use for judging.
         scorer_name: Name of the scorer class (for error messages).
+        max_tokens: Maximum tokens in the judge response.
+        temperature: Sampling temperature for the judge.
 
     Returns:
         A judge function that validates and calls OpenAI on first use.
     """
     _client: list = []  # Mutable container for lazy initialization
 
-    def judge(prompt: str) -> str:
+    def judge(prompt: str, *, system_prompt: str | None = None) -> str:
         import os
 
         if not _client:
@@ -91,11 +99,16 @@ def build_openai_judge_fn(
 
             _client.append(OpenAI(api_key=api_key))
 
+        messages: list[dict[str, str]] = []
+        if system_prompt is not None:
+            messages.append({"role": "system", "content": system_prompt})
+        messages.append({"role": "user", "content": prompt})
+
         response = _client[0].chat.completions.create(
             model=model,
-            messages=[{"role": "user", "content": prompt}],
-            temperature=0.0,
-            max_tokens=10,
+            messages=messages,
+            temperature=temperature,
+            max_tokens=max_tokens,
         )
         return response.choices[0].message.content or ""
 

--- a/src/olmo_eval/data/backends/huggingface.py
+++ b/src/olmo_eval/data/backends/huggingface.py
@@ -46,12 +46,19 @@ class HuggingFaceBackend:
         # Use HF_TOKEN for authentication if available
         token = os.getenv("HF_TOKEN")
 
+        kwargs: dict[str, Any] = {}
+        if source.data_files is not None:
+            kwargs["data_files"] = source.data_files
+        if source.revision is not None:
+            kwargs["revision"] = source.revision
+
         dataset = load_dataset(
             path,
             name=source.subset,
             split=source.split,
             streaming=streaming,
             token=token,
+            **kwargs,
         )
 
         yield from dataset

--- a/src/olmo_eval/data/sources.py
+++ b/src/olmo_eval/data/sources.py
@@ -121,6 +121,8 @@ class DataSource:
             subset=kwargs.get("subset", subset),
             split=kwargs.get("split", split),
             source_type=kwargs.get("source_type", source_type),
+            data_files=kwargs.get("data_files"),
+            revision=kwargs.get("revision"),
         )
 
     def with_split(self, split: str) -> DataSource:
@@ -130,6 +132,8 @@ class DataSource:
             subset=self.subset,
             split=split,
             source_type=self.source_type,
+            data_files=self.data_files,
+            revision=self.revision,
         )
 
     def with_subset(self, subset: str | None) -> DataSource:
@@ -139,6 +143,8 @@ class DataSource:
             subset=subset,
             split=self.split,
             source_type=self.source_type,
+            data_files=self.data_files,
+            revision=self.revision,
         )
 
     def to_dict(self) -> dict:

--- a/src/olmo_eval/evals/suites/astabench.py
+++ b/src/olmo_eval/evals/suites/astabench.py
@@ -1,0 +1,9 @@
+"""AstaBench evaluation suite."""
+
+from olmo_eval.evals.suites.registry import make_suite
+
+ASTABENCH = make_suite(
+    "astabench",
+    ("astabench_scholarqa",),
+    description="AstaBench scientific evaluation suite (allenai/asta-bench)",
+)

--- a/src/olmo_eval/evals/tasks/astabench_sqa.py
+++ b/src/olmo_eval/evals/tasks/astabench_sqa.py
@@ -568,8 +568,8 @@ class AstaBenchSQA(Task):
     def format_request(self, instance: Instance) -> LMRequest:
         prompt_text = SQA_GENERATION_PROMPT + instance.question
         return LMRequest(
-            request_type=RequestType.COMPLETION,
-            prompt=prompt_text,
+            request_type=RequestType.CHAT,
+            messages=({"role": "user", "content": prompt_text},),
         )
 
     def extract_answer(self, output: LMOutput) -> Any:

--- a/src/olmo_eval/evals/tasks/astabench_sqa.py
+++ b/src/olmo_eval/evals/tasks/astabench_sqa.py
@@ -1,0 +1,745 @@
+"""AstaBench ScholArQA-CS2 scientific question answering task.
+
+Evaluates models on generating well-cited research reports with inline citations.
+Scoring uses 4 LLM-as-judge metrics (each 25% weight):
+ingredient_recall, answer_precision, citation_precision, citation_recall.
+
+Reference implementation: https://github.com/allenai/asta-bench
+"""
+
+from __future__ import annotations
+
+import difflib
+import json
+import logging
+import re
+from abc import ABC
+from collections.abc import Iterator, Sequence
+from dataclasses import dataclass
+from typing import Any, ClassVar
+
+from olmo_eval.common.metrics import Metric
+from olmo_eval.common.scorers.base import Scorer
+from olmo_eval.common.scorers.llm_judge import JudgeFn, build_openai_judge_fn
+from olmo_eval.common.types import (
+    Instance,
+    LMOutput,
+    LMRequest,
+    RequestType,
+    Response,
+    SamplingParams,
+)
+from olmo_eval.data import DataSource
+from olmo_eval.evals.tasks.common import Task, register, register_variant
+
+logger = logging.getLogger(__name__)
+
+# =============================================================================
+# Constants
+# =============================================================================
+
+ASTA_BENCH_REPO = "allenai/asta-bench"
+ASTA_BENCH_REVISION = "a600dc767f850385f4664772e3ba7a7f8be17d5e"
+
+JUST_HAS_A_TITLE = "Paper content unavailable. The paper's title is: "
+
+# =============================================================================
+# Prompt Templates
+# =============================================================================
+
+SQA_GENERATION_PROMPT = """Generate a report answering the following research question. Be sure to include inline citations for each claim. Return your result as valid JSON with a single key `sections` which is a list of sections, each having keys `title`, `text`, and `citations`. Each entry in `citations` should have a JSON list of `snippets` extracted from the reference document and an `id`, each of which appears exactly in the text. Each `id` should be an inline citation as it appears in the text (with wrapping parentheses or square brackets if appropriate). Each citation should have a `title` if one is available. Any additional information about the citation should go under `metadata`. Do not create a References section.
+
+Here is an example `section` to help you with formatting:
+
+        {
+          "title": "Background",
+          "text": "Convolutional neural networks (CNNs) have achieved state-of-the-art results in image classification [1][2].",
+          "citations": [
+            {
+              "id": "[1]",
+              "snippets": [
+                "CNNs have become the standard for many visual tasks."
+              ],
+              "title": "ImageNet Classification with Deep Convolutional Neural Networks",
+              "metadata": {
+                "authors": "Krizhevsky, A. et al.",
+                "year": 2012,
+                "arxiv": "1207.0580"
+              }
+            },
+            {
+              "id": "[2]",
+              "snippets": [
+                "Significant improvements in image recognition have been observed with CNNs."
+              ],
+              "title": "Very Deep Convolutional Networks for Large-Scale Image Recognition",
+              "metadata": {
+                "authors": "Simonyan, K. & Zisserman, A.",
+                "year": 2014,
+                "arxiv": "1409.1556"
+              }
+            }
+          ]
+        }
+
+Question: """
+
+INGREDIENT_SYSTEM_PROMPT = """You will be given a question someone asked (in <question></question> tags) and the corresponding response (in <response></response> tags) given to them by an assistant.
+        You will then be given an enumerated list of criteria by which to evaluate the response. Each criterion specifies requirements that the answer must satisfy. You will assign a score accordingly (see below).
+        You will also be given a list of examples (in <examples></examples> tags, below each criterion) that illustrate the type of details that would satisfy the criterion. We do NOT expect any of the specified details to necessarily appear in the answer. These are strictly to be used as guidance for locating the answers that satisfy the set requirement.
+
+        For each criterion, return a score of 0, 1 or 2 indicating how appropriate the response is based on the given criterion. 0 means the response does not meet the criterion, 1 means the response somewhat meets the criterion, 2 means the response perfectly meets the criterion. Judge only the specified aspect(s) delimited by the criterion, not any other qualities of the answer.
+
+        Scoring Example 1:
+        <question>Common medical NLP papers on clinical text benchmarks</question>
+        <response>The application of natural language processing (NLP) and machine learning to medical text presents tremendous opportunities for healthcare tasks such as prediction ... [TRUNCATED]</response>
+        Criteria:
+        <criterion>
+        1. Detail the well-known medical NLP datasets
+        <examples>
+        i2b2 includes datasets focused on temporal relations in clinical narratives, CRAFT Corpus is a collection of 97 full-length, open-access biomedical journal articles with semantic and syntactic annotations.]
+        </examples>
+        </criterion>
+        <criterion>
+        2. ... [TRUNCATED]
+        <examples>
+        ...[TRUNCATED]
+        </examples>
+        </criterion>
+
+        A 2 point answer would fully satisfy the criterion #1. For example, it would include specific names with some details of well-known medical datasets for ML like those mentioned in the examples.
+        A 1 point answer would only partially satisfy the criterion #1. For example, a dataset (like those in examples) may be mentioned, but no detail would be provided. Or datasets may be simply listed without further discussion.
+        A 0 point answer would not mention datasets at all.
+
+        Scoring Example 2:
+        <question>What are some of the documentation methods used in Linguistics fieldwork.</question>
+        <response>Language documentation, also called documentary linguistics, is a specialized subfield of linguistics ... [TRUNCATED]</response>
+        Criteria:
+        <criterion>
+        1. ... [TRUNCATED]
+        <examples>
+        ...[TRUNCATED]
+        </examples>
+        </criterion>
+        <criterion>
+        2. Cover elicitation techniques for capturing specific linguistic data.
+        <examples>
+        structured interviews, elicitations based on standard word lists, prompted speech tasks
+        </examples>
+        </criterion>
+
+        A 2 point answer to criterion #2 would contain common elicitation techniques like (but not limited to) those mentioned in the examples. The answer specifics don't have to match exactly with the examples, but examples show the types of instances that would count towards satisfying the criterion.
+        A 1 point answer to criterion #2 be incomplete in some way. For example, the answer might mention "elicitation sessions" during a discussion on audio recording, but it fails to specifically address the requirement. Or the answer gives a list of standard word lists in the answer as resources, but fails to tie this information to elicitation.
+        A 0 point answer to criterion #2 would simply not include the discussion in any way. For example, if an answer focuses only on data handling (post elicitation) techniques, it would miss out on techniques for documentation interview itself.
+
+        Scoring Example 3:
+
+        <question>How do transformer models differ from recurrent neural networks (RNNs)?</question>
+        <response>Transformer models use self-attention mechanisms to process input, while RNNs process input sequentially. Transformers are better at handling long-range dependencies in data because they don't rely on previous time steps to pass information. RNNs may suffer from vanishing gradients and have trouble with long-term dependencies.</response>
+        Criteria:
+        <criterion>
+        1. Must compare how the architecture and data processing flow differ between transformers and RNNs. <examples>
+        Transformers use parallel processing and self-attention; RNNs process input tokens one at a time in sequence. Transformers can look at the entire input sequence at once, while RNNs have to pass information step by step.
+        </examples>
+        </criterion>
+
+        A 2 point answer would accurately and distinctly contrast both architecture and sequence-processing style of both model families (e.g., parallelism vs. sequential processing, use of self-attention vs. recurrence).
+
+        A 1 point answer would provide a partial or imprecise comparison, perhaps only mentioning one difference, or being vague (e.g., "Transformers work differently from RNNs in how they process text" without further elaboration).
+
+        A 0 point answer would explain only one architecture (e.g., only transformers), or describe both but fail to contrast them on the asked criteria.
+
+        Return your result as a JSON object with a single key `scores` whose value is a list of objects, each having keys `criteria_idx`, `reasoning`, `score` and `evidence` from the text supporting the claim."""
+
+PRECISION_EVAL_PROMPT = """You are given a query and a corresponding long answer.
+
+Goal: find irrelevant paragraphs in the answer. These are paragraphs that don't directly answer the query and shouldn't be in the answer.
+
+For instance, if the query is about datasets for scientific question answering, a paragraph about multilingual question answering datasets that don't contain scientific text would be considered irrelevant.
+
+Explicitly consider whether something may be indirectly relevant. For example, if the question is about the conditions of horses in South Africa, a paragraph about general animal welfare in South Africa is potentially relevant while not being precisely about horses. On the other hand, a paragraph about pig welfare in South Africa is irrelevant.
+
+Note that subtle differences can make the text irrelevant to the query. For instance, text about scientific survey paper generation is not relevant to a query about automatic paper review generation. Even though they seem related, they are about very different tasks.
+
+Also, useful background in general is relevant. If the question is about an approach to creating liver-related proteins, some information about liver-related proteins could contextualize other parts of the answer. If a paragraph contextualizes another part of the answer, then it is relevant.
+
+Go through the answer and output a list of irrelevant paragraphs. Every single paragraph needs to be considered, one by one. Our goal is to catch all the irrelevant paragraphs, so please be thorough.
+Return your result as a JSON object with a single key `irrelevant_paragraphs` whose value is a list of objects, each having keys `reason`, and `answer_text` as follows:
+{{"irrelevant_paragraphs":[
+{{
+"reason": "discuss why something is irrelevant (not indirectly relevant)",
+"answer_text": "exact ENTIRE paragraph (not just a part of it) from the answer that is irrelevant"
+}},
+...
+]
+}}
+Make sure all the irrelevant paragraphs are included.
+
+Question: {query}
+Answer: {answer}
+"""
+
+CITATION_GROUP_PROMPT = """You are a claim validator. For each claim made in the following text you will determine if it is supported by the quote from it's corresponding inline citations. As is typically done in academic writing, assume that consecutive sentences can share citations. Make sure to also include claims presented in table format. For references with only the title available (ie no quotes from the reference are included), judge them as `supporting` if the title indicates that the paper is likely relevant to the claim being considered. Return a JSON object with a single key `claims` which is a list of `claim` objects, one for each sentence in the text. Each `claim` object contains the claim itself (`text`), a list of `supporting` inline citations and `non_supporting` inline citations and finally a boolean `is_fully_supported` which indicates if the claim is entirely supported by the quotations in the associated citations. Each inline citation corresponding to that claim should appear in either `supporting` or `non_supporting`, but not both. Each claim made in the text should appear in your output, but you should skip sentences covering high level introductory information.
+
+Text:
+{}
+
+References:
+{}"""
+
+
+# =============================================================================
+# JSON / Response Parsing Helpers
+# =============================================================================
+
+
+def extract_json_from_response(response: str) -> dict[str, Any] | None:
+    """Extract JSON object from a model response string."""
+    json_start = response.find("{")
+    json_end = response.rfind("}") + 1
+    if json_start == -1 or json_end == 0:
+        return None
+    try:
+        return json.loads(response[json_start:json_end])
+    except json.JSONDecodeError:
+        try:
+            return json.loads(response[json_start + 1 : json_end - 1])
+        except json.JSONDecodeError:
+            logger.warning("Could not decode JSON from response")
+            return None
+
+
+def normalize_agent_response_dict(response_dict: dict[str, Any]) -> dict[str, Any]:
+    """Normalize response format to always have top-level `sections` key."""
+    if not response_dict.get("sections") and response_dict.get("response"):
+        return response_dict["response"]
+    return response_dict
+
+
+def format_report(response_dict: dict[str, Any]) -> str:
+    """Extract plain text from structured response sections."""
+    report = ""
+    for section in response_dict.get("sections", []):
+        text = section.get("text", "")
+        if text:
+            report += f"{text}\n\n"
+        table = section.get("table")
+        if table and isinstance(table, dict):
+            table_text = table.get("text", "")
+            if table_text:
+                report += f"{table_text}\n\n"
+    return report.strip()
+
+
+def clean_sentence(sentence: str) -> str:
+    """Clean XML tags from model-generated sentences."""
+    pattern = r'<Paper [^>]*paperTitle="\W*([ _a-zA-Z0-9,.;]+)\W*"[^>]*/?>\s*</Paper>'
+    sentence = re.sub(pattern, r"(\1)", sentence)
+    pattern = r'<Model name="Anthropic" version="[^"]+">'
+    return re.sub(pattern, "", sentence)
+
+
+# =============================================================================
+# Scoring Helpers
+# =============================================================================
+
+
+def compute_precision_score(
+    parsed_json: dict[str, Any], answer: str
+) -> tuple[float, dict[str, Any]]:
+    """Compute answer precision from judge output identifying irrelevant paragraphs."""
+    metadata: dict[str, Any] = {}
+    irrelevant_texts = [
+        item["answer_text"] for item in parsed_json.get("irrelevant_paragraphs", [])
+    ]
+    metadata["irrelevant_texts"] = irrelevant_texts
+
+    paragraphs = re.split(r"\n\s*\n", answer.strip())
+    metadata["answer_paragraphs"] = paragraphs
+
+    if not paragraphs:
+        return 1.0, metadata
+
+    matching_paragraph_indices: set[int] = set()
+    for sentence in irrelevant_texts:
+        for idx, para in enumerate(paragraphs):
+            if difflib.SequenceMatcher(None, sentence.strip(), para).ratio() >= 0.85:
+                matching_paragraph_indices.add(idx)
+                break
+
+    score = 1 - (len(matching_paragraph_indices) / len(paragraphs))
+    return score, metadata
+
+
+def compute_ingredient_score(
+    parsed_json: dict[str, Any],
+    ingredients: list[dict[str, Any]],
+) -> float:
+    """Compute ingredient recall from joint assessment judge output."""
+    has_criterion = [ing for ing in ingredients if ing.get("criterion")]
+    if not has_criterion:
+        return 0.0
+
+    # Normalize weights so they sum to 1
+    raw_weights = {ing["name"]: ing["weight"] for ing in has_criterion}
+    total_weight = sum(raw_weights.values())
+    if total_weight == 0:
+        return 0.0
+    weights = {k: v / total_weight for k, v in raw_weights.items()}
+
+    scores_list = parsed_json.get("scores", [])
+    score_components: dict[str, float] = {}
+    for item in scores_list:
+        idx = item.get("criteria_idx", 0) - 1  # 1-indexed in prompt
+        if 0 <= idx < len(has_criterion):
+            name = has_criterion[idx]["name"]
+            score_components[name] = item.get("score", 0) / 2  # Normalize 0-2 to 0-1
+
+    return sum(weights.get(k, 0) * score_components.get(k, 0) for k in weights)
+
+
+def _clean_citation_id(c: str) -> str:
+    """Remove brackets/parens from citation ID for comparison."""
+    for char in "[]()":
+        c = c.replace(char, "")
+    return c
+
+
+def _citation_intersection(supporting: list[str], half_credit_ids: list[str]) -> int:
+    """Count supporting citations that are title-only (half credit)."""
+    supporting_clean = {_clean_citation_id(str(c)) for c in supporting}
+    half_clean = {_clean_citation_id(str(c)) for c in half_credit_ids}
+    return len(supporting_clean.intersection(half_clean))
+
+
+def _filter_citation(citation: dict[str, Any], sec_text: str) -> bool:
+    """Check if citation snippets are present and usable."""
+    sec_text_alpha = re.sub(r"[^a-zA-Z]", "", sec_text).lower()
+    snippets_alpha = [re.sub(r"[^a-zA-Z]", "", s).lower() for s in citation.get("snippets", [])]
+    return bool(
+        citation.get("snippets")
+        and not any(s in sec_text_alpha for s in snippets_alpha)
+        and not (
+            citation.get("title")
+            and any(
+                re.sub(r"[^a-zA-Z]", "", citation["title"]).lower() == s for s in snippets_alpha
+            )
+        )
+    )
+
+
+def compute_citation_scores_from_groups(
+    group_results: list[dict[str, Any]],
+) -> dict[str, float]:
+    """Aggregate citation precision and recall from per-group scoring results."""
+    n_attributable = 0
+    n_extrapolatory = 0
+    n_half_credit = 0
+    precisions: list[float] = []
+
+    for result in group_results:
+        n_attributable += result["n_attributable"]
+        n_extrapolatory += result["n_extrapolatory"]
+        n_half_credit += result["n_half_credit_claims"]
+        for s, e, p in zip(
+            result["supporting_counts"],
+            result["non_supporting_counts"],
+            result["n_half_credit_citations"],
+            strict=True,
+        ):
+            if s + e:
+                precisions.append((s - 0.5 * p) / (s + e))
+
+    total = n_attributable + n_extrapolatory
+    recall = ((n_attributable - 0.5 * n_half_credit) / total) if total else 0.0
+    precision = (sum(precisions) / len(precisions)) if precisions else 0.0
+
+    return {
+        "citation_recall": recall,
+        "citation_precision": precision,
+    }
+
+
+def score_citation_group(
+    judge_fn: JudgeFn,
+    citation_group: str,
+    citations: list[dict[str, str]],
+) -> dict[str, Any]:
+    """Score citations for a single section using the judge.
+
+    Returns counts for aggregation by compute_citation_scores_from_groups.
+    """
+    if not citations:
+        # Count sentences heuristically (split on period + space)
+        n_sentences = len([s for s in re.split(r"(?<=[.!?])\s+", citation_group) if s.strip()])
+        return {
+            "n_attributable": 0,
+            "n_extrapolatory": max(n_sentences, 1),
+            "n_half_credit_claims": 0,
+            "supporting_counts": [],
+            "non_supporting_counts": [],
+            "n_half_credit_citations": [],
+        }
+
+    prompt = CITATION_GROUP_PROMPT.format(
+        citation_group,
+        "\n\n".join(c["id"] + ": " + c["snippets"] for c in citations),
+    )
+    raw = judge_fn(prompt)
+    parsed = extract_json_from_response(raw)
+    if not parsed or "claims" not in parsed:
+        n_sentences = len([s for s in re.split(r"(?<=[.!?])\s+", citation_group) if s.strip()])
+        return {
+            "n_attributable": 0,
+            "n_extrapolatory": max(n_sentences, 1),
+            "n_half_credit_claims": 0,
+            "supporting_counts": [],
+            "non_supporting_counts": [],
+            "n_half_credit_citations": [],
+        }
+
+    claims = parsed["claims"]
+    half_credit_ids = [c["id"] for c in citations if c["snippets"].startswith(JUST_HAS_A_TITLE)]
+
+    n_attributable = 0
+    n_extrapolatory = 0
+    n_half_credit_claims = 0
+    supporting_counts: list[int] = []
+    non_supporting_counts: list[int] = []
+    n_half_credit_citations: list[int] = []
+
+    for claim in claims:
+        supported = claim.get("is_fully_supported", False) and claim.get("supporting", [])
+        n_attributable += 1 if supported else 0
+        n_extrapolatory += 0 if supported else 1
+        supporting_cits = claim.get("supporting", [])
+        hc = _citation_intersection(supporting_cits, half_credit_ids)
+        n_half_credit_citations.append(hc)
+        supporting_counts.append(len(supporting_cits))
+        n_half_credit_claims += (
+            1 if supported and supporting_counts[-1] == n_half_credit_citations[-1] else 0
+        )
+        non_supporting_counts.append(len(claim.get("non_supporting", [])))
+
+    return {
+        "n_attributable": n_attributable,
+        "n_extrapolatory": n_extrapolatory,
+        "n_half_credit_claims": n_half_credit_claims,
+        "supporting_counts": supporting_counts,
+        "non_supporting_counts": non_supporting_counts,
+        "n_half_credit_citations": n_half_credit_citations,
+    }
+
+
+# =============================================================================
+# Scorer (placeholder for Metric ABC requirement)
+# =============================================================================
+
+
+@dataclass(frozen=True)
+class SQAJudgeScorer(Scorer):
+    """Placeholder scorer for SQA metrics.
+
+    Scoring is done in AstaBenchSQA.score_responses, not via this scorer.
+    The score() method reads pre-computed scores from output metadata.
+    """
+
+    name: ClassVar[str] = "sqa_judge"
+    score_key: str = "global_avg"
+
+    def score(self, instance: Instance, output: LMOutput) -> float:
+        return (output.metadata or {}).get(self.score_key, 0.0)
+
+
+# =============================================================================
+# Metrics
+# =============================================================================
+
+
+class _SQAMetricBase(Metric, ABC):
+    """Base for SQA metrics that read from response.scores."""
+
+    scorer: ClassVar[type[Scorer]] = SQAJudgeScorer
+
+    def compute(self, responses: Sequence[Response]) -> float:
+        if not responses:
+            return 0.0
+        total = sum(r.scores.get(self.name, 0.0) for r in responses)
+        return total / len(responses)
+
+
+@dataclass(frozen=True)
+class IngredientRecallMetric(_SQAMetricBase):
+    name: str = "ingredient_recall"
+    scorer: type[Scorer] = SQAJudgeScorer
+
+
+@dataclass(frozen=True)
+class AnswerPrecisionMetric(_SQAMetricBase):
+    name: str = "answer_precision"
+    scorer: type[Scorer] = SQAJudgeScorer
+
+
+@dataclass(frozen=True)
+class CitationPrecisionMetric(_SQAMetricBase):
+    name: str = "citation_precision"
+    scorer: type[Scorer] = SQAJudgeScorer
+
+
+@dataclass(frozen=True)
+class CitationRecallMetric(_SQAMetricBase):
+    name: str = "citation_recall"
+    scorer: type[Scorer] = SQAJudgeScorer
+
+
+@dataclass(frozen=True)
+class GlobalAvgMetric(_SQAMetricBase):
+    name: str = "global_avg"
+    scorer: type[Scorer] = SQAJudgeScorer
+
+
+SQA_METRICS = (
+    GlobalAvgMetric(),
+    IngredientRecallMetric(),
+    AnswerPrecisionMetric(),
+    CitationPrecisionMetric(),
+    CitationRecallMetric(),
+)
+
+SQA_METRIC_LABELS = [
+    "ingredient_recall",
+    "answer_precision",
+    "citation_precision",
+    "citation_recall",
+]
+
+# =============================================================================
+# Task
+# =============================================================================
+
+
+@register("astabench_scholarqa")
+class AstaBenchSQA(Task):
+    """AstaBench ScholArQA-CS2 scientific question answering task."""
+
+    data_source = DataSource(
+        path=ASTA_BENCH_REPO,
+        data_files="tasks/sqa/rubrics_v1_recomputed.json",
+        revision=ASTA_BENCH_REVISION,
+        split="train",  # JSON files load as a single "train" split in HF
+    )
+    metrics = SQA_METRICS
+    primary_metric = GlobalAvgMetric()
+    sampling_params = SamplingParams(temperature=0.0, max_tokens=4096)
+
+    @property
+    def instances(self) -> Iterator[Instance]:
+        yield from self._load_instances_cached()
+
+    def process_doc(self, doc: dict[str, Any], index: int = 0) -> Instance | None:
+        question = doc.get("question", "")
+        if not question:
+            return None
+
+        # Parse metric_config: it may be a JSON string or already a dict
+        metric_config = doc.get("metric_config", {})
+        if isinstance(metric_config, str):
+            try:
+                metric_config = json.loads(metric_config)
+            except json.JSONDecodeError:
+                metric_config = {}
+
+        # The rubric config is nested under metric_config["config"]
+        rubric_config = metric_config.get("config", metric_config)
+
+        return Instance(
+            question=question,
+            metadata={
+                "case_id": doc.get("case_id", f"sqa_{index}"),
+                "annotator": doc.get("annotator", ""),
+                "agreement": doc.get("agreement", False),
+                "rubric_config": rubric_config,
+                "index": index,
+            },
+        )
+
+    def format_request(self, instance: Instance) -> LMRequest:
+        prompt_text = SQA_GENERATION_PROMPT + instance.question
+        return LMRequest(
+            request_type=RequestType.CHAT,
+            messages=({"role": "user", "content": prompt_text},),
+        )
+
+    def extract_answer(self, output: LMOutput) -> Any:
+        """Parse JSON from model output and store structured response."""
+        parsed = extract_json_from_response(output.text)
+        if parsed is not None:
+            parsed = normalize_agent_response_dict(parsed)
+        output.metadata["parsed_response"] = parsed
+        return parsed
+
+    async def score_responses(
+        self,
+        responses: Sequence[Response],
+        context: Any = None,
+    ) -> Sequence[Response]:
+        """Score all responses using LLM-as-judge for 4 metrics."""
+        self._extract_answers(responses)
+
+        judge_fn = build_openai_judge_fn(
+            model="gpt-4o-mini",
+            scorer_name="AstaBenchSQA",
+            max_tokens=4096,
+            temperature=0.5,
+        )
+
+        for response in responses:
+            scores = self._score_single(response, judge_fn)
+            response.scores.update(scores)
+
+        return responses
+
+    def _score_single(self, response: Response, judge_fn: JudgeFn) -> dict[str, float]:
+        """Score a single response across all 4 metrics + global_avg."""
+        output = response.outputs[0] if response.outputs else None
+        if output is None:
+            return {k: 0.0 for k in SQA_METRIC_LABELS + ["global_avg"]}
+
+        parsed = output.metadata.get("parsed_response")
+        if not parsed or not parsed.get("sections"):
+            return {k: 0.0 for k in SQA_METRIC_LABELS + ["global_avg"]}
+
+        rubric_config = response.instance.metadata.get("rubric_config", {})
+        question = response.instance.question
+        answer_text = format_report(parsed)
+
+        # 1. Ingredient recall
+        ingredient_score = self._score_ingredients(judge_fn, question, answer_text, rubric_config)
+
+        # 2. Answer precision
+        precision_score = self._score_precision(judge_fn, question, answer_text)
+
+        # 3. Citation precision & recall
+        citation_scores = self._score_citations(judge_fn, parsed)
+
+        scores = {
+            "ingredient_recall": ingredient_score,
+            "answer_precision": precision_score,
+            "citation_precision": citation_scores.get("citation_precision", 0.0),
+            "citation_recall": citation_scores.get("citation_recall", 0.0),
+        }
+        scores["global_avg"] = sum(scores[k] for k in SQA_METRIC_LABELS) / len(SQA_METRIC_LABELS)
+        return scores
+
+    def _score_ingredients(
+        self,
+        judge_fn: JudgeFn,
+        question: str,
+        answer: str,
+        rubric_config: dict[str, Any],
+    ) -> float:
+        """Score ingredient recall using joint assessment."""
+        ingredients = rubric_config.get("ingredients", [])
+        has_criterion = [ing for ing in ingredients if ing.get("criterion")]
+        if not has_criterion:
+            return 0.0
+
+        # Build criteria text
+        criteria_parts = []
+        for i, ing in enumerate(has_criterion, 1):
+            examples_text = "\n".join(ing.get("examples", []))
+            criteria_parts.append(
+                f"<criterion>\n{i}. {ing['criterion']}\n<examples>\n{examples_text}\n</examples>\n</criterion>"
+            )
+        criteria = "\n".join(criteria_parts)
+
+        user_prompt = (
+            f"<question>{question}</question>\n<response>{answer}</response>\nCriteria:\n{criteria}"
+        )
+        raw = judge_fn(user_prompt, system_prompt=INGREDIENT_SYSTEM_PROMPT)
+        parsed = extract_json_from_response(raw)
+        if not parsed:
+            return 0.0
+
+        return compute_ingredient_score(parsed, ingredients)
+
+    def _score_precision(
+        self,
+        judge_fn: JudgeFn,
+        question: str,
+        answer: str,
+    ) -> float:
+        """Score answer precision by identifying irrelevant paragraphs."""
+        prompt = PRECISION_EVAL_PROMPT.format(query=question, answer=answer)
+        raw = judge_fn(prompt)
+        parsed = extract_json_from_response(raw)
+        if not parsed:
+            return 1.0  # No irrelevant paragraphs identified = perfect precision
+
+        score, _ = compute_precision_score(parsed, answer)
+        return score
+
+    def _score_citations(
+        self,
+        judge_fn: JudgeFn,
+        parsed_response: dict[str, Any],
+    ) -> dict[str, float]:
+        """Score citation precision and recall using all-at-once evaluation."""
+        bad_snippet = "Please click on the paper title to read the abstract on Semantic Scholar."
+        group_results: list[dict[str, Any]] = []
+
+        for section in parsed_response.get("sections", []):
+            sec_iter = [section]
+            if section.get("table") and isinstance(section["table"], dict):
+                sec_iter.append(section["table"])
+
+            for curr_sec in sec_iter:
+                sec_text = curr_sec.get("text", "")
+                raw_citations = curr_sec.get("citations", [])
+
+                citations: list[dict[str, str]] = []
+                for c in raw_citations:
+                    cit_id = c.get("id")
+                    if not cit_id:
+                        continue
+                    snippets = c.get("snippets", [])
+                    if isinstance(snippets, list):
+                        snippet_text = "... ".join(str(s) for s in snippets)
+                    else:
+                        snippet_text = str(snippets)
+
+                    if _filter_citation(c, sec_text) and bad_snippet not in snippet_text:
+                        citations.append({"id": cit_id, "snippets": snippet_text})
+                    else:
+                        title = c.get("title", "")
+                        citations.append(
+                            {
+                                "id": cit_id,
+                                "snippets": f"{JUST_HAS_A_TITLE}{title}",
+                            }
+                        )
+
+                clean_text = clean_sentence(sec_text)
+                result = score_citation_group(judge_fn, clean_text, citations)
+                group_results.append(result)
+
+        if not group_results:
+            return {"citation_precision": 0.0, "citation_recall": 0.0}
+
+        return compute_citation_scores_from_groups(group_results)
+
+
+# =============================================================================
+# Variant: test split
+# =============================================================================
+
+register_variant(
+    "astabench_scholarqa",
+    "test",
+    data_source=DataSource(
+        path=ASTA_BENCH_REPO,
+        data_files="tasks/sqa/rubrics_v2_recomputed.json",
+        revision=ASTA_BENCH_REVISION,
+        split="train",
+    ),
+)

--- a/src/olmo_eval/evals/tasks/astabench_sqa.py
+++ b/src/olmo_eval/evals/tasks/astabench_sqa.py
@@ -42,12 +42,15 @@ logger = logging.getLogger(__name__)
 ASTA_BENCH_REPO = "allenai/asta-bench"
 ASTA_BENCH_REVISION = "a600dc767f850385f4664772e3ba7a7f8be17d5e"
 
-JUST_HAS_A_TITLE = "Paper content unavailable. The paper's title is: "
+JUST_HAS_A_TITLE = (
+    "Paper content unavailable. The paper's title is: "  # from astabench citation_eval.py
+)
 
 # =============================================================================
-# Prompt Templates
+# Prompt Templates (from astabench evals/sqa/task.py, rubric.py, precision_eval.py, citation_eval.py)
 # =============================================================================
 
+# from astabench evals/sqa/task.py:json_to_sample
 SQA_GENERATION_PROMPT = """Generate a report answering the following research question. Be sure to include inline citations for each claim. Return your result as valid JSON with a single key `sections` which is a list of sections, each having keys `title`, `text`, and `citations`. Each entry in `citations` should have a JSON list of `snippets` extracted from the reference document and an `id`, each of which appears exactly in the text. Each `id` should be an inline citation as it appears in the text (with wrapping parentheses or square brackets if appropriate). Each citation should have a `title` if one is available. Any additional information about the citation should go under `metadata`. Do not create a References section.
 
 Here is an example `section` to help you with formatting:
@@ -85,6 +88,7 @@ Here is an example `section` to help you with formatting:
 
 Question: """
 
+# from astabench rubric.py:_assess_properties_jointly
 INGREDIENT_SYSTEM_PROMPT = """You will be given a question someone asked (in <question></question> tags) and the corresponding response (in <response></response> tags) given to them by an assistant.
         You will then be given an enumerated list of criteria by which to evaluate the response. Each criterion specifies requirements that the answer must satisfy. You will assign a score accordingly (see below).
         You will also be given a list of examples (in <examples></examples> tags, below each criterion) that illustrate the type of details that would satisfy the criterion. We do NOT expect any of the specified details to necessarily appear in the answer. These are strictly to be used as guidance for locating the answers that satisfy the set requirement.
@@ -152,6 +156,7 @@ INGREDIENT_SYSTEM_PROMPT = """You will be given a question someone asked (in <qu
 
         Return your result as a JSON object with a single key `scores` whose value is a list of objects, each having keys `criteria_idx`, `reasoning`, `score` and `evidence` from the text supporting the claim."""
 
+# from astabench precision_eval.py:PrecisionEval
 PRECISION_EVAL_PROMPT = """You are given a query and a corresponding long answer.
 
 Goal: find irrelevant paragraphs in the answer. These are paragraphs that don't directly answer the query and shouldn't be in the answer.
@@ -180,6 +185,7 @@ Question: {query}
 Answer: {answer}
 """
 
+# from astabench citation_eval.py:CitationEval.score_citation_group
 CITATION_GROUP_PROMPT = """You are a claim validator. For each claim made in the following text you will determine if it is supported by the quote from it's corresponding inline citations. As is typically done in academic writing, assume that consecutive sentences can share citations. Make sure to also include claims presented in table format. For references with only the title available (ie no quotes from the reference are included), judge them as `supporting` if the title indicates that the paper is likely relevant to the claim being considered. Return a JSON object with a single key `claims` which is a list of `claim` objects, one for each sentence in the text. Each `claim` object contains the claim itself (`text`), a list of `supporting` inline citations and `non_supporting` inline citations and finally a boolean `is_fully_supported` which indicates if the claim is entirely supported by the quotations in the associated citations. Each inline citation corresponding to that claim should appear in either `supporting` or `non_supporting`, but not both. Each claim made in the text should appear in your output, but you should skip sentences covering high level introductory information.
 
 Text:
@@ -190,7 +196,7 @@ References:
 
 
 # =============================================================================
-# JSON / Response Parsing Helpers
+# JSON / Response Parsing Helpers (from astabench evals/sqa/task.py)
 # =============================================================================
 
 
@@ -232,6 +238,7 @@ def format_report(response_dict: dict[str, Any]) -> str:
     return report.strip()
 
 
+# from astabench citation_eval.py:clean_sentence
 def clean_sentence(sentence: str) -> str:
     """Clean XML tags from model-generated sentences."""
     pattern = r'<Paper [^>]*paperTitle="\W*([ _a-zA-Z0-9,.;]+)\W*"[^>]*/?>\s*</Paper>'
@@ -241,10 +248,11 @@ def clean_sentence(sentence: str) -> str:
 
 
 # =============================================================================
-# Scoring Helpers
+# Scoring Helpers (ported from astabench precision_eval.py, rubric.py, citation_eval.py)
 # =============================================================================
 
 
+# from astabench precision_eval.py:PrecisionEval.score
 def compute_precision_score(
     parsed_json: dict[str, Any], answer: str
 ) -> tuple[float, dict[str, Any]]:
@@ -272,6 +280,7 @@ def compute_precision_score(
     return score, metadata
 
 
+# from astabench rubric.py:_assess_properties_jointly
 def compute_ingredient_score(
     parsed_json: dict[str, Any],
     ingredients: list[dict[str, Any]],
@@ -299,6 +308,7 @@ def compute_ingredient_score(
     return sum(weights.get(k, 0) * score_components.get(k, 0) for k in weights)
 
 
+# from astabench citation_eval.py
 def _clean_citation_id(c: str) -> str:
     """Remove brackets/parens from citation ID for comparison."""
     for char in "[]()":
@@ -306,6 +316,7 @@ def _clean_citation_id(c: str) -> str:
     return c
 
 
+# from astabench citation_eval.py
 def _citation_intersection(supporting: list[str], half_credit_ids: list[str]) -> int:
     """Count supporting citations that are title-only (half credit)."""
     supporting_clean = {_clean_citation_id(str(c)) for c in supporting}
@@ -313,6 +324,7 @@ def _citation_intersection(supporting: list[str], half_credit_ids: list[str]) ->
     return len(supporting_clean.intersection(half_clean))
 
 
+# from astabench citation_eval.py
 def _filter_citation(citation: dict[str, Any], sec_text: str) -> bool:
     """Check if citation snippets are present and usable."""
     sec_text_alpha = re.sub(r"[^a-zA-Z]", "", sec_text).lower()
@@ -329,6 +341,7 @@ def _filter_citation(citation: dict[str, Any], sec_text: str) -> bool:
     )
 
 
+# from astabench citation_eval.py:CitationEval
 def compute_citation_scores_from_groups(
     group_results: list[dict[str, Any]],
 ) -> dict[str, float]:
@@ -361,6 +374,7 @@ def compute_citation_scores_from_groups(
     }
 
 
+# from astabench citation_eval.py:CitationEval.score_citation_group
 def score_citation_group(
     judge_fn: JudgeFn,
     citation_group: str,
@@ -433,7 +447,7 @@ def score_citation_group(
 
 
 # =============================================================================
-# Scorer (placeholder for Metric ABC requirement)
+# Scorer + Metrics
 # =============================================================================
 
 
@@ -450,11 +464,6 @@ class SQAJudgeScorer(Scorer):
 
     def score(self, instance: Instance, output: LMOutput) -> float:
         return (output.metadata or {}).get(self.score_key, 0.0)
-
-
-# =============================================================================
-# Metrics
-# =============================================================================
 
 
 class _SQAMetricBase(Metric, ABC):
@@ -543,24 +552,16 @@ class AstaBenchSQA(Task):
         if not question:
             return None
 
-        # Parse metric_config: it may be a JSON string or already a dict
-        metric_config = doc.get("metric_config", {})
-        if isinstance(metric_config, str):
-            try:
-                metric_config = json.loads(metric_config)
-            except json.JSONDecodeError:
-                metric_config = {}
-
-        # The rubric config is nested under metric_config["config"]
-        rubric_config = metric_config.get("config", metric_config)
+        # The HF dataset stores ingredients as a top-level list of dicts,
+        # each with keys: criterion, examples, name, weight.
+        ingredients = doc.get("ingredients", [])
 
         return Instance(
             question=question,
             metadata={
                 "case_id": doc.get("case_id", f"sqa_{index}"),
                 "annotator": doc.get("annotator", ""),
-                "agreement": doc.get("agreement", False),
-                "rubric_config": rubric_config,
+                "rubric_config": {"ingredients": ingredients},
                 "index": index,
             },
         )
@@ -585,7 +586,12 @@ class AstaBenchSQA(Task):
         responses: Sequence[Response],
         context: Any = None,
     ) -> Sequence[Response]:
-        """Score all responses using LLM-as-judge for 4 metrics."""
+        """Score all responses using LLM-as-judge for 4 metrics.
+
+        Overrides Task.score_responses because SQA needs multiple judge calls
+        per instance producing 4+ scores (doesn't fit single-float Scorer.score).
+        Scoring logic ported from astabench evals/sqa/task.py:SQATask.score.
+        """
         self._extract_answers(responses)
 
         judge_fn = build_openai_judge_fn(
@@ -640,7 +646,7 @@ class AstaBenchSQA(Task):
         answer: str,
         rubric_config: dict[str, Any],
     ) -> float:
-        """Score ingredient recall using joint assessment."""
+        """Score ingredient recall. From astabench rubric.py:_assess_properties_jointly."""
         ingredients = rubric_config.get("ingredients", [])
         has_criterion = [ing for ing in ingredients if ing.get("criterion")]
         if not has_criterion:
@@ -671,7 +677,7 @@ class AstaBenchSQA(Task):
         question: str,
         answer: str,
     ) -> float:
-        """Score answer precision by identifying irrelevant paragraphs."""
+        """Score answer precision. From astabench precision_eval.py:PrecisionEval."""
         prompt = PRECISION_EVAL_PROMPT.format(query=question, answer=answer)
         raw = judge_fn(prompt)
         parsed = extract_json_from_response(raw)
@@ -686,7 +692,7 @@ class AstaBenchSQA(Task):
         judge_fn: JudgeFn,
         parsed_response: dict[str, Any],
     ) -> dict[str, float]:
-        """Score citation precision and recall using all-at-once evaluation."""
+        """Score citation precision and recall. From astabench citation_eval.py:CitationEval."""
         bad_snippet = "Please click on the paper title to read the abstract on Semantic Scholar."
         group_results: list[dict[str, Any]] = []
 

--- a/src/olmo_eval/evals/tasks/astabench_sqa.py
+++ b/src/olmo_eval/evals/tasks/astabench_sqa.py
@@ -575,7 +575,13 @@ class AstaBenchSQA(Task):
 
     def extract_answer(self, output: LMOutput) -> Any:
         """Parse JSON from model output and store structured response."""
-        parsed = extract_json_from_response(output.text)
+        text = output.text
+        # Strip <think>...</think> blocks (e.g. Qwen3) so that JSON
+        # extraction doesn't grab braces from the reasoning trace.
+        think_end = text.find("</think>")
+        if think_end >= 0:
+            text = text[think_end + len("</think>") :]
+        parsed = extract_json_from_response(text)
         if parsed is not None:
             parsed = normalize_agent_response_dict(parsed)
         output.metadata["parsed_response"] = parsed

--- a/src/olmo_eval/evals/tasks/astabench_sqa.py
+++ b/src/olmo_eval/evals/tasks/astabench_sqa.py
@@ -568,8 +568,8 @@ class AstaBenchSQA(Task):
     def format_request(self, instance: Instance) -> LMRequest:
         prompt_text = SQA_GENERATION_PROMPT + instance.question
         return LMRequest(
-            request_type=RequestType.CHAT,
-            messages=({"role": "user", "content": prompt_text},),
+            request_type=RequestType.COMPLETION,
+            prompt=prompt_text,
         )
 
     def extract_answer(self, output: LMOutput) -> Any:

--- a/src/olmo_eval/evals/tasks/astabench_sqa.py
+++ b/src/olmo_eval/evals/tasks/astabench_sqa.py
@@ -328,7 +328,10 @@ def _citation_intersection(supporting: list[str], half_credit_ids: list[str]) ->
 def _filter_citation(citation: dict[str, Any], sec_text: str) -> bool:
     """Check if citation snippets are present and usable."""
     sec_text_alpha = re.sub(r"[^a-zA-Z]", "", sec_text).lower()
-    snippets_alpha = [re.sub(r"[^a-zA-Z]", "", s).lower() for s in citation.get("snippets", [])]
+    raw_snippets = citation.get("snippets", [])
+    if isinstance(raw_snippets, str):
+        raw_snippets = [raw_snippets]
+    snippets_alpha = [re.sub(r"[^a-zA-Z]", "", s).lower() for s in raw_snippets]
     return bool(
         citation.get("snippets")
         and not any(s in sec_text_alpha for s in snippets_alpha)
@@ -726,12 +729,15 @@ class AstaBenchSQA(Task):
                         citations.append({"id": cit_id, "snippets": snippet_text})
                     else:
                         title = c.get("title", "")
-                        citations.append(
-                            {
-                                "id": cit_id,
-                                "snippets": f"{JUST_HAS_A_TITLE}{title}",
-                            }
-                        )
+                        if title:
+                            citations.append(
+                                {
+                                    "id": cit_id,
+                                    "snippets": f"{JUST_HAS_A_TITLE}{title}",
+                                }
+                            )
+                        else:
+                            citations.append({"id": cit_id, "snippets": ""})
 
                 clean_text = clean_sentence(sec_text)
                 result = score_citation_group(judge_fn, clean_text, citations)

--- a/src/olmo_eval/evals/tasks/astabench_sqa.py
+++ b/src/olmo_eval/evals/tasks/astabench_sqa.py
@@ -28,6 +28,7 @@ from olmo_eval.common.types import (
     RequestType,
     Response,
     SamplingParams,
+    Split,
 )
 from olmo_eval.data import DataSource
 from olmo_eval.evals.tasks.common import Task, register, register_variant
@@ -522,6 +523,7 @@ SQA_METRIC_LABELS = [
 class AstaBenchSQA(Task):
     """AstaBench ScholArQA-CS2 scientific question answering task."""
 
+    split = Split.TRAIN  # HF JSON files load as a single "train" split
     data_source = DataSource(
         path=ASTA_BENCH_REPO,
         data_files="tasks/sqa/rubrics_v1_recomputed.json",

--- a/tests/evals/tasks/test_astabench_sqa.py
+++ b/tests/evals/tasks/test_astabench_sqa.py
@@ -235,17 +235,16 @@ class TestExtractAnswer:
 
 
 class TestFormatRequest:
-    def test_chat_request(self):
+    def test_completion_request(self):
         task = get_task("astabench_scholarqa")
         instance = Instance(
             question="What is attention?",
             metadata={"case_id": "test", "rubric_config": {}},
         )
         request = task.format_request(instance)
-        assert request.request_type == RequestType.CHAT
-        assert len(request.messages) == 1
-        assert "What is attention?" in request.messages[0]["content"]
-        assert "Generate a report" in request.messages[0]["content"]
+        assert request.request_type == RequestType.COMPLETION
+        assert "What is attention?" in request.prompt
+        assert "Generate a report" in request.prompt
 
 
 # =============================================================================
@@ -591,7 +590,7 @@ class TestMetrics:
     def _make_response(self, scores: dict[str, float]) -> Response:
         return Response(
             instance=Instance(question="Q?", metadata={}),
-            request=LMRequest(request_type=RequestType.CHAT, messages=()),
+            request=LMRequest(request_type=RequestType.COMPLETION, prompt=""),
             outputs=[LMOutput(text="")],
             scores=scores,
         )

--- a/tests/evals/tasks/test_astabench_sqa.py
+++ b/tests/evals/tasks/test_astabench_sqa.py
@@ -1,0 +1,619 @@
+"""Tests for AstaBench ScholArQA task logic."""
+
+import json
+
+import pytest
+
+from olmo_eval.common.types import Instance, LMOutput, LMRequest, RequestType, Response
+from olmo_eval.evals.tasks.astabench_sqa import (
+    JUST_HAS_A_TITLE,
+    AnswerPrecisionMetric,
+    CitationPrecisionMetric,
+    CitationRecallMetric,
+    GlobalAvgMetric,
+    IngredientRecallMetric,
+    _filter_citation,
+    compute_citation_scores_from_groups,
+    compute_ingredient_score,
+    compute_precision_score,
+    extract_json_from_response,
+    format_report,
+    normalize_agent_response_dict,
+    score_citation_group,
+)
+from olmo_eval.evals.tasks.common import get_task, list_tasks
+
+
+@pytest.fixture(autouse=True)
+def _setup_registry():
+    import olmo_eval.evals.tasks  # noqa: F401
+
+
+# =============================================================================
+# Registration
+# =============================================================================
+
+
+class TestRegistration:
+    def test_task_registered(self):
+        assert "astabench_scholarqa" in list_tasks()
+
+    def test_get_task(self):
+        task = get_task("astabench_scholarqa")
+        assert task.config.name == "astabench_scholarqa"
+
+    def test_test_variant(self):
+        task = get_task("astabench_scholarqa:test")
+        assert task.config.data_source.data_files == "tasks/sqa/rubrics_v2_recomputed.json"
+
+    def test_has_all_metrics(self):
+        task = get_task("astabench_scholarqa")
+        metric_names = {m.name for m in task.config.metrics}
+        assert metric_names == {
+            "global_avg",
+            "ingredient_recall",
+            "answer_precision",
+            "citation_precision",
+            "citation_recall",
+        }
+
+
+# =============================================================================
+# JSON Parsing
+# =============================================================================
+
+
+class TestExtractJson:
+    def test_valid_json(self):
+        result = extract_json_from_response('{"sections": []}')
+        assert result == {"sections": []}
+
+    def test_json_with_prefix(self):
+        result = extract_json_from_response('Here is the result: {"key": "value"}')
+        assert result == {"key": "value"}
+
+    def test_no_json(self):
+        assert extract_json_from_response("no json here") is None
+
+    def test_empty_string(self):
+        assert extract_json_from_response("") is None
+
+    def test_malformed_json(self):
+        assert extract_json_from_response("{malformed}") is None
+
+
+class TestNormalizeResponse:
+    def test_direct_sections(self):
+        d = {"sections": [{"text": "hello"}]}
+        assert normalize_agent_response_dict(d) == d
+
+    def test_nested_response(self):
+        d = {"response": {"sections": [{"text": "hello"}]}}
+        result = normalize_agent_response_dict(d)
+        assert result == {"sections": [{"text": "hello"}]}
+
+    def test_empty_sections_with_response(self):
+        d = {"sections": [], "response": {"sections": [{"text": "hi"}]}}
+        # sections is empty (falsy list), but it exists, so don't unwrap
+        # Actually [] is falsy, so it will return response
+        result = normalize_agent_response_dict(d)
+        assert result == {"sections": [{"text": "hi"}]}
+
+
+# =============================================================================
+# format_report
+# =============================================================================
+
+
+class TestFormatReport:
+    def test_basic(self):
+        response = {
+            "sections": [
+                {"text": "First section text."},
+                {"text": "Second section text."},
+            ]
+        }
+        result = format_report(response)
+        assert "First section text." in result
+        assert "Second section text." in result
+
+    def test_with_table(self):
+        response = {
+            "sections": [
+                {
+                    "text": "Main text.",
+                    "table": {"text": "Table content."},
+                }
+            ]
+        }
+        result = format_report(response)
+        assert "Main text." in result
+        assert "Table content." in result
+
+    def test_empty_sections(self):
+        assert format_report({"sections": []}) == ""
+
+    def test_missing_text(self):
+        response = {"sections": [{"title": "Title only"}]}
+        assert format_report(response) == ""
+
+
+# =============================================================================
+# process_doc
+# =============================================================================
+
+
+class TestProcessDoc:
+    @pytest.fixture
+    def task(self):
+        return get_task("astabench_scholarqa")
+
+    def test_basic_conversion(self, task):
+        doc = {
+            "case_id": "test_001",
+            "question": "What is the impact of attention mechanisms?",
+            "annotator": "expert_1",
+            "agreement": True,
+            "metric_config": {
+                "name": "rubric_corpusqa_generic",
+                "config": {
+                    "question": "What is the impact of attention mechanisms?",
+                    "ingredients": [
+                        {
+                            "name": "attention_types",
+                            "criterion": "Discuss different types of attention",
+                            "weight": 0.5,
+                            "examples": ["self-attention", "cross-attention"],
+                        }
+                    ],
+                },
+            },
+        }
+        instance = task.process_doc(doc, index=0)
+        assert instance is not None
+        assert instance.question == "What is the impact of attention mechanisms?"
+        assert instance.metadata["case_id"] == "test_001"
+        assert instance.metadata["annotator"] == "expert_1"
+        assert instance.metadata["agreement"] is True
+        assert "ingredients" in instance.metadata["rubric_config"]
+
+    def test_missing_question_skipped(self, task):
+        doc = {"case_id": "empty", "question": ""}
+        assert task.process_doc(doc, index=0) is None
+
+    def test_string_metric_config(self, task):
+        doc = {
+            "question": "Test question?",
+            "metric_config": json.dumps(
+                {
+                    "name": "rubric",
+                    "config": {"question": "Test?", "ingredients": []},
+                }
+            ),
+        }
+        instance = task.process_doc(doc, index=0)
+        assert instance is not None
+        assert isinstance(instance.metadata["rubric_config"], dict)
+
+
+# =============================================================================
+# extract_answer
+# =============================================================================
+
+
+class TestExtractAnswer:
+    @pytest.fixture
+    def task(self):
+        return get_task("astabench_scholarqa")
+
+    def test_valid_json_response(self, task):
+        output = LMOutput(text='{"sections": [{"text": "hello", "citations": []}]}')
+        result = task.extract_answer(output)
+        assert result is not None
+        assert "sections" in result
+
+    def test_nested_response_format(self, task):
+        output = LMOutput(text='{"response": {"sections": [{"text": "hello", "citations": []}]}}')
+        result = task.extract_answer(output)
+        assert result is not None
+        assert "sections" in result
+
+    def test_invalid_json(self, task):
+        output = LMOutput(text="This is not valid JSON at all")
+        result = task.extract_answer(output)
+        assert result is None
+
+    def test_stores_in_metadata(self, task):
+        output = LMOutput(text='{"sections": []}')
+        task.extract_answer(output)
+        assert "parsed_response" in output.metadata
+
+
+# =============================================================================
+# format_request
+# =============================================================================
+
+
+class TestFormatRequest:
+    def test_chat_request(self):
+        task = get_task("astabench_scholarqa")
+        instance = Instance(
+            question="What is attention?",
+            metadata={"case_id": "test", "rubric_config": {}},
+        )
+        request = task.format_request(instance)
+        assert request.request_type == RequestType.CHAT
+        assert len(request.messages) == 1
+        assert "What is attention?" in request.messages[0]["content"]
+        assert "Generate a report" in request.messages[0]["content"]
+
+
+# =============================================================================
+# Precision Scoring
+# =============================================================================
+
+
+class TestComputePrecisionScore:
+    def test_no_irrelevant(self):
+        parsed = {"irrelevant_paragraphs": []}
+        answer = "Para 1.\n\nPara 2.\n\nPara 3."
+        score, meta = compute_precision_score(parsed, answer)
+        assert score == pytest.approx(1.0)
+
+    def test_one_irrelevant_of_three(self):
+        parsed = {"irrelevant_paragraphs": [{"reason": "off topic", "answer_text": "Para 2."}]}
+        answer = "Para 1.\n\nPara 2.\n\nPara 3."
+        score, meta = compute_precision_score(parsed, answer)
+        assert score == pytest.approx(2 / 3)
+
+    def test_all_irrelevant(self):
+        text_a = "This paragraph discusses cats and their behavior."
+        text_b = "Another paragraph about the history of ancient Rome."
+        parsed = {
+            "irrelevant_paragraphs": [
+                {"reason": "off topic", "answer_text": text_a},
+                {"reason": "off topic", "answer_text": text_b},
+            ]
+        }
+        answer = f"{text_a}\n\n{text_b}"
+        score, meta = compute_precision_score(parsed, answer)
+        assert score == pytest.approx(0.0)
+
+    def test_fuzzy_matching(self):
+        # Slightly different text should still match with 85% threshold
+        parsed = {
+            "irrelevant_paragraphs": [
+                {"reason": "off topic", "answer_text": "This is a paragraph about something."}
+            ]
+        }
+        answer = "This is a paragraph about something.\n\nAnother paragraph."
+        score, meta = compute_precision_score(parsed, answer)
+        assert score == pytest.approx(0.5)
+
+    def test_empty_answer(self):
+        parsed = {"irrelevant_paragraphs": []}
+        score, meta = compute_precision_score(parsed, "")
+        assert score == pytest.approx(1.0)
+
+
+# =============================================================================
+# Ingredient Scoring
+# =============================================================================
+
+
+class TestComputeIngredientScore:
+    def test_all_perfect(self):
+        parsed = {
+            "scores": [
+                {"criteria_idx": 1, "score": 2, "reasoning": "good", "evidence": ""},
+                {"criteria_idx": 2, "score": 2, "reasoning": "good", "evidence": ""},
+            ]
+        }
+        ingredients = [
+            {"name": "a", "criterion": "criterion A", "weight": 0.5, "examples": []},
+            {"name": "b", "criterion": "criterion B", "weight": 0.5, "examples": []},
+        ]
+        assert compute_ingredient_score(parsed, ingredients) == pytest.approx(1.0)
+
+    def test_all_zero(self):
+        parsed = {
+            "scores": [
+                {"criteria_idx": 1, "score": 0, "reasoning": "bad", "evidence": ""},
+            ]
+        }
+        ingredients = [
+            {"name": "a", "criterion": "criterion A", "weight": 1.0, "examples": []},
+        ]
+        assert compute_ingredient_score(parsed, ingredients) == pytest.approx(0.0)
+
+    def test_partial(self):
+        parsed = {
+            "scores": [
+                {"criteria_idx": 1, "score": 1, "reasoning": "ok", "evidence": ""},
+            ]
+        }
+        ingredients = [
+            {"name": "a", "criterion": "criterion A", "weight": 1.0, "examples": []},
+        ]
+        assert compute_ingredient_score(parsed, ingredients) == pytest.approx(0.5)
+
+    def test_unequal_weights(self):
+        parsed = {
+            "scores": [
+                {"criteria_idx": 1, "score": 2, "reasoning": "", "evidence": ""},
+                {"criteria_idx": 2, "score": 0, "reasoning": "", "evidence": ""},
+            ]
+        }
+        ingredients = [
+            {"name": "a", "criterion": "crit A", "weight": 0.75, "examples": []},
+            {"name": "b", "criterion": "crit B", "weight": 0.25, "examples": []},
+        ]
+        # a: 1.0 * 0.75, b: 0.0 * 0.25 => 0.75
+        assert compute_ingredient_score(parsed, ingredients) == pytest.approx(0.75)
+
+    def test_no_criteria(self):
+        parsed = {"scores": []}
+        ingredients = [{"name": "a", "weight": 0.5, "examples": []}]
+        assert compute_ingredient_score(parsed, ingredients) == pytest.approx(0.0)
+
+    def test_skips_ingredients_without_criterion(self):
+        parsed = {
+            "scores": [
+                {"criteria_idx": 1, "score": 2, "reasoning": "", "evidence": ""},
+            ]
+        }
+        ingredients = [
+            {"name": "a", "criterion": "crit A", "weight": 0.5, "examples": []},
+            {"name": "b", "weight": 0.5, "examples": []},  # No criterion
+        ]
+        # Only "a" has criterion, so weight gets normalized to 1.0
+        assert compute_ingredient_score(parsed, ingredients) == pytest.approx(1.0)
+
+
+# =============================================================================
+# Citation Scoring
+# =============================================================================
+
+
+class TestComputeCitationScoresFromGroups:
+    def test_all_supported(self):
+        results = [
+            {
+                "n_attributable": 3,
+                "n_extrapolatory": 0,
+                "n_half_credit_claims": 0,
+                "supporting_counts": [2, 1, 1],
+                "non_supporting_counts": [0, 0, 0],
+                "n_half_credit_citations": [0, 0, 0],
+            }
+        ]
+        scores = compute_citation_scores_from_groups(results)
+        assert scores["citation_recall"] == pytest.approx(1.0)
+        assert scores["citation_precision"] == pytest.approx(1.0)
+
+    def test_none_supported(self):
+        results = [
+            {
+                "n_attributable": 0,
+                "n_extrapolatory": 3,
+                "n_half_credit_claims": 0,
+                "supporting_counts": [],
+                "non_supporting_counts": [],
+                "n_half_credit_citations": [],
+            }
+        ]
+        scores = compute_citation_scores_from_groups(results)
+        assert scores["citation_recall"] == pytest.approx(0.0)
+        assert scores["citation_precision"] == pytest.approx(0.0)
+
+    def test_half_credit_reduces_recall(self):
+        results = [
+            {
+                "n_attributable": 2,
+                "n_extrapolatory": 0,
+                "n_half_credit_claims": 2,
+                "supporting_counts": [1, 1],
+                "non_supporting_counts": [0, 0],
+                "n_half_credit_citations": [1, 1],
+            }
+        ]
+        scores = compute_citation_scores_from_groups(results)
+        # recall = (2 - 0.5*2) / (2 + 0) = 1/2 = 0.5
+        assert scores["citation_recall"] == pytest.approx(0.5)
+
+    def test_mixed_precision(self):
+        results = [
+            {
+                "n_attributable": 1,
+                "n_extrapolatory": 1,
+                "n_half_credit_claims": 0,
+                "supporting_counts": [2, 0],
+                "non_supporting_counts": [1, 1],
+                "n_half_credit_citations": [0, 0],
+            }
+        ]
+        scores = compute_citation_scores_from_groups(results)
+        # precision for claim 1: (2 - 0) / (2 + 1) = 2/3
+        # claim 2: supporting=0 but non_supporting=1, so 0+1=1 > 0 => (0-0)/1 = 0
+        # mean precision: (2/3 + 0) / 2 = 1/3
+        assert scores["citation_precision"] == pytest.approx(1 / 3)
+
+    def test_empty_groups(self):
+        scores = compute_citation_scores_from_groups([])
+        assert scores["citation_recall"] == pytest.approx(0.0)
+        assert scores["citation_precision"] == pytest.approx(0.0)
+
+
+# =============================================================================
+# score_citation_group (with stub judge)
+# =============================================================================
+
+
+class TestScoreCitationGroup:
+    def test_no_citations_uses_sentence_count(self):
+        """With no citations, n_extrapolatory should reflect sentence count."""
+
+        def stub_judge(prompt, **kwargs):
+            raise AssertionError("should not be called")
+
+        result = score_citation_group(
+            stub_judge,
+            "First sentence. Second sentence. Third sentence.",
+            [],
+        )
+        assert result["n_attributable"] == 0
+        assert result["n_extrapolatory"] == 3
+
+    def test_invalid_json_fallback_uses_sentence_count(self):
+        """When judge returns garbage, fallback should count sentences."""
+
+        def stub_judge(prompt, **kwargs):
+            return "this is not json at all"
+
+        result = score_citation_group(
+            stub_judge,
+            "Sentence one. Sentence two.",
+            [{"id": "[1]", "snippets": "some snippet"}],
+        )
+        assert result["n_attributable"] == 0
+        assert result["n_extrapolatory"] == 2
+
+    def test_valid_judge_response(self):
+        """Normal judge response should produce correct counts."""
+        judge_response = json.dumps(
+            {
+                "claims": [
+                    {
+                        "text": "Claim A",
+                        "supporting": ["[1]"],
+                        "non_supporting": [],
+                        "is_fully_supported": True,
+                    },
+                    {
+                        "text": "Claim B",
+                        "supporting": [],
+                        "non_supporting": ["[1]"],
+                        "is_fully_supported": False,
+                    },
+                ]
+            }
+        )
+
+        def stub_judge(prompt, **kwargs):
+            return judge_response
+
+        result = score_citation_group(
+            stub_judge,
+            "Claim A [1]. Claim B [1].",
+            [{"id": "[1]", "snippets": "evidence text"}],
+        )
+        assert result["n_attributable"] == 1
+        assert result["n_extrapolatory"] == 1
+        assert result["supporting_counts"] == [1, 0]
+        assert result["non_supporting_counts"] == [0, 1]
+
+    def test_half_credit_title_only(self):
+        """Citations with only a title should get half credit."""
+        judge_response = json.dumps(
+            {
+                "claims": [
+                    {
+                        "text": "Claim A",
+                        "supporting": ["[1]"],
+                        "non_supporting": [],
+                        "is_fully_supported": True,
+                    },
+                ]
+            }
+        )
+
+        def stub_judge(prompt, **kwargs):
+            return judge_response
+
+        result = score_citation_group(
+            stub_judge,
+            "Claim A [1].",
+            [{"id": "[1]", "snippets": f"{JUST_HAS_A_TITLE}Some Paper"}],
+        )
+        assert result["n_attributable"] == 1
+        assert result["n_half_credit_claims"] == 1
+        assert result["n_half_credit_citations"] == [1]
+
+
+# =============================================================================
+# _filter_citation
+# =============================================================================
+
+
+class TestFilterCitation:
+    def test_usable_snippets_pass(self):
+        """Citation with real snippets not in the text should pass."""
+        citation = {
+            "snippets": ["This is evidence from the paper."],
+            "title": "Paper Title",
+        }
+        assert _filter_citation(citation, "The section discusses CNNs.") is True
+
+    def test_snippet_in_text_fails(self):
+        """Citation whose snippet appears verbatim in the text should fail."""
+        citation = {
+            "snippets": ["CNNs are great"],
+            "title": "Paper Title",
+        }
+        # Alpha-only comparison: "cnnsaregreat" in "thesectiondiscussescnnsaregreat"
+        assert _filter_citation(citation, "The section discusses CNNs are great.") is False
+
+    def test_empty_snippets_fails(self):
+        """Citation with no snippets should fail."""
+        citation = {"snippets": [], "title": "Paper Title"}
+        assert _filter_citation(citation, "Some text.") is False
+
+    def test_snippet_matches_title_fails(self):
+        """Citation whose snippet is just the title should fail."""
+        citation = {
+            "snippets": ["Paper Title"],
+            "title": "Paper Title",
+        }
+        assert _filter_citation(citation, "Some unrelated text.") is False
+
+    def test_no_title_with_real_snippets_passes(self):
+        """Citation without a title but with real snippets should pass."""
+        citation = {"snippets": ["Unique evidence text."]}
+        assert _filter_citation(citation, "Different section text.") is True
+
+
+# =============================================================================
+# Metric Computation
+# =============================================================================
+
+
+class TestMetrics:
+    def _make_response(self, scores: dict[str, float]) -> Response:
+        return Response(
+            instance=Instance(question="Q?", metadata={}),
+            request=LMRequest(request_type=RequestType.CHAT, messages=()),
+            outputs=[LMOutput(text="")],
+            scores=scores,
+        )
+
+    def test_global_avg_metric(self):
+        metric = GlobalAvgMetric()
+        responses = [
+            self._make_response({"global_avg": 0.8}),
+            self._make_response({"global_avg": 0.6}),
+        ]
+        assert metric.compute(responses) == pytest.approx(0.7)
+
+    def test_ingredient_recall_metric(self):
+        metric = IngredientRecallMetric()
+        responses = [
+            self._make_response({"ingredient_recall": 1.0}),
+            self._make_response({"ingredient_recall": 0.5}),
+        ]
+        assert metric.compute(responses) == pytest.approx(0.75)
+
+    def test_empty_responses(self):
+        assert GlobalAvgMetric().compute([]) == pytest.approx(0.0)
+        assert AnswerPrecisionMetric().compute([]) == pytest.approx(0.0)
+        assert CitationPrecisionMetric().compute([]) == pytest.approx(0.0)
+        assert CitationRecallMetric().compute([]) == pytest.approx(0.0)

--- a/tests/evals/tasks/test_astabench_sqa.py
+++ b/tests/evals/tasks/test_astabench_sqa.py
@@ -225,6 +225,16 @@ class TestExtractAnswer:
         task.extract_answer(output)
         assert "parsed_response" in output.metadata
 
+    def test_strips_think_block(self, task):
+        text = (
+            '<think>\nI should format as {"key": "val"}\n</think>\n'
+            '{"sections": [{"text": "hello", "citations": []}]}'
+        )
+        output = LMOutput(text=text)
+        result = task.extract_answer(output)
+        assert result is not None
+        assert "sections" in result
+
 
 # =============================================================================
 # format_request

--- a/tests/evals/tasks/test_astabench_sqa.py
+++ b/tests/evals/tasks/test_astabench_sqa.py
@@ -235,16 +235,17 @@ class TestExtractAnswer:
 
 
 class TestFormatRequest:
-    def test_completion_request(self):
+    def test_chat_request(self):
         task = get_task("astabench_scholarqa")
         instance = Instance(
             question="What is attention?",
             metadata={"case_id": "test", "rubric_config": {}},
         )
         request = task.format_request(instance)
-        assert request.request_type == RequestType.COMPLETION
-        assert "What is attention?" in request.prompt
-        assert "Generate a report" in request.prompt
+        assert request.request_type == RequestType.CHAT
+        assert len(request.messages) == 1
+        assert "What is attention?" in request.messages[0]["content"]
+        assert "Generate a report" in request.messages[0]["content"]
 
 
 # =============================================================================
@@ -590,7 +591,7 @@ class TestMetrics:
     def _make_response(self, scores: dict[str, float]) -> Response:
         return Response(
             instance=Instance(question="Q?", metadata={}),
-            request=LMRequest(request_type=RequestType.COMPLETION, prompt=""),
+            request=LMRequest(request_type=RequestType.CHAT, messages=()),
             outputs=[LMOutput(text="")],
             scores=scores,
         )

--- a/tests/evals/tasks/test_astabench_sqa.py
+++ b/tests/evals/tasks/test_astabench_sqa.py
@@ -153,47 +153,44 @@ class TestProcessDoc:
             "case_id": "test_001",
             "question": "What is the impact of attention mechanisms?",
             "annotator": "expert_1",
-            "agreement": True,
-            "metric_config": {
-                "name": "rubric_corpusqa_generic",
-                "config": {
-                    "question": "What is the impact of attention mechanisms?",
-                    "ingredients": [
-                        {
-                            "name": "attention_types",
-                            "criterion": "Discuss different types of attention",
-                            "weight": 0.5,
-                            "examples": ["self-attention", "cross-attention"],
-                        }
-                    ],
-                },
-            },
+            "ingredients": [
+                {
+                    "name": "attention_types",
+                    "criterion": "Discuss different types of attention",
+                    "weight": 0.5,
+                    "examples": ["self-attention", "cross-attention"],
+                }
+            ],
         }
         instance = task.process_doc(doc, index=0)
         assert instance is not None
         assert instance.question == "What is the impact of attention mechanisms?"
         assert instance.metadata["case_id"] == "test_001"
         assert instance.metadata["annotator"] == "expert_1"
-        assert instance.metadata["agreement"] is True
         assert "ingredients" in instance.metadata["rubric_config"]
+        assert len(instance.metadata["rubric_config"]["ingredients"]) == 1
 
     def test_missing_question_skipped(self, task):
         doc = {"case_id": "empty", "question": ""}
         assert task.process_doc(doc, index=0) is None
 
-    def test_string_metric_config(self, task):
+    def test_empty_ingredients(self, task):
         doc = {
             "question": "Test question?",
-            "metric_config": json.dumps(
-                {
-                    "name": "rubric",
-                    "config": {"question": "Test?", "ingredients": []},
-                }
-            ),
+            "ingredients": [],
         }
         instance = task.process_doc(doc, index=0)
         assert instance is not None
         assert isinstance(instance.metadata["rubric_config"], dict)
+        assert instance.metadata["rubric_config"]["ingredients"] == []
+
+    def test_missing_ingredients(self, task):
+        doc = {
+            "question": "Test question?",
+        }
+        instance = task.process_doc(doc, index=0)
+        assert instance is not None
+        assert instance.metadata["rubric_config"]["ingredients"] == []
 
 
 # =============================================================================

--- a/tests/evals/tasks/test_astabench_sqa.py
+++ b/tests/evals/tasks/test_astabench_sqa.py
@@ -588,6 +588,67 @@ class TestFilterCitation:
         citation = {"snippets": ["Unique evidence text."]}
         assert _filter_citation(citation, "Different section text.") is True
 
+    def test_string_snippets_treated_as_single_item(self):
+        """String snippets should be normalized to a list, not iterated as chars."""
+        citation = {"snippets": "Unique evidence text.", "title": "Paper Title"}
+        # Should pass: the snippet is not in the section text and differs from title
+        assert _filter_citation(citation, "Different section text.") is True
+
+    def test_string_snippets_in_text_fails(self):
+        """String snippet that matches section text should fail."""
+        citation = {"snippets": "CNNs are great", "title": "Paper Title"}
+        assert _filter_citation(citation, "The section discusses CNNs are great.") is False
+
+
+# =============================================================================
+# _score_citations: title-only half-credit
+# =============================================================================
+
+
+class TestScoreCitationsHalfCredit:
+    def _build_citations(self, sec_text, raw_citations):
+        """Replicate the citation-building logic from _score_citations."""
+        bad_snippet = "Please click on the paper title to read the abstract on Semantic Scholar."
+        citations = []
+        for c in raw_citations:
+            cit_id = c.get("id")
+            if not cit_id:
+                continue
+            snippets = c.get("snippets", [])
+            if isinstance(snippets, list):
+                snippet_text = "... ".join(str(s) for s in snippets)
+            else:
+                snippet_text = str(snippets)
+
+            if _filter_citation(c, sec_text) and bad_snippet not in snippet_text:
+                citations.append({"id": cit_id, "snippets": snippet_text})
+            else:
+                title = c.get("title", "")
+                if title:
+                    citations.append({"id": cit_id, "snippets": f"{JUST_HAS_A_TITLE}{title}"})
+                else:
+                    citations.append({"id": cit_id, "snippets": ""})
+        return citations
+
+    def test_no_title_no_snippets_gets_zero_credit(self):
+        """Citation with no valid snippets AND no title should not get half-credit."""
+        citations = self._build_citations(
+            "Claim A [1].",
+            [{"id": "[1]", "snippets": [], "title": ""}],
+        )
+        half_credit_ids = [c["id"] for c in citations if c["snippets"].startswith(JUST_HAS_A_TITLE)]
+        assert "[1]" not in half_credit_ids
+        assert citations[0]["snippets"] == ""
+
+    def test_with_title_gets_half_credit_marker(self):
+        """Citation with a title but no valid snippets should get the half-credit marker."""
+        citations = self._build_citations(
+            "Claim A [1].",
+            [{"id": "[1]", "snippets": [], "title": "Real Paper Title"}],
+        )
+        half_credit_ids = [c["id"] for c in citations if c["snippets"].startswith(JUST_HAS_A_TITLE)]
+        assert "[1]" in half_credit_ids
+
 
 # =============================================================================
 # Metric Computation


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->

## Type of Change

<!-- Put an `x` in all the boxes that apply -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Testing

<!-- Describe how you tested your changes -->

- [x] Unit tests pass locally (`pytest tests/ --ignore=tests/integration/`)
- [x] Integration tests pass (if applicable)
- [x] New tests added for new functionality

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published


## Summary

- New task: astabench_scholarqa — loads from allenai/asta-bench on HuggingFace (pinned revision), with dev/test variants mapping to rubrics_v1/rubrics_v2 data files
- Per-instance rubric scoring — each dataset row carries its own rubric criteria; stored in Instance.metadata["rubric_config"] and read back at scoring time to construct instance-specific judge prompts
- 4 scoring dimensions (25% weight each): ingredient_recall (rubric criteria coverage), answer_precision (irrelevant paragraph detection with fuzzy matching), citation_precision and citation_recall (per-section citation attribution evaluation). Scoring logic ported from https://github.com/allenai/asta-bench
- build_openai_judge_fn enhancements — added max_tokens, temperature, and system_prompt support (backward-compatible defaults)
- HuggingFace backend fix — data_files and revision from DataSource are now passed through to load_dataset(); DataSource.with_split()/with_subset()/from_uri() preserve these fields
- <think> block stripping — model reasoning traces (e.g. Qwen3) are stripped before JSON extraction to prevent braces in <think>...</think> blocks from breaking the parser
- 54 unit tests covering JSON parsing, report formatting, all scoring helpers, citation filtering, think-block stripping, and metrics

## NOTE: What AstaBench measures (and doesn't)

- Citation metrics measure faithfulness, not groundedness. citation_precision and citation_recall check whether cited snippets support the associated claims — they do not verify that citations refer to real papers or that snippets actually appear in cited sources. This means models without retrieval tools can score well on citation metrics by generating internally consistent but fabricated citations.
- ingredient_recall is the most meaningful metric for no-retrieval models. It measures whether the response covers required topical points from the rubric, which genuinely tests the model's knowledge regardless of citation quality.
- The benchmark is designed for tool-augmented agents. The leaderboard models use ReAct harnesses with Semantic Scholar tools (search_papers_by_relevance, snippet_search, etc.). Running without tools produces inflated citation scores because fabricated snippets tautologically support their claims.

For context, Qwen3-8B without tools scores 0.321 on ingredient_recall vs 0.539 for GPT-4.1 with ReAct + tools on the leaderboard — while citation scores are comparable or higher due to the above effect.

## Results

Qwen3-8B (no retrieval tools), 100 instances on rubrics_v1 dev split:

```
  ┌────────────────────┬───────┐
  │       Metric       │ Score │
  ├────────────────────┼───────┤
  │ ingredient_recall  │ 0.321 │
  ├────────────────────┼───────┤
  │ answer_precision   │ 0.956 │
  ├────────────────────┼───────┤
  │ citation_precision │ 0.912 │
  ├────────────────────┼───────┤
  │ citation_recall    │ 0.797 │
  ├────────────────────┼───────┤
  │ global_avg         │ 0.747 │
  └────────────────────┴───────┘
```

1 of 100 instances scores zero due to invalid JSON generation (unescaped quotes in a paper title). Scoring takes ~40 min (serial judge calls via OpenAI API).

## Running

Requires vllm_server provider + openai_agents backend for chat template support, plus OPENAI_API_KEY for judge scoring:

```
  uv run olmo-eval beaker launch \
      -n "astabench_sqa_qwen3_8b" \
      -m Qwen/Qwen3-8B \
      --harness default \
      -o provider.kind=vllm_server \
      -o provider.max_model_len=16384 \
      -o backend=openai_agents \
      -t astabench_scholarqa@urgent \
      -w "ai2/olmo-eval-debug" \
      -B "ai2/oe-base" \
      --cluster ai2/ceres \
      --group roryd_astabench \
      --secret-env OPENAI_API_KEY:OPENAI_API_KEY \
      -y
```

## Testing

- Unit tests pass locally (pytest tests/ --ignore=tests/integration/)
- Integration tests pass (if applicable)
- New tests added for new functionality