### PR TITLE
semi-coherent science suite

### DIFF
--- a/src/olmo_eval/evals/suites/science.py
+++ b/src/olmo_eval/evals/suites/science.py
@@ -1,6 +1,26 @@
-"""Science evaluation suites."""
+"""Science evaluation suites.
 
-from olmo_eval.evals.suites.registry import AggregationStrategy, make_suite
+This module keeps the existing GPQA convenience suites while also defining a
+non-overlapping science hierarchy for aggregate reporting.
+
+Design rules for the ``science:*`` hierarchy:
+1. ``science:all`` should contain each underlying task spec exactly once.
+2. Reuse existing suites where they are already coherent and non-overlapping.
+3. Prefer subject-sliced GPQA tasks inside the hierarchy so biology, chemistry,
+   and physics live in separate domain suites without also including the
+   full-subset GPQA tasks.
+
+The legacy ``gpqa`` / ``gpqa:mc`` / ``gpqa:bpb`` suites are retained as
+convenience entry points, but they are intentionally not nested under
+``science:all`` because they would duplicate the GPQA questions already
+allocated to domain-specific suites.
+"""
+
+import olmo_eval.evals.suites.astabench  # noqa: F401 - ensure suite registration
+import olmo_eval.evals.suites.biology  # noqa: F401 - ensure suite registration
+import olmo_eval.evals.suites.math  # noqa: F401 - ensure suite registration
+import olmo_eval.evals.suites.mmlu  # noqa: F401 - ensure suite registration
+from olmo_eval.evals.suites.registry import AggregationStrategy, get_suite, make_suite
 
 # =============================================================================
 # GPQA Suite
@@ -10,6 +30,21 @@ _GPQA_TASKS = (
     "gpqa_diamond",
     "gpqa_main",
     "gpqa_extended",
+)
+
+_GPQA_BIOLOGY_TASKS = tuple(f"{t}_biology" for t in _GPQA_TASKS)
+_GPQA_CHEMISTRY_TASKS = tuple(f"{t}_chemistry" for t in _GPQA_TASKS)
+_GPQA_PHYSICS_TASKS = tuple(f"{t}_physics" for t in _GPQA_TASKS)
+
+_MMLU_MEDICINE_TASKS = (
+    "mmlu_anatomy",
+    "mmlu_clinical_knowledge",
+    "mmlu_college_medicine",
+    "mmlu_human_aging",
+    "mmlu_medical_genetics",
+    "mmlu_nutrition",
+    "mmlu_professional_medicine",
+    "mmlu_virology",
 )
 
 GPQA = make_suite(
@@ -31,4 +66,105 @@ GPQA_BPB = make_suite(
     tuple(f"{t}:bpb" for t in _GPQA_TASKS),
     aggregation=AggregationStrategy.DISPLAY_ONLY,
     description="GPQA with bits-per-byte evaluation",
+)
+
+# =============================================================================
+# Non-overlapping science hierarchy
+# =============================================================================
+#
+# Notes on composition:
+# - science:core is the broad STEM / school-science layer.
+# - science:biology owns the biology slice of GPQA plus the dedicated biology
+#   benchmarks (LAB-Bench + GeneTuring via the biology suite).
+# - science:physical owns only chemistry + physics GPQA slices, avoiding
+#   duplication with science:core's broader STEM exams.
+# - science:medicine uses med benchmarks plus medicine-heavy MMLU subjects, but
+#   does not include ``medqa`` because it points at the same benchmark family as
+#   ``medqa_en`` and would double-weight that content.
+# - science:research groups scientific literature / evidence-use tasks.
+# - science:math groups mathematical reasoning tasks used in science-adjacent
+#   evaluation.
+
+SCIENCE_CORE = make_suite(
+    "science:core",
+    (
+        "arc_easy",
+        "arc_challenge",
+        "sciq",
+        get_suite("mmlu:stem"),
+    ),
+    aggregation=AggregationStrategy.AVERAGE_OF_AVERAGES,
+    description="Broad STEM knowledge and science exam QA.",
+)
+
+SCIENCE_BIOLOGY = make_suite(
+    "science:biology",
+    (
+        get_suite("biology"),
+        *_GPQA_BIOLOGY_TASKS,
+    ),
+    aggregation=AggregationStrategy.AVERAGE_OF_AVERAGES,
+    description="Biology, genomics, and wet-lab science evaluation, including GPQA biology.",
+)
+
+SCIENCE_MEDICINE = make_suite(
+    "science:medicine",
+    (
+        "medmcqa",
+        "medqa_en",
+        *_MMLU_MEDICINE_TASKS,
+    ),
+    aggregation=AggregationStrategy.AVERAGE_OF_AVERAGES,
+    description=(
+        "Medical QA and medicine-focused knowledge tasks without duplicate MedQA weighting."
+    ),
+)
+
+SCIENCE_PHYSICAL = make_suite(
+    "science:physical",
+    (
+        *_GPQA_CHEMISTRY_TASKS,
+        *_GPQA_PHYSICS_TASKS,
+    ),
+    aggregation=AggregationStrategy.AVERAGE_OF_AVERAGES,
+    description="Chemistry and physics tasks without duplicating broad STEM core coverage.",
+)
+
+SCIENCE_RESEARCH = make_suite(
+    "science:research",
+    (
+        "qasper_yesno",
+        "sciriff_yesno",
+        get_suite("astabench"),
+    ),
+    aggregation=AggregationStrategy.AVERAGE_OF_AVERAGES,
+    description="Scientific literature understanding, evidence use, and scholarly synthesis.",
+)
+
+SCIENCE_MATH = make_suite(
+    "science:math",
+    (
+        "gsm8k",
+        "gsm_symbolic",
+        get_suite("minerva_math"),
+        "math500",
+        "aime_2024",
+        "aime_2025",
+    ),
+    aggregation=AggregationStrategy.AVERAGE_OF_AVERAGES,
+    description="Mathematical reasoning for science-oriented model evaluation.",
+)
+
+SCIENCE_ALL = make_suite(
+    "science:all",
+    (
+        SCIENCE_CORE,
+        SCIENCE_BIOLOGY,
+        SCIENCE_MEDICINE,
+        SCIENCE_PHYSICAL,
+        SCIENCE_RESEARCH,
+        SCIENCE_MATH,
+    ),
+    aggregation=AggregationStrategy.AVERAGE_OF_AVERAGES,
+    description="Non-overlapping umbrella suite covering all current science tasks exactly once.",
 )

--- a/src/olmo_eval/evals/suites/science.py
+++ b/src/olmo_eval/evals/suites/science.py
@@ -9,11 +9,19 @@ Design rules for the ``science:*`` hierarchy:
 3. Prefer subject-sliced GPQA tasks inside the hierarchy so biology, chemistry,
    and physics live in separate domain suites without also including the
    full-subset GPQA tasks.
+4. Provide an execution-oriented split between judge-free and judge-dependent
+   tasks so large science runs can be staged in two passes.
 
 The legacy ``gpqa`` / ``gpqa:mc`` / ``gpqa:bpb`` suites are retained as
 convenience entry points, but they are intentionally not nested under
 ``science:all`` because they would duplicate the GPQA questions already
 allocated to domain-specific suites.
+
+Execution guidance:
+- Use ``science:nojudge`` for the main science stack when you want to avoid
+  external LLM-as-judge dependencies.
+- Use ``science:judge`` for the judge-dependent science tasks.
+- Use ``science:all`` only when you want both together as a single umbrella.
 """
 
 import olmo_eval.evals.suites.astabench  # noqa: F401 - ensure suite registration
@@ -82,6 +90,8 @@ GPQA_BPB = make_suite(
 #   does not include ``medqa`` because it points at the same benchmark family as
 #   ``medqa_en`` and would double-weight that content.
 # - science:research groups scientific literature / evidence-use tasks.
+# - science:nojudge / science:judge are execution helpers for running the full
+#   science stack in two stages.
 # - science:math groups mathematical reasoning tasks used in science-adjacent
 #   evaluation.
 
@@ -155,15 +165,33 @@ SCIENCE_MATH = make_suite(
     description="Mathematical reasoning for science-oriented model evaluation.",
 )
 
-SCIENCE_ALL = make_suite(
-    "science:all",
+SCIENCE_NOJUDGE = make_suite(
+    "science:nojudge",
     (
         SCIENCE_CORE,
         SCIENCE_BIOLOGY,
         SCIENCE_MEDICINE,
         SCIENCE_PHYSICAL,
-        SCIENCE_RESEARCH,
+        "qasper_yesno",
+        "sciriff_yesno",
         SCIENCE_MATH,
+    ),
+    aggregation=AggregationStrategy.AVERAGE_OF_AVERAGES,
+    description="All current science tasks that do not require external LLM judges.",
+)
+
+SCIENCE_JUDGE = make_suite(
+    "science:judge",
+    (get_suite("astabench"),),
+    aggregation=AggregationStrategy.AVERAGE_OF_AVERAGES,
+    description="Current science tasks that require external LLM-as-judge scoring.",
+)
+
+SCIENCE_ALL = make_suite(
+    "science:all",
+    (
+        SCIENCE_NOJUDGE,
+        SCIENCE_JUDGE,
     ),
     aggregation=AggregationStrategy.AVERAGE_OF_AVERAGES,
     description="Non-overlapping umbrella suite covering all current science tasks exactly once.",

--- a/tests/evals/suites/test_science.py
+++ b/tests/evals/suites/test_science.py
@@ -13,6 +13,8 @@ def test_science_suites_are_registered():
         "science:physical",
         "science:research",
         "science:math",
+        "science:nojudge",
+        "science:judge",
         "science:all",
     )
     for name in expected:
@@ -56,3 +58,15 @@ def test_science_research_contains_literature_tasks():
     assert "qasper_yesno" in expanded
     assert "sciriff_yesno" in expanded
     assert "astabench_scholarqa" in expanded
+
+
+def test_science_nojudge_excludes_judge_task():
+    expanded = get_suite("science:nojudge").expand()
+    assert "qasper_yesno" in expanded
+    assert "sciriff_yesno" in expanded
+    assert "astabench_scholarqa" not in expanded
+
+
+def test_science_judge_contains_only_judge_task():
+    expanded = get_suite("science:judge").expand()
+    assert expanded == ("astabench_scholarqa",)

--- a/tests/evals/suites/test_science.py
+++ b/tests/evals/suites/test_science.py
@@ -1,0 +1,58 @@
+"""Tests for science suite composition."""
+
+from collections import Counter
+
+from olmo_eval.evals.suites import get_suite, suite_exists
+
+
+def test_science_suites_are_registered():
+    expected = (
+        "science:core",
+        "science:biology",
+        "science:medicine",
+        "science:physical",
+        "science:research",
+        "science:math",
+        "science:all",
+    )
+    for name in expected:
+        assert suite_exists(name), f"Expected suite {name!r} to be registered"
+
+
+def test_science_all_has_no_duplicate_task_specs():
+    expanded = get_suite("science:all").expand()
+    counts = Counter(expanded)
+    duplicates = {task: count for task, count in counts.items() if count > 1}
+    assert duplicates == {}
+
+
+def test_science_biology_owns_biology_gpqa_slice_only():
+    expanded = get_suite("science:biology").expand()
+    assert "gpqa_diamond_biology" in expanded
+    assert "gpqa_main_biology" in expanded
+    assert "gpqa_extended_biology" in expanded
+    assert "gpqa_diamond" not in expanded
+    assert "gpqa_main" not in expanded
+    assert "gpqa_extended" not in expanded
+
+
+def test_science_medicine_uses_single_medqa_family_entry():
+    expanded = get_suite("science:medicine").expand()
+    assert "medqa_en" in expanded
+    assert "medqa" not in expanded
+
+
+def test_science_all_keeps_physical_science_subject_specific():
+    expanded = get_suite("science:all").expand()
+    assert "gpqa_diamond_chemistry" in expanded
+    assert "gpqa_main_physics" in expanded
+    assert "gpqa_diamond" not in expanded
+    assert "gpqa_main" not in expanded
+    assert "gpqa_extended" not in expanded
+
+
+def test_science_research_contains_literature_tasks():
+    expanded = get_suite("science:research").expand()
+    assert "qasper_yesno" in expanded
+    assert "sciriff_yesno" in expanded
+    assert "astabench_scholarqa" in expanded


### PR DESCRIPTION
## Description

Lightweight suite to unify all the science related evals. 

  - domain suites:
      - science:core
      - science:biology
      - science:medicine
      - science:physical
      - science:research
      - science:math
  - execution-oriented aggregate suites:
      - science:nojudge
      - science:judge
      - science:all

science:all runs everything. Most evals don't need an LLM judge, science:nojudge covers these.

In terms of specific tasks included, we currently have

  | Suite | Task | Instances |
  |---|---|---:|
  | `science:core` | arc_easy | 2376 |
  | `science:core` | arc_challenge | 1172 |
  | `science:core` | sciq | 1000 |
  | `science:core` | mmlu_abstract_algebra | 100 |
  | `science:core` | mmlu_astronomy | 152 |
  | `science:core` | mmlu_college_biology | 144 |
  | `science:core` | mmlu_college_chemistry | 100 |
  | `science:core` | mmlu_college_computer_science | 100 |
  | `science:core` | mmlu_college_mathematics | 100 |
  | `science:core` | mmlu_college_physics | 102 |
  | `science:core` | mmlu_computer_security | 100 |
  | `science:core` | mmlu_conceptual_physics | 235 |
  | `science:core` | mmlu_electrical_engineering | 145 |
  | `science:core` | mmlu_elementary_mathematics | 378 |
  | `science:core` | mmlu_high_school_biology | 310 |
  | `science:core` | mmlu_high_school_chemistry | 203 |
  | `science:core` | mmlu_high_school_computer_science | 100 |
  | `science:core` | mmlu_high_school_mathematics | 270 |
  | `science:core` | mmlu_high_school_physics | 151 |
  | `science:core` | mmlu_high_school_statistics | 216 |
  | `science:core` | mmlu_machine_learning | 112 |
  | `science:biology` | lab_bench_litqa2 | 199 |
  | `science:biology` | lab_bench_dbqa | 520 |
  | `science:biology` | lab_bench_seqqa | 600 |
  | `science:biology` | lab_bench_protocolqa | 108 |
  | `science:biology` | lab_bench_suppqa | 82 |
  | `science:biology` | lab_bench_cloning_scenarios | 33 |
  | `science:biology` | geneturing_gene_name_conversion | 100 |
  | `science:biology` | geneturing_gene_location | 100 |
  | `science:biology` | geneturing_snp_location | 100 |
  | `science:biology` | geneturing_gene_snp_association | 100 |
  | `science:biology` | geneturing_protein_coding_genes | 100 |
  | `science:biology` | geneturing_tf_regulation | 100 |
  | `science:biology` | geneturing_human_genome_dna_alignment | 100 |
  | `science:biology` | geneturing_amino_acid_translation | 100 |
  | `science:biology` | geneturing_dna_sequence_extraction | 100 |
  | `science:biology` | geneturing_gene_name_extraction | 100 |
  | `science:biology` | geneturing_gene_alias | 100 |
  | `science:biology` | geneturing_gene_disease_association | 100 |
  | `science:biology` | geneturing_gene_ontology | 100 |
  | `science:biology` | geneturing_multi_species_dna_alignment | 100 |
  | `science:biology` | gpqa_diamond_biology | 19 |
  | `science:biology` | gpqa_main_biology | 78 |
  | `science:biology` | gpqa_extended_biology | 105 |
  | `science:medicine` | medmcqa | 4183 |
  | `science:medicine` | medqa_en | 1273 |
  | `science:medicine` | mmlu_anatomy | 135 |
  | `science:medicine` | mmlu_clinical_knowledge | 265 |
  | `science:medicine` | mmlu_college_medicine | 173 |
  | `science:medicine` | mmlu_human_aging | 223 |
  | `science:medicine` | mmlu_medical_genetics | 100 |
  | `science:medicine` | mmlu_nutrition | 306 |
  | `science:medicine` | mmlu_professional_medicine | 272 |
  | `science:medicine` | mmlu_virology | 166 |
  | `science:physical` | gpqa_diamond_chemistry | 93 |
  | `science:physical` | gpqa_main_chemistry | 183 |
  | `science:physical` | gpqa_extended_chemistry | 214 |
  | `science:physical` | gpqa_diamond_physics | 86 |
  | `science:physical` | gpqa_main_physics | 187 |
  | `science:physical` | gpqa_extended_physics | 227 |
  | `science:math` | gsm8k | 1319 |
  | `science:math` | gsm_symbolic | 5000 |
  | `science:math` | minerva_math_algebra | 1187 |
  | `science:math` | minerva_math_counting_and_probability | 474 |
  | `science:math` | minerva_math_geometry | 479 |
  | `science:math` | minerva_math_intermediate_algebra | 903 |
  | `science:math` | minerva_math_number_theory | 540 |
  | `science:math` | minerva_math_prealgebra | 871 |
  | `science:math` | minerva_math_precalculus | 546 |
  | `science:math` | math500 | 500 |
  | `science:math` | aime_2024 | 30 |
  | `science:math` | aime_2025 | 30 |

<!-- Describe your changes in detail -->

## Type of Change

<!-- Put an `x` in all the boxes that apply -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Testing

<!-- Describe how you tested your changes -->

- [x] Unit tests pass locally (`pytest tests/ --ignore=tests/integration/`)
- [x] Integration tests pass (if applicable)
- [x] New tests added for new functionality

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
