### PR TITLE
Fix slow scoring

### DIFF
--- a/src/olmo_eval/evals/tasks/common/base.py
+++ b/src/olmo_eval/evals/tasks/common/base.py
@@ -205,6 +205,8 @@ class Task(ABC):
         self.config = config
         self._fewshot_cache: list[Instance] | None = None
         self._instances_cache: list[Instance] | None = None
+        self._scorers_cache: dict[str, Scorer] | None = None
+        self._has_async_cache: bool | None = None
 
     @property
     def request_type(self) -> RequestType:
@@ -405,14 +407,25 @@ class Task(ABC):
 
         return responses
 
+    def _get_scorers(self) -> dict[str, Scorer]:
+        """Return scorer instances, keyed by name. Cached after first call."""
+        if self._scorers_cache is None:
+            scorers_by_name: dict[str, Scorer] = {}
+            for metric in self.config.metrics:
+                if hasattr(metric, "scorer") and metric.scorer is not None:
+                    scorer_instance = metric.scorer()
+                    if scorer_instance.name not in scorers_by_name:
+                        scorers_by_name[scorer_instance.name] = scorer_instance
+            self._scorers_cache = scorers_by_name
+        return self._scorers_cache
+
     def _has_async_scorers(self) -> bool:
         """Check if any configured scorers require async execution."""
-        for metric in self.config.metrics:
-            if hasattr(metric, "scorer") and metric.scorer is not None:
-                scorer_instance = metric.scorer()
-                if getattr(scorer_instance, "requires_async", False):
-                    return True
-        return False
+        if self._has_async_cache is None:
+            self._has_async_cache = any(
+                getattr(s, "requires_async", False) for s in self._get_scorers().values()
+            )
+        return self._has_async_cache
 
     def _extract_answers(self, responses: Sequence[Response]) -> None:
         """Extract answers from outputs. Override for custom extraction logic."""
@@ -422,24 +435,15 @@ class Task(ABC):
 
     def _apply_scorers(self, responses: Sequence[Response]) -> None:
         """Run all scorers synchronously and populate response.scores."""
-        # Collect scorers from metrics, avoiding duplicates by name
-        scorers_by_name: dict[str, Scorer] = {}
-        for metric in self.config.metrics:
-            if hasattr(metric, "scorer") and metric.scorer is not None:
-                scorer_instance = metric.scorer()
-                if scorer_instance.name not in scorers_by_name:
-                    scorers_by_name[scorer_instance.name] = scorer_instance
+        scorers_by_name = self._get_scorers()
 
         for response in responses:
-            # Apply each scorer, taking best score across outputs (for multi-sample)
             for scorer in scorers_by_name.values():
                 scores = [scorer.score(response.instance, o) for o in response.outputs]
-                # Store individual scores in output metadata for pass@k expansion
                 for i, output in enumerate(response.outputs):
                     if output.metadata is None:
                         output.metadata = {}
                     output.metadata[f"score:{scorer.name}"] = scores[i] if i < len(scores) else 0.0
-                # Response-level score is max for backward compatibility
                 response.scores[scorer.name] = max(scores) if scores else 0.0
 
     async def _apply_scorers_async(
@@ -462,16 +466,8 @@ class Task(ABC):
         """
         from olmo_eval.common.scorers.execution import ExecutionScorer, SandboxRequiredError
 
-        # Validate execution environment for execution scorers
         execution_env = context.execution_env if context.has_execution_env else None
-
-        # Collect scorers from metrics, avoiding duplicates by name
-        scorers_by_name: dict[str, Scorer] = {}
-        for metric in self.config.metrics:
-            if hasattr(metric, "scorer") and metric.scorer is not None:
-                scorer_instance = metric.scorer()
-                if scorer_instance.name not in scorers_by_name:
-                    scorers_by_name[scorer_instance.name] = scorer_instance
+        scorers_by_name = self._get_scorers()
 
         # Separate execution scorers (async) from regular scorers (sync)
         execution_scorers: dict[str, ExecutionScorer] = {}

--- a/src/olmo_eval/runners/asynq/results.py
+++ b/src/olmo_eval/runners/asynq/results.py
@@ -191,6 +191,8 @@ async def process_results(
             if traj_dict:
                 trajectory = AgentTrajectory.from_dict(traj_dict)
 
+        assert result_item.instance is not None
+        assert result_item.request is not None
         response = Response(
             instance=result_item.instance,
             request=result_item.request,

--- a/src/olmo_eval/runners/asynq/results.py
+++ b/src/olmo_eval/runners/asynq/results.py
@@ -75,6 +75,10 @@ async def process_results(
     instances_sent: dict[str, int] = {spec: 0 for spec in trackers}
     instances_scored: dict[str, int] = {spec: 0 for spec in trackers}
 
+    # Track which tasks have been sent to the scoring worker so we only
+    # pickle the full Task object once per spec (the dominant serialization cost).
+    tasks_sent_to_scorer: set[str] = set()
+
     def check_task_completion(spec: str) -> None:
         """Check if task is complete and finalize if so."""
         nonlocal tasks_complete
@@ -194,25 +198,31 @@ async def process_results(
             trajectory=trajectory,
         )
 
-        # Send to scoring worker immediately
-        # Pre-pickle to catch errors synchronously (queue.put uses a background thread
-        # that silently swallows pickling errors, causing the job to stall)
+        # Send to scoring worker immediately.
+        # Include the Task only on the first item per spec so the scoring
+        # worker can cache it; subsequent items skip the expensive Task pickle.
         assert tracker.task is not None
+        include_task = result_item.task_id not in tasks_sent_to_scorer
         scoring_item = ScoringItem(
             spec=result_item.task_id,
             instance_idx=result_item.instance_idx,
             response=response,
-            task=tracker.task,
+            task=tracker.task if include_task else None,
         )
-        try:
-            pickle.dumps(scoring_item)
-        except (pickle.PicklingError, TypeError, AttributeError) as e:
-            task_id = result_item.task_id
-            idx = result_item.instance_idx
-            logger.error(f"Failed to pickle scoring item for {task_id}[{idx}]: {e}")
-            tracker.add_failure(result_item.instance_idx, f"Pickling failed: {e}")
-            check_task_completion(result_item.task_id)
-            continue
+        if include_task:
+            # Validate pickling on the first item (which carries the Task).
+            # queue.put uses a background thread that silently swallows
+            # pickling errors, causing the job to stall.
+            try:
+                pickle.dumps(scoring_item)
+            except (pickle.PicklingError, TypeError, AttributeError) as e:
+                task_id = result_item.task_id
+                idx = result_item.instance_idx
+                logger.error(f"Failed to pickle scoring item for {task_id}[{idx}]: {e}")
+                tracker.add_failure(result_item.instance_idx, f"Pickling failed: {e}")
+                check_task_completion(result_item.task_id)
+                continue
+            tasks_sent_to_scorer.add(result_item.task_id)
         scoring_queue.put(scoring_item)
         instances_sent[result_item.task_id] += 1
 

--- a/src/olmo_eval/runners/asynq/types.py
+++ b/src/olmo_eval/runners/asynq/types.py
@@ -84,8 +84,8 @@ class ResultItem:
     model_name: str  # Which model produced this result
     task_id: str
     instance_idx: int
-    instance: Instance
-    request: LMRequest
+    instance: Instance | None  # None only for fatal error signals
+    request: LMRequest | None  # None only for fatal error signals
     outputs: list[LMOutput]
     error: str | None = None
     attempt: int = 0

--- a/src/olmo_eval/runners/asynq/types.py
+++ b/src/olmo_eval/runners/asynq/types.py
@@ -93,12 +93,17 @@ class ResultItem:
 
 @dataclass
 class ScoringItem:
-    """Single response to be scored by the scoring worker."""
+    """Single response to be scored by the scoring worker.
+
+    The ``task`` field is only set on the first item for each spec;
+    the scoring worker caches it and subsequent items leave it as None
+    to avoid re-pickling the full Task object through the multiprocessing queue.
+    """
 
     spec: str
     instance_idx: int
     response: Response
-    task: Task
+    task: Task | None = None
 
 
 @dataclass

--- a/src/olmo_eval/runners/asynq/workers.py
+++ b/src/olmo_eval/runners/asynq/workers.py
@@ -202,8 +202,8 @@ def inference_worker(
                 model_name=model_name,
                 task_id=WORKER_FATAL,
                 instance_idx=-1,
-                instance=None,  # type: ignore[arg-type]
-                request=None,  # type: ignore[arg-type]
+                instance=None,
+                request=None,
                 outputs=[],
                 error=f"Worker process crashed: {e}",
             )

--- a/src/olmo_eval/runners/asynq/workers.py
+++ b/src/olmo_eval/runners/asynq/workers.py
@@ -258,16 +258,32 @@ def scoring_worker(
         in-flight tasks without callbacks or sleeps. This approach is modeled
         after ContinuousBatchDispatcher in dispatch.py.
         """
+        from olmo_eval.evals.tasks.common import Task
+
         progress: ProgressLogger | None = None
         in_flight: dict[asyncio.Task[ScoredResponse], ScoringItem] = {}
         shutdown = False
 
+        # Cache Task objects by spec so only the first ScoringItem per spec
+        # needs to carry (and unpickle) the full Task.
+        task_cache: dict[str, Task] = {}
+
+        def get_task(item: ScoringItem) -> Task:
+            if item.task is not None:
+                task_cache[item.spec] = item.task
+            task = task_cache.get(item.spec)
+            if task is None:
+                raise RuntimeError(
+                    f"No cached Task for spec {item.spec!r}. "
+                    "The first ScoringItem for each spec must include the Task."
+                )
+            return task
+
         async def score_item(item: ScoringItem) -> ScoredResponse:
             """Score a single item."""
             try:
-                scored_list = await item.task.score_responses(
-                    [item.response], context=scoring_context
-                )
+                task = get_task(item)
+                scored_list = await task.score_responses([item.response], context=scoring_context)
                 scored = scored_list[0] if scored_list else item.response
                 return ScoredResponse(
                     spec=item.spec,


### PR DESCRIPTION
## Description

Finally have time to dig back into my parity experiments for the base eval tasks. I have a benchmark running, CoQA, which uses exact match as the scorer, and it seems like the scoring logic is taking much longer than the vLLM generator:

https://beaker.org/orgs/ai2/workspaces/olmo-3-evals/work/01KN2TDR1BWRZW4BE0VQKTGPVF

I think this is because the scoring logic is optimized for async execution (e.g. code exec), but the overhead causes problems for simple scoring funcs. I believe the fix is to cache the Task object

All tests pass

## To test locally:

On `main` this command is quite slow, on `fast-scoring` it's quite fast.

```sh
olmo-eval run -m mock -t c4_10k:ppl
```