### PR TITLE
Apply chat template in in-process vllm provider

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,10 +41,11 @@ Issues = "https://github.com/allenai/olmo-eval/issues"
 
 [project.optional-dependencies]
 hf = [
-    "transformers~=4.57.3",
+    "transformers>=5.4.0",
 ]
 vllm = [
-    "vllm[runai]==0.13.0",  # runai extras enable S3 model loading
+    "vllm[runai]>=0.19.0",  # runai extras enable S3 model loading
+    "transformers>=5.4.0",
     "opencv-python-headless==4.13.0.92",  # Required to avoid libxcb import error
     "torch-c-dlpack-ext",  # Required for TVM tensor allocation in vLLM
 ]

--- a/src/olmo_eval/inference/providers/vllm.py
+++ b/src/olmo_eval/inference/providers/vllm.py
@@ -8,7 +8,7 @@ import os
 from typing import TYPE_CHECKING, Any
 
 from olmo_eval.common.debug import is_debug_provider, is_debug_requests
-from olmo_eval.common.types import LMOutput, LMRequest, LogProbEntry, SamplingParams
+from olmo_eval.common.types import LMOutput, LMRequest, LogProbEntry, RequestType, SamplingParams
 from olmo_eval.inference.base import InferenceProvider
 from olmo_eval.inference.tokenizer_utils import encode_context_and_continuation
 
@@ -224,7 +224,19 @@ class VLLMProvider(InferenceProvider):
         params = self._default_sampling_params(sampling_params)
         vllm_params = self._build_sampling_params(params)
 
-        prompt_strs = [req.prompt for req in requests]
+        tokenizer = self.llm.get_tokenizer()
+        prompt_strs: list[str] = []
+        for req in requests:
+            if req.request_type == RequestType.CHAT and req.messages:
+                prompt_strs.append(
+                    tokenizer.apply_chat_template(
+                        list(req.messages),
+                        tokenize=False,
+                        add_generation_prompt=True,
+                    )
+                )
+            else:
+                prompt_strs.append(req.prompt)
 
         if is_debug_requests():
             for i, prompt in enumerate(prompt_strs):
@@ -234,7 +246,6 @@ class VLLMProvider(InferenceProvider):
         # This bypasses vLLM's internal tokenization, matching the old framework behavior of
         # calling tokenizer(text, add_special_tokens=False) before passing to vLLM.
         if self._add_bos_token is False:
-            tokenizer = self.llm.get_tokenizer()
             vllm_prompts: list = [
                 {"prompt_token_ids": tokenizer.encode(p, add_special_tokens=False)}
                 for p in prompt_strs


### PR DESCRIPTION
## Summary
- The in-process `VLLMProvider.generate` was passing `req.prompt` directly to vLLM, which is empty for `RequestType.CHAT` requests (where only `req.messages` is populated). All chat-style tasks (e.g. `aime_2025:pass_at_32`) failed with `ValueError: The decoder prompt cannot be empty`.
- Fix: when the request is CHAT with messages, apply the tokenizer's chat template (`add_generation_prompt=True`) to build the prompt string before handing it to vLLM.
- Also bump pinned `vllm`/`transformers` versions so the provider can load models saved with `transformers>=5.4.0` (new `rope_parameters`/`layer_types` config shape).

## Test plan
- [x] `olmo-eval run -m /model --harness default -o provider.kind=vllm -t aime_2025:pass_at_32` on a Qwen3 4B base model. Previously failed with empty-prompt errors for all 30 instances; now completes with `pass_at_1:minerva_math_flex=0.2156`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)