### PR TITLE
Add general:posttrain:dev suite

### DIFF
--- a/src/olmo_eval/evals/suites/general.py
+++ b/src/olmo_eval/evals/suites/general.py
@@ -1,0 +1,19 @@
+"""General post-training dev suite."""
+
+import olmo_eval.evals.suites.ifbench  # noqa: F401 - ensure suite registration
+import olmo_eval.evals.suites.math  # noqa: F401 - ensure suite registration
+from olmo_eval.evals.suites.registry import AggregationStrategy, get_suite, make_suite
+
+make_suite(
+    "general:posttrain:dev",
+    (
+        get_suite("math:posttrain:dev"),
+        "scicode",
+        get_suite("ifbench"),
+        "gpqa_diamond",
+    ),
+    aggregation=AggregationStrategy.AVERAGE_OF_AVERAGES,
+    description=(
+        "Dev suite for general post-training: math:posttrain:dev, SciCode, IFBench, GPQA Diamond."
+    ),
+)


### PR DESCRIPTION
## Summary
- New `general:posttrain:dev` suite combining `math:posttrain:dev`, SciCode, IFBench, and GPQA Diamond
- Uses `AVERAGE_OF_AVERAGES` aggregation, matching sibling dev-style suites
- Expands to 12 underlying tasks

## Test plan
- [x] `get_suite("general:posttrain:dev")` resolves and expands correctly
- [x] Pre-commit ruff format / check pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)