### PR TITLE
tau2 verified

### DIFF
--- a/src/olmo_eval/evals/external/benchmarks/tau2/__init__.py
+++ b/src/olmo_eval/evals/external/benchmarks/tau2/__init__.py
@@ -2,9 +2,10 @@
 
 tau2_bench is a benchmark for evaluating language model agents on realistic
 customer service tasks. It measures both task completion and constraint
-satisfaction.
+satisfaction. We use the "verified" version of the benchmark, which fixes
+some issues in the original version. For more details, see https://arxiv.org/abs/2512.07850.
 
-Repository: https://github.com/sierra-research/tau2-bench
+Repository: https://github.com/amazon-agi/tau2-bench-verified
 """
 
 from olmo_eval.evals.external.benchmarks.tau2.eval import Tau2ExternalEval

--- a/src/olmo_eval/evals/external/benchmarks/tau2/eval.py
+++ b/src/olmo_eval/evals/external/benchmarks/tau2/eval.py
@@ -133,7 +133,7 @@ class Tau2ExternalEval(SandboxedExternalEval):
     def setup_command(self) -> tuple[str, ...]:
         repo = f"{self.working_dir}/tau2-bench"
         return (
-            f"git clone --depth 1 https://github.com/sierra-research/tau2-bench.git {repo}",
+            f"git clone --depth 1 https://github.com/amazon-agi/tau2-bench-verified.git {repo}",
             f"cd {repo} && uv sync",
             f"mkdir -p {self.results_dir}",
         )


### PR DESCRIPTION
## Description

Switch from the original Tau2 Bench to [Tau2 Bench Verified](https://github.com/amazon-agi/tau2-bench-verified). The verified version contains manual fixes of some instances with incorrect ground-truth values.

One related issue to note: Qwen often runs out of context window while evaluating on Tau2 Bench. In the original version, we would pass a truncation argument to the agent like `"truncate": "left"` to truncate the input to fit the context window. However, the verified version uses a newer version of litellm which does not support this argument. We need to call [trim_messages](https://docs.litellm.ai/docs/completion/message_trimming) on the input messages, which needs to happen in the benchmark code. But that is independent of this PR.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Testing

- [x] Unit tests pass locally (`pytest tests/ --ignore=tests/integration/`)
- [ ] Integration tests pass (if applicable)
- [ ] New tests added for new functionality

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published
