### PR TITLE
Fix vLLM-server startup failure from web-stack dependency drift

### DIFF
--- a/src/olmo_eval/launch/beaker/launcher.py
+++ b/src/olmo_eval/launch/beaker/launcher.py
@@ -862,19 +862,14 @@ class BeakerLauncher:
             # Custom provider packages (e.g., a vLLM fork) are installed below
             # into the same isolated environment.
             if has_vllm:
-                # Constrain this install to uv.lock so the web stack doesn't
-                # re-resolve to latest PyPI, which breaks vLLM's Prometheus
-                # middleware. Torch is left unconstrained on purpose (no
-                # cuda-constraints here, unlike the main venv): vLLM requires a
-                # newer torch than the base image provides, so pinning it to the
-                # base build makes the install unresolvable. VCS lines are
-                # dropped because uv export pins them to a resolved commit, which
-                # conflicts with the branch-ref URL pyproject declares for the
-                # same package (e.g. ifbench).
+                # Build a lockfile constraint set scoped to vLLM. Keep torch/CUDA
+                # out so vLLM can pick its required build, and drop direct refs
+                # that uv exports as commit-pinned URLs.
                 vllm_lock_constraints = "/tmp/vllm-lock-constraints.txt"
                 steps.append(
                     f"cd /gantry-runtime && uv export --extra vllm "
-                    f"--no-hashes --no-emit-project --frozen 2>/dev/null "
+                    f"--no-default-groups --no-hashes --no-emit-project "
+                    f"--no-header --no-annotate --frozen 2>/dev/null "
                     f"| grep -vE '^(torch|nvidia-)' | grep -vE ' @ ' "
                     f"> {vllm_lock_constraints}"
                 )

--- a/src/olmo_eval/launch/beaker/launcher.py
+++ b/src/olmo_eval/launch/beaker/launcher.py
@@ -862,10 +862,28 @@ class BeakerLauncher:
             # Custom provider packages (e.g., a vLLM fork) are installed below
             # into the same isolated environment.
             if has_vllm:
+                # Derive web-stack constraints from uv.lock so the isolated
+                # vLLM install doesn't re-resolve starlette/fastapi/etc. to
+                # latest PyPI, which breaks vLLM's Prometheus middleware. Strip
+                # torch/nvidia- and VCS requirements: vLLM pulls its own torch
+                # (which the lock resolves to a newer build than the base image
+                # provides), so torch must stay unconstrained here, and VCS
+                # specifiers are illegal in a constraints file. We deliberately
+                # do NOT pass cuda-constraints here, unlike the main-venv
+                # install: pinning torch to the base-image build conflicts with
+                # vLLM's torch requirement.
+                vllm_lock_constraints = "/tmp/vllm-lock-constraints.txt"
+                steps.append(
+                    f"cd /gantry-runtime && uv export --extra vllm "
+                    f"--no-hashes --no-emit-project --frozen 2>/dev/null "
+                    f"| grep -vE '^(torch|nvidia-)' | grep -vE ' @ ' "
+                    f"> {vllm_lock_constraints}"
+                )
                 steps.append(
                     f"cd /gantry-runtime && uv pip install "
                     f"--python {vllm_venv}/bin/python "
-                    f"--cache-dir \"$UV_CACHE_DIR\" -e '.[vllm]'"
+                    f'--cache-dir "$UV_CACHE_DIR" '
+                    f"-c {vllm_lock_constraints} -e '.[vllm]'"
                 )
             # Set VLLM_PYTHON so VLLMServerProcess uses the isolated venv
             steps.append(f"export VLLM_PYTHON={vllm_venv}/bin/python")

--- a/src/olmo_eval/launch/beaker/launcher.py
+++ b/src/olmo_eval/launch/beaker/launcher.py
@@ -867,12 +867,15 @@ class BeakerLauncher:
                 # middleware. Torch is left unconstrained on purpose (no
                 # cuda-constraints here, unlike the main venv): vLLM requires a
                 # newer torch than the base image provides, so pinning it to the
-                # base build makes the install unresolvable.
+                # base build makes the install unresolvable. VCS lines are
+                # dropped because uv export pins them to a resolved commit, which
+                # conflicts with the branch-ref URL pyproject declares for the
+                # same package (e.g. ifbench).
                 vllm_lock_constraints = "/tmp/vllm-lock-constraints.txt"
                 steps.append(
                     f"cd /gantry-runtime && uv export --extra vllm "
                     f"--no-hashes --no-emit-project --frozen 2>/dev/null "
-                    f"| grep -vE '^(torch|nvidia-)' "
+                    f"| grep -vE '^(torch|nvidia-)' | grep -vE ' @ ' "
                     f"> {vllm_lock_constraints}"
                 )
                 steps.append(

--- a/src/olmo_eval/launch/beaker/launcher.py
+++ b/src/olmo_eval/launch/beaker/launcher.py
@@ -862,21 +862,17 @@ class BeakerLauncher:
             # Custom provider packages (e.g., a vLLM fork) are installed below
             # into the same isolated environment.
             if has_vllm:
-                # Derive web-stack constraints from uv.lock so the isolated
-                # vLLM install doesn't re-resolve starlette/fastapi/etc. to
-                # latest PyPI, which breaks vLLM's Prometheus middleware. Strip
-                # torch/nvidia- and VCS requirements: vLLM pulls its own torch
-                # (which the lock resolves to a newer build than the base image
-                # provides), so torch must stay unconstrained here, and VCS
-                # specifiers are illegal in a constraints file. We deliberately
-                # do NOT pass cuda-constraints here, unlike the main-venv
-                # install: pinning torch to the base-image build conflicts with
-                # vLLM's torch requirement.
+                # Constrain this install to uv.lock so the web stack doesn't
+                # re-resolve to latest PyPI, which breaks vLLM's Prometheus
+                # middleware. Torch is left unconstrained on purpose (no
+                # cuda-constraints here, unlike the main venv): vLLM requires a
+                # newer torch than the base image provides, so pinning it to the
+                # base build makes the install unresolvable.
                 vllm_lock_constraints = "/tmp/vllm-lock-constraints.txt"
                 steps.append(
                     f"cd /gantry-runtime && uv export --extra vllm "
                     f"--no-hashes --no-emit-project --frozen 2>/dev/null "
-                    f"| grep -vE '^(torch|nvidia-)' | grep -vE ' @ ' "
+                    f"| grep -vE '^(torch|nvidia-)' "
                     f"> {vllm_lock_constraints}"
                 )
                 steps.append(

--- a/tests/launch/test_beaker.py
+++ b/tests/launch/test_beaker.py
@@ -604,6 +604,14 @@ class TestBuildCommandWithTaskPackages:
         )
 
         assert (
+            "cd /gantry-runtime && uv export --extra vllm "
+            "--no-default-groups --no-hashes --no-emit-project "
+            "--no-header --no-annotate --frozen 2>/dev/null "
+            "| grep -vE '^(torch|nvidia-)' | grep -vE ' @ ' "
+            "> /tmp/vllm-lock-constraints.txt"
+        ) in install_cmd
+        assert "-c /tmp/vllm-lock-constraints.txt -e '.[vllm]'" in install_cmd
+        assert (
             "uv --no-config --no-cache pip install --python /opt/vllm-venv/bin/python "
             "--refresh --refresh-package repo --reinstall-package repo "
             "'repo @ git+https://github.com/user/repo@v1.0' -c /tmp/cuda-constraints.txt"


### PR DESCRIPTION
## Description


### Problem
Every `vllm_server` beaker eval fails at vLLM startup. The isolated vLLM-venv
install ran `uv pip install -e '.[vllm]'` with no constraints, so the web stack
re-resolves to latest PyPI on every run (`uv pip install` does not consult
`uv.lock`). The current resolution is mutually incompatible:

starlette==1.3.x, prometheus-fastapi-instrumentator==8.0.0

vLLM's Prometheus middleware then throws on every request:

prometheus_fastapi_instrumentator/routing.py:55 -> route.path
AttributeError: '_IncludedRouter' object has no attribute 'path'

### Fix

Derive constraints for the isolated vLLM install from `uv.lock` via
`uv export --extra vllm`, instead of leaving it unconstrained. `uv.lock` already
pins the compatible set (`starlette==0.52.1`, `fastapi==0.136.1`,
`prometheus-fastapi-instrumentator==7.1.0`), so no lock change is needed.

Two things are stripped from the exported constraints:
- `torch`/`nvidia-`: vLLM pulls its own torch, which the lock resolves to a newer
  build than the base image provides. Pinning torch here conflicts with vLLM's
  requirement, so torch stays unconstrained (the symlink + base image handle it).
  This is also why we do not pass `cuda-constraints` to this install, unlike the
  main-venv install.
- the `ifbench` VCS requirement, which is was also causing an error with the constraints file.

Scope is limited to the vLLM venv via the `vllm` extra only. The main-venv install
is unchanged, so agents/openhands keep their `starlette 1.x` resolution.

### Validation
Verified on beaker (this can only be exercised on a GPU):

- `Qwen3-8B` + `vllm_server`, expertqa smoke run: vLLM ready in ~69s, completed
  10/10. (ex/01KV6MYNYD7WEE7ZX5GCBF15FM)
- Install now produces the locked web stack in the vLLM venv
  (`starlette==0.52.1`, `prometheus-fastapi-instrumentator==7.1.0`) while the main
  venv resolves `starlette==1.3.x`, confirming the per-venv scoping.

Local: `ruff check`, `ruff format --check`, `ty check`, and the 90 launcher tests
in `tests/launch/test_beaker.py` pass.

## Type of Change

<!-- Put an `x` in all the boxes that apply -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Testing

<!-- Describe how you tested your changes -->

- [x] Unit tests pass locally (`pytest tests/ --ignore=tests/integration/`)
- [x] Integration tests pass (if applicable)
- [ ] New tests added for new functionality

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
