### PR TITLE
Accept SamplingParams fields as task-level -o overrides

### DIFF
--- a/src/olmo_eval/cli/utils.py
+++ b/src/olmo_eval/cli/utils.py
@@ -1,5 +1,6 @@
 """Shared utilities for the CLI."""
 
+import dataclasses
 import json
 from dataclasses import dataclass
 from datetime import datetime
@@ -7,6 +8,8 @@ from typing import TYPE_CHECKING, Any
 
 import click
 from rich.console import Console
+
+from olmo_eval.common import types
 
 if TYPE_CHECKING:
     from olmo_eval.evals.external.base import ExternalEval
@@ -171,10 +174,12 @@ def process_ordered_args(
 
             # Apply to task or harness with validation
             if last_flag == "t" and current_task:
-                if top_key not in TASK_CONFIG_FIELDS:
+                sampling_fields = {f.name for f in dataclasses.fields(types.SamplingParams)}
+                if top_key not in TASK_CONFIG_FIELDS and top_key not in sampling_fields:
                     raise click.UsageError(
-                        f"Invalid task override: '{top_key}' is not a TaskConfig field. "
-                        f"Did you mean to put this after --harness instead of -t?"
+                        f"Invalid task override: '{top_key}' is not a TaskConfig or "
+                        f"SamplingParams field. Did you mean to put this after --harness "
+                        f"instead of -t?"
                     )
                 task_overrides[current_task].append(arg.value)
             elif last_flag == "h":


### PR DESCRIPTION
The CLI validator in ``process_ordered_args`` only permits ``TaskConfig`` field
names after ``-t``, which makes it impossible to override sampling params like
``max_tokens`` at the task level:

- ``-o max_tokens=16384`` is rejected: \"'max_tokens' is not a TaskConfig field\".
- ``-o sampling_params.max_tokens=16384`` passes validation but produces a broken
  ``sampling_params={\"max_tokens\": 16384}`` dict that replaces the dataclass,
  crashing at runtime with ``AttributeError: 'dict' object has no attribute 'stop_sequences'``.

The runtime code in [``runners/common/base.py::_build_task_overrides``](https://github.com/allenai/olmo-eval-internal/blob/36984cf955e7c21cf94414d9967c37fa7b7f41c8/src/olmo_eval/runners/common/base.py#L91) already
routes flat sampling field names into ``sampling_overrides``, so the only fix
needed is to let the CLI validator accept them.

I hit this while trying to shorten the reasoning budget for AIME on a 32k-context model:
the task's default ``max_tokens=32768`` leaves zero input budget, and
``/v1/chat/completions`` on ``vllm_server`` strictly enforces
``input_tokens + max_tokens <= max_model_len``.

## Test plan
- [x] ``uv run pytest tests/cli/test_utils.py`` — all 21 tests pass
- [x] Submitted a real eval job with ``-o max_tokens=16384`` after ``-t aime_2025:pass_at_32`` — passes CLI validation