### PR TITLE
Parity fixes for OlmoBaseEval

### DIFF
--- a/src/olmo_eval/evals/suites/olmobase.py
+++ b/src/olmo_eval/evals/suites/olmobase.py
@@ -21,7 +21,7 @@ make_suite(
 )
 make_suite(
     name="arc:mc:olmo3base",
-    tasks=("arc_challenge:mc:olmo3base", "arc_easy:mc:olmo3base"),
+    tasks=("arc_challenge:mc_olmo3base", "arc_easy:mc:olmo3base"),
 )
 
 # -- MMLU ---------------------------------------------------------------------
@@ -211,9 +211,9 @@ make_suite(
         get_suite("mmlu:humanities:mc:olmo3base"),
         get_suite("mmlu:other:mc:olmo3base"),
         get_suite("mmlu:social_sciences:mc:olmo3base"),
-        "csqa:mc:olmo3base",
-        "piqa:mc:olmo3base",
-        "socialiqa:mc:olmo3base",
+        "csqa:mc_olmo3base",
+        "piqa:mc_olmo3base",
+        "socialiqa:mc_olmo3base",
         "coqa:mc:olmo3base",
         "drop:mc:olmo3base",
         "jeopardy:mc:olmo3base",

--- a/src/olmo_eval/evals/tasks/arc.py
+++ b/src/olmo_eval/evals/tasks/arc.py
@@ -219,14 +219,15 @@ register_variant(
     "olmo3base",
     num_fewshot=5,
     fewshot_source="olmes_arc_easy_fixed",
-    split=Split.ALL,
+    split=Split.TEST,
+    metrics=(LogprobPerCharMCAccuracyMetric(),),
 )
 register_regime(
     "arc_easy",
     "olmo3base",
     num_fewshot=5,
     fewshot_source="olmes_arc_easy_fixed",
-    split=Split.ALL,
+    split=Split.TEST,
 )
 register_variant("arc_easy", "olmes", num_fewshot=5, fewshot_source="olmes_arc_easy_fixed")
 register_variant("arc_easy", "full")
@@ -241,11 +242,20 @@ register_variant(
     "olmo3base",
     num_fewshot=5,
     fewshot_source="olmes_arc_challenge_fixed",
-    split=Split.ALL,
+    split=Split.TEST,
+    metrics=(LogprobUncondMCAccuracyMetric(),),
 )
 register_regime(
     "arc_challenge",
     "olmo3base",
+    num_fewshot=5,
+    fewshot_source="olmes_arc_challenge_fixed",
+    split=Split.TEST,
+)
+register_variant(
+    "arc_challenge",
+    "mc_olmo3base",
+    formatter=MultipleChoiceFormatter(),
     num_fewshot=5,
     fewshot_source="olmes_arc_challenge_fixed",
     split=Split.ALL,

--- a/src/olmo_eval/evals/tasks/arc.py
+++ b/src/olmo_eval/evals/tasks/arc.py
@@ -219,15 +219,14 @@ register_variant(
     "olmo3base",
     num_fewshot=5,
     fewshot_source="olmes_arc_easy_fixed",
-    split=Split.TEST,
-    metrics=(LogprobPerCharMCAccuracyMetric(),),
+    split=Split.ALL,
 )
 register_regime(
     "arc_easy",
     "olmo3base",
     num_fewshot=5,
     fewshot_source="olmes_arc_easy_fixed",
-    split=Split.TEST,
+    split=Split.ALL,
 )
 register_variant("arc_easy", "olmes", num_fewshot=5, fewshot_source="olmes_arc_easy_fixed")
 register_variant("arc_easy", "full")
@@ -242,15 +241,14 @@ register_variant(
     "olmo3base",
     num_fewshot=5,
     fewshot_source="olmes_arc_challenge_fixed",
-    split=Split.TEST,
-    metrics=(LogprobUncondMCAccuracyMetric(),),
+    split=Split.ALL,
 )
 register_regime(
     "arc_challenge",
     "olmo3base",
     num_fewshot=5,
     fewshot_source="olmes_arc_challenge_fixed",
-    split=Split.TEST,
+    split=Split.ALL,
 )
 register_variant(
     "arc_challenge", "olmes", num_fewshot=5, fewshot_source="olmes_arc_challenge_fixed"

--- a/src/olmo_eval/evals/tasks/csqa.py
+++ b/src/olmo_eval/evals/tasks/csqa.py
@@ -157,15 +157,18 @@ register_variant(
     "olmo3base",
     num_fewshot=5,
     fewshot_source="olmes_csqa_fixed",
-    data_source=DataSource(path="commonsense_qa", split="validation"),
-    metrics=(LogprobUncondMCAccuracyMetric(),),
+    data_source=DataSource(path="commonsense_qa", split="validation+train"),
+    limit=10000,
+    seed=1234,
 )
 register_regime(
     "csqa",
     "olmo3base",
     num_fewshot=5,
     fewshot_source="olmes_csqa_fixed",
-    data_source=DataSource(path="commonsense_qa", split="validation"),
+    data_source=DataSource(path="commonsense_qa", split="validation+train"),
+    limit=10000,
+    seed=1234,
 )
 register_variant(
     "csqa",

--- a/src/olmo_eval/evals/tasks/csqa.py
+++ b/src/olmo_eval/evals/tasks/csqa.py
@@ -157,13 +157,20 @@ register_variant(
     "olmo3base",
     num_fewshot=5,
     fewshot_source="olmes_csqa_fixed",
-    data_source=DataSource(path="commonsense_qa", split="validation+train"),
-    limit=10000,
-    seed=1234,
+    data_source=DataSource(path="commonsense_qa", split="validation"),
+    metrics=(LogprobUncondMCAccuracyMetric(),),
 )
 register_regime(
     "csqa",
     "olmo3base",
+    num_fewshot=5,
+    fewshot_source="olmes_csqa_fixed",
+    data_source=DataSource(path="commonsense_qa", split="validation"),
+)
+register_variant(
+    "csqa",
+    "mc_olmo3base",
+    formatter=MultipleChoiceFormatter(),
     num_fewshot=5,
     fewshot_source="olmes_csqa_fixed",
     data_source=DataSource(path="commonsense_qa", split="validation+train"),

--- a/src/olmo_eval/evals/tasks/piqa.py
+++ b/src/olmo_eval/evals/tasks/piqa.py
@@ -149,7 +149,8 @@ register_variant(
     "olmo3base",
     num_fewshot=5,
     fewshot_source="olmes_piqa_fixed",
-    split=Split.VALIDATION,
+    split=Split.ALL,
+    limit=10_000,
     metrics=(LogprobPerCharMCAccuracyMetric(),),
 )
 register_regime(
@@ -157,7 +158,8 @@ register_regime(
     "olmo3base",
     num_fewshot=5,
     fewshot_source="olmes_piqa_fixed",
-    split=Split.VALIDATION,
+    split=Split.ALL,
+    limit=10_000,
 )
 
 register_variant(

--- a/src/olmo_eval/evals/tasks/piqa.py
+++ b/src/olmo_eval/evals/tasks/piqa.py
@@ -149,8 +149,7 @@ register_variant(
     "olmo3base",
     num_fewshot=5,
     fewshot_source="olmes_piqa_fixed",
-    split=Split.ALL,
-    limit=10_000,
+    split=Split.VALIDATION,
     metrics=(LogprobPerCharMCAccuracyMetric(),),
 )
 register_regime(
@@ -158,8 +157,17 @@ register_regime(
     "olmo3base",
     num_fewshot=5,
     fewshot_source="olmes_piqa_fixed",
+    split=Split.VALIDATION,
+)
+register_variant(
+    "piqa",
+    "mc_olmo3base",
+    formatter=MultipleChoiceFormatter(),
+    num_fewshot=5,
+    fewshot_source="olmes_piqa_fixed",
     split=Split.ALL,
     limit=10_000,
+    metrics=(LogprobPerCharMCAccuracyMetric(),),
 )
 
 register_variant(

--- a/src/olmo_eval/evals/tasks/socialiqa.py
+++ b/src/olmo_eval/evals/tasks/socialiqa.py
@@ -150,6 +150,13 @@ register_variant("socialiqa", "mc", formatter=MultipleChoiceFormatter())
 register_variant(
     "socialiqa",
     "olmo3base",
+    num_fewshot=5,
+    fewshot_source="olmes_socialiqa_fixed",
+)
+register_variant(
+    "socialiqa",
+    "mc_olmo3base",
+    formatter=MultipleChoiceFormatter(),
     data_source=DataSource(
         path="social_i_qa", split="train+validation", revision="refs/convert/parquet"
     ),

--- a/src/olmo_eval/evals/tasks/socialiqa.py
+++ b/src/olmo_eval/evals/tasks/socialiqa.py
@@ -150,7 +150,11 @@ register_variant("socialiqa", "mc", formatter=MultipleChoiceFormatter())
 register_variant(
     "socialiqa",
     "olmo3base",
+    data_source=DataSource(
+        path="social_i_qa", split="train+validation", revision="refs/convert/parquet"
+    ),
     num_fewshot=5,
+    limit=10000,
     fewshot_source="olmes_socialiqa_fixed",
 )
 register_variant(

--- a/src/olmo_eval/evals/tasks/winogrande.py
+++ b/src/olmo_eval/evals/tasks/winogrande.py
@@ -183,7 +183,6 @@ register_variant(
     "winogrande",
     "olmo3base",
     num_fewshot=5,
-    limit=10_000,
     fewshot_source="olmes_winogrande_fixed",
 )
 register_variant(


### PR DESCRIPTION
## Description

From https://github.com/allenai/olmo-eval-internal/pull/117:

> Theres a few that may be wrong as of now (>2% diff): socialiqa:mc::olmo3base, winogrande:rc::olmo3base, winogrande:bpb::olmo3base (WinoGrande has been really tricky due to it's specific logprob setup).
>
> There are a few that are a slightly off (between 1-2% diff): arc_challenge:mc::olmo3base, csqa:mc::olmo3base, piqa:mc::olmo3base, hellaswag:rc::olmo3base, lab_bench_dbqa::olmo3base, medmcqa:rc::olmo3base (I suspect the in-context examples might not be the same, or slight prompt differences).

This PR fixes parity on those tasks. All tasks seemed to have some split name or instance limit that wasn't specified correctly.

## Full Parity Test

```sh
main_tasks=(
  "olmobase:mcqa_stem"
  "olmobase:mcqa_non_stem"
  # "olmobase:gen"
  # "olmobase:math"
)

easy_tasks=(
  "olmobase:easy:qa:rc"
  "olmobase:easy:qa:bpb"
  # "olmobase:easy:math:bpb"
  # "olmobase:easy:code:bpb"
)

for task in "${main_tasks[@]}"; do
  olmo-eval beaker launch \
    -n "olmo-eval-parity-final" -m allenai/Olmo-3-1025-7B -H default \
    -c h100 -B ai2/oe-base -p urgent --store -y \
    -g olmo-3-parity-baseline-fixed \
    -w ai2/olmo-eval-debug \
    --gpus 4 \
    --no-follow \
    -t "$task"
done

for task in "${easy_tasks[@]}"; do
  olmo-eval beaker launch \
    -n "olmo-eval-parity-final" -m allenai/OLMo-2-0425-1B -H default \
    -c h100 -B ai2/oe-base -p urgent --store -y \
    -g olmo-3-parity-baseline-fixed \
    -w ai2/olmo-eval-debug \
    --gpus 4 \
    --no-follow \
    -t "$task"
done
```

## Type of Change

<!-- Put an `x` in all the boxes that apply -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Testing

<!-- Describe how you tested your changes -->

- [x] Unit tests pass locally (`pytest tests/ --ignore=tests/integration/`)
- [x] Integration tests pass (if applicable)
- [ ] New tests added for new functionality

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
