### PR TITLE
Make Beaker budget optional

### DIFF
--- a/src/olmo_eval/cli/beaker/config_loader.py
+++ b/src/olmo_eval/cli/beaker/config_loader.py
@@ -22,7 +22,7 @@ class LaunchConfig:
     task_specs: list[str]
     cluster: str
     workspace: str
-    budget: str
+    budget: str | None = None
 
     task_overrides: dict[str, list[str]] = field(default_factory=dict)
 
@@ -164,7 +164,6 @@ class LaunchConfigLoader:
         assert name is not None
         assert cluster is not None
         assert workspace is not None
-        assert budget is not None
 
         from olmo_eval.launch.beaker.constants import DEFAULT_S3_BUCKET, DEFAULT_S3_PREFIX
 
@@ -233,9 +232,6 @@ class LaunchConfigLoader:
             raise SystemExit(1) from None
         if not workspace:
             console.print("[red]Error:[/red] --workspace/-w is required")
-            raise SystemExit(1) from None
-        if not budget:
-            console.print("[red]Error:[/red] --budget/-B is required")
             raise SystemExit(1) from None
 
     def _generate_experiment_name(self, model_specs: list[str], task_specs: list[str]) -> str:

--- a/src/olmo_eval/cli/beaker/config_loader.py
+++ b/src/olmo_eval/cli/beaker/config_loader.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
+import beaker
 from rich.console import Console
 
 if TYPE_CHECKING:
@@ -233,6 +234,15 @@ class LaunchConfigLoader:
         if not workspace:
             console.print("[red]Error:[/red] --workspace/-w is required")
             raise SystemExit(1) from None
+        if not budget and not self._workspace_has_bound_budget(workspace):
+            console.print(
+                "[red]Error:[/red] --budget/-B is required when the workspace has no bound budget"
+            )
+            raise SystemExit(1) from None
+
+    def _workspace_has_bound_budget(self, workspace: str) -> bool:
+        client = beaker.Beaker.from_env(default_workspace=workspace)
+        return bool(client.workspace.get().budget_id)
 
     def _generate_experiment_name(self, model_specs: list[str], task_specs: list[str]) -> str:
         """Generate experiment name from model and task specs.

--- a/src/olmo_eval/cli/beaker/job_assembler.py
+++ b/src/olmo_eval/cli/beaker/job_assembler.py
@@ -6,7 +6,6 @@ import json
 from typing import TYPE_CHECKING, Any
 
 from olmo_eval.common.constants.infrastructure import (
-    BEAKER_DEFAULT_BUDGET,
     BEAKER_RESULT_DIR,
     cluster_has_weka,
 )
@@ -325,7 +324,7 @@ def assemble_external_eval_job(
         shared_memory="10GiB",
         retries=retries,
         workspace=workspace,
-        budget=budget or BEAKER_DEFAULT_BUDGET,
+        budget=budget,
         groups=groups or [],
         beaker_image=beaker_image,
         inject_aws_credentials=inject_aws_credentials,

--- a/src/olmo_eval/launch/beaker/launcher.py
+++ b/src/olmo_eval/launch/beaker/launcher.py
@@ -336,7 +336,7 @@ class BeakerJobConfig:
         command: Command to run in the container (required).
         cluster: Cluster alias ("h100", "a100", "aus") or full name(s) (required).
         workspace: Beaker workspace (required).
-        budget: Beaker budget (required).
+        budget: Beaker budget. If None, gantry uses the workspace's bound budget.
         num_gpus: Number of GPUs to request.
         shared_memory: Shared memory size (e.g., "10GiB").
         priority: Job priority level.
@@ -357,7 +357,7 @@ class BeakerJobConfig:
     command: list[str]
     cluster: str | list[str]  # Cluster alias ("h100", "a100", "aus") or full name(s)
     workspace: str  # Beaker workspace
-    budget: str  # Beaker budget
+    budget: str | None = None  # Beaker budget; None uses the workspace's bound budget
 
     # Resources
     num_gpus: int = 0


### PR DESCRIPTION
Makes the budget flag (`-B`, `--B`) optional. When omitted, gantry uses the workspace's bound budget; this is the only path that works for workspaces (e.g. `ai2/open-instruct-dev`) that are pinned to a specific budget account. For those workspaces, as there's only one valid budget, it's redundant to pass a budget in. 

Validated with ([Beaker](https://beaker.org/orgs/ai2/workspaces/open-instruct-dev/work/01KRKH2D9P79ZVF8SX0ZF0DXTW?taskId=01KRKH2DFBXKF2Q55PEZ4M0FW1&jobId=01KRKH2DJVZ4KF74XBTBW406CC)): 

```
uv run olmo-eval beaker launch -y \
    -m Qwen/Qwen3-4B \
    --harness default \
    -o provider.kind=vllm_server \
    -t ifbench --gpus 1 -c h100 \
    -w ai2/open-instruct-dev \
    -p urgent
```