### PR TITLE
Add AIME 2022/2023 tasks and aime_2022_to_2025 suite

### DIFF
--- a/src/olmo_eval/evals/suites/math.py
+++ b/src/olmo_eval/evals/suites/math.py
@@ -22,6 +22,8 @@ make_suite(
 make_suite(
     "math:posttrain:dev",
     (
+        "aime_2022:pass_at_32:16k",
+        "aime_2023:pass_at_32:16k",
         "aime_2025:pass_at_32:16k",
         "aime_2026:pass_at_32:16k",
         "hmmt_nov_2025:pass_at_32:16k",
@@ -29,6 +31,7 @@ make_suite(
     ),
     aggregation=AggregationStrategy.AVERAGE,
     description=(
-        "Dev set for post-training math experiments: AIME 2025/2026 and HMMT Nov 2025 / Feb 2026."
+        "Dev set for post-training math experiments: AIME 2022/2023/2025/2026 "
+        "and HMMT Nov 2025 / Feb 2026."
     ),
 )

--- a/src/olmo_eval/evals/suites/math.py
+++ b/src/olmo_eval/evals/suites/math.py
@@ -8,15 +8,16 @@ make_suite(
 )
 
 make_suite(
-    "aime_2022_to_2025",
+    "aime_2022_to_2026",
     (
         "aime_2022:pass_at_32",
         "aime_2023:pass_at_32",
         "aime_2024:pass_at_32",
         "aime_2025:pass_at_32",
+        "aime_2026:pass_at_32",
     ),
     aggregation=AggregationStrategy.AVERAGE_OF_AVERAGES,
-    description="AIME 2022-2025 combined.",
+    description="AIME 2022-2026 combined.",
 )
 
 make_suite(
@@ -24,6 +25,7 @@ make_suite(
     (
         "aime_2022:pass_at_32:16k",
         "aime_2023:pass_at_32:16k",
+        "aime_2024:pass_at_32:16k",
         "aime_2025:pass_at_32:16k",
         "aime_2026:pass_at_32:16k",
         "hmmt_nov_2025:pass_at_32:16k",
@@ -31,7 +33,6 @@ make_suite(
     ),
     aggregation=AggregationStrategy.AVERAGE,
     description=(
-        "Dev set for post-training math experiments: AIME 2022/2023/2025/2026 "
-        "and HMMT Nov 2025 / Feb 2026."
+        "Dev set for post-training math experiments: AIME 2022-2026 and HMMT Nov 2025 / Feb 2026."
     ),
 )

--- a/src/olmo_eval/evals/suites/math.py
+++ b/src/olmo_eval/evals/suites/math.py
@@ -8,6 +8,18 @@ make_suite(
 )
 
 make_suite(
+    "aime_2022_to_2025",
+    (
+        "aime_2022:pass_at_32",
+        "aime_2023:pass_at_32",
+        "aime_2024:pass_at_32",
+        "aime_2025:pass_at_32",
+    ),
+    aggregation=AggregationStrategy.AVERAGE_OF_AVERAGES,
+    description="AIME 2022-2025 combined.",
+)
+
+make_suite(
     "math:posttrain:dev",
     (
         "aime_2025:pass_at_32:16k",

--- a/src/olmo_eval/evals/tasks/aime.py
+++ b/src/olmo_eval/evals/tasks/aime.py
@@ -64,7 +64,7 @@ def _build_aime_instance(
 
 
 class AIMETask(MinervaMathTask):
-    data_source = DataSource(path="allenai/aime-2021-2025")
+    data_source = DataSource(path="allenai/aime-2022-2025")
     split = Split.TRAIN  # HF dataset only has a train split
     formatter = ChatFormatter(user_template="{question}")
     metrics = (AccuracyMetric(scorer=MinervaMathScorer),)
@@ -89,6 +89,16 @@ class AIMETask(MinervaMathTask):
             year=year,
             problem_number=doc.get("problem_number"),
         )
+
+
+@register("aime_2022")
+class AIME2022Task(AIMETask):
+    years = (2022,)
+
+
+@register("aime_2023")
+class AIME2023Task(AIMETask):
+    years = (2023,)
 
 
 @register("aime_2024")
@@ -127,7 +137,7 @@ _RLZERO_SAMPLING = SamplingParams(
     num_samples=32,
 )
 
-for _year in (2024, 2025, 2026):
+for _year in (2022, 2023, 2024, 2025, 2026):
     register_variant(
         f"aime_{_year}",
         "pass_at_32",

--- a/src/olmo_eval/evals/tasks/aime.py
+++ b/src/olmo_eval/evals/tasks/aime.py
@@ -156,7 +156,7 @@ for _year in (2022, 2023, 2024, 2025, 2026):
         sampling_params=_RLZERO_SAMPLING,
     )
 
-for _year in (2025, 2026):
+for _year in (2022, 2023, 2024, 2025, 2026):
     register_variant(
         f"aime_{_year}",
         "16k",


### PR DESCRIPTION
- Register `aime_2022` and `aime_2023` tasks 
- Add `aime_2022_to_2026` suite combining 2022-2026
- Adds AIME 2022-24 to the `math:posttrain:dev` suite