### PR TITLE
Remove the unused type checking suppression comments

### DIFF
--- a/src/olmo_eval/common/types/tools.py
+++ b/src/olmo_eval/common/types/tools.py
@@ -211,7 +211,7 @@ class ToolResult:
         Returns:
             Dictionary representation of the ToolResult.
         """
-        result = {
+        result: dict[str, Any] = {
             "tool_call_id": self.tool_call_id,
             "content": self.content,
             "is_error": self.is_error,
@@ -256,16 +256,17 @@ class ToolSchema:
         Returns:
             Dictionary suitable for use in OpenAI's tools parameter.
         """
+        function_payload: dict[str, Any] = {
+            "name": self.name,
+            "description": self.description,
+            "parameters": self.parameters,
+        }
         result: dict[str, Any] = {
             "type": "function",
-            "function": {
-                "name": self.name,
-                "description": self.description,
-                "parameters": self.parameters,
-            },
+            "function": function_payload,
         }
         if self.strict:
-            result["function"]["strict"] = True
+            function_payload["strict"] = True
         return result
 
     @classmethod

--- a/src/olmo_eval/data/backends/gcs.py
+++ b/src/olmo_eval/data/backends/gcs.py
@@ -107,7 +107,7 @@ class GCSBackend:
 
     def _prefix_has_objects(self, prefix: str) -> bool:
         """Check if a GCS prefix contains any objects."""
-        from google.api_core import exceptions as gcs_exceptions  # type: ignore[import-not-found]
+        from google.api_core import exceptions as gcs_exceptions
 
         bucket_name, blob_prefix = self._parse_gcs_uri(prefix)
         try:
@@ -286,7 +286,7 @@ class GCSBackend:
         Returns:
             True if the path exists (as file or prefix with objects).
         """
-        from google.api_core import exceptions as gcs_exceptions  # type: ignore[import-not-found]
+        from google.api_core import exceptions as gcs_exceptions
 
         bucket_name, blob_name = self._parse_gcs_uri(path)
         bucket = self.gcs_client.bucket(bucket_name)

--- a/src/olmo_eval/inference/dispatch.py
+++ b/src/olmo_eval/inference/dispatch.py
@@ -59,7 +59,7 @@ class ContinuousBatchDispatcher[T, R]:
         self._stats = DispatchStats(total=total)
 
         # Results array preserves ordering
-        results: list[R | None] = [None] * total
+        results: list[R | None] = [None for _ in range(total)]
 
         # Queue of (index, item, attempt) tuples
         pending: list[tuple[int, T, int]] = [(i, item, 0) for i, item in enumerate(items)]

--- a/src/olmo_eval/inference/providers/huggingface.py
+++ b/src/olmo_eval/inference/providers/huggingface.py
@@ -55,9 +55,9 @@ class HuggingFaceProvider(InferenceProvider):
         """Get the tokenizer for this provider."""
         return self.tokenizer
 
-    def _build_generate_kwargs(self, params: SamplingParams) -> dict:
+    def _build_generate_kwargs(self, params: SamplingParams) -> dict[str, Any]:
         """Convert SamplingParams to HuggingFace generate kwargs."""
-        kwargs = {
+        kwargs: dict[str, Any] = {
             "max_new_tokens": params.max_tokens,
             "do_sample": params.temperature > 0,
         }

--- a/src/olmo_eval/inference/providers/vllm.py
+++ b/src/olmo_eval/inference/providers/vllm.py
@@ -235,7 +235,7 @@ class VLLMProvider(InferenceProvider):
                 for p in prompt_strs
             ]
         else:
-            vllm_prompts = prompt_strs  # type: ignore[assignment]
+            vllm_prompts = prompt_strs
 
         # Disable tqdm progress bar - we use our own worker-scoped logging
         outputs: list[RequestOutput] = self.llm.generate(vllm_prompts, vllm_params, use_tqdm=False)


### PR DESCRIPTION
I couldn't get the type checking to pass locally on main, I think the per line `# type: ignore[import-not-found]` comments are superfluous with the rule in pyproject.toml

```toml
[tool.ty.overrides.rules]
unresolved-import = "ignore"
```

I was seeing this:

```bash
❯ uv run ty check src/
warning[unused-type-ignore-comment]: Unused blanket `type: ignore` directive
   --> src/olmo_eval/data/backends/gcs.py:110:67
    |
108 |     def _prefix_has_objects(self, prefix: str) -> bool:
109 |         """Check if a GCS prefix contains any objects."""
110 |         from google.api_core import exceptions as gcs_exceptions  # type: ignore[import-not-found]
    |                                                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
111 |
112 |         bucket_name, blob_prefix = self._parse_gcs_uri(prefix)
    |
help: Remove the unused suppression comment
107 |
108 |     def _prefix_has_objects(self, prefix: str) -> bool:
109 |         """Check if a GCS prefix contains any objects."""
    -         from google.api_core import exceptions as gcs_exceptions  # type: ignore[import-not-found]
110 +         from google.api_core import exceptions as gcs_exceptions
111 |
112 |         bucket_name, blob_prefix = self._parse_gcs_uri(prefix)
113 |         try:

warning[unused-type-ignore-comment]: Unused blanket `type: ignore` directive
   --> src/olmo_eval/data/backends/gcs.py:289:67
    |
287 |             True if the path exists (as file or prefix with objects).
288 |         """
289 |         from google.api_core import exceptions as gcs_exceptions  # type: ignore[import-not-found]
    |                                                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
290 |
291 |         bucket_name, blob_name = self._parse_gcs_uri(path)
    |
help: Remove the unused suppression comment
286 |         Returns:
287 |             True if the path exists (as file or prefix with objects).
288 |         """
    -         from google.api_core import exceptions as gcs_exceptions  # type: ignore[import-not-found]
289 +         from google.api_core import exceptions as gcs_exceptions
290 |
291 |         bucket_name, blob_name = self._parse_gcs_uri(path)
292 |         bucket = self.gcs_client.bucket(bucket_name)

Found 2 diagnostics
```

but just removing those comments gets `ty check` green.