### PR TITLE
Fix vLLM temperature

### DIFF
--- a/src/olmo_eval/inference/providers/vllm.py
+++ b/src/olmo_eval/inference/providers/vllm.py
@@ -193,7 +193,7 @@ class VLLMProvider(InferenceProvider):
             "n": params.num_samples,
         }
 
-        if params.temperature > 0:
+        if params.temperature is not None:
             kwargs["temperature"] = params.temperature
         if params.top_p is not None:
             kwargs["top_p"] = params.top_p


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->

Note:
vLLM default temperature is 1.0. Currently, if `params.temperature` is `0`, then vLLM receives no temperature argument and uses its default value.

## Type of Change

<!-- Put an `x` in all the boxes that apply -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Testing

<!-- Describe how you tested your changes -->

- [ ] Unit tests pass locally (`pytest tests/ --ignore=tests/integration/`)
- [ ] Integration tests pass (if applicable)
- [ ] New tests added for new functionality

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added/updated documentation as needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published


