### PR TITLE
Propagate suite-level CLI overrides to constituent task specs

### DIFF
--- a/src/olmo_eval/cli/run/config.py
+++ b/src/olmo_eval/cli/run/config.py
@@ -339,10 +339,16 @@ class RunConfigBuilder:
         for task_spec, cli_overrides in self.cli_task_overrides.items():
             if not cli_overrides:
                 continue
-            base_spec = task_spec.rsplit("@", 1)[0] if "@" in task_spec else task_spec
+            if "@" in task_spec:
+                base_spec, priority = task_spec.rsplit("@", 1)
+                priority_suffix = f"@{priority}"
+            else:
+                base_spec = task_spec
+                priority_suffix = ""
             if suite_exists(base_spec):
                 for child_spec in get_suite(base_spec).expand():
-                    resolved_cli_overrides.setdefault(child_spec, []).extend(cli_overrides)
+                    key = f"{child_spec}{priority_suffix}"
+                    resolved_cli_overrides.setdefault(key, []).extend(cli_overrides)
             else:
                 resolved_cli_overrides.setdefault(task_spec, []).extend(cli_overrides)
 

--- a/src/olmo_eval/cli/run/config.py
+++ b/src/olmo_eval/cli/run/config.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from rich.console import Console
 
+from olmo_eval.evals.suites import get_suite, suite_exists
 from olmo_eval.harness.config import HarnessConfig, ProviderConfig
 
 console = Console()
@@ -331,14 +332,25 @@ class RunConfigBuilder:
         Returns:
             RunConfig with parsed and validated settings.
         """
-        # Build task specs and overrides from CLI -o flags
+        # Build task specs and overrides from CLI -o flags. Suite-level overrides
+        # are propagated to each constituent task spec.
         task_specs: list[str] = list(self.task)
-        task_overrides: dict[str, dict[str, Any]] = {}
+        resolved_cli_overrides: dict[str, list[str]] = {}
         for task_spec, cli_overrides in self.cli_task_overrides.items():
-            if cli_overrides:
-                override_dict: dict[str, Any] = {}
-                _apply_dotlist_overrides(override_dict, cli_overrides)
-                task_overrides[task_spec] = override_dict
+            if not cli_overrides:
+                continue
+            base_spec = task_spec.rsplit("@", 1)[0] if "@" in task_spec else task_spec
+            if suite_exists(base_spec):
+                for child_spec in get_suite(base_spec).expand():
+                    resolved_cli_overrides.setdefault(child_spec, []).extend(cli_overrides)
+            else:
+                resolved_cli_overrides.setdefault(task_spec, []).extend(cli_overrides)
+
+        task_overrides: dict[str, dict[str, Any]] = {}
+        for task_spec, cli_overrides in resolved_cli_overrides.items():
+            override_dict: dict[str, Any] = {}
+            _apply_dotlist_overrides(override_dict, cli_overrides)
+            task_overrides[task_spec] = override_dict
 
         # Resolve harness configuration with provider config built in
         harness_config = self._resolve_harness_config(self.model)


### PR DESCRIPTION
## Summary
- When a `-o` CLI override targets a suite name, expand the suite and apply the override to every constituent task spec instead of dropping it.
- Non-suite task specs continue to receive overrides directly.

## Example of the bug

```
olmo-eval run -m <model> -t aime_2022_to_2025 -o sampling_params.max_tokens=16384
```

Before this fix, the override is keyed by `aime_2022_to_2025` but the runner only sees the expanded constituent specs (`aime_2022:pass_at_32`, `aime_2023:pass_at_32`, `aime_2024:pass_at_32`, `aime_2025:pass_at_32`), so the `max_tokens=16384` override is silently dropped and each task runs with its default `max_tokens`. After the fix, the override is propagated to each child spec.

## Test plan
- [ ] Invoke a suite with a CLI override (e.g. `aime_2022_to_2025 -o sampling_params.max_tokens=16384`) and confirm each constituent task receives the override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)