### PR TITLE
Fix: ignore vllm-specific kwargs for HF provider

### DIFF
--- a/src/olmo_eval/runners/asynq/workers.py
+++ b/src/olmo_eval/runners/asynq/workers.py
@@ -101,15 +101,22 @@ def inference_worker(
         if provider_kind == "vllm_server" and output_dir:
             log_dir = os.path.join(output_dir, "logs")
 
+        # Only inject vllm-specific kwargs for vllm providers
+        vllm_only_overrides: dict[str, Any] = {}
+        if provider_kind in ("vllm", "vllm_server"):
+            vllm_only_overrides = dict(
+                tensor_parallel_size=len(gpu_ids) if gpu_ids else None,
+                load_format=load_format,
+                model_loader_extra_config=extra_loader_config,
+                enable_auto_tool_choice=enable_auto_tool_choice or None,
+                log_dir=log_dir,
+            )
+
         harness_config = harness_config.with_provider_overrides(
-            tensor_parallel_size=len(gpu_ids) if gpu_ids else None,
             max_model_len=max_model_len,
             max_concurrency=max_concurrency,
             tokenizer=tokenizer,
-            load_format=load_format,
-            model_loader_extra_config=extra_loader_config,
-            enable_auto_tool_choice=enable_auto_tool_choice or None,
-            log_dir=log_dir,
+            **vllm_only_overrides,
         )
 
         # Update metrics config with runtime values (output_dir, provider_kind, model_name)


### PR DESCRIPTION
## Summary
- Only inject vllm-specific kwargs (`tensor_parallel_size`, `load_format`, `model_loader_extra_config`, `enable_auto_tool_choice`, `log_dir`) when the provider is `vllm` or `vllm_server`
- Fixes errors when using the HF provider, which doesn't accept these kwargs

## Test plan
- [x] Run eval with HF provider and verify no unexpected kwargs are passed
- [x] Run eval with vllm provider and verify vllm-specific kwargs still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)