### PR TITLE
Add opt-in real-dataset oracle no-GPU task pipeline tests

### DIFF
--- a/plans/001_oracle_no_gpu_task_pipeline_tests.md
+++ b/plans/001_oracle_no_gpu_task_pipeline_tests.md
@@ -1,0 +1,64 @@
+# No-GPU Oracle-vs-Corrupted Task Tests (Real Dataset Instances)
+
+## Summary
+Add deterministic no-GPU task-pipeline tests for:
+- `humaneval:bpb`
+- `lab_bench_litqa2:mc`
+- `minerva_math_algebra` (default end-task metric)
+
+Each test follows the same pattern:
+1. Build real requests from loaded task instances.
+2. Build perfect synthetic responses.
+3. Build corrupted synthetic responses.
+4. Score both and assert corrupted performance is lower.
+
+Execution mode:
+- Tests are **opt-in** and non-blocking by default.
+- They run only when `RUN_REAL_DATASET_TESTS=1` is set.
+- Without that env var, tests are collected and skipped.
+
+## Placement
+- Test file: `tests/evals/tasks/test_oracle_no_gpu_pipeline.py`
+- Rationale: validates concrete task formatting/extraction/scoring contracts.
+
+## Data source policy
+- Use **real dataset instances** loaded from `task.instances` for all three tasks.
+- Do **not** use synthetic fallback instances if dataset loading fails.
+- Keep these checks non-blocking for normal CI via skip-by-default gating.
+
+## Task-specific behavior
+
+### humaneval:bpb
+- Request type: `LOGLIKELIHOOD` with one continuation.
+- Perfect: continuation text with mild token logprobs.
+- Corrupted: same continuation text with degraded logprobs on selected tokens.
+- Metric comparison: BPB quality uses `-bits_per_byte` (higher is better).
+
+### lab_bench_litqa2:mc
+- Request type: `LOGLIKELIHOOD` with one continuation per choice.
+- Perfect: highest `total_logprob` at gold choice index.
+- Corrupted: highest `total_logprob` at deterministic non-gold index.
+- Metric comparison: accuracy (`accuracy.multiple_choice`).
+
+### minerva_math_algebra
+- Request type: `COMPLETION` (no `request.continuations`).
+- Perfect: generated text uses the real instance `solution_text` when available.
+- Corrupted: generated text is parseable but intentionally wrong.
+- Metric comparison: end-task accuracy (`accuracy.minerva_math_flex`).
+
+## Explicit keyword arguments
+All relevant method calls should use explicit keyword arguments, e.g.:
+- `get_task(spec=..., config_overrides=...)`
+- `task.process_doc(doc=..., index=...)`
+- `task.format_request(instance=...)`
+- `task.score_responses(responses=...)`
+- `task.compute_metrics(responses=...)`
+
+## Acceptance criteria
+- Plan file exists in `plans/`.
+- New test file contains 3 async tests (humaneval, labbench mc, minerva).
+- Each test checks request shape and `corrupted_quality < perfect_quality`.
+- Tests are skipped by default and do not block merges:
+  - `uv run pytest tests/evals/tasks/test_oracle_no_gpu_pipeline.py -v`
+- Real-dataset run passes when explicitly enabled:
+  - `RUN_REAL_DATASET_TESTS=1 uv run pytest tests/evals/tasks/test_oracle_no_gpu_pipeline.py -v`

--- a/tests/evals/tasks/test_oracle_no_gpu_pipeline.py
+++ b/tests/evals/tasks/test_oracle_no_gpu_pipeline.py
@@ -68,10 +68,7 @@ async def test_humaneval_bpb_perfect_vs_corrupted_quality() -> None:
     loaded_instances = list(islice(task.instances, 3))
     assert loaded_instances
 
-    requests = [
-        task.format_request(instance=instance)
-        for instance in loaded_instances
-    ]
+    requests = [task.format_request(instance=instance) for instance in loaded_instances]
 
     for request in requests:
         assert request.request_type == RequestType.LOGLIKELIHOOD
@@ -101,19 +98,13 @@ async def test_humaneval_bpb_perfect_vs_corrupted_quality() -> None:
         perfect_output = LMOutput(
             text=continuation,
             logprobs=perfect_logprobs,
-            metadata={
-                "total_logprob": float(
-                    sum(entry["logprob"] for entry in perfect_logprobs)
-                )
-            },
+            metadata={"total_logprob": float(sum(entry["logprob"] for entry in perfect_logprobs))},
         )
         corrupted_output = LMOutput(
             text=continuation,
             logprobs=corrupted_logprobs,
             metadata={
-                "total_logprob": float(
-                    sum(entry["logprob"] for entry in corrupted_logprobs)
-                )
+                "total_logprob": float(sum(entry["logprob"] for entry in corrupted_logprobs))
             },
         )
 
@@ -147,10 +138,7 @@ async def test_labbench_mc_perfect_vs_corrupted_quality() -> None:
     loaded_instances = list(islice(task.instances, 3))
     assert loaded_instances
 
-    requests = [
-        task.format_request(instance=instance)
-        for instance in loaded_instances
-    ]
+    requests = [task.format_request(instance=instance) for instance in loaded_instances]
 
     for request, instance in zip(requests, loaded_instances, strict=True):
         assert request.request_type == RequestType.LOGLIKELIHOOD
@@ -167,9 +155,7 @@ async def test_labbench_mc_perfect_vs_corrupted_quality() -> None:
         assert request.continuations is not None
         gold_idx = int(instance.metadata["gold_idx"])
 
-        wrong_candidates = [
-            idx for idx in range(len(request.continuations)) if idx != gold_idx
-        ]
+        wrong_candidates = [idx for idx in range(len(request.continuations)) if idx != gold_idx]
         wrong_idx = rng.choice(wrong_candidates)
 
         perfect_outputs: list[LMOutput] = []
@@ -224,10 +210,7 @@ async def test_minerva_end_metric_perfect_vs_corrupted_quality() -> None:
     loaded_instances = list(islice(task.instances, 3))
     assert loaded_instances
 
-    requests = [
-        task.format_request(instance=instance)
-        for instance in loaded_instances
-    ]
+    requests = [task.format_request(instance=instance) for instance in loaded_instances]
 
     for request in requests:
         assert request.request_type == RequestType.COMPLETION
@@ -251,8 +234,7 @@ async def test_minerva_end_metric_perfect_vs_corrupted_quality() -> None:
         # Keep format parseable but force likely-wrong extracted answer.
         wrong_value = str(3141592653589793 + rng.randint(1, 99))
         corrupted_text = (
-            "Final Answer: The final answer is "
-            f"$\\boxed{{{wrong_value}}}$. I hope it is correct."
+            f"Final Answer: The final answer is $\\boxed{{{wrong_value}}}$. I hope it is correct."
         )
 
         perfect_output = LMOutput(text=perfect_text)

--- a/tests/evals/tasks/test_oracle_no_gpu_pipeline.py
+++ b/tests/evals/tasks/test_oracle_no_gpu_pipeline.py
@@ -1,0 +1,277 @@
+"""No-GPU oracle-vs-corrupted task pipeline tests.
+
+These tests validate task-level formatting + scoring behavior without real model
+inference by constructing synthetic responses for real task requests.
+"""
+
+from __future__ import annotations
+
+import os
+import random
+from itertools import islice
+
+import pytest
+
+from olmo_eval.common.types import LMOutput, RequestType, Response
+from olmo_eval.evals.tasks.common import get_task
+
+RUN_REAL_DATASET_TESTS = os.getenv("RUN_REAL_DATASET_TESTS") == "1"
+
+
+def _build_char_logprobs(
+    *,
+    text: str,
+    rng: random.Random,
+    corrupted: bool,
+) -> list[dict[str, float | str]]:
+    """Build deterministic token logprobs from text, with optional corruption."""
+    tokens = list(text) if text else [""]
+    n_tokens = len(tokens)
+
+    corrupted_indices: set[int] = set()
+    if corrupted:
+        count = max(1, n_tokens // 5)
+        corrupted_indices = set(rng.sample(range(n_tokens), count))
+
+    logprobs: list[dict[str, float | str]] = []
+    for idx, token in enumerate(tokens):
+        logprob = -3.0 if idx in corrupted_indices else -0.05
+        logprobs.append({"token": token, "logprob": logprob})
+
+    return logprobs
+
+
+def _quality_from_metrics(
+    *,
+    metrics: dict[str, dict[str, float]],
+    mode: str,
+) -> float:
+    """Normalize metrics to a higher-is-better quality scalar."""
+    if mode == "bpb":
+        bpb = metrics["bits_per_byte"]["bits_per_byte"]
+        return -bpb
+    if mode == "labbench_accuracy":
+        return metrics["accuracy"]["multiple_choice"]
+    if mode == "minerva_accuracy":
+        return metrics["accuracy"]["minerva_math_flex"]
+    raise ValueError(f"Unknown quality mode: {mode}")
+
+
+@pytest.mark.anyio
+@pytest.mark.skipif(
+    not RUN_REAL_DATASET_TESTS,
+    reason="Set RUN_REAL_DATASET_TESTS=1 to run real-dataset task tests.",
+)
+async def test_humaneval_bpb_perfect_vs_corrupted_quality() -> None:
+    task = get_task(spec="humaneval:bpb", config_overrides={"num_fewshot": 0})
+
+    loaded_instances = list(islice(task.instances, 3))
+    assert loaded_instances
+
+    requests = [
+        task.format_request(instance=instance)
+        for instance in loaded_instances
+    ]
+
+    for request in requests:
+        assert request.request_type == RequestType.LOGLIKELIHOOD
+        assert request.continuations is not None
+        assert len(request.continuations) == 1
+
+    perfect_rng = random.Random(13)
+    corrupted_rng = random.Random(13)
+
+    perfect_responses: list[Response] = []
+    corrupted_responses: list[Response] = []
+
+    for instance, request in zip(loaded_instances, requests, strict=True):
+        continuation = request.continuations[0]
+
+        perfect_logprobs = _build_char_logprobs(
+            text=continuation,
+            rng=perfect_rng,
+            corrupted=False,
+        )
+        corrupted_logprobs = _build_char_logprobs(
+            text=continuation,
+            rng=corrupted_rng,
+            corrupted=True,
+        )
+
+        perfect_output = LMOutput(
+            text=continuation,
+            logprobs=perfect_logprobs,
+            metadata={
+                "total_logprob": float(
+                    sum(entry["logprob"] for entry in perfect_logprobs)
+                )
+            },
+        )
+        corrupted_output = LMOutput(
+            text=continuation,
+            logprobs=corrupted_logprobs,
+            metadata={
+                "total_logprob": float(
+                    sum(entry["logprob"] for entry in corrupted_logprobs)
+                )
+            },
+        )
+
+        perfect_responses.append(
+            Response(instance=instance, request=request, outputs=[perfect_output])
+        )
+        corrupted_responses.append(
+            Response(instance=instance, request=request, outputs=[corrupted_output])
+        )
+
+    perfect_scored = await task.score_responses(responses=perfect_responses)
+    corrupted_scored = await task.score_responses(responses=corrupted_responses)
+
+    perfect_metrics = task.compute_metrics(responses=perfect_scored)
+    corrupted_metrics = task.compute_metrics(responses=corrupted_scored)
+
+    perfect_quality = _quality_from_metrics(metrics=perfect_metrics, mode="bpb")
+    corrupted_quality = _quality_from_metrics(metrics=corrupted_metrics, mode="bpb")
+
+    assert corrupted_quality < perfect_quality
+
+
+@pytest.mark.anyio
+@pytest.mark.skipif(
+    not RUN_REAL_DATASET_TESTS,
+    reason="Set RUN_REAL_DATASET_TESTS=1 to run real-dataset task tests.",
+)
+async def test_labbench_mc_perfect_vs_corrupted_quality() -> None:
+    task = get_task(spec="lab_bench_litqa2:mc", config_overrides={"num_fewshot": 0})
+
+    loaded_instances = list(islice(task.instances, 3))
+    assert loaded_instances
+
+    requests = [
+        task.format_request(instance=instance)
+        for instance in loaded_instances
+    ]
+
+    for request, instance in zip(requests, loaded_instances, strict=True):
+        assert request.request_type == RequestType.LOGLIKELIHOOD
+        assert request.continuations is not None
+        assert instance.choices is not None
+        assert len(request.continuations) == len(instance.choices)
+
+    rng = random.Random(29)
+
+    perfect_responses: list[Response] = []
+    corrupted_responses: list[Response] = []
+
+    for instance, request in zip(loaded_instances, requests, strict=True):
+        assert request.continuations is not None
+        gold_idx = int(instance.metadata["gold_idx"])
+
+        wrong_candidates = [
+            idx for idx in range(len(request.continuations)) if idx != gold_idx
+        ]
+        wrong_idx = rng.choice(wrong_candidates)
+
+        perfect_outputs: list[LMOutput] = []
+        corrupted_outputs: list[LMOutput] = []
+
+        for idx, continuation in enumerate(request.continuations):
+            perfect_total = -0.1 if idx == gold_idx else -10.0
+            corrupted_total = -0.1 if idx == wrong_idx else -10.0
+
+            perfect_outputs.append(
+                LMOutput(
+                    text=continuation,
+                    logprobs=[{"token": continuation, "logprob": perfect_total}],
+                    metadata={"total_logprob": perfect_total},
+                )
+            )
+            corrupted_outputs.append(
+                LMOutput(
+                    text=continuation,
+                    logprobs=[{"token": continuation, "logprob": corrupted_total}],
+                    metadata={"total_logprob": corrupted_total},
+                )
+            )
+
+        perfect_responses.append(
+            Response(instance=instance, request=request, outputs=perfect_outputs)
+        )
+        corrupted_responses.append(
+            Response(instance=instance, request=request, outputs=corrupted_outputs)
+        )
+
+    perfect_scored = await task.score_responses(responses=perfect_responses)
+    corrupted_scored = await task.score_responses(responses=corrupted_responses)
+
+    perfect_metrics = task.compute_metrics(responses=perfect_scored)
+    corrupted_metrics = task.compute_metrics(responses=corrupted_scored)
+
+    perfect_quality = _quality_from_metrics(metrics=perfect_metrics, mode="labbench_accuracy")
+    corrupted_quality = _quality_from_metrics(metrics=corrupted_metrics, mode="labbench_accuracy")
+
+    assert corrupted_quality < perfect_quality
+
+
+@pytest.mark.anyio
+@pytest.mark.skipif(
+    not RUN_REAL_DATASET_TESTS,
+    reason="Set RUN_REAL_DATASET_TESTS=1 to run real-dataset task tests.",
+)
+async def test_minerva_end_metric_perfect_vs_corrupted_quality() -> None:
+    task = get_task(spec="minerva_math_algebra", config_overrides={"num_fewshot": 0})
+
+    loaded_instances = list(islice(task.instances, 3))
+    assert loaded_instances
+
+    requests = [
+        task.format_request(instance=instance)
+        for instance in loaded_instances
+    ]
+
+    for request in requests:
+        assert request.request_type == RequestType.COMPLETION
+        assert request.continuations is None
+
+    rng = random.Random(41)
+
+    perfect_responses: list[Response] = []
+    corrupted_responses: list[Response] = []
+
+    for instance, request in zip(loaded_instances, requests, strict=True):
+        solution_text = str(instance.metadata.get("solution_text", ""))
+        if solution_text:
+            perfect_text = solution_text
+        else:
+            perfect_text = (
+                "Final Answer: The final answer is "
+                f"$\\boxed{{{instance.gold_answer}}}$. I hope it is correct."
+            )
+
+        # Keep format parseable but force likely-wrong extracted answer.
+        wrong_value = str(3141592653589793 + rng.randint(1, 99))
+        corrupted_text = (
+            "Final Answer: The final answer is "
+            f"$\\boxed{{{wrong_value}}}$. I hope it is correct."
+        )
+
+        perfect_output = LMOutput(text=perfect_text)
+        corrupted_output = LMOutput(text=corrupted_text)
+
+        perfect_responses.append(
+            Response(instance=instance, request=request, outputs=[perfect_output])
+        )
+        corrupted_responses.append(
+            Response(instance=instance, request=request, outputs=[corrupted_output])
+        )
+
+    perfect_scored = await task.score_responses(responses=perfect_responses)
+    corrupted_scored = await task.score_responses(responses=corrupted_responses)
+
+    perfect_metrics = task.compute_metrics(responses=perfect_scored)
+    corrupted_metrics = task.compute_metrics(responses=corrupted_scored)
+
+    perfect_quality = _quality_from_metrics(metrics=perfect_metrics, mode="minerva_accuracy")
+    corrupted_quality = _quality_from_metrics(metrics=corrupted_metrics, mode="minerva_accuracy")
+
+    assert corrupted_quality < perfect_quality


### PR DESCRIPTION
## Summary
- add real-dataset no-GPU oracle-vs-corrupted task pipeline tests
- cover `humaneval:bpb`, `lab_bench_litqa2:mc`, and `minerva_math_algebra`
- make tests non-blocking by default via `RUN_REAL_DATASET_TESTS=1` opt-in
- persist plan details in `plans/001_oracle_no_gpu_task_pipeline_tests.md`

## Details
- new tests file: `tests/evals/tasks/test_oracle_no_gpu_pipeline.py`
- each test loads **real task instances** and builds:
  - perfect fake model outputs
  - corrupted fake model outputs
- assertions verify corrupted performance is lower than perfect performance
- minerva test uses default end-task metric path (accuracy)

## Qualitative Examples (real loaded instances, exact fake predictions)

### 1) `humaneval:bpb`
Gold instance (canonical solution):

```python
result = []
current_string = []
current_depth = 0

for c in paren_string:
    if c == '(':
        current_depth += 1
        current_string.append(c)
    elif c == ')':
        current_depth -= 1
        current_string.append(c)

        if current_depth == 0:
            result.append(''.join(current_string))
            current_string.clear()

return result
```

Fake model prediction (perfect):

```python
result = []
current_string = []
current_depth = 0

for c in paren_string:
    if c == '(':
        current_depth += 1
        current_string.append(c)
    elif c == ')':
        current_depth -= 1
        current_string.append(c)

        if current_depth == 0:
            result.append(''.join(current_string))
            current_string.clear()

return result
```

Fake model prediction (corrupted):
- exact same text as above
- but token logprobs are degraded at sampled positions
- total logprob (perfect): `-20.95`
- total logprob (corrupted): `-265.8`
- sampled degraded token indices (prefix):
  `[7, 15, 36, 37, 43, 60, 64, 66, 67, 69, 71, 75, 90, 91, 95, 99, ...]`

Final scoring:
- perfect: `{'bits_per_byte': {'bits_per_byte': 0.07213475204444818}}`
- corrupted: `{'bits_per_byte': {'bits_per_byte': 0.9151989066068891}}`

### 2) `lab_bench_litqa2:mc`
Gold instance:
- Question: `Acinetobacter lwoffii has been evolved in the lab to be resistant to which of these antibiotics?`
- Choices: `['gentamicin', 'meropenem', 'Insufficient information to answer the question', 'ampicillin', 'ciproflaxin']`
- Gold letter: `E`

Fake model prediction (perfect):
- per-continuation total_logprob: `[-10.0, -10.0, -10.0, -10.0, -0.1]`
- predicted letter: `E`

Fake model prediction (corrupted):
- per-continuation total_logprob: `[-0.1, -10.0, -10.0, -10.0, -10.0]`
- predicted letter: `A`

Final scoring:
- perfect: `{'accuracy': {'multiple_choice': 1.0}, 'precision': {'multiple_choice': 1.0}, 'coverage': {'multiple_choice': 1.0}}`
- corrupted: `{'accuracy': {'multiple_choice': 0.0}, 'precision': {'multiple_choice': 0.0}, 'coverage': {'multiple_choice': 1.0}}`

### 3) `minerva_math_algebra`
Gold instance:
- Question: `How many vertical asymptotes does the graph of y=2/(x^2+x-6) have?`
- Gold answer: `2`

Fake model prediction (perfect):

```text
The denominator of the rational function factors into x^2+x-6=(x-2)(x+3). Since the numerator is always nonzero, there is a vertical asymptote whenever the denominator is 0, which occurs for x = 2 and x = -3. Therefore, the graph has \boxed{2} vertical asymptotes.
```

Fake model prediction (corrupted):

```text
Final Answer: The final answer is $\boxed{3141592653589842}$. I hope it is correct.
```

Extracted answers:
- perfect: `2`
- corrupted: `\3141592653589842`

Final scoring:
- perfect: `{'accuracy': {'minerva_math_flex': 1.0}}`
- corrupted: `{'accuracy': {'minerva_math_flex': 0.0}}`

## Validation
- `uv run ruff check tests/evals/tasks/test_oracle_no_gpu_pipeline.py`
- `uv run pytest tests/evals/tasks/test_oracle_no_gpu_pipeline.py -v` (skipped by default)
- `RUN_REAL_DATASET_TESTS=1 uv run pytest tests/evals/tasks/test_oracle_no_gpu_pipeline.py -q` (passes)
