### PR TITLE
Update the location of tau2-bench-verified to pradeep's fork

### DIFF
--- a/src/olmo_eval/evals/external/benchmarks/tau2/eval.py
+++ b/src/olmo_eval/evals/external/benchmarks/tau2/eval.py
@@ -137,7 +137,9 @@ class Tau2ExternalEval(SandboxedExternalEval):
             # 1) The assistant returning an empty response.
             # 2) Litellm's timeouts errors.
             f"git clone --depth 1 https://github.com/pdasigi/tau2-bench-verified.git {repo}",
-            f"cd {repo} && uv sync",
+            # Pin to commit 6a0dbca
+            f"cd {repo} && git checkout 6a0dbca",
+            "uv sync",
             f"mkdir -p {self.results_dir}",
         )
 

--- a/src/olmo_eval/evals/external/benchmarks/tau2/eval.py
+++ b/src/olmo_eval/evals/external/benchmarks/tau2/eval.py
@@ -139,7 +139,7 @@ class Tau2ExternalEval(SandboxedExternalEval):
             f"git clone --depth 1 https://github.com/pdasigi/tau2-bench-verified.git {repo}",
             # Pin to commit 6a0dbca
             f"cd {repo} && git checkout 6a0dbca",
-            "uv sync",
+            f"cd {repo} && uv sync",
             f"mkdir -p {self.results_dir}",
         )
 

--- a/src/olmo_eval/evals/external/benchmarks/tau2/eval.py
+++ b/src/olmo_eval/evals/external/benchmarks/tau2/eval.py
@@ -133,7 +133,10 @@ class Tau2ExternalEval(SandboxedExternalEval):
     def setup_command(self) -> tuple[str, ...]:
         repo = f"{self.working_dir}/tau2-bench"
         return (
-            f"git clone --depth 1 https://github.com/amazon-agi/tau2-bench-verified.git {repo}",
+            # Using Pradeep's repo as it handles two errors that the original does not:
+            # 1) The assistant returning an empty response.
+            # 2) Litellm's timeouts errors.
+            f"git clone --depth 1 https://github.com/pdasigi/tau2-bench-verified.git {repo}",
             f"cd {repo} && uv sync",
             f"mkdir -p {self.results_dir}",
         )

--- a/src/olmo_eval/launch/beaker/launcher.py
+++ b/src/olmo_eval/launch/beaker/launcher.py
@@ -378,6 +378,7 @@ class BeakerJobConfig:
         default_factory=lambda: [
             BeakerWekaBucket("oe-training-default"),
             BeakerWekaBucket("oe-eval-default"),
+            BeakerWekaBucket("oe-adapt-default"),
         ]
     )
     nfs: bool = False


### PR DESCRIPTION
## Description

Main change: Update the path to the tau2 bench verified repository. The path now points to my fork where I made the following changes without which the eval run crashes on issues unrelated to the evaluation:
1. Trim input messages when the context is too long (and let the user specify max input tokens in the agent args).
2. Treat empty assistant messages as task failures (instead of runtime errors), log them, and continue.
3. Handle timeout errors also as task failures instead of runtime errors.

I made [a PR](https://github.com/amazon-agi/tau2-bench-verified/pull/4) with the first change to the original repo, and since there was no response, I propose we switch to using my fork.

Another minor change: Also mount the oe-adapt-default Weka directory by default.

## Type of Change

<!-- Put an `x` in all the boxes that apply -->

- [x] Bug fix (non-breaking change that fixes an issue) -- but not in this repository
- [x] New feature (non-breaking change that adds functionality) -- also mount oe-adapt-default
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Testing

<!-- Describe how you tested your changes -->

- [x] Unit tests pass locally (`pytest tests/ --ignore=tests/integration/`)
- [ ] Integration tests pass (if applicable)
- [ ] New tests added for new functionality

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published
