### PR TITLE
Add GeneTuring genomics benchmark (14 tasks, 6 custom scorers)

### DIFF
--- a/src/olmo_eval/evals/suites/biology.py
+++ b/src/olmo_eval/evals/suites/biology.py
@@ -32,3 +32,40 @@ LAB_BENCH_BPB = make_suite(
     tuple(f"{t}:bpb" for t in _LAB_BENCH_TASKS),
     description="LAB-Bench with bits-per-byte evaluation",
 )
+
+# =============================================================================
+# GeneTuring Suite
+# =============================================================================
+
+_GENETURING_TASKS = (
+    "geneturing_gene_name_conversion",
+    "geneturing_gene_location",
+    "geneturing_snp_location",
+    "geneturing_gene_snp_association",
+    "geneturing_protein_coding_genes",
+    "geneturing_tf_regulation",
+    "geneturing_human_genome_dna_alignment",
+    "geneturing_amino_acid_translation",
+    "geneturing_dna_sequence_extraction",
+    "geneturing_gene_name_extraction",
+    "geneturing_gene_alias",
+    "geneturing_gene_disease_association",
+    "geneturing_gene_ontology",
+    "geneturing_multi_species_dna_alignment",
+)
+
+GENETURING = make_suite(
+    "geneturing",
+    _GENETURING_TASKS,
+    description="GeneTuring genomics Q&A benchmark (14 modules, 1,400 questions)",
+)
+
+# =============================================================================
+# Combined Biology Suite
+# =============================================================================
+
+BIOLOGY = make_suite(
+    "biology",
+    (LAB_BENCH, GENETURING),
+    description="Combined biology benchmarks (LAB-Bench + GeneTuring)",
+)

--- a/src/olmo_eval/evals/tasks/geneturing.py
+++ b/src/olmo_eval/evals/tasks/geneturing.py
@@ -103,8 +103,36 @@ class SetRecallScorer(Scorer):
 
 
 @dataclass(frozen=True, slots=True)
+class GeneRecallScorer(Scorer):
+    """Fraction of gold gene symbols mentioned anywhere in the model response.
+
+    Follows the GeneTuring paper: "The answer provided by an LLM was scored
+    based on the proportion of gold standard genes mentioned in the response."
+    Checks the full (think-stripped) output text rather than the extracted answer.
+    """
+
+    name: str = "gene_recall"
+
+    def score(self, instance: Instance, output: LMOutput) -> float:
+        if instance.gold_answer is None:
+            return 0.0
+        gold_genes = [
+            g.strip().upper() for g in re.split(r"[,;]", instance.gold_answer) if g.strip()
+        ]
+        if not gold_genes:
+            return 0.0
+        response = _strip_thinking(output.text).upper()
+        found = sum(1 for g in gold_genes if g in response)
+        return found / len(gold_genes)
+
+
+@dataclass(frozen=True, slots=True)
 class ContainmentScorer(Scorer):
-    """1.0 for exact match, 0.5 if gold is a substring of prediction, else 0.0."""
+    """1.0 for exact match, 0.5 for partial match (either direction), else 0.0.
+
+    Follows the GeneTuring paper: "A score of 0.5 was assigned if one of the
+    GO terms partially matched the gold standard."
+    """
 
     name: str = "containment"
 
@@ -115,8 +143,39 @@ class ContainmentScorer(Scorer):
         pred = str(output.extracted_answer).strip().lower()
         if gold == pred:
             return 1.0
-        if gold in pred:
+        if gold in pred or pred in gold:
             return 0.5
+        return 0.0
+
+
+@dataclass(frozen=True, slots=True)
+class SpeciesScorer(Scorer):
+    """Species matching with partial credit for superset answers.
+
+    Follows the GeneTuring paper: 1.0 for exact match, 0.5 if the model's
+    response contains the gold species (a "correct superset"), 0.0 otherwise.
+    """
+
+    name: str = "species"
+
+    def score(self, instance: Instance, output: LMOutput) -> float:
+        if instance.gold_answer is None:
+            return 0.0
+        gold = instance.gold_answer.strip().lower()
+        # Check extracted answer first for exact match
+        if output.extracted_answer is not None:
+            pred = str(output.extracted_answer).strip().lower()
+            if gold == pred:
+                return 1.0
+        # Check if the gold species appears anywhere in the raw output
+        # (the model mentioned the right answer among other text)
+        raw = _strip_thinking(output.text).lower()
+        if gold in raw:
+            return 0.5
+        # Also check aliases in reverse: if gold is "worm", check for "c. elegans"
+        for alias, common in _SPECIES_ALIASES.items():
+            if common == gold and alias in raw:
+                return 0.5
         return 0.0
 
 
@@ -148,7 +207,28 @@ _THINK_PATTERN = re.compile(r"<think>.*?</think>\s*", re.DOTALL)
 _CHR_PATTERN = re.compile(r"chr(?:omosome\s*)?(\d+|[XYxy])", re.IGNORECASE)
 _AMINO_ACID_PATTERN = re.compile(r"[ACDEFGHIKLMNPQRSTVWY]{5,}", re.IGNORECASE)
 _DNA_PATTERN = re.compile(r"[ACGTacgt]{10,}")
-_KNOWN_SPECIES = frozenset({"human", "mouse", "rat", "zebrafish", "worm", "yeast", "fruit fly"})
+_KNOWN_SPECIES = frozenset(
+    {"human", "mouse", "rat", "zebrafish", "worm", "yeast", "fruit fly", "chicken"}
+)
+
+# Scientific / Latin name → common name mapping for species extraction.
+_SPECIES_ALIASES: dict[str, str] = {
+    "homo sapiens": "human",
+    "mus musculus": "mouse",
+    "rattus norvegicus": "rat",
+    "rattus": "rat",
+    "danio rerio": "zebrafish",
+    "caenorhabditis elegans": "worm",
+    "c. elegans": "worm",
+    "c.elegans": "worm",
+    "saccharomyces cerevisiae": "yeast",
+    "s. cerevisiae": "yeast",
+    "s.cerevisiae": "yeast",
+    "drosophila melanogaster": "fruit fly",
+    "drosophila": "fruit fly",
+    "d. melanogaster": "fruit fly",
+    "gallus gallus": "chicken",
+}
 
 
 def _strip_thinking(text: str) -> str:
@@ -235,33 +315,56 @@ def _extract_first_line_answer(text: str) -> str | None:
         line = re.sub(r"\*{1,2}([^*]+)\*{1,2}", r"\1", line)
         # Strip common verbose prefixes (e.g. "The official gene symbol is ...")
         line = re.sub(
-            r"^(the\s+(official\s+)?(gene\s+)?(symbol|name|answer)\s+"
-            r"(is|for|of|corresponding to)\s+[^:]*?(is\s+|:\s*)"
+            r"^(the\s+(?:official\s+)?(?:gene\s+)?(?:symbol|name|answer|identifier)\s+"
+            r"(?:is|for|of|corresponding to)\s+[^:]*?(?:is\s+|:\s*)"
+            r"|the\s+(?:ensembl\s+)?(?:gene\s+)?identifier\s+\S+\s+"
+            r"(?:corresponds?\s+to|maps?\s+to|is)\s+"
+            r"(?:the\s+)?(?:official\s+)?(?:gene\s+)?(?:symbol\s+)?"
             r"|based on[^,]*,\s*"
             r"|according to[^,]*,\s*"
             r"|the\s+gene\s+symbol\s+for\s+.*?\s+is\s+"
-            r"|the\s+official\s+gene\s+symbol\s+.*?\s+is\s+)",
+            r"|the\s+official\s+gene\s+symbol\s+.*?\s+is\s+"
+            r"|the\s+SNP\s+\S+\s+is\s+(?:most\s+closely\s+)?associated\s+with\s+"
+            r"(?:the\s+)?(?:gene\s+)?)",
             "",
             line,
             flags=re.IGNORECASE,
         )
-        # Strip trailing punctuation and parenthetical notes
-        line = re.sub(r"\s*\(.*?\)\s*$", "", line)
         line = line.rstrip(".")
         # Take first sentence only ("GENE. This gene encodes..." → "GENE")
         cleaned = line.split(". ")[0].strip()
+        # Strip trailing parenthetical notes ("PTK7 (Protein Tyrosine Kinase 7)" → "PTK7")
+        cleaned = re.sub(r"\s*\(.*?\)\s*$", "", cleaned).strip()
         if cleaned:
             return cleaned
     return None
 
 
 def _extract_species(text: str) -> str | None:
-    """Extract a species name from model output."""
+    """Extract a species name from model output.
+
+    Prefers the *last* mentioned species (the model's conclusion) over earlier
+    incidental mentions.  Also resolves scientific / Latin names via
+    ``_SPECIES_ALIASES``.
+    """
     lower = _strip_thinking(text).lower()
+
+    # Build list of (position, common_name) for every mention.
+    mentions: list[tuple[int, str]] = []
     for species in _KNOWN_SPECIES:
-        if species in lower:
-            return species
-    return None
+        idx = lower.rfind(species)
+        if idx >= 0:
+            mentions.append((idx, species))
+    for alias, common in _SPECIES_ALIASES.items():
+        idx = lower.rfind(alias)
+        if idx >= 0:
+            mentions.append((idx, common))
+
+    if not mentions:
+        return None
+    # Return the species whose *last* mention is latest in the text.
+    mentions.sort(key=lambda t: t[0], reverse=True)
+    return mentions[0][1]
 
 
 def _parse_name_set(text: str) -> set[str]:
@@ -281,6 +384,147 @@ def _extract_gene_names(text: str) -> str | None:
     lower = _strip_thinking(text).strip().lower()
     if "no gene" in lower or "no protein" in lower or lower.startswith("none"):
         return "No gene"
+    return _extract_first_line_answer(text)
+
+
+# Pattern for plausible human gene symbols: 1-2 uppercase letters followed by
+# at least one alphanumeric char, optionally with hyphens (e.g. HLA-A).
+_GENE_SYMBOL_PATTERN = re.compile(r"\b([A-Z][A-Z0-9][A-Z0-9/.-]{0,12})\b")
+
+# Common abbreviations that look like gene symbols but aren't.
+_NOT_GENE_SYMBOLS = frozenset(
+    {
+        "THE",
+        "AND",
+        "FOR",
+        "NOT",
+        "ARE",
+        "BUT",
+        "ALL",
+        "CAN",
+        "HAS",
+        "WAS",
+        "ONE",
+        "OUR",
+        "OUT",
+        "YOU",
+        "DNA",
+        "RNA",
+        "SNP",
+        "GO",
+        "NCBI",
+        "OMIM",
+        "PHP",
+        "PFK",
+        "MRI",
+        "QT",
+        "AD",
+        "AR",
+        "IV",
+        "CKD",
+        "MDS",
+        "ASD",
+        "ECM",
+        "BAM",
+        "HERE",
+        "THIS",
+        "THAT",
+        "WITH",
+        "HAVE",
+        "FROM",
+        "THEY",
+        "BEEN",
+        "SAID",
+        "EACH",
+        "WILL",
+        "ALSO",
+        "THAN",
+        "NOW",
+        "ITS",
+        "WHO",
+        "MAY",
+        "USE",
+        "DUE",
+        "TYPE",
+        "GENE",
+        "HUGO",
+        "HGNC",
+        "HGMD",
+        "KEY",
+        "RARE",
+        "NOTE",
+        "HTTP",
+        "HTTPS",
+        "STEP",
+        "VIA",
+    }
+)
+
+
+def _extract_gene_symbols(text: str) -> str | None:
+    """Extract gene symbols from the full model output.
+
+    Scans all uppercase tokens that look like gene symbols, returning them as
+    a comma-separated string for use with set-based scorers.
+    """
+    text = _strip_thinking(text)
+    # Prefer bold-formatted symbols (**GENE**) as the model's primary answers
+    bold_genes = re.findall(r"\*\*([A-Z][A-Z0-9/.-]{1,12})\*\*", text)
+    bold_genes = [g for g in bold_genes if g not in _NOT_GENE_SYMBOLS]
+    if bold_genes:
+        return ", ".join(bold_genes)
+
+    # Fall back to all uppercase gene-like tokens
+    candidates = _GENE_SYMBOL_PATTERN.findall(text)
+    candidates = [c for c in candidates if c not in _NOT_GENE_SYMBOLS]
+    if candidates:
+        # Deduplicate while preserving order
+        seen: set[str] = set()
+        unique = []
+        for c in candidates:
+            if c not in seen:
+                seen.add(c)
+                unique.append(c)
+        return ", ".join(unique)
+    return None
+
+
+def _extract_go_term(text: str) -> str | None:
+    """Extract a Gene Ontology term name from model output.
+
+    Looks for quoted terms or terms following "is (likely)" patterns, which is
+    how models typically present GO term predictions.
+    """
+    text = _strip_thinking(text)
+
+    # Try to find quoted GO term (the most reliable signal)
+    # Prefer the first quoted term after "is likely" or "is"
+    quoted_after_is = re.search(
+        r'is\s+(?:likely\s+)?["\u201c]([^"\u201d]+)["\u201d]',
+        text,
+        re.IGNORECASE,
+    )
+    if quoted_after_is:
+        return quoted_after_is.group(1).strip()
+
+    # Any quoted string that isn't a gene name or GO ID
+    quoted = re.findall(r'["\u201c]([^"\u201d]{5,})["\u201d]', text)
+    for q in quoted:
+        if not re.fullmatch(r"GO:\d+", q) and not q.isupper():
+            return q.strip()
+
+    # Fall back to bold text after "is (likely)"
+    bold_after_is = re.search(
+        r"is\s+(?:likely\s+)?\*\*([^*]+)\*\*",
+        text,
+        re.IGNORECASE,
+    )
+    if bold_after_is:
+        term = bold_after_is.group(1).strip()
+        # Strip GO ID suffix like "(GO:0006629)"
+        term = re.sub(r"\s*\(GO:\d+\)\s*$", "", term)
+        return term
+
     return _extract_first_line_answer(text)
 
 
@@ -334,8 +578,12 @@ _MULTI_SPECIES_FORMATTER = ChatFormatter(
     system_prompt="""\
 You are a genomics expert. You will be given a DNA sequence and asked which \
 organism it comes from. The answer is one of: human, mouse, rat, zebrafish, \
-worm, yeast, fruit fly. Give only the organism name with no explanation.""",
+worm, yeast, fruit fly, chicken. Give only the organism name with no explanation.""",
 )
+
+# Lower max_tokens for tasks where the answer is short but inputs are long
+# (DNA sequences), to reduce generation time and avoid vLLM timeouts.
+_SHORT_ANSWER_SAMPLING = SamplingParams(temperature=0.0, max_tokens=128)
 
 
 # =============================================================================
@@ -352,6 +600,7 @@ class GeneTuringTask(Task):
         scorer: type[Scorer] = ExactMatchScorer,
         metric_name: str = "accuracy",
         formatter: ChatFormatter | None = None,
+        sampling_params: SamplingParams | None = None,
         **kwargs: Any,
     ) -> None:
         super().__init_subclass__(**kwargs)
@@ -362,7 +611,7 @@ class GeneTuringTask(Task):
 
         cls.data_source = DataSource(path="allenai/geneturing", subset=subset)
         cls.formatter = formatter or _DEFAULT_FORMATTER
-        cls.sampling_params = _DEFAULT_SAMPLING
+        cls.sampling_params = sampling_params or _DEFAULT_SAMPLING
 
         if metric_name == "accuracy":
             metric: Metric = AccuracyMetric(scorer=scorer)
@@ -450,7 +699,11 @@ class HumanGenomeDnaAlignment(
         return _extract_chromosome(output.text)
 
 
-class AminoAcidTranslation(GeneTuringTask, subset="amino_acid_translation"):
+class AminoAcidTranslation(
+    GeneTuringTask,
+    subset="amino_acid_translation",
+    sampling_params=_SHORT_ANSWER_SAMPLING,
+):
     def extract_answer(self, output: LMOutput) -> str | None:
         return _extract_sequence(output.text, _AMINO_ACID_PATTERN)
 
@@ -489,12 +742,12 @@ class GeneAlias(
 class GeneDiseaseAssociation(
     GeneTuringTask,
     subset="gene_disease_association",
-    scorer=SetRecallScorer,
+    scorer=GeneRecallScorer,
     metric_name="recall",
     formatter=_GENE_DISEASE_FORMATTER,
 ):
     def extract_answer(self, output: LMOutput) -> str | None:
-        return _extract_first_line_answer(output.text)
+        return _extract_gene_symbols(output.text)
 
 
 # =============================================================================
@@ -510,13 +763,16 @@ class GeneOntology(
     formatter=_GENE_ONTOLOGY_FORMATTER,
 ):
     def extract_answer(self, output: LMOutput) -> str | None:
-        return _extract_first_line_answer(output.text)
+        return _extract_go_term(output.text)
 
 
 class MultiSpeciesDnaAlignment(
     GeneTuringTask,
     subset="multi_species_dna_alignment",
+    scorer=SpeciesScorer,
+    metric_name="species",
     formatter=_MULTI_SPECIES_FORMATTER,
+    sampling_params=_SHORT_ANSWER_SAMPLING,
 ):
     def extract_answer(self, output: LMOutput) -> str | None:
         return _extract_species(output.text)

--- a/src/olmo_eval/evals/tasks/geneturing.py
+++ b/src/olmo_eval/evals/tasks/geneturing.py
@@ -122,7 +122,7 @@ class GeneRecallScorer(Scorer):
         if not gold_genes:
             return 0.0
         response = _strip_thinking(output.text).upper()
-        found = sum(1 for g in gold_genes if g in response)
+        found = sum(1 for g in gold_genes if re.search(r"\b" + re.escape(g) + r"\b", response))
         return found / len(gold_genes)
 
 
@@ -259,10 +259,18 @@ def _extract_chromosome(text: str) -> str | None:
 def _extract_boolean(text: str) -> str | None:
     """Map yes/no/true/false to TRUE/NA (protein-coding convention)."""
     lower = _strip_thinking(text).strip().lower()
-    # Check for explicit TRUE/NA first
-    if "true" in lower and "na" not in lower:
+    # Check for explicit TRUE/NA/FALSE first
+    if "true" in lower and "na" not in lower and "false" not in lower:
         return "TRUE"
-    if lower.startswith("na") or "not a protein" in lower or "non-coding" in lower:
+    if re.search(r"\bfalse\b", lower):
+        return "NA"
+    if (
+        lower.startswith("na")
+        or lower.startswith("n/a")
+        or "not a protein" in lower
+        or "not protein" in lower
+        or "non-coding" in lower
+    ):
         return "NA"
     # Check yes/no
     first_line = lower.split("\n")[0]

--- a/src/olmo_eval/evals/tasks/geneturing.py
+++ b/src/olmo_eval/evals/tasks/geneturing.py
@@ -1,0 +1,510 @@
+"""GeneTuring genomics Q&A benchmark.
+
+GeneTuring evaluates LLMs on 14 genomics tasks (1,400 questions total) spanning
+gene nomenclature, genomic location, functional analysis, sequence alignment,
+and more. Each task has 100 questions with gold-standard answers.
+
+Dataset: allenai/geneturing (derived from Hou & Ji, 2024 supplementary data)
+
+Tasks:
+    geneturing_gene_name_conversion      Ensembl ID → gene symbol
+    geneturing_gene_location             Gene → chromosome
+    geneturing_snp_location              SNP → chromosome
+    geneturing_gene_snp_association      SNP → associated gene
+    geneturing_protein_coding_genes      Is gene protein-coding? (TRUE/NA)
+    geneturing_tf_regulation             TF activates or represses gene?
+    geneturing_human_genome_dna_alignment  DNA → genomic coordinates
+    geneturing_amino_acid_translation    Nucleotide → amino acid sequence
+    geneturing_dna_sequence_extraction   Genomic coordinates → DNA sequence
+    geneturing_gene_name_extraction      Sentence → gene/protein names
+    geneturing_gene_alias               Alias → official gene symbol
+    geneturing_gene_disease_association  Disease → associated genes
+    geneturing_gene_ontology            Gene set → GO term
+    geneturing_multi_species_dna_alignment  DNA → species of origin
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterator, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from olmo_eval.common.formatters import ChatFormatter
+from olmo_eval.common.metrics import AccuracyMetric, Metric
+from olmo_eval.common.scorers import ExactMatchScorer, Scorer
+from olmo_eval.common.types import (
+    Instance,
+    LMOutput,
+    LMRequest,
+    RequestType,
+    Response,
+    SamplingParams,
+)
+from olmo_eval.data import DataSource
+from olmo_eval.evals.tasks.common import Task, register
+
+# =============================================================================
+# Custom Scorers
+# =============================================================================
+
+
+@dataclass(frozen=True, slots=True)
+class ChromosomeScorer(Scorer):
+    """Normalize both gold and predicted to ``chrN`` format, then exact-match."""
+
+    name: str = "chromosome"
+
+    def score(self, instance: Instance, output: LMOutput) -> float:
+        if instance.gold_answer is None or output.extracted_answer is None:
+            return 0.0
+        gold = _normalize_chromosome(instance.gold_answer)
+        pred = _normalize_chromosome(str(output.extracted_answer))
+        if gold is None or pred is None:
+            return 0.0
+        return 1.0 if gold == pred else 0.0
+
+
+@dataclass(frozen=True, slots=True)
+class JaccardScorer(Scorer):
+    """Jaccard index (|A∩B|/|A∪B|) over comma-separated name sets."""
+
+    name: str = "jaccard"
+
+    def score(self, instance: Instance, output: LMOutput) -> float:
+        if instance.gold_answer is None or output.extracted_answer is None:
+            return 0.0
+        gold_set = _parse_name_set(instance.gold_answer)
+        pred_set = _parse_name_set(str(output.extracted_answer))
+        if not gold_set and not pred_set:
+            return 1.0
+        if not gold_set or not pred_set:
+            return 0.0
+        intersection = gold_set & pred_set
+        union = gold_set | pred_set
+        return len(intersection) / len(union)
+
+
+@dataclass(frozen=True, slots=True)
+class SetRecallScorer(Scorer):
+    """Recall: fraction of gold set items found in predicted set."""
+
+    name: str = "set_recall"
+
+    def score(self, instance: Instance, output: LMOutput) -> float:
+        if instance.gold_answer is None or output.extracted_answer is None:
+            return 0.0
+        gold_set = _parse_name_set(instance.gold_answer)
+        pred_set = _parse_name_set(str(output.extracted_answer))
+        if not gold_set:
+            return 1.0 if not pred_set else 0.0
+        found = sum(1 for g in gold_set if g in pred_set)
+        return found / len(gold_set)
+
+
+@dataclass(frozen=True, slots=True)
+class ContainmentScorer(Scorer):
+    """1.0 for exact match, 0.5 if gold is a substring of prediction, else 0.0."""
+
+    name: str = "containment"
+
+    def score(self, instance: Instance, output: LMOutput) -> float:
+        if instance.gold_answer is None or output.extracted_answer is None:
+            return 0.0
+        gold = instance.gold_answer.strip().lower()
+        pred = str(output.extracted_answer).strip().lower()
+        if gold == pred:
+            return 1.0
+        if gold in pred:
+            return 0.5
+        return 0.0
+
+
+# =============================================================================
+# Custom Metrics (thin wrappers binding scorer to AccuracyMetric pattern)
+# =============================================================================
+
+
+@dataclass(frozen=True, slots=True)
+class MeanScoreMetric(Metric):
+    """Mean of per-response scores for a given scorer."""
+
+    name: str = "mean_score"
+    scorer: type[Scorer] = ExactMatchScorer
+
+    def compute(self, responses: Sequence[Response]) -> float:
+        if not responses:
+            return 0.0
+        scorer_name = self.scorer().name
+        total = sum(r.scores.get(scorer_name, 0.0) for r in responses)
+        return total / len(responses)
+
+
+# =============================================================================
+# Answer Extraction Helpers
+# =============================================================================
+
+_CHR_PATTERN = re.compile(r"chr(?:omosome\s*)?(\d+|[XYxy])", re.IGNORECASE)
+_AMINO_ACID_PATTERN = re.compile(r"[ACDEFGHIKLMNPQRSTVWY]{5,}", re.IGNORECASE)
+_DNA_PATTERN = re.compile(r"[ACGTacgt]{10,}")
+_KNOWN_SPECIES = frozenset({"human", "mouse", "rat", "zebrafish", "worm", "yeast", "fruit fly"})
+
+
+def _normalize_chromosome(text: str) -> str | None:
+    """Extract and normalize a chromosome identifier to ``chrN`` format."""
+    m = _CHR_PATTERN.search(text)
+    if m:
+        num = m.group(1).upper()
+        return f"chr{num}"
+    # Handle bare numbers like "18" or "Y"
+    stripped = text.strip().upper()
+    if re.fullmatch(r"\d{1,2}", stripped):
+        return f"chr{stripped}"
+    if stripped in ("X", "Y"):
+        return f"chr{stripped}"
+    return None
+
+
+def _extract_chromosome(text: str) -> str | None:
+    """Extract chromosome from model output."""
+    return _normalize_chromosome(text)
+
+
+def _extract_boolean(text: str) -> str | None:
+    """Map yes/no/true/false to TRUE/NA (protein-coding convention)."""
+    lower = text.strip().lower()
+    # Check for explicit TRUE/NA first
+    if "true" in lower and "na" not in lower:
+        return "TRUE"
+    if lower.startswith("na") or "not a protein" in lower or "non-coding" in lower:
+        return "NA"
+    # Check yes/no
+    first_line = lower.split("\n")[0]
+    if re.search(r"\byes\b", first_line):
+        return "TRUE"
+    if re.search(r"\bno\b", first_line):
+        return "NA"
+    return None
+
+
+def _extract_activation(text: str) -> str | None:
+    """Extract Activation or Repression from model output."""
+    lower = text.lower()
+    has_activation = "activat" in lower
+    has_repression = "repress" in lower
+    if has_activation and not has_repression:
+        return "Activation"
+    if has_repression and not has_activation:
+        return "Repression"
+    # Both mentioned — check which comes first in the first sentence
+    if has_activation and has_repression:
+        first_line = lower.split("\n")[0].split(".")[0]
+        act_pos = first_line.find("activat")
+        rep_pos = first_line.find("repress")
+        if act_pos >= 0 and (rep_pos < 0 or act_pos < rep_pos):
+            return "Activation"
+        return "Repression"
+    return None
+
+
+def _extract_sequence(text: str, pattern: re.Pattern[str]) -> str | None:
+    """Extract the longest contiguous sequence matching the pattern."""
+    matches: list[str] = pattern.findall(text)
+    if not matches:
+        return None
+    best = matches[0]
+    for m in matches[1:]:
+        if len(m) > len(best):
+            best = m
+    return best.upper()
+
+
+def _extract_first_line_answer(text: str) -> str | None:
+    """Extract the first meaningful line, stripping common boilerplate."""
+    lines = text.strip().split("\n")
+    for line in lines:
+        line = line.strip()
+        # Skip empty lines and common prefixes
+        line = re.sub(
+            r"^(the\s+(official\s+)?(gene\s+)?(symbol|name|answer)\s+(is|for)\s+[^:]*:\s*"
+            r"|based on[^,]*,\s*"
+            r"|according to[^,]*,\s*"
+            r"|the\s+gene\s+symbol\s+for\s+.*?\s+is\s+)",
+            "",
+            line,
+            flags=re.IGNORECASE,
+        )
+        # Strip trailing punctuation and parenthetical notes
+        line = re.sub(r"\s*\(.*?\)\s*$", "", line)
+        line = line.rstrip(".")
+        cleaned = line.strip()
+        if cleaned:
+            return cleaned
+    return None
+
+
+def _extract_species(text: str) -> str | None:
+    """Extract a species name from model output."""
+    lower = text.lower()
+    for species in _KNOWN_SPECIES:
+        if species in lower:
+            return species
+    return None
+
+
+def _parse_name_set(text: str) -> set[str]:
+    """Parse a comma/semicolon-separated list of names into a normalized set."""
+    # Split on comma, semicolon, " and ", or newline
+    parts = re.split(r"[,;\n]|\band\b", text)
+    result = set()
+    for part in parts:
+        cleaned = part.strip().strip(".")
+        if cleaned and cleaned.lower() not in ("", "no gene", "none"):
+            result.add(cleaned.lower())
+    return result
+
+
+def _extract_gene_names(text: str) -> str | None:
+    """Extract gene/protein names from model output for gene_name_extraction."""
+    lower = text.strip().lower()
+    if "no gene" in lower or "no protein" in lower or lower.startswith("none"):
+        return "No gene"
+    return _extract_first_line_answer(text)
+
+
+# =============================================================================
+# System Prompt and Defaults
+# =============================================================================
+
+_SYSTEM_PROMPT = """\
+You are a genomics expert. Answer the following question concisely and accurately.
+Give only the answer with no explanation unless asked."""
+
+_DEFAULT_SAMPLING = SamplingParams(temperature=0.0, max_tokens=512)
+_DEFAULT_FORMATTER = ChatFormatter(system_prompt=_SYSTEM_PROMPT)
+
+# Per-task formatters for modules where the gold answer format is non-obvious.
+_PROTEIN_CODING_FORMATTER = ChatFormatter(
+    system_prompt="""\
+You are a genomics expert. You will be asked whether a gene is protein-coding.
+Answer "TRUE" if the gene is protein-coding, or "NA" if it is not. \
+Give only the answer with no explanation.""",
+)
+
+_TF_REGULATION_FORMATTER = ChatFormatter(
+    system_prompt="""\
+You are a genomics expert. You will be asked whether a transcription factor \
+activates or represses a target gene.
+Answer "Activation" or "Repression". Give only the answer with no explanation.""",
+)
+
+_GENE_DISEASE_FORMATTER = ChatFormatter(
+    system_prompt="""\
+You are a genomics expert. You will be asked which genes are associated with \
+a disease. List the official gene symbols separated by commas. \
+Give only the gene symbols with no explanation.""",
+)
+
+_GENE_ALIAS_FORMATTER = ChatFormatter(
+    system_prompt="""\
+You are a genomics expert. You will be asked for the official gene symbol \
+corresponding to a gene alias. Give only the official symbol with no explanation.""",
+)
+
+_GENE_ONTOLOGY_FORMATTER = ChatFormatter(
+    system_prompt="""\
+You are a genomics expert. You will be given a set of genes and asked for the \
+enriched Gene Ontology term they share. Give only the GO term name with no \
+explanation.""",
+)
+
+_MULTI_SPECIES_FORMATTER = ChatFormatter(
+    system_prompt="""\
+You are a genomics expert. You will be given a DNA sequence and asked which \
+organism it comes from. The answer is one of: human, mouse, rat, zebrafish, \
+worm, yeast, fruit fly. Give only the organism name with no explanation.""",
+)
+
+
+# =============================================================================
+# Base Task
+# =============================================================================
+
+
+class GeneTuringTask(Task):
+    """Base class for GeneTuring subtasks."""
+
+    def __init_subclass__(
+        cls,
+        subset: str | None = None,
+        scorer: type[Scorer] = ExactMatchScorer,
+        metric_name: str = "accuracy",
+        formatter: ChatFormatter | None = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init_subclass__(**kwargs)
+        if subset is None:
+            return
+
+        name = f"geneturing_{subset}"
+
+        cls.data_source = DataSource(path="allenai/geneturing", subset=subset)
+        cls.formatter = formatter or _DEFAULT_FORMATTER
+        cls.sampling_params = _DEFAULT_SAMPLING
+
+        if metric_name == "accuracy":
+            metric: Metric = AccuracyMetric(scorer=scorer)
+        else:
+            metric = MeanScoreMetric(name=metric_name, scorer=scorer)
+
+        cls.metrics = (metric,)
+        cls.primary_metric = metric
+        register(name)(cls)
+
+    @property
+    def instances(self) -> Iterator[Instance]:
+        yield from self._load_instances_cached()
+
+    def process_doc(self, doc: dict[str, Any], index: int = 0) -> Instance | None:
+        question = doc.get("question", "")
+        gold_answer = doc.get("gold_answer", "")
+        if not question:
+            return None
+        return Instance(
+            question=question,
+            gold_answer=gold_answer,
+            metadata={
+                "id": doc.get("id", f"geneturing_{index}"),
+                "index": index,
+            },
+        )
+
+    @property
+    def request_type(self) -> RequestType:
+        if self.config.formatter is not None:
+            return self.config.formatter.request_type
+        return RequestType.CHAT
+
+    def format_request(self, instance: Instance) -> LMRequest:
+        if self.config.formatter is not None:
+            return self.config.formatter.format(instance, self.get_fewshot())
+        return LMRequest(
+            request_type=RequestType.CHAT,
+            messages=({"role": "user", "content": instance.question},),
+        )
+
+
+# =============================================================================
+# Tier 1 — Exact Match Tasks (9 modules)
+# =============================================================================
+
+
+class GeneNameConversion(GeneTuringTask, subset="gene_name_conversion"):
+    def extract_answer(self, output: LMOutput) -> str | None:
+        return _extract_first_line_answer(output.text)
+
+
+class GeneLocation(GeneTuringTask, subset="gene_location", scorer=ChromosomeScorer):
+    def extract_answer(self, output: LMOutput) -> str | None:
+        return _extract_chromosome(output.text)
+
+
+class SnpLocation(GeneTuringTask, subset="snp_location", scorer=ChromosomeScorer):
+    def extract_answer(self, output: LMOutput) -> str | None:
+        return _extract_chromosome(output.text)
+
+
+class GeneSnpAssociation(GeneTuringTask, subset="gene_snp_association"):
+    def extract_answer(self, output: LMOutput) -> str | None:
+        return _extract_first_line_answer(output.text)
+
+
+class ProteinCodingGenes(
+    GeneTuringTask, subset="protein_coding_genes", formatter=_PROTEIN_CODING_FORMATTER
+):
+    def extract_answer(self, output: LMOutput) -> str | None:
+        return _extract_boolean(output.text)
+
+
+class TfRegulation(GeneTuringTask, subset="tf_regulation", formatter=_TF_REGULATION_FORMATTER):
+    def extract_answer(self, output: LMOutput) -> str | None:
+        return _extract_activation(output.text)
+
+
+class HumanGenomeDnaAlignment(
+    GeneTuringTask, subset="human_genome_dna_alignment", scorer=ChromosomeScorer
+):
+    def extract_answer(self, output: LMOutput) -> str | None:
+        return _extract_chromosome(output.text)
+
+
+class AminoAcidTranslation(GeneTuringTask, subset="amino_acid_translation"):
+    def extract_answer(self, output: LMOutput) -> str | None:
+        return _extract_sequence(output.text, _AMINO_ACID_PATTERN)
+
+
+class DnaSequenceExtraction(GeneTuringTask, subset="dna_sequence_extraction"):
+    def extract_answer(self, output: LMOutput) -> str | None:
+        return _extract_sequence(output.text, _DNA_PATTERN)
+
+
+# =============================================================================
+# Tier 2 — Set Overlap Tasks (3 modules)
+# =============================================================================
+
+
+class GeneNameExtraction(
+    GeneTuringTask,
+    subset="gene_name_extraction",
+    scorer=JaccardScorer,
+    metric_name="jaccard",
+):
+    def extract_answer(self, output: LMOutput) -> str | None:
+        return _extract_gene_names(output.text)
+
+
+class GeneAlias(
+    GeneTuringTask,
+    subset="gene_alias",
+    scorer=JaccardScorer,
+    metric_name="jaccard",
+    formatter=_GENE_ALIAS_FORMATTER,
+):
+    def extract_answer(self, output: LMOutput) -> str | None:
+        return _extract_first_line_answer(output.text)
+
+
+class GeneDiseaseAssociation(
+    GeneTuringTask,
+    subset="gene_disease_association",
+    scorer=SetRecallScorer,
+    metric_name="recall",
+    formatter=_GENE_DISEASE_FORMATTER,
+):
+    def extract_answer(self, output: LMOutput) -> str | None:
+        return _extract_first_line_answer(output.text)
+
+
+# =============================================================================
+# Tier 3 — Partial Credit Tasks (2 modules)
+# =============================================================================
+
+
+class GeneOntology(
+    GeneTuringTask,
+    subset="gene_ontology",
+    scorer=ContainmentScorer,
+    metric_name="containment",
+    formatter=_GENE_ONTOLOGY_FORMATTER,
+):
+    def extract_answer(self, output: LMOutput) -> str | None:
+        return _extract_first_line_answer(output.text)
+
+
+class MultiSpeciesDnaAlignment(
+    GeneTuringTask,
+    subset="multi_species_dna_alignment",
+    formatter=_MULTI_SPECIES_FORMATTER,
+):
+    def extract_answer(self, output: LMOutput) -> str | None:
+        return _extract_species(output.text)

--- a/src/olmo_eval/evals/tasks/geneturing.py
+++ b/src/olmo_eval/evals/tasks/geneturing.py
@@ -144,10 +144,16 @@ class MeanScoreMetric(Metric):
 # Answer Extraction Helpers
 # =============================================================================
 
+_THINK_PATTERN = re.compile(r"<think>.*?</think>\s*", re.DOTALL)
 _CHR_PATTERN = re.compile(r"chr(?:omosome\s*)?(\d+|[XYxy])", re.IGNORECASE)
 _AMINO_ACID_PATTERN = re.compile(r"[ACDEFGHIKLMNPQRSTVWY]{5,}", re.IGNORECASE)
 _DNA_PATTERN = re.compile(r"[ACGTacgt]{10,}")
 _KNOWN_SPECIES = frozenset({"human", "mouse", "rat", "zebrafish", "worm", "yeast", "fruit fly"})
+
+
+def _strip_thinking(text: str) -> str:
+    """Remove ``<think>...</think>`` blocks from model output."""
+    return _THINK_PATTERN.sub("", text).strip()
 
 
 def _normalize_chromosome(text: str) -> str | None:
@@ -167,12 +173,12 @@ def _normalize_chromosome(text: str) -> str | None:
 
 def _extract_chromosome(text: str) -> str | None:
     """Extract chromosome from model output."""
-    return _normalize_chromosome(text)
+    return _normalize_chromosome(_strip_thinking(text))
 
 
 def _extract_boolean(text: str) -> str | None:
     """Map yes/no/true/false to TRUE/NA (protein-coding convention)."""
-    lower = text.strip().lower()
+    lower = _strip_thinking(text).strip().lower()
     # Check for explicit TRUE/NA first
     if "true" in lower and "na" not in lower:
         return "TRUE"
@@ -189,7 +195,7 @@ def _extract_boolean(text: str) -> str | None:
 
 def _extract_activation(text: str) -> str | None:
     """Extract Activation or Repression from model output."""
-    lower = text.lower()
+    lower = _strip_thinking(text).lower()
     has_activation = "activat" in lower
     has_repression = "repress" in lower
     if has_activation and not has_repression:
@@ -209,7 +215,7 @@ def _extract_activation(text: str) -> str | None:
 
 def _extract_sequence(text: str, pattern: re.Pattern[str]) -> str | None:
     """Extract the longest contiguous sequence matching the pattern."""
-    matches: list[str] = pattern.findall(text)
+    matches: list[str] = pattern.findall(_strip_thinking(text))
     if not matches:
         return None
     best = matches[0]
@@ -220,16 +226,21 @@ def _extract_sequence(text: str, pattern: re.Pattern[str]) -> str | None:
 
 
 def _extract_first_line_answer(text: str) -> str | None:
-    """Extract the first meaningful line, stripping common boilerplate."""
+    """Extract the first meaningful line, stripping thinking traces and boilerplate."""
+    text = _strip_thinking(text)
     lines = text.strip().split("\n")
     for line in lines:
         line = line.strip()
-        # Skip empty lines and common prefixes
+        # Strip markdown bold/italic
+        line = re.sub(r"\*{1,2}([^*]+)\*{1,2}", r"\1", line)
+        # Strip common verbose prefixes (e.g. "The official gene symbol is ...")
         line = re.sub(
-            r"^(the\s+(official\s+)?(gene\s+)?(symbol|name|answer)\s+(is|for)\s+[^:]*:\s*"
+            r"^(the\s+(official\s+)?(gene\s+)?(symbol|name|answer)\s+"
+            r"(is|for|of|corresponding to)\s+[^:]*?(is\s+|:\s*)"
             r"|based on[^,]*,\s*"
             r"|according to[^,]*,\s*"
-            r"|the\s+gene\s+symbol\s+for\s+.*?\s+is\s+)",
+            r"|the\s+gene\s+symbol\s+for\s+.*?\s+is\s+"
+            r"|the\s+official\s+gene\s+symbol\s+.*?\s+is\s+)",
             "",
             line,
             flags=re.IGNORECASE,
@@ -245,7 +256,7 @@ def _extract_first_line_answer(text: str) -> str | None:
 
 def _extract_species(text: str) -> str | None:
     """Extract a species name from model output."""
-    lower = text.lower()
+    lower = _strip_thinking(text).lower()
     for species in _KNOWN_SPECIES:
         if species in lower:
             return species
@@ -266,7 +277,7 @@ def _parse_name_set(text: str) -> set[str]:
 
 def _extract_gene_names(text: str) -> str | None:
     """Extract gene/protein names from model output for gene_name_extraction."""
-    lower = text.strip().lower()
+    lower = _strip_thinking(text).strip().lower()
     if "no gene" in lower or "no protein" in lower or lower.startswith("none"):
         return "No gene"
     return _extract_first_line_answer(text)

--- a/src/olmo_eval/evals/tasks/geneturing.py
+++ b/src/olmo_eval/evals/tasks/geneturing.py
@@ -248,7 +248,8 @@ def _extract_first_line_answer(text: str) -> str | None:
         # Strip trailing punctuation and parenthetical notes
         line = re.sub(r"\s*\(.*?\)\s*$", "", line)
         line = line.rstrip(".")
-        cleaned = line.strip()
+        # Take first sentence only ("GENE. This gene encodes..." → "GENE")
+        cleaned = line.split(". ")[0].strip()
         if cleaned:
             return cleaned
     return None

--- a/tests/evals/tasks/test_geneturing.py
+++ b/tests/evals/tasks/test_geneturing.py
@@ -1,0 +1,825 @@
+"""Tests for GeneTuring task scorers and extraction functions."""
+
+import pytest
+
+from olmo_eval.common.metrics import AccuracyMetric
+from olmo_eval.common.scorers import ExactMatchScorer
+from olmo_eval.common.types import Instance, LMOutput, LMRequest, RequestType, Response
+from olmo_eval.evals.tasks.common import get_task, list_tasks
+from olmo_eval.evals.tasks.geneturing import (
+    _AMINO_ACID_PATTERN,
+    _DEFAULT_SAMPLING,
+    _DNA_PATTERN,
+    _SHORT_ANSWER_SAMPLING,
+    ChromosomeScorer,
+    ContainmentScorer,
+    GeneRecallScorer,
+    JaccardScorer,
+    MeanScoreMetric,
+    SetRecallScorer,
+    SpeciesScorer,
+    _extract_activation,
+    _extract_boolean,
+    _extract_chromosome,
+    _extract_first_line_answer,
+    _extract_gene_names,
+    _extract_gene_symbols,
+    _extract_go_term,
+    _extract_sequence,
+    _extract_species,
+    _normalize_chromosome,
+    _parse_name_set,
+    _strip_thinking,
+)
+
+
+@pytest.fixture(autouse=True)
+def _setup_registry():
+    import olmo_eval.evals.tasks  # noqa: F401
+
+
+# =============================================================================
+# Extraction Functions
+# =============================================================================
+
+
+class TestStripThinking:
+    def test_removes_think_block(self):
+        text = "<think>reasoning here</think>\nThe answer is 42."
+        assert _strip_thinking(text) == "The answer is 42."
+
+    def test_removes_multiline_think_block(self):
+        text = "<think>\nline 1\nline 2\n</think>\nAnswer"
+        assert _strip_thinking(text) == "Answer"
+
+    def test_no_think_block(self):
+        assert _strip_thinking("plain text") == "plain text"
+
+    def test_empty_string(self):
+        assert _strip_thinking("") == ""
+
+    def test_multiple_think_blocks(self):
+        text = "<think>first</think> middle <think>second</think> end"
+        assert _strip_thinking(text) == "middle end"
+
+
+class TestNormalizeChromosome:
+    def test_chr_format(self):
+        assert _normalize_chromosome("chr18") == "chr18"
+
+    def test_chromosome_word(self):
+        assert _normalize_chromosome("chromosome 7") == "chr7"
+
+    def test_bare_number(self):
+        assert _normalize_chromosome("18") == "chr18"
+
+    def test_bare_x(self):
+        assert _normalize_chromosome("X") == "chrX"
+
+    def test_bare_y(self):
+        assert _normalize_chromosome("Y") == "chrY"
+
+    def test_lowercase_x(self):
+        assert _normalize_chromosome("chrx") == "chrX"
+
+    def test_no_match(self):
+        assert _normalize_chromosome("not a chromosome") is None
+
+    def test_embedded_in_text(self):
+        assert _normalize_chromosome("located on chr3p21") == "chr3"
+
+
+class TestExtractChromosome:
+    def test_with_thinking(self):
+        text = "<think>let me think</think>\nchromosome 5"
+        assert _extract_chromosome(text) == "chr5"
+
+    def test_plain(self):
+        assert _extract_chromosome("chr12") == "chr12"
+
+
+class TestExtractBoolean:
+    def test_true(self):
+        assert _extract_boolean("TRUE") == "TRUE"
+
+    def test_yes(self):
+        assert _extract_boolean("Yes, it is protein-coding.") == "TRUE"
+
+    def test_na(self):
+        assert _extract_boolean("NA") == "NA"
+
+    def test_no(self):
+        assert _extract_boolean("No, it is not protein-coding.") == "NA"
+
+    def test_non_coding_phrase(self):
+        assert _extract_boolean("This is a non-coding RNA gene.") == "NA"
+
+    def test_not_a_protein(self):
+        assert _extract_boolean("It is not a protein-coding gene.") == "NA"
+
+    def test_with_thinking(self):
+        text = "<think>hmm</think>\nYes"
+        assert _extract_boolean(text) == "TRUE"
+
+    def test_false(self):
+        assert _extract_boolean("False") == "NA"
+
+    def test_false_in_sentence(self):
+        assert _extract_boolean("It is false that this gene is protein-coding.") == "NA"
+
+    def test_n_slash_a(self):
+        assert _extract_boolean("N/A") == "NA"
+
+    def test_not_protein_coding(self):
+        assert _extract_boolean("This gene is not protein-coding.") == "NA"
+
+    def test_ambiguous(self):
+        assert _extract_boolean("I'm not sure about this gene.") is None
+
+
+class TestExtractActivation:
+    def test_activation(self):
+        assert _extract_activation("Activation") == "Activation"
+
+    def test_repression(self):
+        assert _extract_activation("Repression") == "Repression"
+
+    def test_activates_keyword(self):
+        assert _extract_activation("The TF activates the gene.") == "Activation"
+
+    def test_represses_keyword(self):
+        assert _extract_activation("The TF represses the gene.") == "Repression"
+
+    def test_both_activation_first(self):
+        text = "It activates some genes but represses this one."
+        assert _extract_activation(text) == "Activation"
+
+    def test_both_repression_first(self):
+        text = "It represses this gene, not activates it."
+        assert _extract_activation(text) == "Repression"
+
+    def test_neither(self):
+        assert _extract_activation("This gene does something.") is None
+
+    def test_with_thinking(self):
+        text = "<think>reasoning about repression</think>\nActivation"
+        assert _extract_activation(text) == "Activation"
+
+
+class TestExtractSequence:
+    def test_amino_acid_sequence(self):
+        text = "The protein sequence is MKWVTFISLLFLFSSAYS"
+        result = _extract_sequence(text, _AMINO_ACID_PATTERN)
+        assert result == "MKWVTFISLLFLFSSAYS"
+
+    def test_dna_sequence(self):
+        text = "The DNA is ACGTACGTACGT"
+        result = _extract_sequence(text, _DNA_PATTERN)
+        assert result == "ACGTACGTACGT"
+
+    def test_longest_match(self):
+        text = "Short ACGTACGTAC and longer ACGTACGTACGTACGTACGT"
+        result = _extract_sequence(text, _DNA_PATTERN)
+        assert result == "ACGTACGTACGTACGTACGT"
+
+    def test_no_match(self):
+        assert _extract_sequence("no sequences here", _DNA_PATTERN) is None
+
+    def test_uppercases_result(self):
+        text = "The sequence is acgtacgtacgt"
+        result = _extract_sequence(text, _DNA_PATTERN)
+        assert result == "ACGTACGTACGT"
+
+    def test_with_thinking(self):
+        text = "<think>ACGTACGTACGTACGTACGTACGT</think>\nacgtacgtacgt"
+        # Think block stripped, so only the shorter one outside is found
+        result = _extract_sequence(text, _DNA_PATTERN)
+        assert result == "ACGTACGTACGT"
+
+
+class TestExtractFirstLineAnswer:
+    def test_simple_answer(self):
+        assert _extract_first_line_answer("BRCA1") == "BRCA1"
+
+    def test_strips_bold(self):
+        assert _extract_first_line_answer("**BRCA1**") == "BRCA1"
+
+    def test_strips_verbose_prefix(self):
+        text = "The gene symbol for ENSG00000141510 is BRCA1."
+        assert _extract_first_line_answer(text) == "BRCA1"
+
+    def test_takes_first_sentence(self):
+        text = "BRCA1. This gene encodes a tumor suppressor."
+        assert _extract_first_line_answer(text) == "BRCA1"
+
+    def test_strips_parenthetical(self):
+        text = "PTK7 (Protein Tyrosine Kinase 7)"
+        assert _extract_first_line_answer(text) == "PTK7"
+
+    def test_strips_thinking(self):
+        text = "<think>thinking</think>\nTP53"
+        assert _extract_first_line_answer(text) == "TP53"
+
+    def test_skips_blank_lines(self):
+        text = "\n\n  \nBRCA2"
+        assert _extract_first_line_answer(text) == "BRCA2"
+
+    def test_strips_ensembl_prefix(self):
+        text = "The Ensembl gene identifier ENSG00000141510 corresponds to TP53"
+        assert _extract_first_line_answer(text) == "TP53"
+
+    def test_strips_snp_association_prefix(self):
+        text = "The SNP rs1234 is associated with the gene BRCA1"
+        assert _extract_first_line_answer(text) == "BRCA1"
+
+    def test_based_on_prefix(self):
+        text = "Based on current databases, BRCA1 is the gene."
+        assert _extract_first_line_answer(text) == "BRCA1 is the gene"
+
+    def test_empty_string(self):
+        assert _extract_first_line_answer("") is None
+
+    def test_whitespace_only(self):
+        assert _extract_first_line_answer("   ") is None
+
+
+class TestExtractSpecies:
+    def test_simple_species(self):
+        assert _extract_species("human") == "human"
+
+    def test_species_in_sentence(self):
+        assert _extract_species("This sequence is from a mouse.") == "mouse"
+
+    def test_scientific_name(self):
+        assert _extract_species("Homo sapiens genome") == "human"
+
+    def test_abbreviated_scientific_name(self):
+        assert _extract_species("Found in C. elegans") == "worm"
+
+    def test_chicken(self):
+        assert _extract_species("Gallus gallus domesticus") == "chicken"
+
+    def test_last_mention_wins(self):
+        text = "Could be human but is actually mouse"
+        assert _extract_species(text) == "mouse"
+
+    def test_drosophila_alias(self):
+        assert _extract_species("Drosophila melanogaster") == "fruit fly"
+
+    def test_yeast_scientific(self):
+        assert _extract_species("Saccharomyces cerevisiae") == "yeast"
+
+    def test_no_species(self):
+        assert _extract_species("no species mentioned here") is None
+
+    def test_with_thinking(self):
+        text = "<think>could be human</think>\nmouse"
+        assert _extract_species(text) == "mouse"
+
+
+class TestParseNameSet:
+    def test_comma_separated(self):
+        assert _parse_name_set("BRCA1, TP53, EGFR") == {"brca1", "tp53", "egfr"}
+
+    def test_semicolon_separated(self):
+        assert _parse_name_set("BRCA1; TP53") == {"brca1", "tp53"}
+
+    def test_and_separator(self):
+        assert _parse_name_set("BRCA1 and TP53") == {"brca1", "tp53"}
+
+    def test_filters_none(self):
+        assert _parse_name_set("None") == set()
+
+    def test_filters_no_gene(self):
+        assert _parse_name_set("No gene") == set()
+
+    def test_empty_string(self):
+        assert _parse_name_set("") == set()
+
+    def test_strips_periods(self):
+        assert _parse_name_set("BRCA1.") == {"brca1"}
+
+
+class TestExtractGeneNames:
+    def test_no_gene(self):
+        assert _extract_gene_names("No gene or protein mentioned.") == "No gene"
+
+    def test_no_protein(self):
+        assert _extract_gene_names("No protein is referenced.") == "No gene"
+
+    def test_none_answer(self):
+        assert _extract_gene_names("None") == "No gene"
+
+    def test_extracts_gene(self):
+        result = _extract_gene_names("BRCA1")
+        assert result is not None
+        assert "BRCA1" in result
+
+
+class TestExtractGeneSymbols:
+    def test_bold_genes(self):
+        text = "The associated genes are **BRCA1**, **TP53**, and **EGFR**."
+        result = _extract_gene_symbols(text)
+        assert result == "BRCA1, TP53, EGFR"
+
+    def test_uppercase_tokens(self):
+        text = "Genes include BRCA1 and TP53 in this pathway."
+        result = _extract_gene_symbols(text)
+        assert result is not None
+        assert "BRCA1" in result
+        assert "TP53" in result
+
+    def test_filters_common_words(self):
+        text = "THE GENE BRCA1 AND TP53 ARE ASSOCIATED WITH DNA REPAIR."
+        result = _extract_gene_symbols(text)
+        assert result is not None
+        assert "BRCA1" in result
+        assert "TP53" in result
+        assert "THE" not in result
+        assert "AND" not in result
+        assert "DNA" not in result
+        assert "ARE" not in result
+
+    def test_prefers_bold(self):
+        # When bold symbols exist, plain uppercase tokens are ignored
+        text = "EGFR is mentioned but **BRCA1** is the answer."
+        result = _extract_gene_symbols(text)
+        assert result == "BRCA1"
+
+    def test_no_genes(self):
+        assert _extract_gene_symbols("this has no gene symbols") is None
+
+    def test_with_thinking(self):
+        text = "<think>**TP53** is relevant</think>\n**BRCA1** is the gene."
+        result = _extract_gene_symbols(text)
+        assert result == "BRCA1"
+
+    def test_deduplicates(self):
+        text = "BRCA1 is mentioned, and BRCA1 again, also TP53."
+        result = _extract_gene_symbols(text)
+        assert result is not None
+        assert result.count("BRCA1") == 1
+
+
+class TestExtractGoTerm:
+    def test_quoted_after_is(self):
+        text = 'The enriched GO term is "lipid metabolic process".'
+        assert _extract_go_term(text) == "lipid metabolic process"
+
+    def test_unicode_quotes(self):
+        text = "The enriched GO term is \u201clipid metabolic process\u201d."
+        assert _extract_go_term(text) == "lipid metabolic process"
+
+    def test_bold_after_is(self):
+        text = "The enriched GO term is **lipid metabolic process**."
+        assert _extract_go_term(text) == "lipid metabolic process"
+
+    def test_bold_strips_go_id(self):
+        text = "The enriched GO term is **lipid metabolic process (GO:0006629)**."
+        assert _extract_go_term(text) == "lipid metabolic process"
+
+    def test_quoted_string_fallback(self):
+        text = 'These genes share "signal transduction" as a common function.'
+        assert _extract_go_term(text) == "signal transduction"
+
+    def test_is_likely_quoted(self):
+        text = 'The enriched GO term is likely "cell adhesion".'
+        assert _extract_go_term(text) == "cell adhesion"
+
+    def test_falls_back_to_first_line(self):
+        text = "lipid metabolic process"
+        assert _extract_go_term(text) == "lipid metabolic process"
+
+    def test_with_thinking(self):
+        text = '<think>"thinking term"</think>\nThe term is "signal transduction".'
+        assert _extract_go_term(text) == "signal transduction"
+
+    def test_skips_go_id_only_quotes(self):
+        text = '"GO:0006629" is the GO ID. The term is "lipid metabolic process".'
+        assert _extract_go_term(text) == "lipid metabolic process"
+
+
+# =============================================================================
+# Scorers
+# =============================================================================
+
+
+class TestChromosomeScorer:
+    def setup_method(self):
+        self.scorer = ChromosomeScorer()
+
+    def _score(self, gold: str, extracted: str) -> float:
+        instance = Instance(question="Q", gold_answer=gold)
+        output = LMOutput(text="")
+        output.extracted_answer = extracted
+        return self.scorer.score(instance, output)
+
+    def test_exact_match(self):
+        assert self._score("chr18", "chr18") == 1.0
+
+    def test_normalized_match(self):
+        assert self._score("18", "chromosome 18") == 1.0
+
+    def test_mismatch(self):
+        assert self._score("chr18", "chr7") == 0.0
+
+    def test_x_chromosome(self):
+        assert self._score("chrX", "X") == 1.0
+
+    def test_none_gold(self):
+        instance = Instance(question="Q", gold_answer=None)
+        output = LMOutput(text="")
+        output.extracted_answer = "chr1"
+        assert self.scorer.score(instance, output) == 0.0
+
+    def test_none_extracted(self):
+        instance = Instance(question="Q", gold_answer="chr1")
+        output = LMOutput(text="")
+        output.extracted_answer = None
+        assert self.scorer.score(instance, output) == 0.0
+
+    def test_unparseable_gold(self):
+        assert self._score("not a chromosome", "chr1") == 0.0
+
+    def test_name(self):
+        assert self.scorer.name == "chromosome"
+
+
+class TestJaccardScorer:
+    def setup_method(self):
+        self.scorer = JaccardScorer()
+
+    def _score(self, gold: str, extracted: str) -> float:
+        instance = Instance(question="Q", gold_answer=gold)
+        output = LMOutput(text="")
+        output.extracted_answer = extracted
+        return self.scorer.score(instance, output)
+
+    def test_exact_match(self):
+        assert self._score("BRCA1, TP53", "BRCA1, TP53") == 1.0
+
+    def test_partial_overlap(self):
+        # gold={brca1, tp53}, pred={brca1, egfr} → intersection=1, union=3
+        assert self._score("BRCA1, TP53", "BRCA1, EGFR") == pytest.approx(1 / 3)
+
+    def test_no_overlap(self):
+        assert self._score("BRCA1, TP53", "EGFR, KRAS") == 0.0
+
+    def test_both_empty(self):
+        assert self._score("", "") == 1.0
+
+    def test_gold_empty_pred_nonempty(self):
+        assert self._score("", "BRCA1") == 0.0
+
+    def test_none_gold(self):
+        instance = Instance(question="Q", gold_answer=None)
+        output = LMOutput(text="")
+        output.extracted_answer = "BRCA1"
+        assert self.scorer.score(instance, output) == 0.0
+
+    def test_none_extracted(self):
+        instance = Instance(question="Q", gold_answer="BRCA1")
+        output = LMOutput(text="")
+        output.extracted_answer = None
+        assert self.scorer.score(instance, output) == 0.0
+
+    def test_name(self):
+        assert self.scorer.name == "jaccard"
+
+
+class TestSetRecallScorer:
+    def setup_method(self):
+        self.scorer = SetRecallScorer()
+
+    def _score(self, gold: str, extracted: str) -> float:
+        instance = Instance(question="Q", gold_answer=gold)
+        output = LMOutput(text="")
+        output.extracted_answer = extracted
+        return self.scorer.score(instance, output)
+
+    def test_full_recall(self):
+        assert self._score("BRCA1, TP53", "BRCA1, TP53, EGFR") == 1.0
+
+    def test_partial_recall(self):
+        assert self._score("BRCA1, TP53", "BRCA1") == pytest.approx(0.5)
+
+    def test_zero_recall(self):
+        assert self._score("BRCA1, TP53", "EGFR") == 0.0
+
+    def test_empty_gold_empty_pred(self):
+        assert self._score("", "") == 1.0
+
+    def test_empty_gold_nonempty_pred(self):
+        assert self._score("", "BRCA1") == 0.0
+
+    def test_none_gold(self):
+        instance = Instance(question="Q", gold_answer=None)
+        output = LMOutput(text="")
+        output.extracted_answer = "BRCA1"
+        assert self.scorer.score(instance, output) == 0.0
+
+    def test_none_extracted(self):
+        instance = Instance(question="Q", gold_answer="BRCA1")
+        output = LMOutput(text="")
+        output.extracted_answer = None
+        assert self.scorer.score(instance, output) == 0.0
+
+    def test_name(self):
+        assert self.scorer.name == "set_recall"
+
+
+class TestGeneRecallScorer:
+    def setup_method(self):
+        self.scorer = GeneRecallScorer()
+
+    def _score(self, gold: str, raw_text: str) -> float:
+        instance = Instance(question="Q", gold_answer=gold)
+        output = LMOutput(text=raw_text)
+        return self.scorer.score(instance, output)
+
+    def test_all_found(self):
+        assert self._score("BRCA1, TP53", "The genes BRCA1 and TP53 are relevant.") == 1.0
+
+    def test_partial_found(self):
+        assert self._score("BRCA1, TP53", "Only BRCA1 is relevant.") == pytest.approx(0.5)
+
+    def test_none_found(self):
+        assert self._score("BRCA1, TP53", "No relevant genes.") == 0.0
+
+    def test_case_insensitive(self):
+        assert self._score("BRCA1", "the gene brca1 is mentioned") == 1.0
+
+    def test_strips_thinking(self):
+        text = "<think>BRCA1 in thinking</think>\nNo genes mentioned."
+        # BRCA1 is only in the think block, which gets stripped
+        assert self._score("BRCA1", text) == 0.0
+
+    def test_checks_raw_text_not_extracted(self):
+        """Scorer checks raw output text, not extracted_answer."""
+        instance = Instance(question="Q", gold_answer="BRCA1")
+        output = LMOutput(text="BRCA1 is the gene.")
+        output.extracted_answer = "something else"
+        assert self.scorer.score(instance, output) == 1.0
+
+    def test_none_gold(self):
+        instance = Instance(question="Q", gold_answer=None)
+        output = LMOutput(text="BRCA1")
+        assert self.scorer.score(instance, output) == 0.0
+
+    def test_semicolon_separated_gold(self):
+        assert self._score("BRCA1; TP53", "BRCA1 and TP53") == 1.0
+
+    def test_word_boundary_no_false_positive(self):
+        """BRCA1 should not match BRCA10 or BRCA1P."""
+        assert self._score("BRCA1", "The gene BRCA10 was found.") == 0.0
+
+    def test_word_boundary_correct_match(self):
+        """BRCA1 should still match when bounded by non-word chars."""
+        assert self._score("BRCA1", "Found BRCA1, TP53.") == 1.0
+
+    def test_name(self):
+        assert self.scorer.name == "gene_recall"
+
+
+class TestContainmentScorer:
+    def setup_method(self):
+        self.scorer = ContainmentScorer()
+
+    def _score(self, gold: str, extracted: str) -> float:
+        instance = Instance(question="Q", gold_answer=gold)
+        output = LMOutput(text="")
+        output.extracted_answer = extracted
+        return self.scorer.score(instance, output)
+
+    def test_exact_match(self):
+        assert self._score("lipid metabolic process", "lipid metabolic process") == 1.0
+
+    def test_case_insensitive_exact(self):
+        assert self._score("Lipid Metabolic Process", "lipid metabolic process") == 1.0
+
+    def test_gold_in_pred(self):
+        assert self._score("cell adhesion", "regulation of cell adhesion") == 0.5
+
+    def test_pred_in_gold(self):
+        assert self._score("regulation of cell adhesion", "cell adhesion") == 0.5
+
+    def test_no_match(self):
+        assert self._score("lipid metabolic process", "DNA repair") == 0.0
+
+    def test_none_gold(self):
+        instance = Instance(question="Q", gold_answer=None)
+        output = LMOutput(text="")
+        output.extracted_answer = "something"
+        assert self.scorer.score(instance, output) == 0.0
+
+    def test_none_extracted(self):
+        instance = Instance(question="Q", gold_answer="something")
+        output = LMOutput(text="")
+        output.extracted_answer = None
+        assert self.scorer.score(instance, output) == 0.0
+
+    def test_name(self):
+        assert self.scorer.name == "containment"
+
+
+class TestSpeciesScorer:
+    def setup_method(self):
+        self.scorer = SpeciesScorer()
+
+    def test_exact_match(self):
+        instance = Instance(question="Q", gold_answer="human")
+        output = LMOutput(text="human")
+        output.extracted_answer = "human"
+        assert self.scorer.score(instance, output) == 1.0
+
+    def test_partial_credit_in_raw(self):
+        instance = Instance(question="Q", gold_answer="human")
+        output = LMOutput(text="This sequence is from a human genome.")
+        output.extracted_answer = "mouse"  # wrong extraction
+        assert self.scorer.score(instance, output) == 0.5
+
+    def test_alias_partial_credit(self):
+        """Gold is 'worm', raw text says 'C. elegans' → 0.5."""
+        instance = Instance(question="Q", gold_answer="worm")
+        output = LMOutput(text="The sequence is from C. elegans.")
+        output.extracted_answer = "nematode"
+        assert self.scorer.score(instance, output) == 0.5
+
+    def test_no_match(self):
+        instance = Instance(question="Q", gold_answer="human")
+        output = LMOutput(text="This is from mouse genome.")
+        output.extracted_answer = "mouse"
+        assert self.scorer.score(instance, output) == 0.0
+
+    def test_none_gold(self):
+        instance = Instance(question="Q", gold_answer=None)
+        output = LMOutput(text="human")
+        assert self.scorer.score(instance, output) == 0.0
+
+    def test_strips_thinking_for_raw_check(self):
+        instance = Instance(question="Q", gold_answer="human")
+        output = LMOutput(text="<think>human is likely</think>\nmouse")
+        output.extracted_answer = "mouse"
+        # "human" is only in think block, should be stripped
+        assert self.scorer.score(instance, output) == 0.0
+
+    def test_name(self):
+        assert self.scorer.name == "species"
+
+
+# =============================================================================
+# MeanScoreMetric
+# =============================================================================
+
+
+class TestMeanScoreMetric:
+    def _make_response(self, score: float, scorer_name: str = "jaccard") -> Response:
+        return Response(
+            instance=Instance(question="Q", gold_answer="A"),
+            request=LMRequest(request_type=RequestType.CHAT, messages=()),
+            outputs=[LMOutput(text="")],
+            scores={scorer_name: score},
+        )
+
+    def test_mean_of_scores(self):
+        metric = MeanScoreMetric(name="jaccard", scorer=JaccardScorer)
+        responses = [
+            self._make_response(1.0),
+            self._make_response(0.5),
+            self._make_response(0.0),
+        ]
+        assert metric.compute(responses) == pytest.approx(0.5)
+
+    def test_empty_responses(self):
+        metric = MeanScoreMetric(name="jaccard", scorer=JaccardScorer)
+        assert metric.compute([]) == 0.0
+
+    def test_missing_scorer_key_defaults_zero(self):
+        metric = MeanScoreMetric(name="jaccard", scorer=JaccardScorer)
+        responses = [self._make_response(0.0, scorer_name="other_scorer")]
+        assert metric.compute(responses) == 0.0
+
+
+# =============================================================================
+# Task Registration and Wiring
+# =============================================================================
+
+_ALL_TASKS = (
+    "geneturing_gene_name_conversion",
+    "geneturing_gene_location",
+    "geneturing_snp_location",
+    "geneturing_gene_snp_association",
+    "geneturing_protein_coding_genes",
+    "geneturing_tf_regulation",
+    "geneturing_human_genome_dna_alignment",
+    "geneturing_amino_acid_translation",
+    "geneturing_dna_sequence_extraction",
+    "geneturing_gene_name_extraction",
+    "geneturing_gene_alias",
+    "geneturing_gene_disease_association",
+    "geneturing_gene_ontology",
+    "geneturing_multi_species_dna_alignment",
+)
+
+
+class TestTaskRegistration:
+    @pytest.mark.parametrize("task_name", _ALL_TASKS)
+    def test_task_registered(self, task_name):
+        assert task_name in list_tasks()
+
+    @pytest.mark.parametrize("task_name", _ALL_TASKS)
+    def test_get_task(self, task_name):
+        task = get_task(task_name)
+        assert task.config.name == task_name
+
+
+class TestTaskWiring:
+    """Verify each task has the correct scorer, metric, formatter, and sampling_params."""
+
+    @pytest.mark.parametrize(
+        "task_name, expected_scorer",
+        [
+            ("geneturing_gene_name_conversion", ExactMatchScorer),
+            ("geneturing_gene_location", ChromosomeScorer),
+            ("geneturing_snp_location", ChromosomeScorer),
+            ("geneturing_gene_snp_association", ExactMatchScorer),
+            ("geneturing_protein_coding_genes", ExactMatchScorer),
+            ("geneturing_tf_regulation", ExactMatchScorer),
+            ("geneturing_human_genome_dna_alignment", ChromosomeScorer),
+            ("geneturing_amino_acid_translation", ExactMatchScorer),
+            ("geneturing_dna_sequence_extraction", ExactMatchScorer),
+            ("geneturing_gene_name_extraction", JaccardScorer),
+            ("geneturing_gene_alias", JaccardScorer),
+            ("geneturing_gene_disease_association", GeneRecallScorer),
+            ("geneturing_gene_ontology", ContainmentScorer),
+            ("geneturing_multi_species_dna_alignment", SpeciesScorer),
+        ],
+    )
+    def test_scorer_type(self, task_name, expected_scorer):
+        task = get_task(task_name)
+        metric = task.config.primary_metric
+        if isinstance(metric, AccuracyMetric):
+            assert metric.scorer == expected_scorer
+        else:
+            assert isinstance(metric, MeanScoreMetric)
+            assert metric.scorer == expected_scorer
+
+    @pytest.mark.parametrize(
+        "task_name, expected_metric_name",
+        [
+            ("geneturing_gene_name_conversion", "accuracy"),
+            ("geneturing_gene_location", "accuracy"),
+            ("geneturing_gene_name_extraction", "jaccard"),
+            ("geneturing_gene_alias", "jaccard"),
+            ("geneturing_gene_disease_association", "recall"),
+            ("geneturing_gene_ontology", "containment"),
+            ("geneturing_multi_species_dna_alignment", "species"),
+        ],
+    )
+    def test_metric_name(self, task_name, expected_metric_name):
+        task = get_task(task_name)
+        assert task.config.primary_metric.name == expected_metric_name
+
+    @pytest.mark.parametrize(
+        "task_name",
+        [
+            "geneturing_amino_acid_translation",
+            "geneturing_multi_species_dna_alignment",
+        ],
+    )
+    def test_short_answer_sampling(self, task_name):
+        task = get_task(task_name)
+        assert task.config.sampling_params.max_tokens == _SHORT_ANSWER_SAMPLING.max_tokens
+
+    @pytest.mark.parametrize(
+        "task_name",
+        [
+            "geneturing_gene_name_conversion",
+            "geneturing_gene_location",
+            "geneturing_dna_sequence_extraction",
+        ],
+    )
+    def test_default_sampling(self, task_name):
+        task = get_task(task_name)
+        assert task.config.sampling_params.max_tokens == _DEFAULT_SAMPLING.max_tokens
+
+    @pytest.mark.parametrize(
+        "task_name",
+        [
+            "geneturing_protein_coding_genes",
+            "geneturing_tf_regulation",
+            "geneturing_gene_disease_association",
+            "geneturing_gene_alias",
+            "geneturing_gene_ontology",
+            "geneturing_multi_species_dna_alignment",
+        ],
+    )
+    def test_custom_formatter(self, task_name):
+        """Tasks with custom formatters should not use the default system prompt."""
+        task = get_task(task_name)
+        default_prompt = (
+            "You are a genomics expert. Answer the following question "
+            "concisely and accurately.\n"
+            "Give only the answer with no explanation unless asked."
+        )
+        assert task.config.formatter.system_prompt != default_prompt


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->

## Type of Change

<!-- Put an `x` in all the boxes that apply -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Testing

<!-- Describe how you tested your changes -->

- [x] Unit tests pass locally (`pytest tests/ --ignore=tests/integration/`)
- [x] Integration tests pass (if applicable)
- [x] New tests added for new functionality

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published


## Summary

- Add GeneTuring genomics Q&A benchmark: 14 tasks, 1,400 questions spanning gene nomenclature, genomic location, sequence alignment, functional analysis, and more
- Implement 6 custom scorers (`ChromosomeScorer`, `JaccardScorer`, `SetRecallScorer`, `GeneRecallScorer`, `ContainmentScorer`, `SpeciesScorer`) aligned with the original paper's methodology
- Add 203 unit tests covering all extraction functions, scorers, metrics, and task-level wiring
- Register `geneturing` suite and combined biology meta-suite (LAB-Bench + GeneTuring)

## Dataset

- Source: Hou & Ji, 2024 (bioRxiv 2023.03.11.532238), supplementary data (Excel)
- HuggingFace: [allenai/geneturing](https://huggingface.co/datasets/allenai/geneturing) (private, CC-BY-4.0)
- Structure: 16 subsets, 100 questions each, schema {id, question, gold_answer}
- Implemented: 14 of 16 modules. The two omitted modules (gene_network_analysis and gene_network_visualization) require executing model-generated Python code against live APIs (STRING, KEGG), which is a bit of a stretch right now.

## Scoring methodology

Scoring follows the paper's per-task methodology:

###  Tier: Exact match
- Tasks: `gene_name_conversion`, `gene_snp_association`, `protein_coding_genes`, `tf_regulation`, `amino_acid_translation`, `dna_sequence_extraction`
- Scorer: `ExactMatchScorer`
- Metric: `accuracy`
  
### Tier: Chromosome
- Tasks: `gene_location`, `snp_location`, `human_genome_dna_alignment`
- Scorer: `ChromosomeScorer` (normalize to `chr<N>` notation)
- Metric: `accuracy`

### Tier: Set overlap
- Tasks: `gene_name_extraction`, `gene_alias`
- Scorer: `JaccardScorer`
- Metric: `jaccard`

### Tier: Gene recall
- Tasks: `gene_disease_association`
- Scorer: `GeneRecallScorer` (word-boundary match in raw output)
- Metric: `recall`

### Tier: Containment
- Tasks: `gene_ontology`
- Scorer: `ContainmentScorer` (1.0 exact / 0.5 partial)
- Metric: `containment`

### Tier: Species
- Tasks: `multi_species_dna_alignment`
- Scorer: `SpeciesScorer` (1.0 exact / 0.5 if gold in output, with scientific name aliases)
- Metric: `species`

## Baseline results (Qwen3-8B)

```
  ┌─────────────────────────────┬───────┬───────────────────────────────────────┐
  │            Task             │ Score │                 Notes                 │
  ├─────────────────────────────┼───────┼───────────────────────────────────────┤
  │ protein_coding_genes        │ 0.71  │                                       │
  ├─────────────────────────────┼───────┼───────────────────────────────────────┤
  │ tf_regulation               │ 0.67  │                                       │
  ├─────────────────────────────┼───────┼───────────────────────────────────────┤
  │ gene_name_extraction        │ 0.38  │                                       │
  ├─────────────────────────────┼───────┼───────────────────────────────────────┤
  │ gene_disease_association    │ 0.26  │                                       │
  ├─────────────────────────────┼───────┼───────────────────────────────────────┤
  │ multi_species_dna_alignment │ 0.11  │ 82/100 timed out (long DNA prefill)   │
  ├─────────────────────────────┼───────┼───────────────────────────────────────┤
  │ gene_location               │ 0.10  │                                       │
  ├─────────────────────────────┼───────┼───────────────────────────────────────┤
  │ gene_alias                  │ 0.09  │                                       │
  ├─────────────────────────────┼───────┼───────────────────────────────────────┤
  │ human_genome_dna_alignment  │ 0.06  │                                       │
  ├─────────────────────────────┼───────┼───────────────────────────────────────┤
  │ snp_location                │ 0.03  │                                       │
  ├─────────────────────────────┼───────┼───────────────────────────────────────┤
  │ gene_ontology               │ 0.02  │                                       │
  ├─────────────────────────────┼───────┼───────────────────────────────────────┤
  │ gene_name_conversion        │ 0.00  │ Model hallucinates wrong gene symbols │
  ├─────────────────────────────┼───────┼───────────────────────────────────────┤
  │ gene_snp_association        │ 0.00  │ Model refuses / confabulates          │
  ├─────────────────────────────┼───────┼───────────────────────────────────────┤
  │ dna_sequence_extraction     │ 0.00  │ Extraction failures on long outputs   │
  ├─────────────────────────────┼───────┼───────────────────────────────────────┤
  │ amino_acid_translation      │ ERROR │ 100/100 timed out (long DNA prefill)  │
  └─────────────────────────────┴───────┴───────────────────────────────────────┘
```

## Files changed

- `src/olmo_eval/evals/tasks/geneturing.py` — new (786 lines): 14 task classes, 6 scorers, extraction helpers
- `src/olmo_eval/evals/suites/biology.py` — modified (+37 lines): GeneTuring suite + combined biology suite
- `tests/evals/tasks/test_geneturing.py` — new: 203 unit tests

## Tests

- `uv run pytest tests/evals/tasks/test_geneturing.py` — 203 pass
- `make lint` — clean
- Beaker end-to-end run with Qwen3-8B (geneturing_all_qwen3_8b_v2)