### PR TITLE
Add MMMU-Pro image-QA benchmark (Molmo2-4B)

### DIFF
--- a/src/olmo_eval/common/image_qa/mmmu_pro.py
+++ b/src/olmo_eval/common/image_qa/mmmu_pro.py
@@ -1,0 +1,147 @@
+"""Pure logic for the MMMU-Pro benchmark (decoupled from the MMMU task).
+
+Vendored verbatim from the official MMMU-Pro eval repo
+(``MMMU-Benchmark/MMMU`` → ``mmmu-pro/{prompts.yaml,evaluate.py,infer/infer_gemini.py}``) so
+MMMU-Pro is scored exactly as the benchmark authors intend — independent of the (different) MMMU
+parser/prompts in :mod:`olmo_eval.common.image_qa.mmmu_parsing`.
+
+Contents:
+
+* the official **direct** prompt strings;
+* the standard-setting prompt assembly (``parse_options`` / ``construct_standard_prompt``) and the
+  interleaved-image handling (``replace_images_tokens`` — options are shuffled, so ``<image i>``
+  token order need not match ``image_i`` key order);
+* the official answer parser (``parse_multi_choice_response``) and ``mmmu_pro_score``.
+
+MMMU-Pro is multiple-choice only.
+"""
+
+from __future__ import annotations
+
+import random
+import re
+import zlib
+
+# Direct-mode prompts, verbatim from mmmu-pro/prompts.yaml (CoT mode is not used).
+MMMU_PRO_STANDARD_DIRECT = "Answer with the option letter from the given choices directly."
+MMMU_PRO_VISION_DIRECT = (
+    "Answer with the option letter from the given choices directly. The last line of your "
+    "response should be of the following format: 'Answer: $LETTER' (without quotes) where LETTER "
+    "is one of options."
+)
+
+_IMAGE_TOKEN_RE = re.compile(r"<image\s+(\d+)>")
+
+
+def parse_options(options: list[str]) -> str:
+    """Render options as ``"A. <opt>\\nB. <opt>\\n…"`` (official ``parse_options``)."""
+    letters = [chr(ord("A") + i) for i in range(len(options))]
+    return "\n".join(f"{letter}. {opt}" for letter, opt in zip(letters, options, strict=True))
+
+
+def construct_standard_prompt(question: str, options: list[str]) -> str:
+    """Official ``construct_prompt`` for the standard setting (question + options + direct prompt)."""
+    return f"{question}\n{parse_options(options)}\n{MMMU_PRO_STANDARD_DIRECT}"
+
+
+def replace_images_tokens(text: str) -> tuple[str, list[int]]:
+    """Official ``replace_images_tokens``: record ``<image i>`` order, replace with ``<image>``.
+
+    Returns ``(text, image_order)`` where ``image_order`` is the list of image indices in their
+    order of appearance across the assembled text (duplicates kept). Each ``<image i>`` maps to the
+    dataset's ``image_i`` key; the option shuffle means this order need not be ``1, 2, 3, …``.
+    """
+    image_order = [int(n) for n in _IMAGE_TOKEN_RE.findall(text)]
+    text = _IMAGE_TOKEN_RE.sub("<image>", text)
+    return text, image_order
+
+
+def get_multi_choice_info(options: list[str]) -> tuple[dict[str, str], list[str]]:
+    """Official ``get_multi_choice_info``: ``(index2ans, all_choices)`` lettered A, B, C, …."""
+    index2ans: dict[str, str] = {}
+    all_choices: list[str] = []
+    for i, option in enumerate(options):
+        letter = chr(ord("A") + i)
+        index2ans[letter] = option
+        all_choices.append(letter)
+    return index2ans, all_choices
+
+
+def parse_multi_choice_response(
+    response: str,
+    all_choices: list[str],
+    index2ans: dict[str, str],
+    *,
+    seed: int | None = None,
+) -> str:
+    """Official MMMU-Pro ``parse_multi_choice_response`` (fed the raw model response).
+
+    Ladder: (1) the last ``"Answer:"`` marker — if exactly one choice letter follows it, take it;
+    (2) else strip trailing punctuation + pad, then prefer ``(A)`` → ``"A "`` → ``"A."`` → option
+    text (only when >5 tokens); (3) no candidate → random choice; (4) multiple → the last
+    occurrence. The only change from the official code is that the random fallback is seeded
+    (``random.Random(seed)``) so re-runs are deterministic on otherwise-unparseable outputs.
+    """
+    last_answer_pos = response.rfind("Answer:")
+    if last_answer_pos != -1:
+        answer_str = response[last_answer_pos + len("Answer:") :].strip()
+        matching_options = [option for option in all_choices if option in answer_str]
+        if len(matching_options) == 1:
+            return matching_options[0]
+
+    for char in [",", ".", "!", "?", ";", ":", "'"]:
+        response = response.strip(char)
+    response = " " + response + " "  # avoid partial matches
+
+    index_ans = True
+    ans_with_brack = False
+    candidates: list[str] = []
+    for choice in all_choices:  # (A) (B) (C) …
+        if f"({choice})" in response:
+            candidates.append(choice)
+            ans_with_brack = True
+    if len(candidates) == 0:
+        for choice in all_choices:  # A B C …
+            if f"{choice} " in response:
+                candidates.append(choice)
+    if len(candidates) == 0:
+        for choice in all_choices:  # A. B. C. …
+            if f"{choice}." in response:
+                candidates.append(choice)
+    if len(candidates) == 0 and len(response.split()) > 5:
+        for index, ans in index2ans.items():
+            if ans.lower() in response.lower():
+                candidates.append(index)
+                index_ans = False  # matched on content, not the letter
+
+    if len(candidates) == 0:
+        rng = random.Random(seed) if seed is not None else random
+        return rng.choice(all_choices)
+    if len(candidates) > 1:
+        start_indexes: list[int] = []
+        if index_ans:
+            for can in candidates:
+                pattern = f"({can})" if ans_with_brack else f" {can} "
+                start_indexes.append(response.rfind(pattern))
+        else:
+            for can in candidates:
+                start_indexes.append(response.lower().rfind(index2ans[can].lower()))
+        # the last occurrence wins (official uses np.argmax over rfind positions)
+        return candidates[max(range(len(candidates)), key=lambda i: start_indexes[i])]
+    return candidates[0]
+
+
+def mmmu_pro_score(
+    response: str,
+    options: list[str],
+    answer: str | list[str],
+    *,
+    example_id: str = "",
+) -> float:
+    """1.0 if the parsed option letter matches the gold answer, else 0.0."""
+    index2ans, all_choices = get_multi_choice_info(options)
+    seed = zlib.crc32(str(example_id).encode())
+    parsed = parse_multi_choice_response(response or "", all_choices, index2ans, seed=seed)
+    if isinstance(answer, list):
+        return float(parsed in answer)
+    return float(parsed == answer)

--- a/src/olmo_eval/common/scorers/mmmu_pro.py
+++ b/src/olmo_eval/common/scorers/mmmu_pro.py
@@ -1,0 +1,30 @@
+"""Scorer for the MMMU-Pro benchmark (decoupled from the MMMU scorer).
+
+Uses the official MMMU-Pro answer parser (:mod:`olmo_eval.common.image_qa.mmmu_pro`) on the **raw**
+model response — no ``clean_prediction`` preprocessing, matching the reference ``evaluate.py``.
+Reads ``options``/``answer``/``example_id`` from ``instance.metadata`` and returns 1.0/0.0.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from olmo_eval.common.image_qa.mmmu_pro import mmmu_pro_score
+from olmo_eval.common.scorers.base import Scorer
+from olmo_eval.common.types import Instance, LMOutput
+
+
+@dataclass(frozen=True, slots=True)
+class MmmuProScorer(Scorer):
+    """Official MMMU-Pro multiple-choice scoring (1.0 if the parsed letter matches the gold)."""
+
+    name: str = "mmmu_pro"
+
+    def score(self, instance: Instance, output: LMOutput) -> float:
+        meta = instance.metadata
+        return mmmu_pro_score(
+            output.text or "",
+            list(meta.get("options") or []),
+            meta["answer"],
+            example_id=str(meta.get("example_id", "")),
+        )

--- a/src/olmo_eval/evals/suites/molmo2.py
+++ b/src/olmo_eval/evals/suites/molmo2.py
@@ -2,7 +2,8 @@
 
 from olmo_eval.evals.suites.registry import AggregationStrategy, make_suite
 
-# The 11 single-image QA / counting benchmarks Molmo2 reports.
+# The image-QA benchmarks Molmo2 reports. ``mmmu_pro`` is a single task whose primary metric is the
+# MMMU-Pro Overall = (standard-10 + vision)/2, so it contributes one 0-1 entry like the others.
 MOLMO2_IMAGE_QA_TASKS = (
     "chart_qa",
     "vqa2",
@@ -11,6 +12,7 @@ MOLMO2_IMAGE_QA_TASKS = (
     "text_vqa",
     "real_world_qa",
     "mmmu",
+    "mmmu_pro",
     "math_vista",
     "countbench_qa",
     "pixmo_count",
@@ -21,7 +23,7 @@ make_suite(
     "molmo2_imageqa",
     MOLMO2_IMAGE_QA_TASKS,
     aggregation=AggregationStrategy.AVERAGE,
-    description="Molmo2's 11 image-QA benchmarks (primary metrics are all 0-1).",
+    description="Molmo2's image-QA benchmarks (primary metrics are all 0-1).",
 )
 
 make_suite(
@@ -29,7 +31,7 @@ make_suite(
     (*MOLMO2_IMAGE_QA_TASKS, "dense_caption"),
     # dense_caption's primary metric is 0-100, so no cross-task average is computed.
     aggregation=AggregationStrategy.DISPLAY_ONLY,
-    description="Molmo2's 11 image-QA benchmarks plus PixMo-Cap dense caption (GPT judge).",
+    description="Molmo2's image-QA benchmarks plus PixMo-Cap dense caption (GPT judge).",
 )
 
 # Image-pointing benchmarks — a separate family from the image-QA tasks above

--- a/src/olmo_eval/evals/tasks/mmmu_pro.py
+++ b/src/olmo_eval/evals/tasks/mmmu_pro.py
@@ -1,0 +1,187 @@
+"""MMMU-Pro (test) — a single image-QA task covering all three official settings.
+
+One run produces one ``metrics.json`` with ``standard_10_accuracy``, ``standard_4_accuracy``,
+``vision_accuracy`` and the primary **``overall`` = (standard_10 + vision) / 2** (the number SOTA
+models report). The benchmark is decoupled from the existing ``mmmu`` task: prompts/parser/scorer
+come from :mod:`olmo_eval.common.image_qa.mmmu_pro` / :mod:`olmo_eval.common.scorers.mmmu_pro`,
+faithful to the official ``MMMU-Benchmark/MMMU`` ``mmmu-pro`` repo.
+
+Settings (each the 1730-row ``test`` split of an ``MMMU/MMMU_Pro`` config):
+* ``standard10`` / ``standard4`` — text question + lettered options (A–J / A–D), interleaved
+  ``image_1..image_7`` attached in ``<image i>`` token-appearance order (options are shuffled);
+* ``vision`` — a single screenshot image with the question+options rendered inside; the model is
+  sent only the direct instruction + that screenshot.
+
+Set ``HF_DATASETS_CACHE`` for offline loading (the dataset is cached like ``MMMU/MMMU``).
+"""
+
+from __future__ import annotations
+
+import ast
+import itertools
+from collections.abc import Iterator, Sequence
+from dataclasses import dataclass
+
+from olmo_eval.common.image_qa.mmmu_pro import (
+    MMMU_PRO_VISION_DIRECT,
+    construct_standard_prompt,
+    replace_images_tokens,
+)
+from olmo_eval.common.metrics.base import Metric
+from olmo_eval.common.scorers.base import Scorer
+from olmo_eval.common.scorers.mmmu_pro import MmmuProScorer
+from olmo_eval.common.types import Instance, LMRequest, RequestType, Response, SamplingParams, Split
+from olmo_eval.evals.tasks.common import register
+from olmo_eval.evals.tasks.common.image_qa_base import (
+    ImageQATask,
+    lazy_hf_image,
+    load_instance_image,
+)
+
+# Short setting key -> HF config name.
+_SETTINGS: dict[str, str] = {
+    "standard10": "standard (10 options)",
+    "standard4": "standard (4 options)",
+    "vision": "vision",
+}
+
+_SCORER = MmmuProScorer()
+
+
+# ---------------------------------------------------------------------------
+# Metrics (partition responses by the per-instance ``mmmu_pro_setting`` tag)
+# ---------------------------------------------------------------------------
+
+
+def _setting_mean(responses: Sequence[Response], scorer_name: str, setting: str) -> float | None:
+    vals = [
+        r.scores.get(scorer_name, 0.0)
+        for r in responses
+        if r.instance.metadata.get("mmmu_pro_setting") == setting
+    ]
+    return sum(vals) / len(vals) if vals else None
+
+
+@dataclass(frozen=True)
+class MmmuProSettingMetric(Metric):
+    """Accuracy over one MMMU-Pro setting (``standard10`` / ``standard4`` / ``vision``)."""
+
+    name: str  # type: ignore[misc]
+    scorer: Scorer  # type: ignore[misc]
+    setting: str = ""
+
+    def compute(self, responses: Sequence[Response]) -> float:
+        return _setting_mean(responses, self.scorer().name, self.setting) or 0.0
+
+
+@dataclass(frozen=True)
+class MmmuProOverallMetric(Metric):
+    """MMMU-Pro Overall = mean(standard-10 accuracy, vision accuracy) — the SOTA-reported number."""
+
+    name: str  # type: ignore[misc]
+    scorer: Scorer  # type: ignore[misc]
+
+    def compute(self, responses: Sequence[Response]) -> float:
+        scorer_name = self.scorer().name
+        parts = [
+            _setting_mean(responses, scorer_name, "standard10"),
+            _setting_mean(responses, scorer_name, "vision"),
+        ]
+        present = [p for p in parts if p is not None]
+        return sum(present) / len(present) if present else 0.0
+
+
+_OVERALL = MmmuProOverallMetric(name="overall", scorer=_SCORER)
+_METRICS: tuple[Metric, ...] = (
+    _OVERALL,
+    MmmuProSettingMetric(name="standard_10_accuracy", scorer=_SCORER, setting="standard10"),
+    MmmuProSettingMetric(name="standard_4_accuracy", scorer=_SCORER, setting="standard4"),
+    MmmuProSettingMetric(name="vision_accuracy", scorer=_SCORER, setting="vision"),
+)
+
+
+@register("mmmu_pro")
+class MmmuProTask(ImageQATask):
+    sampling_params = SamplingParams(temperature=0.0, max_tokens=64)
+    metrics = _METRICS
+    primary_metric = _OVERALL
+    split = Split.TEST
+
+    def _build_instances(self) -> Iterator[Instance]:
+        import datasets
+
+        per_setting: list[list[Instance]] = []
+        for key, cfg in _SETTINGS.items():
+            ds = datasets.load_dataset("MMMU/MMMU_Pro", cfg, split=self.config.split.value)
+            if key == "vision":
+                ds_nd = ds.cast_column("image", datasets.Image(decode=False))
+                per_setting.append(list(self._vision_instances(ds_nd)))
+            else:
+                ds_nd = ds
+                for col in (f"image_{i}" for i in range(1, 8)):
+                    ds_nd = ds_nd.cast_column(col, datasets.Image(decode=False))
+                per_setting.append(list(self._standard_instances(ds_nd, key)))
+
+        # Round-robin interleave so a small ``limit`` samples all three settings.
+        for group in itertools.zip_longest(*per_setting):
+            for inst in group:
+                if inst is not None:
+                    yield inst
+
+    @staticmethod
+    def _standard_instances(ds_nd, setting: str) -> Iterator[Instance]:
+        for idx in range(len(ds_nd)):
+            ex = ds_nd[idx]
+            options = ast.literal_eval(str(ex["options"]))
+            text, image_order = replace_images_tokens(
+                construct_standard_prompt(str(ex["question"]), options)
+            )
+            images = [
+                lazy_hf_image(ds_nd, idx, f"image_{i}")
+                for i in image_order
+                if ex[f"image_{i}"] is not None
+            ]
+            yield Instance(
+                question=text,
+                gold_answer=str(ex["answer"]),
+                metadata={
+                    "mmmu_pro_setting": setting,
+                    "answer": ex["answer"],
+                    "options": options,
+                    "example_id": ex["id"],
+                    "subject": ex["subject"],
+                    "images": images,
+                },
+            )
+
+    @staticmethod
+    def _vision_instances(ds_nd) -> Iterator[Instance]:
+        for idx in range(len(ds_nd)):
+            ex = ds_nd[idx]
+            options = ast.literal_eval(str(ex["options"]))
+            yield Instance(
+                question=MMMU_PRO_VISION_DIRECT,
+                gold_answer=str(ex["answer"]),
+                metadata={
+                    "mmmu_pro_setting": "vision",
+                    "answer": ex["answer"],
+                    "options": options,
+                    "example_id": ex["id"],
+                    "subject": ex["subject"],
+                    "image": lazy_hf_image(ds_nd, idx, "image"),
+                },
+            )
+
+    def format_request(self, instance: Instance) -> LMRequest:
+        meta = instance.metadata
+        if "images" in meta:  # standard: attach all interleaved images, in token order
+            resolved = [c() if callable(c) else c for c in meta["images"]]
+            images = tuple(im for im in resolved if im is not None) or None
+        else:  # vision: single screenshot
+            image = load_instance_image(instance)
+            images = (image,) if image is not None else None
+        return LMRequest(
+            request_type=RequestType.CHAT,
+            messages=({"role": "user", "content": instance.question},),
+            images=images,
+        )

--- a/tests/evals/tasks/test_mmmu_pro.py
+++ b/tests/evals/tasks/test_mmmu_pro.py
@@ -1,0 +1,133 @@
+"""Unit tests for MMMU-Pro (parser, prompts, image-order, metrics, request).
+
+Pure CPU — no GPU, no model, no dataset. The parser/prompt logic mirrors the official
+``MMMU-Benchmark/MMMU`` ``mmmu-pro`` repo.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from olmo_eval.common.image_qa.mmmu_pro import (
+    MMMU_PRO_STANDARD_DIRECT,
+    MMMU_PRO_VISION_DIRECT,
+    construct_standard_prompt,
+    get_multi_choice_info,
+    mmmu_pro_score,
+    parse_multi_choice_response,
+    replace_images_tokens,
+)
+from olmo_eval.common.types import Instance, LMOutput, Response
+from olmo_eval.evals.tasks.common.registry import get_task
+from olmo_eval.evals.tasks.mmmu_pro import (
+    _SCORER,
+    MmmuProOverallMetric,
+    MmmuProSettingMetric,
+)
+
+_OPTS10 = [f"opt{i}" for i in range(10)]
+_I2A, _CHOICES = get_multi_choice_info(_OPTS10)  # A..J
+
+
+class TestParseMultiChoiceResponse:
+    @pytest.mark.parametrize(
+        ("response", "expected"),
+        [
+            ("blah Answer: J", "J"),  # rfind("Answer:") priority
+            ("I think (J) is right", "J"),  # (X)
+            ("the answer is J here", "J"),  # "X "
+            ("J.", "J"),  # "X."
+            ("the correct choice is opt3 obviously here", "D"),  # option text (>5 tokens)
+            ("(A) no wait (C)", "C"),  # multiple -> last occurrence
+            ("(A) ... Answer: D", "D"),  # Answer: overrides an earlier bracket letter
+        ],
+    )
+    def test_ladder(self, response: str, expected: str) -> None:
+        assert parse_multi_choice_response(response, _CHOICES, _I2A, seed=1) == expected
+
+    def test_ten_options_reach_j(self) -> None:
+        assert "J" in _CHOICES and len(_CHOICES) == 10
+
+    def test_fallback_is_seeded_deterministic(self) -> None:
+        a = parse_multi_choice_response("xyzzy", _CHOICES, _I2A, seed=123)
+        b = parse_multi_choice_response("xyzzy", _CHOICES, _I2A, seed=123)
+        assert a == b and a in _CHOICES
+
+    def test_score_match(self) -> None:
+        assert mmmu_pro_score("Answer: B", _OPTS10, "B", example_id="x") == 1.0
+        assert mmmu_pro_score("Answer: A", _OPTS10, "B", example_id="x") == 0.0
+
+
+class TestPromptsAndImageOrder:
+    def test_replace_images_tokens_shuffled(self) -> None:
+        text, order = replace_images_tokens("Compare <image 2> and <image 1>.\nA. <image 3>\nB. x")
+        assert order == [2, 1, 3]  # token-appearance order, not key order
+        assert "<image 2>" not in text and text.count("<image>") == 3
+
+    def test_construct_standard_prompt(self) -> None:
+        prompt = construct_standard_prompt("Q?", ["a", "b"])
+        assert prompt == f"Q?\nA. a\nB. b\n{MMMU_PRO_STANDARD_DIRECT}"
+
+    def test_prompt_constants_verbatim(self) -> None:
+        assert MMMU_PRO_STANDARD_DIRECT == (
+            "Answer with the option letter from the given choices directly."
+        )
+        assert MMMU_PRO_VISION_DIRECT.startswith(
+            "Answer with the option letter from the given choices directly. The last line"
+        )
+
+
+def _resp(setting: str, score: float) -> Response:
+    instance = Instance(question="q", metadata={"mmmu_pro_setting": setting})
+    output = LMOutput(text="", metadata={})
+    response = Response(instance=instance, request=None, outputs=[output])
+    response.scores["mmmu_pro"] = score
+    return response
+
+
+class TestMetrics:
+    RESPONSES = [
+        _resp("standard10", 1.0),
+        _resp("standard10", 0.0),
+        _resp("standard4", 1.0),
+        _resp("vision", 1.0),
+        _resp("vision", 0.0),
+    ]
+
+    def test_per_setting(self) -> None:
+        assert MmmuProSettingMetric(name="s", scorer=_SCORER, setting="standard10").compute(
+            self.RESPONSES
+        ) == pytest.approx(0.5)
+        assert MmmuProSettingMetric(name="s", scorer=_SCORER, setting="standard4").compute(
+            self.RESPONSES
+        ) == pytest.approx(1.0)
+        assert MmmuProSettingMetric(name="s", scorer=_SCORER, setting="vision").compute(
+            self.RESPONSES
+        ) == pytest.approx(0.5)
+
+    def test_overall_ignores_standard4(self) -> None:
+        # (mean(standard10)=0.5 + mean(vision)=0.5) / 2
+        assert MmmuProOverallMetric(name="overall", scorer=_SCORER).compute(
+            self.RESPONSES
+        ) == pytest.approx(0.5)
+
+    def test_empty(self) -> None:
+        assert MmmuProOverallMetric(name="overall", scorer=_SCORER).compute([]) == 0.0
+
+
+class TestFormatRequest:
+    def test_standard_multi_image(self) -> None:
+        task = get_task("mmmu_pro")
+        inst = Instance(
+            question="Q <image>",
+            metadata={"images": [lambda: "img1", lambda: "img2", lambda: None]},
+        )
+        req = task.format_request(inst)
+        assert req.images == ("img1", "img2")  # None filtered, order preserved
+        assert req.messages[0]["content"] == "Q <image>"
+
+    def test_vision_single_image(self) -> None:
+        task = get_task("mmmu_pro")
+        inst = Instance(question=MMMU_PRO_VISION_DIRECT, metadata={"image": "screenshot"})
+        req = task.format_request(inst)
+        assert req.images == ("screenshot",)


### PR DESCRIPTION
## Summary

Adds **MMMU-Pro** (`MMMU/MMMU_Pro`) — the harder, more-robust successor to MMMU — as a new
**image-QA** benchmark for the released HF `allenai/Molmo2-4B`, evaluated through the same
`HuggingFaceProvider` multimodal path (preset `molmo2-4b`).

A single **`mmmu_pro`** task runs all three official settings and produces **one `metrics.json`**
with `standard_10_accuracy`, `standard_4_accuracy`, `vision_accuracy`, and the **primary
`overall` = (standard-10 + vision) / 2** — the number SOTA models report.

It is **decoupled from the existing `mmmu` task** (its own prompts, parser, and scorer; no reuse of
`mmmu_parsing.py` / `MmmuScorer` / `format_mc_question`), faithful to the official
`MMMU-Benchmark/MMMU` `mmmu-pro` repo, and is added to the `molmo2_imageqa` suite (its `overall`
counts as one 0-1 entry, like the other image-QA benchmarks).

## Verified — Molmo2-4B (fp32 + bf16 autocast, full run, 5190 examples)

| Metric | Score |
|---|---:|
| **overall** (= (standard-10 + vision)/2) — primary | **26.01%** |
| standard_10_accuracy | 35.20% |
| standard_4_accuracy | 44.62% |
| vision_accuracy | 16.82% |

## Faithful to the official MMMU-Pro protocol

- **Direct prompts, verbatim** from `prompts.yaml` (CoT mode not used): standard = `"Answer with the
  option letter from the given choices directly."`; vision = the same + `" The last line of your
  response should be of the following format: 'Answer: $LETTER' …"`.
- **Standard** = `question + "A. …\nB. …" + direct prompt` (A–J for 10 options) with **all
  interleaved images attached in `<image i>` token-appearance order** — options are shuffled, so
  token order need not match `image_i` key order (official `replace_images_tokens`, `<image i>` →
  `<image>`). **Vision** sends only the instruction + the single screenshot (`image` column); the
  question/options are rendered inside the screenshot.
- **Answer parser** (on the raw response, MC-only): last `Answer:` marker → `(A)` → `"A "` → `"A."`
  → option text; multiple → last occurrence; per-example seeded fallback for re-run determinism.

## Changes

- `src/olmo_eval/common/image_qa/mmmu_pro.py` (new) — prompts, prompt assembly,
  `replace_images_tokens`, and the official `parse_multi_choice_response` / `mmmu_pro_score`.
- `src/olmo_eval/common/scorers/mmmu_pro.py` (new) — `MmmuProScorer` (raw response, no
  `clean_prediction`).
- `src/olmo_eval/evals/tasks/mmmu_pro.py` (new) — the single `mmmu_pro` task (3 settings,
  interleaved), per-setting + `overall` metrics, and a `format_request` that attaches the
  multi-image (standard) or single-screenshot (vision) tuple.
- `src/olmo_eval/evals/suites/molmo2.py` — `"mmmu_pro"` added to `MOLMO2_IMAGE_QA_TASKS`.
- `tests/evals/tasks/test_mmmu_pro.py` (new) — CPU-only: parser ladder, shuffled image-order,
  prompts, per-setting + overall metrics, request construction.

No new dependencies (pure HF hub; `MMMU/MMMU_Pro` cached like `MMMU/MMMU`).

## Verification

`ruff check` / `ruff format --check` clean; `ty check` clean on the new files; full suite
**1773 passed, 5 skipped**. Full GPU run completed and produced the numbers above.
