### PR TITLE
Fixes bugs in roundtrip JSON

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,6 +123,7 @@ dev = [
     "olmo-eval-internal[storage,analysis]",
     "jinja2>=3.1.6",
     "google-api-core>=2.0.0",
+    "parameterized>=0.9.0",
 ]
 
 [tool.ruff]

--- a/src/olmo_eval/cli/beaker/job_assembler.py
+++ b/src/olmo_eval/cli/beaker/job_assembler.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from typing import TYPE_CHECKING, Any
 
 from olmo_eval.common.constants.infrastructure import (
@@ -205,12 +206,12 @@ def assemble_external_eval_job(
     # Add eval_args
     if eval_args:
         for key, value in eval_args.items():
-            command.extend(["-a", f"{key}={value}"])
+            command.extend(["-a", f"{key}={json.dumps(value)}"])
 
     # Add provider_kwargs
     if provider_kwargs:
         for key, value in provider_kwargs.items():
-            command.extend(["-K", f"{key}={value}"])
+            command.extend(["-K", f"{key}={json.dumps(value)}"])
 
     # Add storage options (only when --store is enabled)
     if store:

--- a/src/olmo_eval/cli/utils.py
+++ b/src/olmo_eval/cli/utils.py
@@ -239,14 +239,16 @@ def _coerce_value(value: str) -> Any:
 
     Handles booleans, integers, floats, JSON objects/arrays, and plain strings.
     """
-    # Booleans
+    # JSON scalar literals
     if value.lower() == "true":
         return True
     if value.lower() == "false":
         return False
+    if value == "null":
+        return None
 
-    # JSON objects and arrays
-    if value.startswith("{") or value.startswith("["):
+    # JSON objects, arrays, and quoted strings (so launcher round-trips survive)
+    if value.startswith(("{", "[", '"')):
         try:
             return json.loads(value)
         except json.JSONDecodeError:

--- a/tests/cli/test_arg_round_trip.py
+++ b/tests/cli/test_arg_round_trip.py
@@ -1,0 +1,42 @@
+"""Round-trip tests for eval-arg / provider-kwarg serialization.
+
+The Beaker launcher serializes parsed args back into ``-a key=value`` strings
+that the inner ``run-external`` CLI re-parses. ``json.dumps`` on the way out and
+``json.loads`` (via ``_coerce_value``) on the way in must agree on every shape
+we care about: strings, bools, ints, floats, lists, dicts, None.
+"""
+
+from __future__ import annotations
+
+import json
+import unittest
+from typing import Any
+
+from parameterized import parameterized
+
+from olmo_eval.cli import utils as cli_utils
+
+
+class TestArgRoundTrip(unittest.TestCase):
+    @parameterized.expand(
+        [
+            ("string", "hello"),
+            ("string_with_spaces", "hello world"),
+            ("bool_true", True),
+            ("bool_false", False),
+            ("int", 123),
+            ("float", 3.14),
+            ("list_of_strings", ["2", "11"]),
+            ("list_of_ints", [1, 2, 3]),
+            ("dict", {"a": 1, "b": "two"}),
+            ("none", None),
+        ]
+    )
+    def test_round_trip(self, _name: str, value: Any) -> None:
+        encoded = json.dumps(value)
+        parsed = cli_utils.parse_key_value_args((f"k={encoded}",), coerce_types=True)
+        self.assertEqual(parsed["k"], value)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

Without it, `-a key=value` from the Beaker launcher is built with raw `f"{key}={value}"` — Python's `str()` on
  dicts/lists produces single-quoted output `({'a': 1})` which `json.loads` rejects on the remote side, so
  structured eval args get mangled or fail to parse. The PR routes values through `json.dumps` so they
  round-trip cleanly through the CLI as valid JSON.

Example failing command: 

```
olmo-eval launch beaker \
    --harness scicode \
    -m Qwen/Qwen3-8B \
    -a problem_ids='["13.1","62.1"]'
```

Round trip:
  1. Launcher parses `-a` → `eval_args = {"problem_ids": ["13.1", "62.1"]}` (a Python list).
  2. Without the fix: the inner command is built as `f"{key}={value}"` → `-a problem_ids=['13.1', '62.1']`
  (Python str() uses single quotes).
  3. The remote run-external CLI calls `json.loads` on the value to coerce types. `json.loads("['13.1',
  '62.1']")` raises json.JSONDecodeError (JSON only allows double quotes), so it falls back to treating it
  as the literal string `"['13.1', '62.1']"`.

## Type of Change

<!-- Put an `x` in all the boxes that apply -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Testing

<!-- Describe how you tested your changes -->

- [x] Unit tests pass locally (`pytest tests/ --ignore=tests/integration/`)
- [ ] Integration tests pass (if applicable)
- [x] New tests added for new functionality

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
