### PR TITLE
Merge main into vision (olmo-core #218 + torch 2.10 #226)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    rebase-strategy: "disabled"
     open-pull-requests-limit: 10
     groups:
       dev-dependencies:
@@ -39,6 +40,7 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    rebase-strategy: "disabled"
     open-pull-requests-limit: 5
     groups:
       actions:

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,10 @@
 #   ./scripts/build_image.sh --platform linux/amd64
 #
 # Tags: cu{cuda}-trc{torch}-{arch}
-# Example: cu128-trc291-amd64
+# Example: cu1281-trc2100-amd64
 
 ARG CUDA_VERSION=12.8.1
-ARG TORCH_VERSION=2.9.0
+ARG TORCH_VERSION=2.10.0
 ARG PYTHON_VERSION=3.12
 ARG INSTALL_CHANNEL=whl
 ARG GIT_COMMIT=""

--- a/README.md
+++ b/README.md
@@ -1533,6 +1533,38 @@ uv run olmo-eval beaker launch -n "eval" \
 uv pip install -e '.[vllm]'  # includes vllm[runai]
 ```
 
+For raw OLMo-core checkpoints, force the provider kind through the harness and
+use `provider.package` when you need a specific `ai2-olmo-core` install:
+
+```bash
+# Pin the PyPI package version
+uv run olmo-eval beaker launch -n "eval" \
+    --harness default \
+    -o provider.kind=olmo_core \
+    -o provider.package=2.3.0 \
+    -m /weka/path/to/raw-olmo-core-checkpoint \
+    -t mmlu \
+    --cluster h100 \
+    -w "ai2/olmo-eval-debug" \
+    -B "ai2/oe-base"
+
+# Override ai2-olmo-core from a GitHub branch
+uv run olmo-eval beaker launch -n "eval" \
+    --harness default \
+    -o provider.kind=olmo_core \
+    -o provider.package=https://github.com/allenai/OLMo-core.git@my-branch \
+    -m /weka/path/to/raw-olmo-core-checkpoint \
+    -t mmlu \
+    --cluster h100 \
+    -w "ai2/olmo-eval-debug" \
+    -B "ai2/oe-base"
+```
+
+The OLMo-core source URL is normalized to install the
+`ai2-olmo-core[torchao,transformers]` distribution, so branch overrides replace
+the bundled OLMo-core dependency instead of installing a separate repo-named
+package.
+
 ### Task-Specific Dependencies
 
 Tasks can declare runtime dependencies that are installed at job startup (see [Tasks](#tasks)). Dependencies are automatically merged, deduplicated, and installed after the inference provider.

--- a/README.md
+++ b/README.md
@@ -1469,7 +1469,7 @@ Images are tagged with CUDA and PyTorch versions: `cu{version}-trc{version}-{arc
 ./scripts/build_image.sh
 
 # Specific CUDA + PyTorch version
-./scripts/build_image.sh --cuda-version 12.8.1 --torch-version 2.9.0
+./scripts/build_image.sh --cuda-version 12.8.1 --torch-version 2.10.0
 
 # Production build
 ./scripts/build_image.sh --platform linux/amd64
@@ -1492,7 +1492,7 @@ Images are tagged with CUDA and PyTorch versions: `cu{version}-trc{version}-{arc
 ./scripts/beaker/push_beaker_image.sh --dry-run
 ```
 
-The script auto-detects the image name from the tag (e.g., `olmo-eval-cu128-trc291-amd64`)
+The script auto-detects the image name from the tag (e.g., `olmo-eval-cu1281-trc2100-amd64`)
 
 ### What's in the Image
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "numpy>=1.20.0",
     "omegaconf>=2.4.0.dev10,<2.5.0",
     "prometheus_client>=0.21.0",
-    "rich~=14.3.4",
+    "rich>=13.7,<15",
     "sympy>=1.12",
     "textual-plot>=0.10.1",
     "tree-sitter>=0.24.0",
@@ -45,6 +45,9 @@ Issues = "https://github.com/allenai/olmo-eval/issues"
 [project.optional-dependencies]
 hf = [
     "transformers>=5.4.0",
+]
+olmo_core = [
+    "ai2-olmo-core[torchao,transformers]==2.4.0",
 ]
 vllm = [
     # vllm + its companions are Linux/CUDA-only; skip on macOS so the lockfile
@@ -113,6 +116,10 @@ conflicts = [
     ],
     [
         { extra = "vllm" },
+        { extra = "openhands" },
+    ],
+    [
+        { extra = "olmo_core" },
         { extra = "openhands" },
     ],
     [
@@ -226,6 +233,8 @@ allowed-unresolved-imports = [
     "google.cloud.**",
     "matplotlib.**",
     "scipy.**",
+    "olmo_core.**",
+    "cached_path.**",
     "instructions_registry.**",
     "instructions.**",
 ]

--- a/scripts/beaker/get_beaker_image.sh
+++ b/scripts/beaker/get_beaker_image.sh
@@ -4,10 +4,10 @@ set -euo pipefail
 # Get the full Beaker image name for olmo-eval
 #
 # Usage:
-#   ./scripts/get_beaker_image.sh                    # Returns ai2/oe-data/olmo-eval-latest
-#   ./scripts/get_beaker_image.sh ai2/other          # Custom workspace
+#   ./scripts/beaker/get_beaker_image.sh
+#   ./scripts/beaker/get_beaker_image.sh ai2-other olmo-eval-custom
 
-WORKSPACE="${1:-ai2/oe-data}"
-IMAGE_NAME="olmo-eval-latest"
+IMAGE_OWNER="${1:-ai2-tylerm}"
+IMAGE_NAME="${2:-olmo-eval-cu1281-trc2100-amd64}"
 
-echo "${WORKSPACE}/${IMAGE_NAME}"
+echo "${IMAGE_OWNER}/${IMAGE_NAME}"

--- a/scripts/beaker/push_beaker_image.sh
+++ b/scripts/beaker/push_beaker_image.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 #
 # Usage:
 #   ./scripts/push_beaker_image.sh                              # Use defaults
-#   ./scripts/push_beaker_image.sh --source olmo-eval:latest    # Custom source
+#   ./scripts/push_beaker_image.sh --source olmo-eval:cu1281-trc2100-amd64
 #   ./scripts/push_beaker_image.sh --workspace ai2/oe-data      # Custom workspace
 #   ./scripts/push_beaker_image.sh --dry-run                    # Preview only
 #   ./scripts/push_beaker_image.sh --force                      # Force re-upload (delete existing tmp)
@@ -57,7 +57,7 @@ while [[ $# -gt 0 ]]; do
             echo ""
             echo "Options:"
             echo "  --source IMAGE        Local Docker image (default: olmo-eval:latest)"
-            echo "  --beaker-image NAME   Beaker image name (default: olmo-eval-latest)"
+            echo "  --beaker-image NAME   Beaker image name (default: auto-generated from source tag)"
             echo "  --workspace WS        Beaker workspace (default: ai2/oe-data)"
             echo "  --dry-run             Preview without pushing"
             echo "  --force               Force upload even if tmp image exists (deletes existing tmp)"
@@ -84,7 +84,7 @@ fi
 
 # Auto-generate Beaker image name from source tag
 if [[ "$AUTO_NAME" == "true" ]]; then
-    # Extract tag from source image (e.g., olmo-eval:cu128-trc291-amd64 -> cu128-trc291-amd64)
+    # Extract tag from source image (e.g., olmo-eval:cu1281-trc2100-amd64 -> cu1281-trc2100-amd64)
     SOURCE_TAG=$(echo "$SOURCE_IMAGE" | cut -d':' -f2)
     BEAKER_IMAGE="olmo-eval-${SOURCE_TAG}"
     echo "Auto-generated Beaker image name: ${BEAKER_IMAGE}"

--- a/scripts/build_config.sh
+++ b/scripts/build_config.sh
@@ -2,8 +2,8 @@
 # Docker build configuration
 # This file contains shared configuration for building olmo-eval Docker images
 #
-# Note: PyTorch is NOT included in the base image. It's installed at runtime
-# as a transitive dependency of the backend (vllm, transformers, etc.)
+# Note: PyTorch is included in the base image. Backend dependencies
+# (vllm, transformers, etc.) are installed at runtime.
 
 # Supported CUDA versions (full patch versions required by NVIDIA images)
 # Format: "MAJOR.MINOR.PATCH"
@@ -18,7 +18,7 @@ SUPPORTED_CUDA_VERSIONS=(
 DEFAULT_CUDA_VERSION="12.8.1"
 
 # Default PyTorch version
-DEFAULT_TORCH_VERSION="2.9.0"
+DEFAULT_TORCH_VERSION="2.10.0"
 
 # Supported platforms
 SUPPORTED_PLATFORMS=(

--- a/scripts/build_image.sh
+++ b/scripts/build_image.sh
@@ -116,8 +116,8 @@ PLATFORM_ARCH=$(echo "$PLATFORM" | cut -d'/' -f2)
 # Auto-generate tag if not specified
 if [[ -z "$TAG" ]]; then
     # Format: cu{version}-trc{version}-{arch}[-sandbox]
-    # Example: cu128-trc290-amd64 (for CUDA 12.8.x, PyTorch 2.9.0)
-    # Example: cu128-trc290-amd64-sandbox (with Podman support)
+    # Example: cu1281-trc2100-amd64 (for CUDA 12.8.1, PyTorch 2.10.0)
+    # Example: cu1281-trc2100-amd64-sandbox (with Podman support)
     CUDA_SHORT=$(cuda_short "$CUDA_VERSION")
     TORCH_SHORT=$(echo "${TORCH_VERSION}" | sed 's/\.//g')
     TAG="cu${CUDA_SHORT}-trc${TORCH_SHORT}-${PLATFORM_ARCH}"

--- a/src/olmo_eval/analysis/pairwise.py
+++ b/src/olmo_eval/analysis/pairwise.py
@@ -103,7 +103,7 @@ class FilteredModel:
 
 
 @dataclass(frozen=True)
-class _PairwiseTaskRow:
+class PairwiseTaskRow:
     experiment_pk: int
     task_name: str
     task_hash: str
@@ -113,14 +113,14 @@ class _PairwiseTaskRow:
 
 
 @dataclass(frozen=True)
-class _PairwiseInstanceKeyRow:
+class PairwiseInstanceKeyRow:
     experiment_pk: int
     native_id: str
     task_hash: str
 
 
 @dataclass(frozen=True)
-class _PairwiseInstanceScoreRow:
+class PairwiseInstanceScoreRow:
     experiment_pk: int
     native_id: str
     task_hash: str
@@ -128,7 +128,7 @@ class _PairwiseInstanceScoreRow:
 
 
 @dataclass(frozen=True)
-class _PairwiseTaskCountRow:
+class PairwiseTaskCountRow:
     experiment_pk: int
     task_hash: str
     num_instances: int
@@ -379,11 +379,11 @@ def _canonicalize_scope_task_rows(
     task_rows: Sequence[Any],
     *,
     alias_to_canonical: dict[str, str],
-) -> list[_PairwiseTaskRow]:
-    canonical_rows: list[_PairwiseTaskRow] = []
+) -> list[PairwiseTaskRow]:
+    canonical_rows: list[PairwiseTaskRow] = []
     for row in task_rows:
         canonical_rows.append(
-            _PairwiseTaskRow(
+            PairwiseTaskRow(
                 experiment_pk=int(row.experiment_pk),
                 task_name=alias_to_canonical.get(
                     str(row.task_name or ""),
@@ -610,7 +610,7 @@ def _merge_latest_task_rows(
     task_rows: list[Any],
     source_experiments: list[Any],
     display_experiments: list[Any],
-) -> list[_PairwiseTaskRow]:
+) -> list[PairwiseTaskRow]:
     normalized_rows: list[LatestTaskRowInput] = []
     for row in task_rows:
         try:
@@ -639,7 +639,7 @@ def _merge_latest_task_rows(
         display_experiments=display_experiments,
     )
     return [
-        _PairwiseTaskRow(
+        PairwiseTaskRow(
             experiment_pk=row.experiment_pk,
             task_name=row.task_name,
             task_hash=str(row.task_hash or ""),
@@ -656,7 +656,7 @@ def _merge_latest_instance_key_rows(
     instance_rows: list[Any],
     source_experiments: list[Any],
     display_experiments: list[Any],
-) -> list[_PairwiseInstanceKeyRow]:
+) -> list[PairwiseInstanceKeyRow]:
     (
         source_experiment_by_pk,
         display_experiment_by_hash,
@@ -695,7 +695,7 @@ def _merge_latest_instance_key_rows(
 
     enriched_rows.sort()
 
-    merged_keys: list[_PairwiseInstanceKeyRow] = []
+    merged_keys: list[PairwiseInstanceKeyRow] = []
     seen_keys: set[tuple[int, str, str]] = set()
     for display_pk, task_hash, native_id, _, _ in enriched_rows:
         key = (display_pk, task_hash, native_id)
@@ -703,7 +703,7 @@ def _merge_latest_instance_key_rows(
             continue
         seen_keys.add(key)
         merged_keys.append(
-            _PairwiseInstanceKeyRow(
+            PairwiseInstanceKeyRow(
                 experiment_pk=display_pk,
                 native_id=native_id,
                 task_hash=task_hash,
@@ -724,20 +724,20 @@ def _update_task_rows_num_instances(
     *,
     task_rows: list[Any],
     instance_rows: list[Any],
-) -> list[_PairwiseTaskRow]:
+) -> list[PairwiseTaskRow]:
     instance_count_by_task: dict[tuple[int, str], int] = {}
     for row in instance_rows:
         key = (int(row.experiment_pk), str(row.task_hash or ""))
         instance_count_by_task[key] = instance_count_by_task.get(key, 0) + 1
 
-    updated_rows: list[_PairwiseTaskRow] = []
+    updated_rows: list[PairwiseTaskRow] = []
     for row in task_rows:
         resolved_count = max(
             int(getattr(row, "num_instances", 0) or 0),
             instance_count_by_task.get((int(row.experiment_pk), str(row.task_hash or "")), 0),
         )
         updated_rows.append(
-            _PairwiseTaskRow(
+            PairwiseTaskRow(
                 experiment_pk=int(row.experiment_pk),
                 task_name=str(row.task_name or ""),
                 task_hash=str(row.task_hash or ""),
@@ -756,7 +756,7 @@ def _merge_latest_instance_score_rows(
     instance_rows: Sequence[Any],
     source_experiments: Sequence[Any],
     display_experiments: Sequence[Any],
-) -> list[_PairwiseInstanceScoreRow]:
+) -> list[PairwiseInstanceScoreRow]:
     (
         source_experiment_by_pk,
         display_experiment_by_hash,
@@ -797,12 +797,12 @@ def _merge_latest_instance_score_rows(
 
     enriched_rows.sort()
 
-    merged_rows_by_key: dict[tuple[int, str, str], _PairwiseInstanceScoreRow] = {}
+    merged_rows_by_key: dict[tuple[int, str, str], PairwiseInstanceScoreRow] = {}
     for display_pk, task_hash, native_id, _, _, raw_score in enriched_rows:
         key = (display_pk, task_hash, native_id)
         existing = merged_rows_by_key.get(key)
         if existing is None:
-            merged_rows_by_key[key] = _PairwiseInstanceScoreRow(
+            merged_rows_by_key[key] = PairwiseInstanceScoreRow(
                 experiment_pk=display_pk,
                 native_id=native_id,
                 task_hash=task_hash,
@@ -810,7 +810,7 @@ def _merge_latest_instance_score_rows(
             )
             continue
         if existing.raw_score is None and raw_score is not None:
-            merged_rows_by_key[key] = _PairwiseInstanceScoreRow(
+            merged_rows_by_key[key] = PairwiseInstanceScoreRow(
                 experiment_pk=display_pk,
                 native_id=native_id,
                 task_hash=task_hash,
@@ -846,7 +846,7 @@ def _merge_latest_task_count_rows(
     *,
     count_rows: Sequence[Any],
     display_experiments: Sequence[Any],
-) -> list[_PairwiseTaskCountRow]:
+) -> list[PairwiseTaskCountRow]:
     display_experiment_by_hash = {
         str(experiment.model_hash or ""): experiment
         for experiment in display_experiments
@@ -856,14 +856,14 @@ def _merge_latest_task_count_rows(
         int(experiment.id): index for index, experiment in enumerate(display_experiments)
     }
 
-    merged_rows: list[_PairwiseTaskCountRow] = []
+    merged_rows: list[PairwiseTaskCountRow] = []
     for row in count_rows:
         model_hash = str(getattr(row, "model_hash", "") or "")
         display_experiment = display_experiment_by_hash.get(model_hash)
         if display_experiment is None:
             continue
         merged_rows.append(
-            _PairwiseTaskCountRow(
+            PairwiseTaskCountRow(
                 experiment_pk=int(display_experiment.id),
                 task_hash=str(getattr(row, "task_hash", "") or ""),
                 num_instances=int(getattr(row, "num_instances", 0) or 0),
@@ -883,7 +883,7 @@ def _update_task_rows_num_instances_from_counts(
     *,
     task_rows: Sequence[Any],
     count_rows: Sequence[Any],
-) -> list[_PairwiseTaskRow]:
+) -> list[PairwiseTaskRow]:
     instance_count_by_task: dict[tuple[int, str], int] = {}
     for row in count_rows:
         key = (int(row.experiment_pk), str(row.task_hash or ""))
@@ -892,14 +892,14 @@ def _update_task_rows_num_instances_from_counts(
             int(getattr(row, "num_instances", 0) or 0),
         )
 
-    updated_rows: list[_PairwiseTaskRow] = []
+    updated_rows: list[PairwiseTaskRow] = []
     for row in task_rows:
         resolved_count = max(
             int(getattr(row, "num_instances", 0) or 0),
             instance_count_by_task.get((int(row.experiment_pk), str(row.task_hash or "")), 0),
         )
         updated_rows.append(
-            _PairwiseTaskRow(
+            PairwiseTaskRow(
                 experiment_pk=int(row.experiment_pk),
                 task_name=str(row.task_name or ""),
                 task_hash=str(row.task_hash or ""),

--- a/src/olmo_eval/analysis/pairwise_metrics.py
+++ b/src/olmo_eval/analysis/pairwise_metrics.py
@@ -11,7 +11,7 @@ import numpy as np
 from olmo_eval.analysis.pairwise import ModelMeta, PairwiseResult, get_task_metric_profile
 
 
-class _PairCell(NamedTuple):
+class PairCell(NamedTuple):
     win_rate: float
     se: float
     prob_a_gt_b: float
@@ -37,7 +37,7 @@ class TaskMetrics(NamedTuple):
     worst_model_score: float | None
 
 
-type PairCellLookup = dict[tuple[int, int], _PairCell]
+type PairCellLookup = dict[tuple[int, int], PairCell]
 
 _SIGNIFICANCE_Z = 2.0
 
@@ -56,12 +56,12 @@ def _build_pair_cell_lookup(result: PairwiseResult) -> PairCellLookup:
     for pair in result.pairs:
         se = pair.se
         prob_a_gt_b = pair.prob_a_gt_b
-        pair_lookup[(pair.index_a, pair.index_b)] = _PairCell(
+        pair_lookup[(pair.index_a, pair.index_b)] = PairCell(
             win_rate=pair.win_rate_a,
             se=se,
             prob_a_gt_b=prob_a_gt_b,
         )
-        pair_lookup[(pair.index_b, pair.index_a)] = _PairCell(
+        pair_lookup[(pair.index_b, pair.index_a)] = PairCell(
             win_rate=pair.win_rate_b,
             se=se,
             prob_a_gt_b=1.0 - prob_a_gt_b,

--- a/src/olmo_eval/cli/beaker/job_assembler.py
+++ b/src/olmo_eval/cli/beaker/job_assembler.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 from typing import TYPE_CHECKING, Any
 
 from olmo_eval.common.constants.infrastructure import (
@@ -16,6 +17,10 @@ if TYPE_CHECKING:
     from olmo_eval.cli.beaker.config_loader import LaunchConfig
     from olmo_eval.cli.beaker.experiment_plan import ExperimentPlan
     from olmo_eval.launch import BeakerJobConfig
+
+
+OLMO_CORE_PACKAGE_WITH_EXTRAS = "ai2-olmo-core[torchao,transformers]"
+_VERSION_SELECTOR_RE = re.compile(r"^(?:\d|==|!=|~=|>=|<=|>|<)")
 
 
 def get_provider_kind(model_spec: str, default_kind: str | None = None) -> str | None:
@@ -43,14 +48,15 @@ def get_provider_extras(model_spec: str, default_kind: str | None = None) -> lis
 
     Args:
         model_spec: Model name or path.
-        default_kind: Default provider kind if model is not a preset.
+        default_kind: Effective provider kind to use when the caller has already resolved
+            harness/provider overrides. When omitted, the model spec is inspected.
 
     Returns:
         List of pip extras needed for the provider.
     """
     from olmo_eval.common.constants.infrastructure import BACKEND_OPTIONAL_GROUPS
 
-    provider_kind = get_provider_kind(model_spec, default_kind)
+    provider_kind = default_kind or get_provider_kind(model_spec)
 
     extras: list[str] = []
     if provider_kind:
@@ -79,6 +85,54 @@ def get_provider_dependencies(model_spec: str) -> list[str]:
         return list(provider_config.dependencies)
     except Exception:
         return []
+
+
+def _is_olmo_core_version_selector(package: str) -> bool:
+    """Whether a provider.package value is shorthand for an ai2-olmo-core version."""
+    return bool(_VERSION_SELECTOR_RE.match(package))
+
+
+def _format_install_spec(package: str, flags: list[str]) -> str:
+    return " ".join([package, *flags]) if flags else package
+
+
+def _normalize_olmo_core_package(package: str) -> str:
+    """Normalize OLMo-core provider package overrides.
+
+    The GitHub repository is named ``OLMo-core``, but the Python distribution is
+    ``ai2-olmo-core``. A bare source URL therefore needs a PEP 508 name binding
+    so uv replaces the already-installed distribution instead of targeting the
+    repository basename.
+    """
+    from olmo_eval.launch.beaker.launcher import (
+        is_direct_source_package,
+        normalize_provider_package,
+        parse_install_spec,
+    )
+
+    pkg_spec, flags = parse_install_spec(package.strip())
+    if not pkg_spec:
+        return package
+
+    if _is_olmo_core_version_selector(pkg_spec):
+        version_spec = pkg_spec if not pkg_spec[0].isdigit() else f"=={pkg_spec}"
+        return _format_install_spec(f"{OLMO_CORE_PACKAGE_WITH_EXTRAS}{version_spec}", flags)
+
+    if " @ " not in pkg_spec and is_direct_source_package(pkg_spec):
+        normalized_source = normalize_provider_package(pkg_spec)
+        return _format_install_spec(
+            f"{OLMO_CORE_PACKAGE_WITH_EXTRAS} @ {normalized_source}",
+            flags,
+        )
+
+    return package
+
+
+def normalize_provider_package_for_kind(provider_kind: str | None, package: str) -> str:
+    """Normalize a provider package override for the effective provider kind."""
+    if provider_kind == "olmo_core":
+        return _normalize_olmo_core_package(package)
+    return package
 
 
 def collect_install_extras(
@@ -417,10 +471,21 @@ class JobConfigAssembler:
         vllm_isolated_venv = provider_kind == "vllm_server"
         model_provider_extras = get_provider_extras(exp.model_spec, default_kind=provider_kind)
 
-        # If provider.package is set, it replaces the default vllm extra but
-        # keeps companion extras like clients for vllm_server.
-        if harness_provider_package:
-            provider_extras = [extra for extra in model_provider_extras if extra != "vllm"]
+        # If provider.package is set, it replaces the provider's bundled extra.
+        # Keep companion extras like clients for vllm_server.
+        provider_extra_override = (
+            {
+                "olmo_core": "olmo_core",
+                "vllm": "vllm",
+                "vllm_server": "vllm",
+            }.get(provider_kind)
+            if provider_kind is not None
+            else None
+        )
+        if harness_provider_package and provider_extra_override:
+            provider_extras = [
+                extra for extra in model_provider_extras if extra != provider_extra_override
+            ]
         else:
             provider_extras = model_provider_extras
 
@@ -526,7 +591,9 @@ class JobConfigAssembler:
         # 3. provider.dependencies (additional deps)
         provider_packages: list[str] = []
         if harness_provider_package:
-            provider_packages.append(harness_provider_package)
+            provider_packages.append(
+                normalize_provider_package_for_kind(provider_kind, harness_provider_package)
+            )
         provider_packages.extend(get_provider_dependencies(exp.model_spec))
         provider_packages.extend(harness_provider_deps)
         provider_packages = provider_packages or None  # type: ignore[ty:invalid-assignment]

--- a/src/olmo_eval/cli/results/viewer_server.py
+++ b/src/olmo_eval/cli/results/viewer_server.py
@@ -73,20 +73,20 @@ _VIEWER_ERROR_EMPTY_COLLECTION_FIELDS = (
 
 
 @dataclass(slots=True)
-class _TimedCacheEntry:
+class TimedCacheEntry:
     created_at: float
     value: Any
 
 
 @dataclass(slots=True, frozen=True)
-class _ScopeTarget:
+class ScopeTarget:
     task_name: str | None = None
     task_hash: str | None = None
     suite_name: str | None = None
 
 
 @dataclass(slots=True)
-class _TaskColumnState:
+class TaskColumnState:
     task_name: str
     task_hash: str | None
     metric: str | None = None
@@ -99,7 +99,7 @@ class _TaskColumnState:
         return str(self.task_hash or self.task_name)
 
 
-class _TimedValueCache:
+class TimedValueCache:
     """Small in-process TTL cache for browser response building."""
 
     def __init__(
@@ -112,7 +112,7 @@ class _TimedValueCache:
         self._ttl_seconds = ttl_seconds
         self._max_entries = max_entries
         self._clock = clock
-        self._entries: dict[Any, _TimedCacheEntry] = {}
+        self._entries: dict[Any, TimedCacheEntry] = {}
         self._lock = RLock()
 
     def get_or_set(self, key: Any, factory: Any) -> Any:
@@ -125,7 +125,7 @@ class _TimedValueCache:
         value = factory()
 
         with self._lock:
-            self._entries[key] = _TimedCacheEntry(created_at=self._clock(), value=value)
+            self._entries[key] = TimedCacheEntry(created_at=self._clock(), value=value)
             self._prune_locked()
             return value
 
@@ -206,8 +206,8 @@ def _pluralized_label(count: int, singular: str, plural: str | None = None) -> s
     return singular if count == 1 else (plural or f"{singular}s")
 
 
-def _scope_target(scope_kind: str | None, scope_value: str | None) -> _ScopeTarget:
-    return _ScopeTarget(
+def _scope_target(scope_kind: str | None, scope_value: str | None) -> ScopeTarget:
+    return ScopeTarget(
         task_name=scope_value if scope_kind == "task" else None,
         task_hash=scope_value if scope_kind == "task-hash" else None,
         suite_name=scope_value if scope_kind == "suite" else None,
@@ -376,19 +376,19 @@ def _task_scope_id(task_name: Any, task_hash: Any) -> str:
 
 
 def _record_task_column_state(
-    task_states_by_id: dict[str, _TaskColumnState],
+    task_states_by_id: dict[str, TaskColumnState],
     *,
     task_name: Any,
     task_hash: Any,
     metrics: Any,
     primary_metric: Any,
-) -> _TaskColumnState:
+) -> TaskColumnState:
     resolved_name = str(task_name or "")
     resolved_hash = str(task_hash) if task_hash else None
     task_id = _task_scope_id(resolved_name, resolved_hash)
     task_state = task_states_by_id.setdefault(
         task_id,
-        _TaskColumnState(task_name=resolved_name, task_hash=resolved_hash),
+        TaskColumnState(task_name=resolved_name, task_hash=resolved_hash),
     )
 
     metric_key = str(primary_metric) if primary_metric else None
@@ -404,8 +404,8 @@ def _record_task_column_state(
 
 
 def _ordered_task_columns(
-    task_states: list[_TaskColumnState],
-) -> list[tuple[_TaskColumnState, TaskDisplayEntry]]:
+    task_states: list[TaskColumnState],
+) -> list[tuple[TaskColumnState, TaskDisplayEntry]]:
     ordered_states = sorted(
         task_states,
         key=lambda task_state: (task_state.task_name, task_state.task_hash or ""),
@@ -418,7 +418,7 @@ def _ordered_task_columns(
 
 
 def _serialize_task_column(
-    task_state: _TaskColumnState,
+    task_state: TaskColumnState,
     task_entry: TaskDisplayEntry,
 ) -> dict[str, Any]:
     profile = task_state.profile
@@ -524,7 +524,7 @@ def _build_results_table(
             for experiment in display_experiments
         }
 
-    task_states_by_id: dict[str, _TaskColumnState] = {}
+    task_states_by_id: dict[str, TaskColumnState] = {}
     task_scores_by_pk: dict[int, dict[str, float | None]] = {pk: {} for pk in selected_pks}
     for experiment_pk, task_name, task_hash, metrics, primary_metric in task_rows:
         task_state = _record_task_column_state(
@@ -2898,7 +2898,7 @@ def _build_scope_options_endpoint_bundle(
     requested_scope: str | None,
     keep_all: bool,
     require_full_coverage: bool,
-    group_browser_cache: _TimedValueCache,
+    group_browser_cache: TimedValueCache,
 ) -> dict[str, Any]:
     """Compute the JSON payload for the deferred ``/scope-options`` endpoint."""
     empty: dict[str, Any] = {
@@ -2949,8 +2949,8 @@ def _build_pairwise_endpoint_bundle(
     keep_all: bool,
     margin: float,
     require_full_coverage: bool,
-    group_browser_cache: _TimedValueCache,
-    pairwise_cache: _TimedValueCache,
+    group_browser_cache: TimedValueCache,
+    pairwise_cache: TimedValueCache,
 ) -> dict[str, Any]:
     """Compute the JSON payload for the deferred ``/pairwise`` endpoint."""
     empty: dict[str, Any] = {
@@ -3012,7 +3012,7 @@ def _load_group_browser_data_for_request(
     requested_scope: str | None,
     keep_all: bool,
     require_full_coverage: bool,
-    group_browser_cache: _TimedValueCache,
+    group_browser_cache: TimedValueCache,
 ) -> tuple[dict[str, Any] | None, str | None, bool]:
     """Load initial page group data while tolerating stale suite/task URLs."""
     scope_task_names, scope_suite_name = _resolve_scope_filter(requested_scope)
@@ -3168,12 +3168,12 @@ def serve_results_viewer(
     require_full_coverage: bool,
 ) -> int:
     """Start the local results viewer server and block until interrupted."""
-    groups_cache = _TimedValueCache(ttl_seconds=_GROUP_LIST_CACHE_TTL_SECONDS, max_entries=1)
-    group_browser_cache = _TimedValueCache(
+    groups_cache = TimedValueCache(ttl_seconds=_GROUP_LIST_CACHE_TTL_SECONDS, max_entries=1)
+    group_browser_cache = TimedValueCache(
         ttl_seconds=_GROUP_BROWSER_CACHE_TTL_SECONDS,
         max_entries=_GROUP_BROWSER_CACHE_MAX_ENTRIES,
     )
-    pairwise_cache = _TimedValueCache(
+    pairwise_cache = TimedValueCache(
         ttl_seconds=_PAIRWISE_CACHE_TTL_SECONDS,
         max_entries=_PAIRWISE_CACHE_MAX_ENTRIES,
     )

--- a/src/olmo_eval/common/constants/infrastructure.py
+++ b/src/olmo_eval/common/constants/infrastructure.py
@@ -192,6 +192,7 @@ BACKEND_OPTIONAL_GROUPS: dict[str, str | None] = {
     "vllm": "vllm",
     "vllm_server": "vllm",
     "hf": "hf",
+    "olmo_core": "olmo_core",
     "litellm": "litellm",
     "mock": None,
 }

--- a/src/olmo_eval/common/constants/infrastructure.py
+++ b/src/olmo_eval/common/constants/infrastructure.py
@@ -19,10 +19,10 @@ BEAKER_DEFAULT_BUDGET = "ai2/oe-base"
 BEAKER_DEFAULT_PRIORITY = "normal"
 """Default job priority level."""
 
-BEAKER_DEFAULT_IMAGE = "ai2-tylerm/olmo-eval-cu1281-trc290-amd64"
+BEAKER_DEFAULT_IMAGE = "ai2-tylerm/olmo-eval-cu1281-trc2100-amd64"
 """Default Docker image for Beaker evaluation jobs."""
 
-BEAKER_SANDBOX_IMAGE = "ai2-tylerm/olmo-eval-cu1281-trc290-amd64-sandbox"
+BEAKER_SANDBOX_IMAGE = "ai2-tylerm/olmo-eval-cu1281-trc2100-amd64-sandbox"
 """Docker image for Beaker evaluation jobs with sandbox support (includes Podman)."""
 
 BEAKER_RESULT_DIR = "/results"

--- a/src/olmo_eval/common/types/literals.py
+++ b/src/olmo_eval/common/types/literals.py
@@ -10,11 +10,12 @@ class ProviderKind(StrEnum):
     VLLM = "vllm"
     VLLM_SERVER = "vllm_server"
     HF = "hf"
+    OLMO_CORE = "olmo_core"
     MOCK = "mock"
     LITELLM = "litellm"
 
 
-ProviderLiteral = Literal["vllm", "vllm_server", "hf", "mock", "litellm"]
+ProviderLiteral = Literal["vllm", "vllm_server", "hf", "olmo_core", "mock", "litellm"]
 DtypeLiteral = Literal["auto", "float16", "bfloat16", "float32"]
 PriorityLiteral = Literal["low", "normal", "high", "urgent"]
 LoadFormatLiteral = Literal[

--- a/src/olmo_eval/evals/tasks/arc.py
+++ b/src/olmo_eval/evals/tasks/arc.py
@@ -83,7 +83,7 @@ def _build_arc_fixed_fewshot(
     return instances
 
 
-class _ARCBase(Task):
+class ARCBase(Task):
     metrics = (LogprobMCAccuracyMetric(),)
     num_fewshot = 0
     fewshot_split = "train"
@@ -194,7 +194,7 @@ class _ARCBase(Task):
 
 
 @register("arc_easy")
-class ARCEasy(_ARCBase):
+class ARCEasy(ARCBase):
     data_source = DataSource(path="allenai/ai2_arc", subset="ARC-Easy", split="test")
     split = Split.TEST
     _fewshot_data = ARC_EASY_FIXED_FEWSHOT
@@ -203,7 +203,7 @@ class ARCEasy(_ARCBase):
 
 
 @register("arc_challenge")
-class ARCChallenge(_ARCBase):
+class ARCChallenge(ARCBase):
     data_source = DataSource(path="allenai/ai2_arc", subset="ARC-Challenge", split="test")
     split = Split.TEST
     _fewshot_data = ARC_CHALLENGE_FIXED_FEWSHOT

--- a/src/olmo_eval/evals/tasks/astabench_sqa.py
+++ b/src/olmo_eval/evals/tasks/astabench_sqa.py
@@ -469,7 +469,7 @@ class SQAJudgeScorer(Scorer):
         return (output.metadata or {}).get(self.score_key, 0.0)
 
 
-class _SQAMetricBase(Metric, ABC):
+class SQAMetricBase(Metric, ABC):
     """Base for SQA metrics that read from response.scores."""
 
     scorer: type[Scorer] = SQAJudgeScorer
@@ -482,31 +482,31 @@ class _SQAMetricBase(Metric, ABC):
 
 
 @dataclass(frozen=True)
-class IngredientRecallMetric(_SQAMetricBase):
+class IngredientRecallMetric(SQAMetricBase):
     name: str = "ingredient_recall"
     scorer: type[Scorer] = SQAJudgeScorer
 
 
 @dataclass(frozen=True)
-class AnswerPrecisionMetric(_SQAMetricBase):
+class AnswerPrecisionMetric(SQAMetricBase):
     name: str = "answer_precision"
     scorer: type[Scorer] = SQAJudgeScorer
 
 
 @dataclass(frozen=True)
-class CitationPrecisionMetric(_SQAMetricBase):
+class CitationPrecisionMetric(SQAMetricBase):
     name: str = "citation_precision"
     scorer: type[Scorer] = SQAJudgeScorer
 
 
 @dataclass(frozen=True)
-class CitationRecallMetric(_SQAMetricBase):
+class CitationRecallMetric(SQAMetricBase):
     name: str = "citation_recall"
     scorer: type[Scorer] = SQAJudgeScorer
 
 
 @dataclass(frozen=True)
-class GlobalAvgMetric(_SQAMetricBase):
+class GlobalAvgMetric(SQAMetricBase):
     name: str = "global_avg"
     scorer: type[Scorer] = SQAJudgeScorer
 

--- a/src/olmo_eval/evals/tasks/basic_skills.py
+++ b/src/olmo_eval/evals/tasks/basic_skills.py
@@ -32,7 +32,7 @@ BASIC_SKILLS_SUBTASKS = [
 ]
 
 
-class _BasicSkillsBase(Task):
+class BasicSkillsBase(Task):
     metrics = (LogprobPerTokenMCAccuracyMetric(),)
     num_fewshot = 0
     split = Split.VALIDATION
@@ -129,7 +129,7 @@ for _subtask in BASIC_SKILLS_SUBTASKS:
     _class_name = f"BasicSkills_{_subtask.title().replace('_', '')}"
     _cls = type(
         _class_name,
-        (_BasicSkillsBase,),
+        (BasicSkillsBase,),
         {
             "_subset": _subtask,
             "data_source": DataSource(

--- a/src/olmo_eval/evals/tasks/common/base.py
+++ b/src/olmo_eval/evals/tasks/common/base.py
@@ -65,7 +65,7 @@ def _store_output_score(
         existing[scorer_name] = scoring_error
 
 
-class _OutputScore(NamedTuple):
+class OutputScore(NamedTuple):
     """Scoring result for a single output (execution / context scorers)."""
 
     resp_idx: int
@@ -75,7 +75,7 @@ class _OutputScore(NamedTuple):
     scoring_error: dict[str, str] | None
 
 
-class _ResponseScore(NamedTuple):
+class ResponseScore(NamedTuple):
     """Scoring result for a whole response (process scorers)."""
 
     resp_idx: int
@@ -686,7 +686,7 @@ class Task(ABC):
 
             async def score_execution(
                 resp_idx: int, scorer: ExecutionScorer, out_idx: int
-            ) -> _OutputScore:
+            ) -> OutputScore:
                 response = responses[resp_idx]
                 output = response.outputs[out_idx]
                 try:
@@ -703,12 +703,12 @@ class Task(ABC):
                         scorer.name,
                         error.get("message", error["type"]),
                     )
-                    return _OutputScore(resp_idx, scorer.name, out_idx, 0.0, error)
-                return _OutputScore(resp_idx, scorer.name, out_idx, score, None)
+                    return OutputScore(resp_idx, scorer.name, out_idx, 0.0, error)
+                return OutputScore(resp_idx, scorer.name, out_idx, score, None)
 
             async def score_context(
                 resp_idx: int, scorer: ContextScorer, out_idx: int
-            ) -> _OutputScore:
+            ) -> OutputScore:
                 response = responses[resp_idx]
                 output = response.outputs[out_idx]
                 try:
@@ -724,13 +724,13 @@ class Task(ABC):
                         scorer.name,
                         error.get("message", error["type"]),
                     )
-                    return _OutputScore(resp_idx, scorer.name, out_idx, 0.0, error)
-                return _OutputScore(resp_idx, scorer.name, out_idx, score, None)
+                    return OutputScore(resp_idx, scorer.name, out_idx, 0.0, error)
+                return OutputScore(resp_idx, scorer.name, out_idx, score, None)
 
             async def score_process(
                 resp_idx: int,
                 scorer: ProcessScorer,
-            ) -> _ResponseScore:
+            ) -> ResponseScore:
                 response = responses[resp_idx]
                 assert process_pool_manager is not None
                 results = await process_pool_manager.score_outputs(
@@ -744,7 +744,7 @@ class Task(ABC):
                     for out_idx, result in enumerate(results)
                     if result.error is not None
                 }
-                return _ResponseScore(resp_idx, scorer.name, output_scores, output_errors)
+                return ResponseScore(resp_idx, scorer.name, output_scores, output_errors)
 
             tasks = []
             for resp_idx, response in enumerate(responses):
@@ -768,7 +768,7 @@ class Task(ABC):
             scores_by_response: dict[int, dict[str, dict[int, float]]] = {}
             scoring_errors_by_response: dict[int, dict[int, dict[str, dict[str, str]]]] = {}
             for result in results:
-                if isinstance(result, _OutputScore):
+                if isinstance(result, OutputScore):
                     resp_idx, scorer_name, out_idx, score, scoring_error = result
                     if resp_idx not in scores_by_response:
                         scores_by_response[resp_idx] = {}

--- a/src/olmo_eval/evals/tasks/ds1000.py
+++ b/src/olmo_eval/evals/tasks/ds1000.py
@@ -210,21 +210,21 @@ import subprocess, sys, tempfile, os
 _inner = '''
 import contextlib, io, os, sys, tempfile
 
-class _WriteOnlyStringIO(io.StringIO):
+class WriteOnlyStringIO(io.StringIO):
     def read(self, *a, **k): raise IOError
     def readline(self, *a, **k): raise IOError
     def readlines(self, *a, **k): raise IOError
     def readable(self, *a, **k): return False
 
-class _RedirectStdin(contextlib._RedirectStream):
+class RedirectStdin(contextlib._RedirectStream):
     _stream = "stdin"
 
 _td = tempfile.mkdtemp()
 os.chdir(_td)
-_stream = _WriteOnlyStringIO()
+_stream = WriteOnlyStringIO()
 with contextlib.redirect_stdout(_stream):
     with contextlib.redirect_stderr(_stream):
-        with _RedirectStdin(_stream):
+        with RedirectStdin(_stream):
             exec(compile(_TEST_CODE, "<test>", "exec"), {})
 '''
 _py310 = "/root/python310/python/bin/python3"

--- a/src/olmo_eval/evals/tasks/hmmt.py
+++ b/src/olmo_eval/evals/tasks/hmmt.py
@@ -44,7 +44,7 @@ _RLZERO_SAMPLING = SamplingParams(
 
 
 @dataclass(frozen=True, slots=True)
-class _HMMTCompetition:
+class HMMTCompetition:
     dataset_path: str
     year: int
     season: str
@@ -56,19 +56,19 @@ class _HMMTCompetition:
 
 
 _HMMT_COMPETITIONS = (
-    _HMMTCompetition(
+    HMMTCompetition(
         dataset_path="MathArena/hmmt_feb_2025",
         year=2025,
         season="feb",
         date="2025-02-15",
     ),
-    _HMMTCompetition(
+    HMMTCompetition(
         dataset_path="MathArena/hmmt_nov_2025",
         year=2025,
         season="nov",
         date="2025-11-08",
     ),
-    _HMMTCompetition(
+    HMMTCompetition(
         dataset_path="MathArena/hmmt_feb_2026",
         year=2026,
         season="feb",
@@ -107,7 +107,7 @@ class HMMTTask(MinervaMathTask):
     def instances(self) -> Iterator[Instance]:
         yield from self._load_instances_cached()
 
-    def _selected_competitions(self) -> tuple[_HMMTCompetition, ...]:
+    def _selected_competitions(self) -> tuple[HMMTCompetition, ...]:
         competitions = []
         for competition in _HMMT_COMPETITIONS:
             if self.years is not None and competition.year not in self.years:
@@ -117,7 +117,7 @@ class HMMTTask(MinervaMathTask):
             competitions.append(competition)
         return tuple(competitions)
 
-    def _resolve_competition(self, doc: dict[str, Any]) -> _HMMTCompetition:
+    def _resolve_competition(self, doc: dict[str, Any]) -> HMMTCompetition:
         competition = doc.get("_hmmt_competition")
         if competition is not None:
             return competition
@@ -150,7 +150,7 @@ class HMMTTask(MinervaMathTask):
         *,
         problem_idx: Any,
         fallback_index: int,
-        competition: _HMMTCompetition,
+        competition: HMMTCompetition,
     ) -> Any:
         base_identifier = problem_idx if problem_idx is not None else fallback_index
         if len(self._selected_competitions()) == 1:

--- a/src/olmo_eval/evals/tasks/ifeval_mt.py
+++ b/src/olmo_eval/evals/tasks/ifeval_mt.py
@@ -44,7 +44,7 @@ _SAMPLING_PARAMS = SamplingParams(
 )
 
 
-class _IFEvalMTBase(Task):
+class IFEvalMTBase(Task):
     split = Split.TEST
     metrics = (
         IFEvalPromptStrictAccuracy(),
@@ -93,12 +93,12 @@ class _IFEvalMTBase(Task):
 
 
 @register("ifeval_mt_wildchat_unused_withRewrite")
-class IFEvalMTWildchatUnusedWithRewrite(_IFEvalMTBase):
+class IFEvalMTWildchatUnusedWithRewrite(IFEvalMTBase):
     data_source = DataSource(path=_DATASET_PATH, subset="wildchat_unused_withRewrite", split="test")
 
 
 @register("ifeval_mt_ood_wildchat_unused_withRewrite")
-class IFEvalMTOODWildchatUnusedWithRewrite(_IFEvalMTBase):
+class IFEvalMTOODWildchatUnusedWithRewrite(IFEvalMTBase):
     data_source = DataSource(
         path=_DATASET_PATH, subset="ood_wildchat_unused_withRewrite", split="test"
     )

--- a/src/olmo_eval/evals/tasks/jeopardy.py
+++ b/src/olmo_eval/evals/tasks/jeopardy.py
@@ -20,7 +20,7 @@ def _format_query(category: str, question: str) -> str:
     return f"Category: {category}\nQuestion: {question}\nAnswer:"
 
 
-class _JeopardyBase(Task):
+class JeopardyBase(Task):
     fewshot_split: str = "train"
     metrics = (SQuADF1Metric(),)
     sampling_params = SamplingParams(
@@ -81,7 +81,7 @@ class _JeopardyBase(Task):
 
 
 @register("jeopardy")
-class Jeopardy(_JeopardyBase):
+class Jeopardy(JeopardyBase):
     data_source = DataSource(path="soldni/jeopardy", subset="mosaicml_gauntlet", split="train")
     split = Split.TRAIN
     num_fewshot = 5

--- a/src/olmo_eval/evals/tasks/jeopardy_mc.py
+++ b/src/olmo_eval/evals/tasks/jeopardy_mc.py
@@ -71,7 +71,7 @@ def _build_jeopardy_mc_fixed_fewshot(
     return instances
 
 
-class _JeopardyMCBase(Task):
+class JeopardyMCBase(Task):
     data_source = DataSource(path="allenai/jeopardy_mc", split="test")
     split = Split.TEST
     metrics = (LogprobMCAccuracyMetric(),)
@@ -157,7 +157,7 @@ class _JeopardyMCBase(Task):
 
 
 @register("jeopardy:mc")
-class JeopardyMC(_JeopardyMCBase):
+class JeopardyMC(JeopardyMCBase):
     data_source = DataSource(path="allenai/jeopardy_mc", split="test")
     split = Split.TEST
     formatter = MultipleChoiceFormatter()
@@ -165,7 +165,7 @@ class JeopardyMC(_JeopardyMCBase):
 
 
 @register("jeopardy:rc")
-class JeopardyRC(_JeopardyMCBase):
+class JeopardyRC(JeopardyMCBase):
     data_source = DataSource(path="allenai/jeopardy_mc", split="test")
     split = Split.TEST
     metrics = (LogprobPerCharMCAccuracyMetric(),)

--- a/src/olmo_eval/evals/tasks/minerva_math.py
+++ b/src/olmo_eval/evals/tasks/minerva_math.py
@@ -13,31 +13,7 @@ from olmo_eval.evals.tasks.constants.minerva_math import MINERVA_MATH_FIXED_FEWS
 
 
 @dataclass(slots=True)
-class _MinervaCompletionFormatter(CompletionFormatter):
-    """CompletionFormatter that omits answer_prefix from the final (test) instance."""
-
-    def format(
-        self,
-        instance: Instance,
-        fewshot: list[Instance] | None = None,
-    ) -> LMRequest:
-        parts: list[str] = []
-        for ex in fewshot or []:
-            example = self.template.format(question=ex.question)
-            if self.fewshot_answer_key and self.fewshot_answer_key in ex.metadata:
-                answer = ex.metadata[self.fewshot_answer_key]
-            else:
-                answer = ex.gold_answer
-            if answer:
-                example += self.answer_prefix + str(answer)
-            parts.append(example)
-        parts.append(self.template.format(question=instance.question))
-        prompt = self.fewshot_separator.join(parts)
-        return LMRequest(request_type=self.request_type, prompt=prompt)
-
-
-@dataclass(slots=True)
-class _MinervaCompletionFormatter(CompletionFormatter):
+class MinervaCompletionFormatter(CompletionFormatter):
     """CompletionFormatter that omits answer_prefix from the final (test) instance."""
 
     def format(
@@ -257,7 +233,7 @@ for _subset in MATH_SUBSETS:
         _task_name,
         "olmo3base",
         fewshot_source="minerva_math_fixed",
-        formatter=_MinervaCompletionFormatter(
+        formatter=MinervaCompletionFormatter(
             template="Problem:\n{question}\n\nSolution:",
             answer_prefix=" ",
             fewshot_answer_key="solution_text",
@@ -282,7 +258,7 @@ for _subset in MATH_SUBSETS:
         _task_name,
         "olmo3base_gen",
         fewshot_source="minerva_math_fixed",
-        formatter=_MinervaCompletionFormatter(
+        formatter=MinervaCompletionFormatter(
             template="Problem:\n{question}\n\nSolution:",
             answer_prefix=" ",
             fewshot_answer_key="solution_text",

--- a/src/olmo_eval/evals/tasks/naturalqs_mc.py
+++ b/src/olmo_eval/evals/tasks/naturalqs_mc.py
@@ -83,7 +83,7 @@ def _format_rc(question: str, choices: tuple[str, ...], answer: str | None = Non
     return prompt
 
 
-class _NaturalQsMCBase(Task):
+class NaturalQsMCBase(Task):
     metrics = (LogprobMCAccuracyMetric(),)
     num_fewshot = 5
     sampling_params = SamplingParams(temperature=0.0)
@@ -132,7 +132,7 @@ class _NaturalQsMCBase(Task):
 
 
 @register("naturalqs:mc")
-class NaturalQsMC(_NaturalQsMCBase):
+class NaturalQsMC(NaturalQsMCBase):
     data_source = DataSource(path="allenai/nq_open_mc", split="validation")
     split = Split.VALIDATION
     from olmo_eval.common.formatters import MultipleChoiceFormatter
@@ -142,7 +142,7 @@ class NaturalQsMC(_NaturalQsMCBase):
 
 
 @register("naturalqs:rc")
-class NaturalQsRC(_NaturalQsMCBase):
+class NaturalQsRC(NaturalQsMCBase):
     data_source = DataSource(path="allenai/nq_open_mc", split="validation")
     split = Split.VALIDATION
     metrics = (LogprobPerCharMCAccuracyMetric(),)
@@ -167,7 +167,7 @@ register_variant(
 
 
 @register("naturalqs:bpb")
-class NaturalQsBPB(_NaturalQsMCBase):
+class NaturalQsBPB(NaturalQsMCBase):
     data_source = DataSource(path="allenai/nq_open_mc", split="validation")
     split = Split.VALIDATION
     formatter = PPLFormatter()

--- a/src/olmo_eval/evals/tasks/ruler.py
+++ b/src/olmo_eval/evals/tasks/ruler.py
@@ -158,15 +158,19 @@ class RulerTask(Task):
         if "context" not in context_fields:
             context_fields["context"] = ""
 
-        # Format the question using the user template
-        if self._templates is None:
-            raise RuntimeError("Templates not loaded. Call _load_data() first.")
-        question = self._templates["user"].format(**context_fields)
-
-        # Add system template as prepend text for non-chat format
+        # Prefer the preformatted RULER input when present. The released JSONL
+        # already includes the benchmark's exact prompt plus answer prefix.
+        question = doc.get("input")
         prepend_text = ""
-        if not self.ruler_config.get("use_chat_template", False):
-            prepend_text = self._templates["system"].format(**context_fields)
+        if not isinstance(question, str) or not question:
+            # Format the question using the user template
+            if self._templates is None:
+                raise RuntimeError("Templates not loaded. Call _load_data() first.")
+            question = self._templates["user"].format(**context_fields)
+
+            # Add system template as prepend text for non-chat format
+            if not self.ruler_config.get("use_chat_template", False):
+                prepend_text = self._templates["system"].format(**context_fields)
 
         # Get answer (handle both "answer" and "outputs" fields)
         answer = doc.get("answer") or doc.get("outputs")

--- a/src/olmo_eval/evals/tasks/squad.py
+++ b/src/olmo_eval/evals/tasks/squad.py
@@ -16,7 +16,7 @@ def _format_query(title: str, context: str, question: str) -> str:
     return f"Title: {title}\nBackground: {context}\nQuestion: {question}\nAnswer:"
 
 
-class _SQuADBase(Task):
+class SQuADBase(Task):
     fewshot_split = "train"
     metrics = (SQuADF1Metric(),)
     sampling_params = SamplingParams(
@@ -84,7 +84,7 @@ class _SQuADBase(Task):
 
 
 @register("squad")
-class SQuAD(_SQuADBase):
+class SQuAD(SQuADBase):
     data_source = DataSource(path="allenai/squad", split="validation")
     split = Split.VALIDATION
     num_fewshot = 5

--- a/src/olmo_eval/evals/tasks/squad_mc.py
+++ b/src/olmo_eval/evals/tasks/squad_mc.py
@@ -89,7 +89,7 @@ def _format_rc(question: str, answer: str | None = None) -> str:
     return prompt
 
 
-class _SquadMCBase(Task):
+class SquadMCBase(Task):
     metrics = (LogprobMCAccuracyMetric(),)
     num_fewshot = 5
     fewshot_split = "train"
@@ -141,7 +141,7 @@ class _SquadMCBase(Task):
 
 
 @register("squad:mc")
-class SquadMC(_SquadMCBase):
+class SquadMC(SquadMCBase):
     data_source = DataSource(path="allenai/squad_mc", split="validation")
     split = Split.VALIDATION
     formatter = MultipleChoiceFormatter()
@@ -149,7 +149,7 @@ class SquadMC(_SquadMCBase):
 
 
 @register("squad:rc")
-class SquadRC(_SquadMCBase):
+class SquadRC(SquadMCBase):
     data_source = DataSource(path="allenai/squad_mc", split="validation")
     split = Split.VALIDATION
     metrics = (LogprobPerCharMCAccuracyMetric(),)
@@ -174,7 +174,7 @@ register_variant(
 
 
 @register("squad:bpb")
-class SquadBPB(_SquadMCBase):
+class SquadBPB(SquadMCBase):
     data_source = DataSource(path="allenai/squad_mc", split="validation")
     split = Split.VALIDATION
     metrics = (BPBMetricInstanceAvg(),)

--- a/src/olmo_eval/harness/presets.py
+++ b/src/olmo_eval/harness/presets.py
@@ -35,7 +35,7 @@ def _get_logs_dir() -> str:
 # ─────────────────────────────────────────────────────────
 
 
-class _Lazy:
+class Lazy:
     """Descriptor for lazily-loaded presets with auto-injected name."""
 
     def __init__(self, factory: Callable[[str], HarnessConfig]):
@@ -52,9 +52,9 @@ class _Lazy:
         return self._cached
 
 
-def lazy(fn: Callable[[str], HarnessConfig]) -> _Lazy:
+def lazy(fn: Callable[[str], HarnessConfig]) -> Lazy:
     """Mark a preset factory for lazy loading. Factory receives preset name."""
-    return _Lazy(fn)
+    return Lazy(fn)
 
 
 # ─────────────────────────────────────────────────────────
@@ -236,11 +236,11 @@ class HarnessPresets:
 
 
 def _is_preset(name: str) -> bool:
-    """Check if a name is a valid preset (not private, is HarnessConfig or _Lazy)."""
+    """Check if a name is a valid preset (not private, is HarnessConfig or Lazy)."""
     if name.startswith("_"):
         return False
     attr = getattr(HarnessPresets, name, None)
-    return isinstance(attr, (HarnessConfig, _Lazy))
+    return isinstance(attr, (HarnessConfig, Lazy))
 
 
 def get_harness_preset(name: str) -> HarnessConfig:

--- a/src/olmo_eval/inference/__init__.py
+++ b/src/olmo_eval/inference/__init__.py
@@ -3,7 +3,6 @@
 from olmo_eval.common.types import ProviderKind
 
 from .base import InferenceProvider
-from .providers.mock import MockProvider
 from .tokenizer_utils import (
     encode_context_and_continuation,
     get_bos_token_ids,
@@ -18,6 +17,7 @@ __all__ = [
     "HuggingFaceProvider",
     "VLLMProvider",
     "VLLMServerProvider",
+    "OlmoCoreProvider",
     "LiteLLMProvider",
     "create_provider",
     # Tokenizer utilities
@@ -95,6 +95,8 @@ def create_provider(
 
     match kind_str:
         case "mock":
+            from .providers.mock import MockProvider
+
             return MockProvider(model_name)
         case "hf":
             from .providers.huggingface import HuggingFaceProvider
@@ -126,6 +128,10 @@ def create_provider(
                 force_download=force_download,
             )
             return VLLMServerProvider(model_name, **kwargs)
+        case "olmo_core":
+            from .providers.olmo_core import OlmoCoreProvider
+
+            return OlmoCoreProvider(model_name, **kwargs)
         case "litellm":
             from .providers.litellm import LiteLLMProvider
 
@@ -136,6 +142,10 @@ def create_provider(
 
 # Lazy imports for optional dependencies
 def __getattr__(name: str):
+    if name == "MockProvider":
+        from .providers.mock import MockProvider
+
+        return MockProvider
     if name == "HuggingFaceProvider":
         from .providers.huggingface import HuggingFaceProvider
 
@@ -148,6 +158,10 @@ def __getattr__(name: str):
         from .providers.vllm_server import VLLMServerProvider
 
         return VLLMServerProvider
+    if name == "OlmoCoreProvider":
+        from .providers.olmo_core import OlmoCoreProvider
+
+        return OlmoCoreProvider
     if name == "LiteLLMProvider":
         from .providers.litellm import LiteLLMProvider
 

--- a/src/olmo_eval/inference/providers/__init__.py
+++ b/src/olmo_eval/inference/providers/__init__.py
@@ -1,17 +1,53 @@
 """Inference provider implementations."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from .config import ProviderConfig
-from .huggingface import HuggingFaceProvider
-from .litellm import LiteLLMProvider
-from .mock import MockProvider
-from .vllm import VLLMProvider
-from .vllm_server import VLLMServerProvider
+
+if TYPE_CHECKING:
+    from .huggingface import HuggingFaceProvider
+    from .litellm import LiteLLMProvider
+    from .mock import MockProvider
+    from .olmo_core import OlmoCoreProvider
+    from .vllm import VLLMProvider
+    from .vllm_server import VLLMServerProvider
 
 __all__ = [
     "HuggingFaceProvider",
     "LiteLLMProvider",
     "MockProvider",
+    "OlmoCoreProvider",
     "ProviderConfig",
     "VLLMProvider",
     "VLLMServerProvider",
 ]
+
+
+def __getattr__(name: str):
+    if name == "HuggingFaceProvider":
+        from .huggingface import HuggingFaceProvider
+
+        return HuggingFaceProvider
+    if name == "LiteLLMProvider":
+        from .litellm import LiteLLMProvider
+
+        return LiteLLMProvider
+    if name == "MockProvider":
+        from .mock import MockProvider
+
+        return MockProvider
+    if name == "OlmoCoreProvider":
+        from .olmo_core import OlmoCoreProvider
+
+        return OlmoCoreProvider
+    if name == "VLLMProvider":
+        from .vllm import VLLMProvider
+
+        return VLLMProvider
+    if name == "VLLMServerProvider":
+        from .vllm_server import VLLMServerProvider
+
+        return VLLMServerProvider
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/olmo_eval/inference/providers/config.py
+++ b/src/olmo_eval/inference/providers/config.py
@@ -23,7 +23,7 @@ class ProviderConfig:
     a provider via the create_provider factory function.
 
     Attributes:
-        kind: Provider type (vllm, vllm_server, hf, litellm, mock).
+        kind: Provider type (vllm, vllm_server, hf, olmo_core, litellm, mock).
         model: Model name or path (HuggingFace ID, API model name, or local path).
         alias: Short display name for the model (used in DB and S3 paths).
         base_url: Base URL for API-based providers (vllm_server, litellm).
@@ -61,13 +61,13 @@ class ProviderConfig:
     kwargs: Mapping[str, Any] = field(default_factory=dict)
 
     # Providers that require GPU resources for local inference
-    _GPU_PROVIDERS: ClassVar[frozenset[str]] = frozenset({"vllm", "vllm_server", "hf"})
+    _GPU_PROVIDERS: ClassVar[frozenset[str]] = frozenset({"vllm", "vllm_server", "hf", "olmo_core"})
 
     @property
     def requires_gpu(self) -> bool:
         """Whether this provider requires GPU resources.
 
-        Returns True for local inference providers (vllm, vllm_server, hf).
+        Returns True for local inference providers (vllm, vllm_server, hf, olmo_core).
         Returns False for API-based providers (litellm, mock).
         """
         return str(self.kind) in self._GPU_PROVIDERS
@@ -76,7 +76,8 @@ class ProviderConfig:
     def requires_local_gpu(self) -> bool:
         """Whether this provider needs local GPU resources.
 
-        Returns True for local inference (vllm, vllm_server, hf) without external base_url.
+        Returns True for local inference (vllm, vllm_server, hf, olmo_core)
+        without external base_url.
         Returns False for API-backed providers or configs pointing to external servers.
         """
         if not self.requires_gpu:
@@ -106,6 +107,14 @@ class ProviderConfig:
         ),
         "litellm": ("base_url", "api_base", "max_concurrency"),
         "hf": ("tokenizer", "revision", "force_download", "trust_remote_code", "dtype"),
+        "olmo_core": (
+            "tokenizer",
+            "revision",
+            "force_download",
+            "trust_remote_code",
+            "dtype",
+            "max_model_len",
+        ),
         "mock": (),
     }
 

--- a/src/olmo_eval/inference/providers/olmo_core.py
+++ b/src/olmo_eval/inference/providers/olmo_core.py
@@ -1,0 +1,777 @@
+"""OLMo-core inference provider."""
+
+from __future__ import annotations
+
+import asyncio
+import gc
+import logging
+from contextlib import suppress
+from typing import TYPE_CHECKING, Literal, cast
+
+import olmo_eval.inference.providers.olmo_core_utils as core_utils
+from olmo_eval.common.debug import is_debug_requests
+from olmo_eval.common.types import LMOutput, LMRequest, LogProbEntry, RequestType, SamplingParams
+from olmo_eval.inference.base import InferenceProvider
+from olmo_eval.inference.tokenizer_utils import (
+    encode_context_and_continuation,
+    get_bos_token_ids,
+)
+
+if TYPE_CHECKING:
+    import torch
+
+logger = logging.getLogger(__name__)
+
+_OLMO_CORE_GENERATION_LOGGER = "olmo_core.generate.generation_module.transformer.generation_module"
+_OLMO_CORE_CONFIG_LOG_PREFIXES = ("TransformerConfig(", "GenerationConfig(")
+
+
+class _OlmoCoreConfigLogFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        return not record.getMessage().startswith(_OLMO_CORE_CONFIG_LOG_PREFIXES)
+
+
+class _TokenizerBosOverride:
+    """Tokenizer proxy that gives logprob encoding the provider's BOS setting."""
+
+    def __init__(self, tokenizer: core_utils.TokenizerProtocol, add_bos_token: bool) -> None:
+        self._tokenizer = tokenizer
+        self.add_bos_token = add_bos_token
+
+    def __getattr__(self, name: str) -> object:
+        return getattr(self._tokenizer, name)
+
+
+class OlmoCoreProvider(InferenceProvider):
+    """Provider using OLMo-core's in-process generation module."""
+
+    # Experimental for now; keep this path close to OLMo-core's public behavior.
+    def __init__(
+        self,
+        model_name: str,
+        tokenizer: str | None = None,
+        *,
+        dtype: str = "bfloat16",
+        max_model_len: int | None = None,
+        attention_backend: str | None = None,
+        use_cache: bool = True,
+        compile_model: bool = False,
+        batch_size: int | None = None,
+        validate_checkpoint: bool = True,
+        allow_tokenizer_fallback: bool = False,
+        chat_template: str | None = None,
+        pad_token_id: int | None = None,
+        eos_token_id: int | None = None,
+        device: str | None = None,
+        load_thread_count: int | None = None,
+        pre_download: bool = True,
+        work_dir: str | None = None,
+        revision: str | None = None,
+        force_download: bool = False,
+        trust_remote_code: bool = False,
+        token: str | None = None,
+        cache_dir: str | None = None,
+        local_files_only: bool = False,
+        add_bos_token: bool = False,
+        **kwargs: object,
+    ) -> None:
+        max_model_len = core_utils._resolve_max_model_len_alias(max_model_len, kwargs)
+        core_utils._validate_max_model_len(max_model_len)
+        core_utils._validate_batch_size(batch_size)
+        core_utils._validate_tensor_parallel_size(kwargs.pop("tensor_parallel_size", 1))
+
+        module_kwargs = core_utils._pop_module_kwargs(kwargs)
+        core_utils._raise_for_unsupported_kwargs(kwargs)
+
+        imports = core_utils._import_olmo_core()
+        super().__init__(model_name)
+
+        checkpoint_config, tokenizer_config = core_utils._resolve_checkpoint(
+            model_name,
+            imports=imports,
+            validate_checkpoint=validate_checkpoint,
+            allow_tokenizer_fallback=allow_tokenizer_fallback,
+        )
+        tokenizer_path, tokenizer_config = core_utils._resolve_tokenizer_path(
+            model_name,
+            explicit_tokenizer=tokenizer,
+            tokenizer_config=tokenizer_config,
+            TokenizerConfig=imports.TokenizerConfig,
+            allow_tokenizer_fallback=allow_tokenizer_fallback,
+        )
+
+        tokenizer_kwargs = {
+            key: value
+            for key, value in {
+                "revision": revision,
+                "force_download": force_download,
+                "trust_remote_code": trust_remote_code,
+                "token": token,
+                "cache_dir": cache_dir,
+                "local_files_only": local_files_only,
+            }.items()
+            if value
+        }
+        self.tokenizer: core_utils.TokenizerProtocol = imports.AutoTokenizer.from_pretrained(
+            tokenizer_path,
+            **tokenizer_kwargs,
+        )
+        self.add_bos_token = add_bos_token
+
+        resolved_pad_token_id, resolved_eos_token_id = core_utils._validate_token_ids(
+            checkpoint_dir=model_name,
+            pad_token_id=core_utils._preferred_token_id(
+                pad_token_id,
+                tokenizer=self.tokenizer,
+                tokenizer_config=tokenizer_config,
+                attr="pad_token_id",
+            ),
+            eos_token_id=core_utils._preferred_token_id(
+                eos_token_id,
+                tokenizer=self.tokenizer,
+                tokenizer_config=tokenizer_config,
+                attr="eos_token_id",
+            ),
+        )
+        self.pad_token_id = resolved_pad_token_id
+        self.eos_token_id = resolved_eos_token_id
+        if getattr(self.tokenizer, "pad_token_id", None) is None:
+            self.tokenizer.pad_token_id = resolved_pad_token_id
+        if getattr(self.tokenizer, "eos_token_id", None) is None:
+            self.tokenizer.eos_token_id = resolved_eos_token_id
+        self.use_cache = use_cache
+        self.batch_size = batch_size
+        self.chat_template = chat_template
+        self.max_length = core_utils._resolve_max_length(
+            explicit_max_length=max_model_len,
+            tokenizer=self.tokenizer,
+            checkpoint_config=checkpoint_config,
+            checkpoint_dir=model_name,
+        )
+
+        self.device = imports.torch.device(
+            device or ("cuda" if imports.torch.cuda.is_available() else "cpu")
+        )
+        attention_backend_value = core_utils._resolve_attention_backend(
+            attention_backend,
+            AttentionBackendName=imports.AttentionBackendName,
+        )
+        transformer_config = self._build_transformer_config_for_display(
+            checkpoint_config=checkpoint_config,
+            dtype=dtype,
+            attention_backend=attention_backend_value,
+        )
+
+        self.generation_config = imports.GenerationConfig(
+            pad_token_id=self.pad_token_id,
+            eos_token_id=self.eos_token_id,
+            use_cache=use_cache,
+        )
+        self._print_olmo_core_config(transformer_config, self.generation_config)
+
+        load_kwargs = {
+            "checkpoint_dir": model_name,
+            "generation_config": self.generation_config,
+            "device": self.device,
+            "pre_download": pre_download,
+            "load_thread_count": load_thread_count,
+            "work_dir": work_dir,
+            "attention_backend": attention_backend_value,
+            "compile_model": compile_model,
+            **module_kwargs,
+        }
+        if dtype != "auto":
+            load_kwargs["dtype"] = dtype
+
+        config_log_filter = _OlmoCoreConfigLogFilter()
+        olmo_core_logger = logging.getLogger(_OLMO_CORE_GENERATION_LOGGER)
+        olmo_core_logger.addFilter(config_log_filter)
+        try:
+            self.generation_module: core_utils.GenerationModuleProtocol = (
+                imports.TransformerGenerationModule.from_checkpoint(
+                    **{key: value for key, value in load_kwargs.items() if value is not None}
+                )
+            )
+        finally:
+            olmo_core_logger.removeFilter(config_log_filter)
+
+    def get_tokenizer(self) -> core_utils.TokenizerProtocol:
+        return self.tokenizer
+
+    @staticmethod
+    def _build_transformer_config_for_display(
+        *,
+        checkpoint_config: dict[str, object] | None,
+        dtype: str,
+        attention_backend: object | None,
+    ) -> object | None:
+        if checkpoint_config is None:
+            return None
+        model_config = checkpoint_config.get("model")
+        if not isinstance(model_config, dict):
+            return None
+
+        try:
+            from olmo_core.config import DType
+            from olmo_core.nn.transformer import TransformerConfig
+
+            transformer_config = TransformerConfig.from_dict(model_config)
+            if dtype != "auto":
+                dtype_value = DType(dtype)
+                transformer_config.apply(
+                    lambda config: (
+                        setattr(config, "dtype", dtype_value) if hasattr(config, "dtype") else None
+                    )
+                )
+            if attention_backend is not None:
+
+                def set_attention_backend(config: object) -> None:
+                    mixer = getattr(config, "sequence_mixer", None) or getattr(
+                        config, "attention", None
+                    )
+                    if mixer is None and hasattr(config, "backend"):
+                        mixer = config
+                    if mixer is not None and hasattr(mixer, "backend"):
+                        setattr(mixer, "backend", attention_backend)  # noqa: B010
+
+                transformer_config.apply(set_attention_backend)
+            return transformer_config
+        except Exception:
+            logger.debug("Could not build OLMo-core TransformerConfig for rich display.")
+            return model_config
+
+    @staticmethod
+    def _config_display_value(config: object) -> object:
+        as_dict = getattr(config, "as_dict", None)
+        if callable(as_dict):
+            with suppress(Exception):
+                return as_dict()
+        return config
+
+    @classmethod
+    def _print_olmo_core_config(
+        cls,
+        transformer_config: object | None,
+        generation_config: object,
+    ) -> None:
+        if not logger.isEnabledFor(logging.INFO):
+            return
+
+        from rich.panel import Panel
+        from rich.pretty import Pretty
+
+        from olmo_eval.common.console import console
+
+        payload = {
+            "generation": cls._config_display_value(generation_config),
+        }
+        if transformer_config is not None:
+            payload = {
+                "transformer": cls._config_display_value(transformer_config),
+                **payload,
+            }
+
+        console.print(
+            Panel(
+                Pretty(payload, expand_all=True),
+                title="[bold]OLMo-core Configuration[/bold]",
+                border_style="cyan",
+            )
+        )
+
+    def _free_inference_cache(self) -> None:
+        self.generation_module.free_inference_cache()
+
+    def _iter_chunks(self, requests: list[LMRequest]) -> list[list[LMRequest]]:
+        if self.batch_size is None:
+            return [requests]
+        return [
+            requests[start : start + self.batch_size]
+            for start in range(0, len(requests), self.batch_size)
+        ]
+
+    def _encode_prompt(self, prompt: str) -> list[int]:
+        token_ids = self.tokenizer.encode(prompt, add_special_tokens=False)
+        if self.add_bos_token:
+            return get_bos_token_ids(self.tokenizer, fallback_to_eos=True) + token_ids
+        return token_ids
+
+    def _format_prompt(self, request: LMRequest) -> str:
+        if request.request_type == RequestType.CHAT and request.messages:
+            if not hasattr(self.tokenizer, "apply_chat_template"):
+                raise ValueError("CHAT requests require a tokenizer with apply_chat_template")
+            kwargs: dict[str, object] = {
+                "tokenize": False,
+                "add_generation_prompt": True,
+            }
+            if self.chat_template is not None:
+                kwargs["chat_template"] = self.chat_template
+            return self.tokenizer.apply_chat_template(list(request.messages), **kwargs)
+        return request.prompt
+
+    def _logprob_tokenizer(self) -> core_utils.TokenizerProtocol:
+        return cast(
+            core_utils.TokenizerProtocol,
+            _TokenizerBosOverride(self.tokenizer, self.add_bos_token),
+        )
+
+    def _encode_logprob_context_and_continuation(
+        self,
+        prompt: str,
+        continuation: str,
+    ) -> tuple[list[int], list[int]]:
+        context_ids, continuation_ids = encode_context_and_continuation(
+            self._logprob_tokenizer(),
+            prompt,
+            continuation,
+        )
+        if continuation_ids and not context_ids:
+            context_ids = get_bos_token_ids(self.tokenizer, fallback_to_eos=True) or [
+                self.eos_token_id
+            ]
+        return context_ids, continuation_ids
+
+    def _pad_sequences(
+        self,
+        sequences: list[list[int]],
+        *,
+        side: Literal["left", "right"],
+        return_attention_mask: bool = False,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        import torch
+
+        max_len = max(max((len(seq) for seq in sequences), default=0), 1)
+        input_ids = torch.full(
+            (len(sequences), max_len),
+            self.pad_token_id,
+            dtype=torch.long,
+            device=self.device,
+        )
+        attention_mask = (
+            torch.zeros(
+                (len(sequences), max_len),
+                dtype=torch.long,
+                device=self.device,
+            )
+            if return_attention_mask
+            else None
+        )
+        for idx, seq in enumerate(sequences):
+            if not seq:
+                continue
+            seq_tensor = torch.tensor(seq, dtype=torch.long, device=self.device)
+            target = slice(-len(seq), None) if side == "left" else slice(0, len(seq))
+            input_ids[idx, target] = seq_tensor
+            if attention_mask is not None:
+                attention_mask[idx, target] = 1
+        return input_ids, attention_mask
+
+    def _left_pad(self, sequences: list[list[int]]) -> tuple[torch.Tensor, torch.Tensor]:
+        input_ids, attention_mask = self._pad_sequences(
+            sequences,
+            side="left",
+            return_attention_mask=True,
+        )
+        assert attention_mask is not None
+        return input_ids, attention_mask
+
+    def _right_pad(self, sequences: list[list[int]]) -> torch.Tensor:
+        input_ids, _ = self._pad_sequences(sequences, side="right")
+        return input_ids
+
+    def _build_generation_kwargs(self, params: SamplingParams) -> dict[str, object]:
+        if params.max_tokens <= 0:
+            raise ValueError("OlmoCoreProvider requires sampling max_tokens > 0")
+        if params.num_samples <= 0:
+            raise ValueError("OlmoCoreProvider requires sampling num_samples > 0")
+
+        do_sample = params.do_sample and params.temperature > 0
+        return {
+            "do_sample": do_sample,
+            "temperature": params.temperature if do_sample else 0.0,
+            "top_k": params.top_k if do_sample and params.top_k is not None else -1,
+            "top_p": params.top_p if do_sample and params.top_p is not None else 1.0,
+            "use_cache": self.use_cache,
+        }
+
+    def _decode(self, token_ids: list[int], *, skip_special_tokens: bool) -> str:
+        return self.tokenizer.decode(token_ids, skip_special_tokens=skip_special_tokens)
+
+    def _text_before_stop(self, text: str, stop_sequences: tuple[str, ...]) -> str | None:
+        stop_idx: int | None = None
+        for stop in stop_sequences:
+            if stop in text:
+                idx = text.find(stop)
+                if stop_idx is None or idx < stop_idx:
+                    stop_idx = idx
+        if stop_idx is None:
+            return None
+        return text[:stop_idx]
+
+    def _stop_sequences_with_eos(self, stop_sequences: tuple[str, ...] | None) -> tuple[str, ...]:
+        stops = [stop for stop in stop_sequences or () if stop]
+        eos = self._decode([self.eos_token_id], skip_special_tokens=False)
+        if eos and eos not in stops:
+            stops.append(eos)
+        return tuple(stops)
+
+    def _validate_generation_lengths(
+        self,
+        prompt_token_ids: list[list[int]],
+        params: SamplingParams,
+    ) -> None:
+        for request_idx, token_ids in enumerate(prompt_token_ids):
+            requested_length = len(token_ids) + params.max_tokens
+            if requested_length > self.max_length:
+                raise ValueError(
+                    "OLMo-core generation request exceeds max_length for request "
+                    f"{request_idx}: prompt length ({len(token_ids)}) + max_tokens "
+                    f"({params.max_tokens}) = {requested_length}, but max_length is "
+                    f"{self.max_length}."
+                )
+
+    def _left_truncate_prompts_for_generation(
+        self,
+        prompt_token_ids: list[list[int]],
+        params: SamplingParams,
+    ) -> list[list[int]]:
+        max_context_len = self.max_length - params.max_tokens
+        if max_context_len <= 0:
+            raise ValueError(
+                f"max_tokens ({params.max_tokens}) is greater than or equal to max_length "
+                f"({self.max_length}) for OlmoCoreProvider generation."
+            )
+        return [token_ids[-max_context_len:] for token_ids in prompt_token_ids]
+
+    def _normalize_generation_output(
+        self,
+        token_ids: list[int],
+        token_logprobs: list[float] | None,
+        stop_sequences: tuple[str, ...] | None,
+    ) -> tuple[list[int], list[float] | None, str]:
+        end = len(token_ids)
+        for idx, token_id in enumerate(token_ids):
+            if token_id in {self.eos_token_id, self.pad_token_id}:
+                end = idx if token_id == self.pad_token_id else idx + 1
+                break
+
+        token_ids = token_ids[:end]
+        if token_logprobs is not None:
+            token_logprobs = token_logprobs[:end]
+
+        stop_sequences = tuple(stop for stop in stop_sequences or () if stop)
+        decoded = self._decode(token_ids, skip_special_tokens=True)
+        text = self._text_before_stop(decoded, stop_sequences)
+        return token_ids, token_logprobs, text if text is not None else decoded
+
+    def _logprob_entries(
+        self,
+        token_ids: list[int],
+        token_logprobs: list[float],
+    ) -> list[LogProbEntry]:
+        entries: list[LogProbEntry] = []
+        for token_id, logprob in zip(token_ids, token_logprobs, strict=True):
+            token_str = self._decode([token_id], skip_special_tokens=False)
+            entries.append(
+                {
+                    "token": token_str,
+                    "logprob": float(logprob),
+                    "bytes": list(token_str.encode("utf-8")),
+                }
+            )
+        return entries
+
+    def _generation_output(
+        self,
+        token_ids: list[int],
+        token_logprobs: list[float] | None,
+        text: str,
+    ) -> LMOutput:
+        entries = (
+            self._logprob_entries(token_ids, token_logprobs) if token_logprobs is not None else None
+        )
+        metadata: dict[str, object] = {}
+        if entries:
+            total = sum(entry["logprob"] for entry in entries)
+            metadata = {
+                "sum_logits": total,
+                "num_tokens": len(entries),
+                "num_tokens_all": len(entries),
+            }
+        return LMOutput(
+            text=text,
+            logprobs=entries,
+            metadata=metadata,
+        )
+
+    def generate(
+        self,
+        requests: list[LMRequest],
+        sampling_params: SamplingParams | None = None,
+    ) -> list[list[LMOutput]]:
+        if not requests:
+            return []
+
+        params = self._default_sampling_params(sampling_params)
+        results: list[list[LMOutput]] = []
+        try:
+            for chunk in self._iter_chunks(requests):
+                results.extend(self._generate_chunk(chunk, params))
+        except Exception:
+            self._free_inference_cache()
+            raise
+
+        self._free_inference_cache()
+        return results
+
+    def _generate_chunk(
+        self,
+        requests: list[LMRequest],
+        params: SamplingParams,
+    ) -> list[list[LMOutput]]:
+        prompt_strs = [self._format_prompt(request) for request in requests]
+        if is_debug_requests():
+            for i, prompt in enumerate(prompt_strs):
+                logger.info(f"Prompt {i}:\n{prompt}")
+
+        generation_kwargs = self._build_generation_kwargs(params)
+        prompt_token_ids = self._left_truncate_prompts_for_generation(
+            [self._encode_prompt(prompt) for prompt in prompt_strs],
+            params,
+        )
+        self._validate_generation_lengths(prompt_token_ids, params)
+        expanded_token_ids = [
+            token_ids for token_ids in prompt_token_ids for _ in range(params.num_samples)
+        ]
+        input_ids, attention_mask = self._left_pad(expanded_token_ids)
+        prompt_len = input_ids.shape[1]
+        generation_kwargs["max_length"] = prompt_len + params.max_tokens
+
+        generated_ids, _, logprobs = self.generation_module.generate_batch(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            return_logprobs=True,
+            completions_only=False,
+            log_timing=False,
+            **generation_kwargs,
+        )
+
+        generated_rows = [row[prompt_len:] for row in cast(list[list[int]], generated_ids.tolist())]
+        logprob_rows = (
+            cast(list[list[float]], logprobs.tolist())
+            if logprobs is not None
+            else [None] * len(generated_rows)
+        )
+
+        results = [[] for _ in requests]
+        for row_idx, (row_ids, row_logprobs) in enumerate(
+            zip(generated_rows, logprob_rows, strict=True)
+        ):
+            request_idx = row_idx // params.num_samples
+            token_ids, token_logprobs, text = self._normalize_generation_output(
+                row_ids,
+                row_logprobs,
+                self._stop_sequences_with_eos(params.stop_sequences),
+            )
+            results[request_idx].append(self._generation_output(token_ids, token_logprobs, text))
+        return results
+
+    def describe_request(
+        self,
+        request: LMRequest,
+        sampling_params: SamplingParams | None = None,
+    ) -> dict[str, object] | None:
+        params = self._default_sampling_params(sampling_params)
+        trace = super().describe_request(request, sampling_params)
+        if trace is None:
+            return None
+
+        trace["provider"] = "OlmoCoreProvider"
+        if request.request_type == RequestType.LOGLIKELIHOOD:
+            trace["endpoint"] = "generation_module.model_forward"
+            trace["input_mode"] = "input_ids"
+            trace["generation_kwargs"] = {
+                "temperature": params.temperature,
+            }
+            trace["stop_sequences"] = []
+            return trace
+
+        trace["endpoint"] = "generation_module.generate_batch"
+        trace["input_mode"] = "input_ids"
+        trace["generation_kwargs"] = {
+            **self._build_generation_kwargs(params),
+            "num_samples": params.num_samples,
+            "return_logprobs": True,
+            "completions_only": False,
+            "max_length": "<padded_prompt_length + max_tokens>",
+        }
+        trace["stop_sequences"] = list(params.stop_sequences or ())
+        return trace
+
+    def logprobs(
+        self,
+        requests: list[LMRequest],
+        sampling_params: SamplingParams | None = None,
+    ) -> list[list[LMOutput]]:
+        del sampling_params
+        if not requests:
+            return []
+
+        self._free_inference_cache()
+        results: list[list[LMOutput]] = []
+        for chunk in self._iter_chunks(requests):
+            results.extend(self._logprobs_chunk(chunk))
+        return results
+
+    def _logprob_inputs_for_request(self, request: LMRequest) -> list[core_utils.LogprobInput]:
+        max_len = request.max_length or self.max_length
+        if max_len <= 0:
+            raise ValueError("OlmoCoreProvider requires max_length > 0 for logprobs")
+
+        rows: list[core_utils.LogprobInput] = []
+        cont_prompts = request.continuation_prompts
+        for i, continuation in enumerate(request.continuations or ()):
+            prompt = cont_prompts[i] if cont_prompts else request.prompt
+            context_ids, continuation_ids = self._encode_logprob_context_and_continuation(
+                prompt,
+                continuation,
+            )
+            if not continuation_ids:
+                rows.append(
+                    core_utils.LogprobInput(
+                        input_ids=context_ids or [self.eos_token_id],
+                        input_length=0,
+                        num_tokens_all=len(context_ids),
+                        continuation_token_ids=[],
+                        continuation=continuation,
+                    )
+                )
+                continue
+            if len(continuation_ids) > max_len:
+                raise ValueError(
+                    "Continuation is longer than the OLMo-core provider max_length "
+                    f"({len(continuation_ids)} > {max_len})"
+                )
+
+            truncated = (context_ids + continuation_ids)[-(max_len + 1) :]
+            model_input = truncated[:-1]
+            rows.append(
+                core_utils.LogprobInput(
+                    input_ids=model_input,
+                    input_length=len(model_input),
+                    num_tokens_all=len(truncated),
+                    continuation_token_ids=continuation_ids,
+                    continuation=continuation,
+                )
+            )
+        return rows
+
+    def _logprob_output_from_logits(
+        self,
+        row: core_utils.LogprobInput,
+        logits: torch.Tensor,
+    ) -> LMOutput:
+        if not row.continuation_token_ids:
+            return LMOutput(
+                text=row.continuation,
+                logprobs=[],
+                metadata={
+                    "total_logprob": 0.0,
+                    "sum_logits": 0.0,
+                    "num_tokens": 0,
+                    "num_tokens_all": row.num_tokens_all,
+                    "is_greedy": True,
+                },
+            )
+
+        import torch
+        import torch.nn.functional as F
+
+        continuation_length = len(row.continuation_token_ids)
+        continuation_logits = logits[
+            row.input_length - continuation_length : row.input_length
+        ].float()
+        log_probs = F.log_softmax(continuation_logits, dim=-1)
+        continuation_tensor = torch.tensor(
+            row.continuation_token_ids,
+            dtype=torch.long,
+            device=log_probs.device,
+        )
+        token_log_probs = torch.gather(
+            log_probs,
+            1,
+            continuation_tensor.unsqueeze(-1),
+        ).squeeze(-1)
+        greedy_tokens = log_probs.argmax(dim=-1)
+        is_greedy = bool((greedy_tokens == continuation_tensor).all().item())
+
+        token_logprob_values = cast(list[float], token_log_probs.tolist())
+        entries = self._logprob_entries(row.continuation_token_ids, token_logprob_values)
+        total = float(sum(token_logprob_values))
+        return LMOutput(
+            text=row.continuation,
+            logprobs=entries,
+            metadata={
+                "total_logprob": total,
+                "sum_logits": total,
+                "num_tokens": len(entries),
+                "num_tokens_all": row.num_tokens_all,
+                "is_greedy": is_greedy,
+            },
+        )
+
+    def _logprobs_chunk(self, requests: list[LMRequest]) -> list[list[LMOutput]]:
+        import torch
+
+        rows_by_request = [self._logprob_inputs_for_request(request) for request in requests]
+        token_inputs = [row.input_ids for rows in rows_by_request for row in rows]
+
+        if token_inputs:
+            batched_inputs = self._right_pad(token_inputs)
+            with torch.no_grad():
+                batch_logits = self.generation_module.model_forward(input_ids=batched_inputs)
+        else:
+            batch_logits = []
+
+        output_iter = iter(batch_logits)
+        results: list[list[LMOutput]] = []
+
+        for rows in rows_by_request:
+            results.append(
+                [self._logprob_output_from_logits(row, next(output_iter)) for row in rows]
+            )
+
+        return results
+
+    async def agenerate(
+        self,
+        requests: list[LMRequest],
+        sampling_params: SamplingParams | None = None,
+    ) -> list[list[LMOutput]]:
+        return await asyncio.to_thread(self.generate, requests, sampling_params)
+
+    async def alogprobs(
+        self,
+        requests: list[LMRequest],
+        sampling_params: SamplingParams | None = None,
+    ) -> list[list[LMOutput]]:
+        return await asyncio.to_thread(self.logprobs, requests, sampling_params)
+
+    def close(self) -> None:
+        if hasattr(self, "generation_module"):
+            try:
+                self._free_inference_cache()
+            except Exception:
+                logger.debug("Failed to free OLMo-core inference cache", exc_info=True)
+        gc.collect()
+        try:
+            import torch
+
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
+        except Exception:
+            logger.debug("Failed to clear CUDA cache", exc_info=True)
+
+    def __del__(self) -> None:
+        with suppress(Exception):
+            self.close()

--- a/src/olmo_eval/inference/providers/olmo_core_utils.py
+++ b/src/olmo_eval/inference/providers/olmo_core_utils.py
@@ -1,0 +1,535 @@
+"""Utilities for the OLMo-core inference provider."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Protocol, TextIO, cast
+
+if TYPE_CHECKING:
+    import torch
+
+
+class CachedPathResult(Protocol):
+    def open(self) -> TextIO: ...
+
+
+CachedPath = Callable[[str], CachedPathResult]
+
+
+class TokenizerProtocol(Protocol):
+    pad_token_id: int | None
+    eos_token_id: int | None
+    model_max_length: int
+    add_bos_token: bool
+
+    def encode(self, text: str, add_special_tokens: bool = False) -> list[int]: ...
+
+    def decode(self, token_ids: int | list[int], skip_special_tokens: bool = True) -> str: ...
+
+    def apply_chat_template(
+        self,
+        messages: Sequence[Mapping[str, object]],
+        **kwargs: object,
+    ) -> str: ...
+
+
+class TokenizerConfigProtocol(Protocol):
+    identifier: str | None
+    pad_token_id: int | None
+    eos_token_id: int | None
+
+
+class AutoTokenizerFactory(Protocol):
+    def from_pretrained(self, tokenizer_path: str, **kwargs: object) -> TokenizerProtocol: ...
+
+
+class TokenizerConfigFactory(Protocol):
+    def from_dict(self, data: object) -> TokenizerConfigProtocol: ...
+
+    def dolma2(self) -> TokenizerConfigProtocol: ...
+
+
+class GenerationConfigFactory(Protocol):
+    def __call__(
+        self,
+        *,
+        pad_token_id: int,
+        eos_token_id: int,
+        use_cache: bool,
+    ) -> object: ...
+
+
+class AttentionBackendFactory(Protocol):
+    def __call__(self, backend: str) -> object: ...
+
+
+class TensorRows(Protocol):
+    shape: tuple[int, ...]
+
+    def tolist(self) -> list[list[int]] | list[list[float]]: ...
+
+
+class GenerationModuleProtocol(Protocol):
+    def free_inference_cache(self) -> None: ...
+
+    def generate_batch(
+        self,
+        *,
+        input_ids: torch.Tensor,
+        attention_mask: torch.Tensor,
+        return_logprobs: bool,
+        completions_only: bool,
+        log_timing: bool,
+        **generation_kwargs: object,
+    ) -> tuple[TensorRows, object | None, TensorRows | None]: ...
+
+    def model_forward(self, *, input_ids: torch.Tensor) -> torch.Tensor: ...
+
+
+class TransformerGenerationModuleFactory(Protocol):
+    def from_checkpoint(self, **kwargs: object) -> GenerationModuleProtocol: ...
+
+
+class CheckpointMetadataProtocol(Protocol):
+    state_dict_metadata: Mapping[str, object]
+
+
+class CudaModuleProtocol(Protocol):
+    def is_available(self) -> bool: ...
+
+    def get_device_capability(self) -> tuple[int, int]: ...
+
+
+class TorchModuleProtocol(Protocol):
+    cuda: CudaModuleProtocol
+
+    def device(self, device: str) -> torch.device: ...
+
+
+# Transformers uses int(1e30) as a sentinel when tokenizer.model_max_length is unset.
+_TRANSFORMERS_UNSET_MODEL_MAX_LENGTH = int(1e30)
+_EXPECTED_CHECKPOINT_FORMAT = (
+    "expected a raw OLMo-core checkpoint with config.json containing 'model' and "
+    "'dataset.tokenizer', plus distributed checkpoint metadata at either "
+    "'model_and_optim/.metadata' or '.metadata'. HF-format checkpoints should use "
+    "the 'hf', 'vllm', or 'vllm_server' provider instead"
+)
+_MAX_LENGTH_CONFIG_KEYS = ("max_sequence_length", "max_seq_len", "max_position_embeddings")
+_MODULE_KWARG_NAMES = ("float8_config", "state_dict_load_opts", "load_key_mapping")
+
+
+@dataclass(frozen=True)
+class OlmoCoreImports:
+    AutoTokenizer: AutoTokenizerFactory
+    AttentionBackendName: AttentionBackendFactory
+    GenerationConfig: GenerationConfigFactory
+    TokenizerConfig: TokenizerConfigFactory
+    TransformerGenerationModule: TransformerGenerationModuleFactory
+    cached_path: CachedPath
+    get_checkpoint_metadata: Callable[[str], CheckpointMetadataProtocol]
+    torch: TorchModuleProtocol
+
+
+@dataclass(frozen=True)
+class CheckpointInfo:
+    config: dict[str, object]
+    tokenizer_config: TokenizerConfigProtocol
+    metadata_dir: str | None = None
+
+
+@dataclass(frozen=True)
+class LogprobInput:
+    input_ids: list[int]
+    input_length: int
+    num_tokens_all: int
+    continuation_token_ids: list[int]
+    continuation: str
+
+
+def _import_olmo_core() -> OlmoCoreImports:
+    try:
+        import torch
+        from cached_path import cached_path
+        from olmo_core.data import TokenizerConfig
+        from olmo_core.distributed.checkpoint import get_checkpoint_metadata
+        from olmo_core.generate.generation_module import (
+            GenerationConfig,
+            TransformerGenerationModule,
+        )
+        from olmo_core.nn.attention import AttentionBackendName
+        from transformers import AutoTokenizer
+    except ImportError as e:
+        raise ImportError(
+            "ai2-olmo-core and transformers are required for OlmoCoreProvider. "
+            "Install with: pip install 'olmo-eval[olmo_core]'"
+        ) from e
+
+    return OlmoCoreImports(
+        AutoTokenizer=cast(AutoTokenizerFactory, AutoTokenizer),
+        AttentionBackendName=cast(AttentionBackendFactory, AttentionBackendName),
+        GenerationConfig=cast(GenerationConfigFactory, GenerationConfig),
+        TokenizerConfig=cast(TokenizerConfigFactory, TokenizerConfig),
+        TransformerGenerationModule=cast(
+            TransformerGenerationModuleFactory,
+            TransformerGenerationModule,
+        ),
+        cached_path=cast(CachedPath, cached_path),
+        get_checkpoint_metadata=cast(
+            Callable[[str], CheckpointMetadataProtocol],
+            get_checkpoint_metadata,
+        ),
+        torch=cast(TorchModuleProtocol, torch),
+    )
+
+
+def _is_remote_path(path: str) -> bool:
+    return "://" in path
+
+
+def _join_checkpoint_path(checkpoint_dir: str, *parts: str) -> str:
+    if _is_remote_path(checkpoint_dir):
+        return "/".join([checkpoint_dir.rstrip("/"), *parts])
+    return str(Path(checkpoint_dir, *parts))
+
+
+def _checkpoint_value_error(checkpoint_dir: str, reason: str) -> ValueError:
+    return ValueError(
+        f"Invalid OLMo-core checkpoint {checkpoint_dir!r}: {reason}. {_EXPECTED_CHECKPOINT_FORMAT}."
+    )
+
+
+def _read_checkpoint_config(
+    checkpoint_dir: str,
+    *,
+    cached_path: CachedPath | None = None,
+) -> dict[str, object]:
+    config_path = _join_checkpoint_path(checkpoint_dir, "config.json")
+    try:
+        if _is_remote_path(checkpoint_dir):
+            if cached_path is None:
+                raise FileNotFoundError(config_path)
+            with cached_path(config_path).open() as f:
+                return cast(dict[str, object], json.load(f))
+        with Path(config_path).open() as f:
+            return cast(dict[str, object], json.load(f))
+    except FileNotFoundError as e:
+        raise _checkpoint_value_error(checkpoint_dir, "missing config.json") from e
+    except json.JSONDecodeError as e:
+        raise _checkpoint_value_error(checkpoint_dir, f"config.json is not valid JSON: {e}") from e
+
+
+def _validate_token_ids(
+    *,
+    checkpoint_dir: str,
+    pad_token_id: int | None,
+    eos_token_id: int | None,
+) -> tuple[int, int]:
+    if pad_token_id is None:
+        raise _checkpoint_value_error(checkpoint_dir, "missing pad_token_id")
+    if eos_token_id is None:
+        raise _checkpoint_value_error(checkpoint_dir, "missing eos_token_id")
+    if pad_token_id < 0:
+        raise _checkpoint_value_error(
+            checkpoint_dir,
+            f"pad_token_id must be >= 0, got {pad_token_id}",
+        )
+    if eos_token_id < 0:
+        raise _checkpoint_value_error(
+            checkpoint_dir,
+            f"eos_token_id must be >= 0, got {eos_token_id}",
+        )
+    if pad_token_id == eos_token_id:
+        raise _checkpoint_value_error(
+            checkpoint_dir,
+            f"pad_token_id and eos_token_id must be different, got {pad_token_id}",
+        )
+    return pad_token_id, eos_token_id
+
+
+def _tokenizer_config_from_checkpoint_config(
+    checkpoint_dir: str,
+    config: Mapping[str, object],
+    *,
+    TokenizerConfig: TokenizerConfigFactory,
+) -> TokenizerConfigProtocol:
+    try:
+        dataset = config["dataset"]
+        if not isinstance(dataset, Mapping):
+            raise TypeError("dataset is not an object")
+        dataset = cast(Mapping[str, object], dataset)
+        return TokenizerConfig.from_dict(dataset["tokenizer"])
+    except KeyError as e:
+        raise _checkpoint_value_error(
+            checkpoint_dir,
+            f"config.json missing required field {e}",
+        ) from e
+    except Exception as e:
+        raise _checkpoint_value_error(
+            checkpoint_dir,
+            f"config.json field 'dataset.tokenizer' is not a valid OLMo-core TokenizerConfig: {e}",
+        ) from e
+
+
+def _validate_olmo_core_checkpoint(
+    checkpoint_dir: str,
+    *,
+    TokenizerConfig: TokenizerConfigFactory,
+    get_checkpoint_metadata: Callable[[str], CheckpointMetadataProtocol],
+    cached_path: CachedPath | None = None,
+) -> CheckpointInfo:
+    config = _read_checkpoint_config(checkpoint_dir, cached_path=cached_path)
+    try:
+        model_config = config["model"]
+    except KeyError as e:
+        raise _checkpoint_value_error(
+            checkpoint_dir,
+            f"config.json missing required field {e}",
+        ) from e
+
+    if not isinstance(model_config, Mapping):
+        raise _checkpoint_value_error(
+            checkpoint_dir,
+            "config.json field 'model' must be an object",
+        )
+
+    tokenizer_config = _tokenizer_config_from_checkpoint_config(
+        checkpoint_dir,
+        config,
+        TokenizerConfig=TokenizerConfig,
+    )
+
+    _validate_token_ids(
+        checkpoint_dir=checkpoint_dir,
+        pad_token_id=getattr(tokenizer_config, "pad_token_id", None),
+        eos_token_id=getattr(tokenizer_config, "eos_token_id", None),
+    )
+
+    metadata = None
+    metadata_dir = None
+    metadata_errors: list[str] = []
+    for candidate in (
+        _join_checkpoint_path(checkpoint_dir, "model_and_optim"),
+        checkpoint_dir,
+    ):
+        try:
+            metadata = get_checkpoint_metadata(candidate)
+            metadata_dir = candidate
+            break
+        except FileNotFoundError as e:
+            metadata_errors.append(str(e))
+        except Exception as e:
+            raise _checkpoint_value_error(
+                checkpoint_dir,
+                f"could not read distributed checkpoint metadata at {candidate!r}: {e}",
+            ) from e
+
+    if metadata is None:
+        detail = "; ".join(error for error in metadata_errors if error)
+        reason = "missing distributed checkpoint metadata"
+        if detail:
+            reason = f"{reason}: {detail}"
+        raise _checkpoint_value_error(checkpoint_dir, reason)
+
+    state_metadata = getattr(metadata, "state_dict_metadata", {}) or {}
+    if not any(str(key).startswith("model") for key in state_metadata):
+        raise _checkpoint_value_error(
+            checkpoint_dir,
+            "distributed checkpoint metadata does not contain model state keys",
+        )
+
+    return CheckpointInfo(
+        config=config,
+        tokenizer_config=tokenizer_config,
+        metadata_dir=metadata_dir,
+    )
+
+
+def _load_checkpoint_config_and_tokenizer_config(
+    checkpoint_dir: str,
+    *,
+    TokenizerConfig: TokenizerConfigFactory,
+    cached_path: CachedPath | None = None,
+) -> tuple[dict[str, object], TokenizerConfigProtocol]:
+    config = _read_checkpoint_config(checkpoint_dir, cached_path=cached_path)
+    return config, _tokenizer_config_from_checkpoint_config(
+        checkpoint_dir,
+        config,
+        TokenizerConfig=TokenizerConfig,
+    )
+
+
+def _resolve_checkpoint(
+    checkpoint_dir: str,
+    *,
+    imports: OlmoCoreImports,
+    validate_checkpoint: bool,
+    allow_tokenizer_fallback: bool,
+) -> tuple[dict[str, object] | None, TokenizerConfigProtocol]:
+    if validate_checkpoint:
+        checkpoint_info = _validate_olmo_core_checkpoint(
+            checkpoint_dir,
+            TokenizerConfig=imports.TokenizerConfig,
+            get_checkpoint_metadata=imports.get_checkpoint_metadata,
+            cached_path=imports.cached_path,
+        )
+        return checkpoint_info.config, checkpoint_info.tokenizer_config
+
+    try:
+        config, tokenizer_config = _load_checkpoint_config_and_tokenizer_config(
+            checkpoint_dir,
+            TokenizerConfig=imports.TokenizerConfig,
+            cached_path=imports.cached_path,
+        )
+    except ValueError:
+        if not allow_tokenizer_fallback:
+            raise
+        return None, imports.TokenizerConfig.dolma2()
+    return config, tokenizer_config
+
+
+def _resolve_max_model_len_alias(
+    max_model_len: int | None,
+    kwargs: dict[str, object],
+) -> int | None:
+    max_length = kwargs.pop("max_length", None)
+    if max_length is None:
+        return max_model_len
+    if not isinstance(max_length, int):
+        raise ValueError("OlmoCoreProvider max_length must be an integer when set")
+    if max_model_len is not None and max_model_len != max_length:
+        raise ValueError(
+            "OlmoCoreProvider received both max_model_len and max_length with different values"
+        )
+    return max_length
+
+
+def _validate_max_model_len(max_model_len: int | None) -> None:
+    if max_model_len is not None and max_model_len <= 0:
+        raise ValueError("OlmoCoreProvider max_model_len must be positive when set")
+
+
+def _validate_batch_size(batch_size: int | None) -> None:
+    if batch_size is not None and (not isinstance(batch_size, int) or batch_size <= 0):
+        raise ValueError("OlmoCoreProvider batch_size must be a positive integer or None")
+
+
+def _validate_tensor_parallel_size(tensor_parallel_size: object) -> None:
+    if tensor_parallel_size in (None, 1):
+        return
+    raise ValueError(
+        "OlmoCoreProvider only supports tensor_parallel_size of 1 or None. "
+        "ai2-olmo-core 2.4.0 generation exposes data-parallel process groups, "
+        "but not tensor-parallel generation config; run multiple provider "
+        "processes instead."
+    )
+
+
+def _pop_module_kwargs(kwargs: dict[str, object]) -> dict[str, object]:
+    return {key: kwargs.pop(key) for key in _MODULE_KWARG_NAMES if key in kwargs}
+
+
+def _raise_for_unsupported_kwargs(kwargs: Mapping[str, object]) -> None:
+    if kwargs:
+        unsupported = ", ".join(sorted(kwargs))
+        raise ValueError(f"Unsupported OlmoCoreProvider kwargs: {unsupported}")
+
+
+def _resolve_tokenizer_path(
+    checkpoint_dir: str,
+    *,
+    explicit_tokenizer: str | None,
+    tokenizer_config: TokenizerConfigProtocol,
+    TokenizerConfig: TokenizerConfigFactory,
+    allow_tokenizer_fallback: bool,
+) -> tuple[str, TokenizerConfigProtocol]:
+    if explicit_tokenizer is not None:
+        return explicit_tokenizer, tokenizer_config
+
+    tokenizer_path = getattr(tokenizer_config, "identifier", None)
+    if tokenizer_path is not None:
+        return tokenizer_path, tokenizer_config
+
+    if not allow_tokenizer_fallback:
+        raise _checkpoint_value_error(
+            checkpoint_dir,
+            "checkpoint tokenizer config does not include an identifier",
+        )
+
+    fallback_config = TokenizerConfig.dolma2()
+    if fallback_config.identifier is None:
+        raise _checkpoint_value_error(
+            checkpoint_dir,
+            "fallback tokenizer config does not include an identifier",
+        )
+    return fallback_config.identifier, fallback_config
+
+
+def _preferred_token_id(
+    explicit_token_id: int | None,
+    *,
+    tokenizer: TokenizerProtocol,
+    tokenizer_config: TokenizerConfigProtocol,
+    attr: str,
+) -> int | None:
+    if explicit_token_id is not None:
+        return explicit_token_id
+    tokenizer_token_id = getattr(tokenizer, attr, None)
+    if isinstance(tokenizer_token_id, int):
+        return tokenizer_token_id
+    config_token_id = getattr(tokenizer_config, attr, None)
+    return config_token_id if isinstance(config_token_id, int) else None
+
+
+def _valid_tokenizer_model_max_length(tokenizer: TokenizerProtocol) -> int | None:
+    model_max_length = getattr(tokenizer, "model_max_length", None)
+    if not isinstance(model_max_length, int) or model_max_length <= 0:
+        return None
+    if model_max_length >= _TRANSFORMERS_UNSET_MODEL_MAX_LENGTH:
+        return None
+    return model_max_length
+
+
+def _resolve_attention_backend(
+    attention_backend: str | None,
+    *,
+    AttentionBackendName: AttentionBackendFactory,
+) -> object | None:
+    if attention_backend is None:
+        return None
+    return AttentionBackendName(attention_backend)
+
+
+def _resolve_max_length(
+    *,
+    explicit_max_length: int | None,
+    tokenizer: TokenizerProtocol,
+    checkpoint_config: Mapping[str, object] | None,
+    checkpoint_dir: str,
+) -> int:
+    if explicit_max_length is not None:
+        return explicit_max_length
+
+    model_config_value = checkpoint_config.get("model", {}) if checkpoint_config else {}
+    model_config = (
+        cast(Mapping[str, object], model_config_value)
+        if isinstance(model_config_value, Mapping)
+        else {}
+    )
+    for key in _MAX_LENGTH_CONFIG_KEYS:
+        value = model_config.get(key)
+        if isinstance(value, int) and value > 0:
+            return value
+
+    tokenizer_model_max_length = _valid_tokenizer_model_max_length(tokenizer)
+    if tokenizer_model_max_length is not None:
+        return tokenizer_model_max_length
+
+    raise ValueError(
+        "Could not determine OLMo-core max_model_len for checkpoint "
+        f"{checkpoint_dir!r}: pass max_model_len explicitly, set one of "
+        "model.max_sequence_length, model.max_seq_len, or model.max_position_embeddings "
+        "in config.json, or use a tokenizer with a real model_max_length."
+    )

--- a/src/olmo_eval/inference/providers/vllm_server.py
+++ b/src/olmo_eval/inference/providers/vllm_server.py
@@ -110,7 +110,7 @@ class RemoteTokenizer:
             self._client = None
 
 
-class _TokenizerBosOverride:
+class TokenizerBosOverride:
     """Tokenizer proxy that overrides add_bos_token without mutating the underlying tokenizer."""
 
     def __init__(self, tokenizer: Any, add_bos_token: bool) -> None:
@@ -220,7 +220,7 @@ async def _log_response(response: httpx.Response) -> None:
         logger.error(f"vLLM response error: {response.status_code} {response.url}\n  body: {body}")
 
 
-class _DebugTransport(httpx.AsyncHTTPTransport):
+class DebugTransport(httpx.AsyncHTTPTransport):
     """Transport wrapper that logs all HTTP errors with full tracebacks."""
 
     async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
@@ -439,7 +439,7 @@ class VLLMServerProvider(InferenceProvider):
                 }
 
             # Use debug transport when enabled to catch connection errors
-            transport = _DebugTransport() if _DEBUG_REQUESTS else None
+            transport = DebugTransport() if _DEBUG_REQUESTS else None
 
             self._http_client = httpx.AsyncClient(
                 transport=transport,
@@ -982,7 +982,7 @@ class VLLMServerProvider(InferenceProvider):
         except (ImportError, Exception):
             tokenizer = self._get_tokenizer(require_local=False)
         if self._add_bos_token is not None:
-            tokenizer = _TokenizerBosOverride(tokenizer, self._add_bos_token)
+            tokenizer = TokenizerBosOverride(tokenizer, self._add_bos_token)
         params = self._default_sampling_params(params)
 
         # Get the context/prompt text

--- a/src/olmo_eval/launch/beaker/launcher.py
+++ b/src/olmo_eval/launch/beaker/launcher.py
@@ -24,6 +24,7 @@ import re
 from dataclasses import dataclass, field
 from datetime import UTC
 from typing import TYPE_CHECKING, Any
+from urllib.parse import urlsplit
 
 from rich.console import Console
 from rich.panel import Panel
@@ -60,6 +61,8 @@ __all__ = [
 
 # Rich console for pretty printing
 _console = Console()
+
+_DIRECT_URL_ARTIFACT_SUFFIXES = (".whl", ".zip", ".tar.gz", ".tar.bz2", ".tar.xz", ".tgz")
 
 
 def print_experiment_config(
@@ -504,6 +507,13 @@ def parse_install_spec(package: str) -> tuple[str, list[str]]:
     return " ".join(pkg_parts), flags
 
 
+def _is_direct_url_artifact(package: str) -> bool:
+    if "://" not in package:
+        return False
+    path = urlsplit(package).path.lower()
+    return path.endswith(_DIRECT_URL_ARTIFACT_SUFFIXES)
+
+
 def normalize_provider_package(package: str) -> str:
     """Normalize a provider package specifier for pip installation.
 
@@ -537,6 +547,11 @@ def normalize_provider_package(package: str) -> str:
     if pkg_spec.startswith("git+"):
         return pkg_spec
 
+    # GitHub release assets and other direct wheel/archive URLs are installable
+    # artifacts, not Git repositories.
+    if _is_direct_url_artifact(pkg_spec):
+        return pkg_spec
+
     # GitHub or GitLab URLs need git+ prefix
     if "github.com" in pkg_spec or "gitlab.com" in pkg_spec:
         return f"git+{pkg_spec}"
@@ -545,30 +560,57 @@ def normalize_provider_package(package: str) -> str:
     return pkg_spec
 
 
+def _strip_package_extras(package_name: str) -> str:
+    """Return the base distribution name from a package name with optional extras."""
+    return package_name.split("[", 1)[0].strip()
+
+
+def _normalize_distribution_name(package_name: str) -> str:
+    """Return a PEP 503-normalized distribution name."""
+    return re.sub(r"[-_.]+", "-", package_name).lower()
+
+
+def _normalize_install_target_name(package_name: str) -> str | None:
+    """Return the canonical distribution name used by uv package flags."""
+    base_name = _strip_package_extras(package_name)
+    return _normalize_distribution_name(base_name) if base_name else None
+
+
+def _infer_wheel_distribution_name(filename: str) -> str | None:
+    """Infer the distribution name from a wheel filename."""
+    if not filename.lower().endswith(".whl"):
+        return None
+    distribution = filename[:-4].split("-", 1)[0]
+    return _normalize_distribution_name(distribution) if distribution else None
+
+
 def _infer_install_target_name_from_normalized(package: str) -> str | None:
     """Infer a distribution name from an already-normalized package spec."""
     normalized = package
 
     # PEP 508 direct references: "name @ URL"
     if " @ " in normalized:
-        return normalized.split(" @ ", 1)[0].strip() or None
+        return _normalize_install_target_name(normalized.split(" @ ", 1)[0].strip())
 
     # Direct URLs and local paths: prefer an explicit egg fragment, otherwise
     # fall back to the trailing path component (e.g., transformers.git -> transformers).
     if normalized.startswith("git+") or "://" in normalized or normalized.startswith("/"):
         match = re.search(r"(?:[#&]egg=)([A-Za-z0-9_.-]+)", normalized)
         if match:
-            return match.group(1)
+            return _normalize_install_target_name(match.group(1))
 
         path_part = normalized.split("#", 1)[0].rsplit("/", 1)[-1]
         if "@" in path_part:
             path_part = path_part.split("@", 1)[0]
+        wheel_distribution = _infer_wheel_distribution_name(path_part)
+        if wheel_distribution:
+            return wheel_distribution
         if path_part.endswith(".git"):
             path_part = path_part[:-4]
-        return path_part or None
+        return _normalize_install_target_name(path_part)
 
     match = re.match(r"^\s*([A-Za-z0-9_.-]+)", normalized)
-    return match.group(1) if match else None
+    return _normalize_install_target_name(match.group(1)) if match else None
 
 
 def bind_direct_source_to_package(package: str) -> str:

--- a/src/olmo_eval/runners/asynq/batching/config.py
+++ b/src/olmo_eval/runners/asynq/batching/config.py
@@ -30,7 +30,7 @@ class BatchConfig:
     """
 
     # Providers that only support sequential (LLM() is not thread-safe)
-    _SEQUENTIAL_ONLY: ClassVar[frozenset[str]] = frozenset({"vllm", "hf"})
+    _SEQUENTIAL_ONLY: ClassVar[frozenset[str]] = frozenset({"vllm", "hf", "olmo_core"})
 
     strategy: BatchStrategy = BatchStrategy.BATCHED
     chunk_size: int = DEFAULT_CHUNK_SIZE

--- a/src/olmo_eval/runners/asynq/monitoring.py
+++ b/src/olmo_eval/runners/asynq/monitoring.py
@@ -11,6 +11,8 @@ from olmo_eval.runners.asynq.types import WORKER_FATAL
 
 logger = get_logger(__name__)
 
+DEFAULT_PROVIDER_INIT_TIMEOUT_SECONDS = 900.0
+
 
 def terminate_workers(
     workers: list[mp.process.BaseProcess],
@@ -144,7 +146,7 @@ def wait_for_init_times(
     num_workers: int,
     workers: list[mp.process.BaseProcess] | None = None,
     result_queue: mp.Queue | None = None,
-    timeout: float = 300.0,
+    timeout: float = DEFAULT_PROVIDER_INIT_TIMEOUT_SECONDS,
     check_interval: float = 1.0,
 ) -> dict[str, float]:
     """Wait for all workers to report their initialization times.
@@ -188,11 +190,15 @@ def wait_for_init_times(
         time.sleep(check_interval)
 
     # Return what we have even if incomplete
-    logger.warning(f"Timed out waiting for init times: got {len(collected)}/{num_workers} workers")
+    logger.warning(
+        f"Timed out after {timeout:.0f}s waiting for init times: "
+        f"got {len(collected)}/{num_workers} workers"
+    )
     return collected
 
 
 __all__ = [
+    "DEFAULT_PROVIDER_INIT_TIMEOUT_SECONDS",
     "terminate_workers",
     "check_workers_alive",
     "wait_for_workers_ready",

--- a/src/olmo_eval/runners/asynq/runner.py
+++ b/src/olmo_eval/runners/asynq/runner.py
@@ -46,7 +46,7 @@ _DEFAULT_PROCESS_POOL = "cpu"
 
 
 @dataclass(frozen=True)
-class _SandboxDemand:
+class SandboxDemand:
     """Execution-aware sandbox demand summary for allocation and logging."""
 
     sandbox_envs: list[SandboxEnv]
@@ -57,7 +57,7 @@ class _SandboxDemand:
 
 
 @dataclass(frozen=True)
-class _SandboxPlan:
+class SandboxPlan:
     """Resolved sandbox configs and allocation data for relevant sandbox envs."""
 
     sandboxes: list[SandboxConfig]
@@ -71,7 +71,7 @@ class _SandboxPlan:
 
 
 @dataclass(frozen=True)
-class _ProcessPoolDemand:
+class ProcessPoolDemand:
     """Observed process-scoring workload for a named process pool."""
 
     task_count: int
@@ -80,11 +80,11 @@ class _ProcessPoolDemand:
 
 
 @dataclass(frozen=True)
-class _ProcessPoolPlan:
+class ProcessPoolPlan:
     """Resolved process pools and demand data for process-backed scorers."""
 
     pools: dict[str, ProcessScoringPoolConfig]
-    demand: dict[str, _ProcessPoolDemand]
+    demand: dict[str, ProcessPoolDemand]
     auto_created: frozenset[str]
 
 
@@ -120,7 +120,7 @@ def _count_process_scorers_by_pool(task: Task) -> dict[str, int]:
 def _collect_process_pool_demand(
     trackers: Mapping[str, TaskTracker],
     expanded_tasks: Sequence[str] | None = None,
-) -> dict[str, _ProcessPoolDemand]:
+) -> dict[str, ProcessPoolDemand]:
     """Collect per-pool demand for process-backed scorers."""
     from olmo_eval.common.execution import ProcessScoringConfigError
 
@@ -152,7 +152,7 @@ def _collect_process_pool_demand(
             )
 
     return {
-        pool_name: _ProcessPoolDemand(
+        pool_name: ProcessPoolDemand(
             task_count=task_counts[pool_name],
             scorer_count=scorer_counts[pool_name],
             response_jobs=response_jobs[pool_name],
@@ -166,7 +166,7 @@ def _plan_process_scoring_pools(
     expanded_tasks: Sequence[str],
     trackers: Mapping[str, TaskTracker],
     scoring_concurrency: int | None,
-) -> _ProcessPoolPlan | None:
+) -> ProcessPoolPlan | None:
     """Resolve the process pools needed by the selected tasks."""
     from olmo_eval.common.execution import ProcessScoringPoolConfig, default_process_pool_workers
 
@@ -201,7 +201,7 @@ def _plan_process_scoring_pools(
         )
 
     pools = {name: explicit[name] for name in sorted(referenced)}
-    return _ProcessPoolPlan(
+    return ProcessPoolPlan(
         pools=pools,
         demand=demand,
         auto_created=frozenset(auto_created),
@@ -222,7 +222,7 @@ def _shutdown_process_scoring_pools(process_pool_manager: Any) -> None:
 def _collect_sandbox_demand(
     trackers: Mapping[str, TaskTracker],
     expanded_tasks: Sequence[str] | None = None,
-) -> _SandboxDemand:
+) -> SandboxDemand:
     """Collect execution-aware sandbox demand and task counts per environment."""
     env_sandbox_items: dict[str, int] = {}
     env_work_units: dict[str, float] = {}
@@ -263,7 +263,7 @@ def _collect_sandbox_demand(
         )
         env_task_count[env_key] = env_task_count.get(env_key, 0) + 1
 
-    return _SandboxDemand(
+    return SandboxDemand(
         sandbox_envs=list(named_envs.values()),
         env_sandbox_items=env_sandbox_items,
         env_work_units=env_work_units,
@@ -328,7 +328,7 @@ def _plan_sandbox_configs(
     trackers: Mapping[str, TaskTracker],
     sandbox_pool_instances: int | None,
     sandbox_pool_min_instances: int | None = None,
-) -> _SandboxPlan | None:
+) -> SandboxPlan | None:
     """Resolve relevant sandbox configs and concrete executor counts."""
     from olmo_eval.harness.sandbox.image import dependencies_to_dockerfile_extra
 
@@ -428,7 +428,7 @@ def _plan_sandbox_configs(
             min_instances=resolved_min,
         )
 
-    return _SandboxPlan(
+    return SandboxPlan(
         sandboxes=materialized_sandboxes,
         env_sandbox_items=sandbox_demand.env_sandbox_items,
         env_work_units=sandbox_demand.env_work_units,
@@ -443,7 +443,7 @@ def _plan_sandbox_configs(
 def _determine_scoring_limits(
     harness_config: HarnessConfig,
     sandbox_configs_list: Sequence[dict[str, Any]] | None,
-    process_pool_plan: _ProcessPoolPlan | None,
+    process_pool_plan: ProcessPoolPlan | None,
 ) -> tuple[int, int]:
     """Return (response_concurrency, context_concurrency) for scoring."""
     import os

--- a/src/olmo_eval/runners/processing/aggregation.py
+++ b/src/olmo_eval/runners/processing/aggregation.py
@@ -7,7 +7,7 @@ from typing import Any
 
 
 @dataclass
-class _ChildAverageResult:
+class ChildAverageResult:
     """Result from computing a child average."""
 
     metrics: dict[str, dict[str, float]]  # Nested: {metric: {scorer: value}}
@@ -66,11 +66,11 @@ def _compute_child_average(
     child: str | Any,  # str or Suite
     priority_suffix: str,
     task_results: dict[str, dict[str, Any]],
-) -> _ChildAverageResult | None:
+) -> ChildAverageResult | None:
     """Compute average metrics for a single child (task string or nested Suite).
 
     Returns:
-        _ChildAverageResult with metrics and task info, or None if no results found.
+        ChildAverageResult with metrics and task info, or None if no results found.
     """
     from olmo_eval.evals.suites.registry import Suite
 
@@ -113,7 +113,7 @@ def _compute_child_average(
         avg_primary = sum(primary_scores) / len(primary_scores) if primary_scores else None
         # Build the key for this nested suite (with suffix)
         nested_key = f"{child.name}{priority_suffix}"
-        return _ChildAverageResult(
+        return ChildAverageResult(
             metrics=averaged,
             tasks=tasks_included,
             primary_score=avg_primary,
@@ -131,7 +131,7 @@ def _compute_child_average(
         if not metrics:
             return None
 
-        return _ChildAverageResult(
+        return ChildAverageResult(
             metrics=dict(metrics),
             tasks=[full_task_spec],
             primary_score=_extract_primary_score(task_data),

--- a/tests/analysis/test_pairwise.py
+++ b/tests/analysis/test_pairwise.py
@@ -823,7 +823,7 @@ class TestLatestRunMergeHelpers:
         assert row_by_hash["task-hash-b"].num_instances == 5
 
 
-class _SequenceExecuteResult:
+class SequenceExecuteResult:
     def __init__(self, rows):
         self._rows = list(rows)
 
@@ -841,7 +841,7 @@ class _SequenceExecuteResult:
         return self._rows[0]
 
 
-class _SequenceSession:
+class SequenceSession:
     def __init__(self, responses, *, compile_queries: bool = False):
         self._responses = list(responses)
         self._compile_queries = compile_queries
@@ -851,7 +851,7 @@ class _SequenceSession:
             raise AssertionError("Unexpected session.execute() call")
         if self._compile_queries:
             _query.compile(dialect=postgresql.dialect())
-        return _SequenceExecuteResult(self._responses.pop(0))
+        return SequenceExecuteResult(self._responses.pop(0))
 
 
 class TestComputePairwiseLatestRunMerge:
@@ -1026,7 +1026,7 @@ class TestComputePairwiseLatestRunMerge:
                 raw_score=0.0,
             ),
         ]
-        session = _SequenceSession(
+        session = SequenceSession(
             [task_rows, instance_count_rows, preflight_rows, score_rows],
             compile_queries=True,
         )
@@ -1097,7 +1097,7 @@ class TestComputePairwiseLatestRunMerge:
             SimpleNamespace(model_hash="hash-a", task_hash="task-a-hash", num_instances=2),
             SimpleNamespace(model_hash="hash-b", task_hash="task-a-hash", num_instances=2),
         ]
-        session = _SequenceSession(
+        session = SequenceSession(
             [
                 task_rows,
                 instance_count_rows,

--- a/tests/cli/beaker/test_launch.py
+++ b/tests/cli/beaker/test_launch.py
@@ -194,6 +194,121 @@ class TestHarnessOverridesProviderDependencies:
         assert job_config.provider_packages is not None
         assert "https://github.com/user/vllm@custom" in job_config.provider_packages
 
+    def test_olmo_core_provider_package_replaces_olmo_core_extra(self):
+        """OLMo-core package overrides should replace the bundled olmo_core extra."""
+        from unittest.mock import patch
+
+        from olmo_eval.cli.beaker.config_loader import LaunchConfig
+        from olmo_eval.cli.beaker.experiment_plan import ExperimentPlan
+        from olmo_eval.cli.beaker.job_assembler import JobConfigAssembler
+
+        package = "ai2-olmo-core[torchao,transformers]==2.3.0"
+        launch_config = LaunchConfig(
+            name="test",
+            model_specs=["/weka/checkpoints/model/step100"],
+            task_specs=["humaneval"],
+            cluster="h100",
+            workspace="ai2/test",
+            budget="ai2/test",
+            harness="default",
+            harness_overrides=[
+                "provider.kind=olmo_core",
+                f"provider.package={package}",
+            ],
+        )
+        exp = ExperimentPlan(
+            name="test",
+            model_spec="/weka/checkpoints/model/step100",
+            priority="normal",
+            tasks=["humaneval"],
+            original_task_specs=["humaneval"],
+            total_expanded_tasks=1,
+            num_gpus=1,
+        )
+        assembler = JobConfigAssembler(
+            config=launch_config,
+            effective_image="test-image",
+            effective_groups=[],
+            beaker_username="test-user",
+            common_secrets=[],
+            store_secrets=[],
+            task_secrets=[],
+            inject_aws_credentials=False,
+            inject_gcs_credentials=False,
+        )
+
+        with patch("olmo_eval.cli.beaker.job_assembler.cluster_has_weka", return_value=False):
+            job_config = assembler.assemble(exp)
+
+        assert "olmo_core" not in job_config.extras
+        assert "vllm" not in job_config.extras
+        assert job_config.provider_packages == [package]
+
+    def test_olmo_core_source_package_override_binds_distribution_name(self):
+        """Bare OLMo-core source URLs should reinstall the ai2-olmo-core distribution."""
+        from unittest.mock import patch
+
+        from olmo_eval.cli.beaker.config_loader import LaunchConfig
+        from olmo_eval.cli.beaker.experiment_plan import ExperimentPlan
+        from olmo_eval.cli.beaker.job_assembler import JobConfigAssembler
+
+        source = "https://github.com/allenai/OLMo-core.git@feature-branch"
+        launch_config = LaunchConfig(
+            name="test",
+            model_specs=["/weka/checkpoints/model/step100"],
+            task_specs=["humaneval"],
+            cluster="h100",
+            workspace="ai2/test",
+            budget="ai2/test",
+            harness="default",
+            harness_overrides=[
+                "provider.kind=olmo_core",
+                f"provider.package={source}",
+            ],
+        )
+        exp = ExperimentPlan(
+            name="test",
+            model_spec="/weka/checkpoints/model/step100",
+            priority="normal",
+            tasks=["humaneval"],
+            original_task_specs=["humaneval"],
+            total_expanded_tasks=1,
+            num_gpus=1,
+        )
+        assembler = JobConfigAssembler(
+            config=launch_config,
+            effective_image="test-image",
+            effective_groups=[],
+            beaker_username="test-user",
+            common_secrets=[],
+            store_secrets=[],
+            task_secrets=[],
+            inject_aws_credentials=False,
+            inject_gcs_credentials=False,
+        )
+
+        with patch("olmo_eval.cli.beaker.job_assembler.cluster_has_weka", return_value=False):
+            job_config = assembler.assemble(exp)
+
+        assert "olmo_core" not in job_config.extras
+        assert job_config.provider_packages == [
+            "ai2-olmo-core[torchao,transformers] @ "
+            "git+https://github.com/allenai/OLMo-core.git@feature-branch"
+        ]
+
+    def test_olmo_core_provider_package_accepts_version_shorthand(self):
+        """Version-only OLMo-core package overrides should target ai2-olmo-core."""
+        from olmo_eval.cli.beaker.job_assembler import normalize_provider_package_for_kind
+
+        assert (
+            normalize_provider_package_for_kind("olmo_core", "2.3.0")
+            == "ai2-olmo-core[torchao,transformers]==2.3.0"
+        )
+        assert (
+            normalize_provider_package_for_kind("olmo_core", ">=2.3,<2.4")
+            == "ai2-olmo-core[torchao,transformers]>=2.3,<2.4"
+        )
+
     def test_apply_harness_overrides_with_global_sandbox_override(self):
         """Test that sandboxes={...} sets the shared pool and common sandbox fields."""
         from olmo_eval.cli.beaker.launch import _apply_harness_overrides

--- a/tests/cli/test_pairwise.py
+++ b/tests/cli/test_pairwise.py
@@ -16,7 +16,7 @@ from click.testing import CliRunner
 from olmo_eval.analysis.pairwise import ModelMeta, PairStats, PairwiseResult
 
 
-class _DummySession:
+class DummySession:
     def __enter__(self) -> object:
         return object()
 
@@ -24,15 +24,15 @@ class _DummySession:
         return False
 
 
-class _DummyDB:
-    def session(self) -> _DummySession:
-        return _DummySession()
+class DummyDB:
+    def session(self) -> DummySession:
+        return DummySession()
 
     def dispose(self) -> None:
         pass
 
 
-class _StaticExecuteResult:
+class StaticExecuteResult:
     def __init__(self, rows):
         self._rows = list(rows)
 
@@ -40,7 +40,7 @@ class _StaticExecuteResult:
         return list(self._rows)
 
 
-class _StaticLookupResult:
+class StaticLookupResult:
     def __init__(self, row):
         self._row = row
 
@@ -51,15 +51,15 @@ class _StaticLookupResult:
         return self._row
 
 
-class _StaticTaskSession:
+class StaticTaskSession:
     def __init__(self, rows):
         self._rows = list(rows)
 
     def execute(self, _query):
-        return _StaticExecuteResult(self._rows)
+        return StaticExecuteResult(self._rows)
 
 
-class _SequentialExecuteSession:
+class SequentialExecuteSession:
     def __init__(self, results):
         self._results = list(results)
 
@@ -149,7 +149,7 @@ def test_results_viewer_json_blob_forwards_exclude_filters(monkeypatch) -> None:
         return _build_pairwise_result()
 
     monkeypatch.setattr(analysis_pairwise, "compute_pairwise", fake_compute_pairwise)
-    monkeypatch.setattr(viewer_cli, "get_database_session", lambda *args: _DummyDB())
+    monkeypatch.setattr(viewer_cli, "get_database_session", lambda *args: DummyDB())
 
     runner = CliRunner()
     result = runner.invoke(
@@ -203,7 +203,7 @@ def test_results_viewer_dump_repeated_runs_status_uses_plain_language(
         "compute_pairwise",
         lambda **kwargs: _build_pairwise_result(),
     )
-    monkeypatch.setattr(viewer_cli, "get_database_session", lambda *args: _DummyDB())
+    monkeypatch.setattr(viewer_cli, "get_database_session", lambda *args: DummyDB())
 
     output_path = tmp_path / "pairwise.json"
     runner = CliRunner()
@@ -296,7 +296,7 @@ def test_results_viewer_csv_dump_streams_to_stdout(monkeypatch) -> None:
         "compute_pairwise",
         lambda **kwargs: _build_pairwise_result(),
     )
-    monkeypatch.setattr(viewer_cli, "get_database_session", lambda *args: _DummyDB())
+    monkeypatch.setattr(viewer_cli, "get_database_session", lambda *args: DummyDB())
 
     runner = CliRunner()
     result = runner.invoke(
@@ -342,7 +342,7 @@ def test_build_results_table_keep_all_preserves_distinct_reruns(monkeypatch) -> 
     )
 
     latest_table = viewer_server._build_results_table(
-        _StaticTaskSession(
+        StaticTaskSession(
             [
                 (
                     11,
@@ -357,7 +357,7 @@ def test_build_results_table_keep_all_preserves_distinct_reruns(monkeypatch) -> 
         keep_all=False,
     )
     all_runs_table = viewer_server._build_results_table(
-        _StaticTaskSession(
+        StaticTaskSession(
             [
                 (
                     10,
@@ -423,7 +423,7 @@ def test_load_results_model_config_bundle_prefers_displayed_run_config(monkeypat
     )
 
     bundle = viewer_server._load_results_model_config_bundle(
-        _SequentialExecuteSession([_StaticLookupResult(detail_row)]),
+        SequentialExecuteSession([StaticLookupResult(detail_row)]),
         group_name="my-group",
         model_ref="abc12345deadbeef",
         keep_all=False,
@@ -469,10 +469,10 @@ def test_load_results_model_config_bundle_falls_back_to_same_hash(monkeypatch) -
     )
 
     bundle = viewer_server._load_results_model_config_bundle(
-        _SequentialExecuteSession(
+        SequentialExecuteSession(
             [
-                _StaticLookupResult(display_row),
-                _StaticLookupResult(fallback_row),
+                StaticLookupResult(display_row),
+                StaticLookupResult(fallback_row),
             ]
         ),
         group_name="my-group",
@@ -519,7 +519,7 @@ def test_load_results_model_config_bundle_repeated_runs_still_require_exact_ref(
     )
 
     bundle = viewer_server._load_results_model_config_bundle(
-        _SequentialExecuteSession([_StaticLookupResult(detail_row)]),
+        SequentialExecuteSession([StaticLookupResult(detail_row)]),
         group_name="my-group",
         model_ref="abc12345deadbeef|2026-04-21T08:00:00+00:00",
         keep_all=True,
@@ -550,7 +550,7 @@ def test_build_results_table_metric_options_do_not_double_count_primary_metric(
     )
 
     results_table = viewer_server._build_results_table(
-        _StaticTaskSession(
+        StaticTaskSession(
             [
                 (
                     11,
@@ -603,7 +603,7 @@ def test_build_results_table_latest_mode_merges_partial_runs_by_model_and_task_h
     )
 
     results_table = viewer_server._build_results_table(
-        _StaticTaskSession(
+        StaticTaskSession(
             [
                 (
                     10,
@@ -663,7 +663,7 @@ def test_build_results_table_latest_mode_keeps_unique_older_metrics_and_latest_d
     )
 
     results_table = viewer_server._build_results_table(
-        _StaticTaskSession(
+        StaticTaskSession(
             [
                 (
                     10,
@@ -714,7 +714,7 @@ def test_build_results_table_splits_same_name_tasks_by_hash(monkeypatch) -> None
     )
 
     results_table = viewer_server._build_results_table(
-        _StaticTaskSession(
+        StaticTaskSession(
             [
                 (
                     11,
@@ -958,7 +958,7 @@ def test_timed_value_cache_reuses_fresh_entries_and_expires_stale_ones() -> None
     viewer_server = importlib.import_module("olmo_eval.cli.results.viewer_server")
 
     now = [100.0]
-    cache = viewer_server._TimedValueCache(ttl_seconds=5.0, clock=lambda: now[0])
+    cache = viewer_server.TimedValueCache(ttl_seconds=5.0, clock=lambda: now[0])
     calls = {"count": 0}
 
     def loader() -> dict[str, int]:
@@ -1056,7 +1056,7 @@ def test_load_group_browser_data_for_request_falls_back_when_scope_is_stale(monk
             requested_scope="task::old-task",
             keep_all=False,
             require_full_coverage=True,
-            group_browser_cache=viewer_server._TimedValueCache(ttl_seconds=60.0),
+            group_browser_cache=viewer_server.TimedValueCache(ttl_seconds=60.0),
         )
     )
 
@@ -1217,9 +1217,9 @@ def test_latest_only_exports_merge_source_rows_back_to_display_models() -> None:
         score_unit="proportion",
         higher_is_better=True,
     )
-    session = _SequentialExecuteSession(
+    session = SequentialExecuteSession(
         [
-            _StaticExecuteResult(
+            StaticExecuteResult(
                 [
                     SimpleNamespace(
                         experiment_pk=11,
@@ -1245,7 +1245,7 @@ def test_latest_only_exports_merge_source_rows_back_to_display_models() -> None:
                     ),
                 ]
             ),
-            _StaticExecuteResult(
+            StaticExecuteResult(
                 [
                     SimpleNamespace(
                         experiment_pk=11,

--- a/tests/evals/external/benchmarks/test_scicode_external.py
+++ b/tests/evals/external/benchmarks/test_scicode_external.py
@@ -115,7 +115,7 @@ class TestVerifierScript(unittest.TestCase):
         self.assertIn("def foo(x)", script)
 
 
-class _FakeProvider:
+class FakeProvider:
     """Minimal async provider that returns fixed code blocks per call."""
 
     def __init__(self, responses: list[str]) -> None:
@@ -139,7 +139,7 @@ class TestRunProblemCascade(unittest.IsolatedAsyncioTestCase):
             "```python\ndef b():\n    return 2\n```",
             "```python\ndef c():\n    return 3\n```",
         ]
-        provider = _FakeProvider(responses)
+        provider = FakeProvider(responses)
         sc_args = scicode_eval.SciCodeConfig(max_concurrency=1, with_background=True)
         evaluator = scicode_eval.SciCodeExternalEval()
 
@@ -168,7 +168,7 @@ class TestRunProblemCascade(unittest.IsolatedAsyncioTestCase):
             "```python\ndef a():\n    return 1\n```",
             "```python\ndef b():\n    return 2\n```",
         ]
-        provider = _FakeProvider(responses)
+        provider = FakeProvider(responses)
         sc_args = scicode_eval.SciCodeConfig(max_concurrency=1, with_background=True)
         evaluator = scicode_eval.SciCodeExternalEval()
 
@@ -198,7 +198,7 @@ class TestRunProblemCascade(unittest.IsolatedAsyncioTestCase):
             "```python\ndef step_two():\n    return 'BETA_MARKER'\n```",
             "```python\ndef step_three():\n    return 'GAMMA_MARKER'\n```",
         ]
-        provider = _FakeProvider(responses)
+        provider = FakeProvider(responses)
         sc_args = scicode_eval.SciCodeConfig(max_concurrency=1, with_background=True)
         evaluator = scicode_eval.SciCodeExternalEval()
 

--- a/tests/evals/tasks/test_base.py
+++ b/tests/evals/tasks/test_base.py
@@ -45,7 +45,7 @@ class ConcreteTask(Task):
 
 
 @dataclass(frozen=True, slots=True)
-class _EchoProcessScorer(ProcessScorer):
+class EchoProcessScorer(ProcessScorer):
     """Simple process scorer that checks extracted answer equality."""
 
     name: str = "echo_process"
@@ -57,7 +57,7 @@ class _EchoProcessScorer(ProcessScorer):
 
 
 @dataclass(frozen=True, slots=True)
-class _FailingProcessScorer(ProcessScorer):
+class FailingProcessScorer(ProcessScorer):
     """Process scorer that fails for selected outputs."""
 
     name: str = "failing_process"
@@ -70,7 +70,7 @@ class _FailingProcessScorer(ProcessScorer):
 
 
 @dataclass(frozen=True, slots=True)
-class _TimedProcessScorer(ProcessScorer):
+class TimedProcessScorer(ProcessScorer):
     """Process scorer used to verify mixed-workload overlap."""
 
     name: str = "timed_process"
@@ -291,7 +291,7 @@ class TestProcessScoring:
         return LMRequest(request_type=RequestType.COMPLETION, prompt=prompt)
 
     async def test_process_scorer_requires_runtime(self):
-        metric = AccuracyMetric(scorer=_EchoProcessScorer)
+        metric = AccuracyMetric(scorer=EchoProcessScorer)
         task = ConcreteTask(TaskConfig(name="test", data_source="test/dataset", metrics=(metric,)))
 
         response = Response(
@@ -304,7 +304,7 @@ class TestProcessScoring:
             await task.score_responses([response], context=ScoringContext(scoring_concurrency=8))
 
     async def test_process_scorer_scores_outputs_with_real_pool(self):
-        metric = AccuracyMetric(scorer=_EchoProcessScorer)
+        metric = AccuracyMetric(scorer=EchoProcessScorer)
         task = ConcreteTask(TaskConfig(name="test", data_source="test/dataset", metrics=(metric,)))
         manager = ProcessPoolManager({"cpu": ProcessScoringPoolConfig(workers=1)})
 
@@ -330,7 +330,7 @@ class TestProcessScoring:
         assert scored[0].outputs[1].metadata["score:echo_process"] == 0.0
 
     async def test_process_scorer_failure_becomes_zero_with_diagnostics(self):
-        metric = PassAtKMetric(k=1, scorer=_FailingProcessScorer)
+        metric = PassAtKMetric(k=1, scorer=FailingProcessScorer)
         task = ConcreteTask(TaskConfig(name="test", data_source="test/dataset", metrics=(metric,)))
         manager = ProcessPoolManager({"cpu": ProcessScoringPoolConfig(workers=1)})
 
@@ -367,7 +367,7 @@ class TestProcessScoring:
 
     async def test_process_scorer_rejects_local_non_reconstructible_class(self):
         @dataclass(frozen=True, slots=True)
-        class _LocalProcessScorer(ProcessScorer):
+        class LocalProcessScorer(ProcessScorer):
             name: str = "local_process"
 
             def process_score(self, instance: Instance, output: LMOutput) -> float:
@@ -378,7 +378,7 @@ class TestProcessScoring:
         try:
             with pytest.raises(ProcessScoringConfigError, match="module scope"):
                 await manager.score_outputs(
-                    _LocalProcessScorer(),
+                    LocalProcessScorer(),
                     Instance(question="Q", gold_answer="A"),
                     [LMOutput(text="A")],
                 )
@@ -493,7 +493,7 @@ class TestTaskMetrics:
 
 
 @dataclass(frozen=True)
-class _ConcurrencyTracker:
+class ConcurrencyTracker:
     """Track peak concurrent calls (mutable internals, frozen wrapper)."""
 
     _current: list[int]  # [current_count] — single-element list for mutability
@@ -501,8 +501,8 @@ class _ConcurrencyTracker:
     _lock: asyncio.Lock
 
     @staticmethod
-    def create() -> _ConcurrencyTracker:
-        return _ConcurrencyTracker(_current=[0], _peak=[0], _lock=asyncio.Lock())
+    def create() -> ConcurrencyTracker:
+        return ConcurrencyTracker(_current=[0], _peak=[0], _lock=asyncio.Lock())
 
     async def enter(self) -> None:
         async with self._lock:
@@ -520,11 +520,11 @@ class _ConcurrencyTracker:
 
 
 @dataclass(frozen=True, slots=True)
-class _TrackedContextScorer(ContextScorer):
+class TrackedContextScorer(ContextScorer):
     """Context scorer that tracks overlap with other async work."""
 
     name: str = "tracked_context"
-    tracker: _ConcurrencyTracker | None = None
+    tracker: ConcurrencyTracker | None = None
     delay: float = 0.05
 
     async def ascore_with_context(self, instance, output, context) -> float:
@@ -539,11 +539,11 @@ class _TrackedContextScorer(ContextScorer):
 
 
 @dataclass(frozen=True, slots=True)
-class _MockExecutionScorer(ExecutionScorer):
+class MockExecutionScorer(ExecutionScorer):
     """ExecutionScorer that tracks concurrency and returns a fixed score."""
 
     name: str = "mock_exec"
-    tracker: _ConcurrencyTracker | None = None
+    tracker: ConcurrencyTracker | None = None
     requires_async: ClassVar[bool] = True
 
     async def ascore(self, instance, output, execution_env) -> float:
@@ -558,11 +558,11 @@ class _MockExecutionScorer(ExecutionScorer):
 
 
 @dataclass(frozen=True, slots=True)
-class _TrackedExecutionScorer(ExecutionScorer):
+class TrackedExecutionScorer(ExecutionScorer):
     """Execution scorer that tracks overlap with other async work."""
 
     name: str = "tracked_exec"
-    tracker: _ConcurrencyTracker | None = None
+    tracker: ConcurrencyTracker | None = None
     delay: float = 0.05
     requires_async: ClassVar[bool] = True
 
@@ -578,7 +578,7 @@ class _TrackedExecutionScorer(ExecutionScorer):
 
 
 @dataclass(frozen=True, slots=True)
-class _FailingExecutionScorer(ExecutionScorer):
+class FailingExecutionScorer(ExecutionScorer):
     """ExecutionScorer that can fail for selected outputs."""
 
     name: str = "failing_exec"
@@ -591,7 +591,7 @@ class _FailingExecutionScorer(ExecutionScorer):
         return 1.0
 
 
-class _MockExecutionEnv:
+class MockExecutionEnv:
     """Minimal mock that satisfies the ExecutionEnvironment protocol + semaphore."""
 
     def __init__(self, semaphore: asyncio.Semaphore | None = None) -> None:
@@ -617,10 +617,10 @@ class _MockExecutionEnv:
         return self._semaphore
 
 
-class _TrackedProcessPoolManager:
+class TrackedProcessPoolManager:
     """Minimal async process manager for overlap tests."""
 
-    def __init__(self, tracker: _ConcurrencyTracker, delay: float = 0.05) -> None:
+    def __init__(self, tracker: ConcurrencyTracker, delay: float = 0.05) -> None:
         self._tracker = tracker
         self._delay = delay
 
@@ -672,11 +672,11 @@ class TestExecutionConcurrency:
 
     async def test_shared_semaphore_bounds_concurrency(self):
         """Peak concurrent sandbox calls must not exceed the semaphore limit."""
-        tracker = _ConcurrencyTracker.create()
+        tracker = ConcurrencyTracker.create()
         semaphore_limit = 2
-        env = _MockExecutionEnv(semaphore=asyncio.Semaphore(semaphore_limit))
+        env = MockExecutionEnv(semaphore=asyncio.Semaphore(semaphore_limit))
 
-        scorer = _MockExecutionScorer(tracker=tracker)
+        scorer = MockExecutionScorer(tracker=tracker)
         metric = PassAtKMetric(k=1, scorer=lambda: scorer)
         config = TaskConfig(name="test", data_source="test/dataset", metrics=(metric,))
         task = ConcreteTask(config)
@@ -696,10 +696,10 @@ class TestExecutionConcurrency:
 
     async def test_no_semaphore_still_works(self):
         """When execution env has no get_execution_semaphore, scoring completes."""
-        tracker = _ConcurrencyTracker.create()
-        env = _MockExecutionEnv(semaphore=None)
+        tracker = ConcurrencyTracker.create()
+        env = MockExecutionEnv(semaphore=None)
 
-        scorer = _MockExecutionScorer(tracker=tracker)
+        scorer = MockExecutionScorer(tracker=tracker)
         metric = PassAtKMetric(k=1, scorer=lambda: scorer)
         config = TaskConfig(name="test", data_source="test/dataset", metrics=(metric,))
         task = ConcreteTask(config)
@@ -719,7 +719,7 @@ class TestExecutionConcurrency:
     async def test_env_without_get_execution_semaphore(self):
         """Execution env that lacks get_execution_semaphore method still works."""
 
-        class _BareEnv:
+        class BareEnv:
             """Env without semaphore support."""
 
             is_running = True
@@ -733,8 +733,8 @@ class TestExecutionConcurrency:
             async def execute_code(self, code, language="python", timeout=None):
                 return ExecutionResult(success=True)
 
-        env = _BareEnv()
-        scorer = _MockExecutionScorer()
+        env = BareEnv()
+        scorer = MockExecutionScorer()
         metric = PassAtKMetric(k=1, scorer=lambda: scorer)
         config = TaskConfig(name="test", data_source="test/dataset", metrics=(metric,))
         task = ConcreteTask(config)
@@ -753,8 +753,8 @@ class TestAsyncScoringFailures:
     """Tests that async scoring failures are recorded instead of dropping metrics."""
 
     async def test_async_scorer_failure_becomes_zero_with_diagnostics(self):
-        env = _MockExecutionEnv(semaphore=asyncio.Semaphore(4))
-        scorer = _FailingExecutionScorer()
+        env = MockExecutionEnv(semaphore=asyncio.Semaphore(4))
+        scorer = FailingExecutionScorer()
         metric = PassAtKMetric(k=1, scorer=lambda: scorer)
         config = TaskConfig(name="test", data_source="test/dataset", metrics=(metric,))
         task = ConcreteTask(config)
@@ -782,8 +782,8 @@ class TestAsyncScoringFailures:
         }
 
     async def test_partial_async_failures_preserve_passing_outputs(self):
-        env = _MockExecutionEnv(semaphore=asyncio.Semaphore(4))
-        scorer = _FailingExecutionScorer()
+        env = MockExecutionEnv(semaphore=asyncio.Semaphore(4))
+        scorer = FailingExecutionScorer()
         metric = PassAtKMetric(k=1, scorer=lambda: scorer)
         config = TaskConfig(name="test", data_source="test/dataset", metrics=(metric,))
         task = ConcreteTask(config)
@@ -811,11 +811,11 @@ class TestMixedWorkloadScoring:
         return LMRequest(request_type=RequestType.COMPLETION, prompt=prompt)
 
     async def test_mixed_workloads_overlap(self):
-        tracker = _ConcurrencyTracker.create()
+        tracker = ConcurrencyTracker.create()
         metric_sync = AccuracyMetric(scorer=ExactMatchScorer)
-        metric_process = PassAtKMetric(k=1, scorer=_TimedProcessScorer)
-        metric_context = PassAtKMetric(k=1, scorer=lambda: _TrackedContextScorer(tracker=tracker))
-        metric_exec = PassAtKMetric(k=1, scorer=lambda: _TrackedExecutionScorer(tracker=tracker))
+        metric_process = PassAtKMetric(k=1, scorer=TimedProcessScorer)
+        metric_context = PassAtKMetric(k=1, scorer=lambda: TrackedContextScorer(tracker=tracker))
+        metric_exec = PassAtKMetric(k=1, scorer=lambda: TrackedExecutionScorer(tracker=tracker))
         task = ConcreteTask(
             TaskConfig(
                 name="test",
@@ -830,9 +830,9 @@ class TestMixedWorkloadScoring:
             outputs=[LMOutput(text="4")],
         )
         context = ScoringContext(
-            execution_env=_MockExecutionEnv(semaphore=None),
+            execution_env=MockExecutionEnv(semaphore=None),
             scoring_concurrency=8,
-            process_pool_manager=_TrackedProcessPoolManager(tracker=tracker, delay=0.05),
+            process_pool_manager=TrackedProcessPoolManager(tracker=tracker, delay=0.05),
         )
 
         scored = await task.score_responses([response], context=context)

--- a/tests/evals/tasks/test_bigcodebench.py
+++ b/tests/evals/tasks/test_bigcodebench.py
@@ -14,7 +14,7 @@ from olmo_eval.evals.tasks.bigcodebench import (
 )
 
 
-class _StubExecutionEnv:
+class StubExecutionEnv:
     """Minimal execution environment stub for scorer tests."""
 
     def __init__(self, result: ExecutionResult | None = None) -> None:
@@ -50,7 +50,7 @@ def _extract_tmp_dir(command: str) -> str:
 class TestCodeExecutionScorerPythonScriptHelper:
     async def test_execute_python_script_uses_file_based_command(self) -> None:
         scorer = CodeExecutionScorer()
-        env = _StubExecutionEnv()
+        env = StubExecutionEnv()
 
         result = await scorer.execute_python_script(
             env,
@@ -82,7 +82,7 @@ class TestCodeExecutionScorerPythonScriptHelper:
 
     async def test_code_execution_scorer_records_execution_result(self) -> None:
         scorer = CodeExecutionScorer()
-        env = _StubExecutionEnv(
+        env = StubExecutionEnv(
             result=ExecutionResult(success=False, output="traceback", exit_code=1)
         )
         instance = Instance(question="Q", metadata={"test": "assert answer() == 42"})
@@ -104,7 +104,7 @@ class TestCodeExecutionScorerPythonScriptHelper:
 class TestBigCodeBenchScorer:
     async def test_ascore_uses_execute_command_with_rlimits(self) -> None:
         scorer = BigCodeBenchScorer()
-        env = _StubExecutionEnv()
+        env = StubExecutionEnv()
         instance = Instance(
             question="Q",
             metadata={
@@ -146,7 +146,7 @@ class TestBigCodeBenchScorer:
 
     async def test_ascore_returns_zero_on_nonzero_command_exit(self) -> None:
         scorer = BigCodeBenchScorer()
-        env = _StubExecutionEnv(result=ExecutionResult(success=False, output="", exit_code=1))
+        env = StubExecutionEnv(result=ExecutionResult(success=False, output="", exit_code=1))
         instance = Instance(
             question="Q",
             metadata={"test": "class TestCases: pass", "code_prompt": ""},
@@ -179,7 +179,7 @@ class TestBigCodeBenchScorer:
         extracted_answer: str | None,
     ) -> None:
         scorer = BigCodeBenchScorer()
-        env = _StubExecutionEnv()
+        env = StubExecutionEnv()
         instance = Instance(question="Q", metadata=metadata)
         output = LMOutput(text="unused")
         output.extracted_answer = extracted_answer

--- a/tests/launch/test_beaker.py
+++ b/tests/launch/test_beaker.py
@@ -669,6 +669,20 @@ class TestBuildCommandWithTaskPackages:
         ) in install_cmd
         assert "[isolated-vllm-check]" not in install_cmd
 
+    def test_olmo_core_extra_does_not_try_to_build_flash_attention(self):
+        """Default OLMo-core jobs must not compile flash-attn at startup."""
+        from olmo_eval.launch import BeakerLauncher
+
+        launcher = BeakerLauncher()
+        install_cmd = launcher._build_install_cmd(
+            extras=["olmo_core"],
+            env_exports=None,
+        )
+
+        assert "uv pip install -e '.[olmo_core,beaker]' -c /tmp/cuda-constraints.txt" in install_cmd
+        assert "flash-attn" not in install_cmd
+        assert "--no-build-isolation-package" not in install_cmd
+
 
 class TestNormalizeProviderPackage:
     """Tests for normalize_provider_package function."""
@@ -829,6 +843,111 @@ class TestBuildInstallCommand:
             cmd == "uv --no-config --no-cache pip install --python /opt/vllm-venv/bin/python "
             "--refresh --refresh-package transformers --reinstall-package transformers "
             "'transformers @ git+https://github.com/user/transformers.git@custom-branch' "
+            "-c /tmp/constraints.txt"
+        )
+
+    def test_force_reinstall_strips_extras_from_named_direct_ref_target(self):
+        """Reinstall flags should use the base distribution name, not extras."""
+        cmd = build_install_command(
+            "ai2-olmo-core[torchao,transformers] @ "
+            "git+https://github.com/allenai/OLMo-core.git@feature-branch",
+            "/tmp/constraints.txt",
+            force_reinstall=True,
+        )
+        assert (
+            cmd == "uv --no-config --no-cache pip install --refresh "
+            "--refresh-package ai2-olmo-core --reinstall-package ai2-olmo-core "
+            "'ai2-olmo-core[torchao,transformers] @ "
+            "git+https://github.com/allenai/OLMo-core.git@feature-branch' "
+            "-c /tmp/constraints.txt"
+        )
+
+    def test_force_reinstall_normalizes_named_direct_ref_target(self):
+        """Named direct-ref reinstall targets should be PEP 503-normalized."""
+        cmd = build_install_command(
+            "flash_attn.interface[dev] @ "
+            "git+https://github.com/user/flash_attn.interface.git@feature-branch",
+            "/tmp/constraints.txt",
+            force_reinstall=True,
+        )
+        assert (
+            cmd == "uv --no-config --no-cache pip install --refresh "
+            "--refresh-package flash-attn-interface --reinstall-package flash-attn-interface "
+            "'flash_attn.interface[dev] @ "
+            "git+https://github.com/user/flash_attn.interface.git@feature-branch' "
+            "-c /tmp/constraints.txt"
+        )
+
+    def test_force_reinstall_normalizes_git_repo_target(self):
+        """Forced git installs should normalize inferred repo names."""
+        cmd = build_install_command(
+            "git+https://github.com/user/flash_attn.interface.git@feature-branch",
+            "/tmp/constraints.txt",
+            force_reinstall=True,
+        )
+        assert (
+            cmd == "uv --no-config --no-cache pip install --refresh "
+            "--refresh-package flash-attn-interface --reinstall-package flash-attn-interface "
+            "'flash-attn-interface @ "
+            "git+https://github.com/user/flash_attn.interface.git@feature-branch' "
+            "-c /tmp/constraints.txt"
+        )
+
+    def test_force_reinstall_normalizes_egg_fragment_target(self):
+        """Explicit egg fragments should normalize to uv's package target form."""
+        cmd = build_install_command(
+            "git+https://github.com/user/repo.git@feature-branch#egg=flash_attn.interface",
+            "/tmp/constraints.txt",
+            force_reinstall=True,
+        )
+        assert (
+            cmd == "uv --no-config --no-cache pip install --refresh "
+            "--refresh-package flash-attn-interface --reinstall-package flash-attn-interface "
+            "'flash-attn-interface @ "
+            "git+https://github.com/user/repo.git@feature-branch#egg=flash_attn.interface' "
+            "-c /tmp/constraints.txt"
+        )
+
+    def test_force_reinstall_normalizes_local_path_target(self):
+        """Forced local path installs should normalize inferred path names."""
+        cmd = build_install_command(
+            "/mnt/packages/flash_attn.interface",
+            "/tmp/constraints.txt",
+            force_reinstall=True,
+        )
+        assert (
+            cmd == "uv --no-config --no-cache pip install --refresh "
+            "--refresh-package flash-attn-interface --reinstall-package flash-attn-interface "
+            "'flash-attn-interface @ /mnt/packages/flash_attn.interface' "
+            "-c /tmp/constraints.txt"
+        )
+
+    def test_force_reinstall_normalizes_plain_package_target(self):
+        """Plain package specs should also target canonical distribution names."""
+        cmd = build_install_command(
+            "flash_attn.interface==1.0.0",
+            "/tmp/constraints.txt",
+            force_reinstall=True,
+        )
+        assert (
+            cmd == "uv pip install --refresh-package flash-attn-interface "
+            "--reinstall-package flash-attn-interface "
+            "'flash_attn.interface==1.0.0' -c /tmp/constraints.txt"
+        )
+
+    def test_force_reinstall_targets_wheel_distribution_name(self):
+        """Forced wheel installs should target the distribution, not the wheel filename."""
+        cmd = build_install_command(
+            "https://example.org/wheels/flash_attn_interface-3.0.0-cp312-cp312-linux_x86_64.whl",
+            "/tmp/constraints.txt",
+            force_reinstall=True,
+        )
+        assert (
+            cmd == "uv --no-config --no-cache pip install --refresh "
+            "--refresh-package flash-attn-interface "
+            "--reinstall-package flash-attn-interface "
+            "'flash-attn-interface @ https://example.org/wheels/"
+            "flash_attn_interface-3.0.0-cp312-cp312-linux_x86_64.whl' "
             "-c /tmp/constraints.txt"
         )
 

--- a/tests/providers/test_olmo_core_provider.py
+++ b/tests/providers/test_olmo_core_provider.py
@@ -1,0 +1,486 @@
+"""Hotspot tests for the OLMo-core provider."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+import olmo_eval.inference.providers.olmo_core_utils as olmo_core_utils
+from olmo_eval.common.types import LMOutput, LMRequest, RequestType, SamplingParams
+from olmo_eval.inference.providers.olmo_core import OlmoCoreProvider
+from olmo_eval.inference.providers.olmo_core_utils import _TRANSFORMERS_UNSET_MODEL_MAX_LENGTH
+
+
+class FakeTokenizerConfig:
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> SimpleNamespace:
+        return SimpleNamespace(
+            identifier=data.get("identifier"),
+            pad_token_id=data.get("pad_token_id"),
+            eos_token_id=data.get("eos_token_id"),
+        )
+
+
+class FakeTokenizer:
+    pad_token_id = 0
+    eos_token_id = 2
+    bos_token_id = 1
+    model_max_length = 32
+
+    def __init__(self) -> None:
+        self.add_bos_token = False
+        self.encode_calls: list[dict[str, Any]] = []
+        self.decode_calls: list[list[int]] = []
+        self.vocab = {
+            "": [],
+            "Prompt": [10, 11],
+            "Prompt!": [10, 11, 6],
+            "Other": [12],
+            "!": [6],
+            " !": [13, 6],
+            " STOP": [4],
+            "STOP": [8, 9],
+        }
+        self.id_to_text = {
+            0: "<pad>",
+            1: "<bos>",
+            2: "<eos>",
+            4: " STOP",
+            5: "hello",
+            6: "!",
+            7: "x",
+            8: "ST",
+            9: "OP",
+            10: "P",
+            11: "rompt",
+            12: "Other",
+            13: " ",
+        }
+
+    def encode(self, text: str, add_special_tokens: bool = False) -> list[int]:
+        self.encode_calls.append(
+            {
+                "text": text,
+                "add_special_tokens": add_special_tokens,
+            }
+        )
+        if text in self.vocab:
+            token_ids = self.vocab[text]
+        else:
+            token_ids = [ord(char) % 13 + 3 for char in text]
+        if add_special_tokens:
+            return [self.bos_token_id, *token_ids]
+        return token_ids
+
+    def decode(self, token_ids: int | list[int], skip_special_tokens: bool = True) -> str:
+        if isinstance(token_ids, int):
+            token_ids = [token_ids]
+        self.decode_calls.append(list(token_ids))
+        pieces = []
+        for token_id in token_ids:
+            if skip_special_tokens and token_id in {self.pad_token_id, self.eos_token_id}:
+                continue
+            pieces.append(self.id_to_text.get(token_id, str(token_id)))
+        return "".join(pieces)
+
+
+class FakeAutoTokenizer:
+    @classmethod
+    def from_pretrained(cls, tokenizer_path: str, **kwargs: Any) -> FakeTokenizer:
+        del cls, kwargs
+        assert tokenizer_path == "fake-tokenizer"
+        tokenizer = FakeTokenizer()
+        tokenizer.model_max_length = _TRANSFORMERS_UNSET_MODEL_MAX_LENGTH
+        return tokenizer
+
+
+class MissingSpecialTokenAutoTokenizer:
+    @classmethod
+    def from_pretrained(cls, tokenizer_path: str, **kwargs: Any) -> FakeTokenizer:
+        del cls
+        tokenizer = FakeAutoTokenizer.from_pretrained(tokenizer_path, **kwargs)
+        tokenizer.pad_token_id = None
+        tokenizer.eos_token_id = None
+        return tokenizer
+
+
+class FakeTensorRows:
+    def __init__(self, rows: list[list[int]] | list[list[float]]) -> None:
+        self._rows = rows
+        self.shape = (len(rows), len(rows[0]) if rows else 0)
+
+    def __getitem__(self, idx: int) -> Any:
+        return SimpleNamespace(tolist=lambda: self._rows[idx])
+
+    def tolist(self) -> list[list[int]] | list[list[float]]:
+        return self._rows
+
+
+class FakeGenerationModule:
+    def __init__(self) -> None:
+        self.generate_calls: list[dict[str, Any]] = []
+        self.checkpoint_kwargs: dict[str, Any] = {}
+        self.prepare_calls: list[tuple[int, int]] = []
+        self.cache_allocated = False
+        self.free_calls = 0
+
+    @classmethod
+    def from_checkpoint(cls, **kwargs: Any) -> FakeGenerationModule:
+        module = cls()
+        module.checkpoint_kwargs = kwargs
+        return module
+
+    def generate_batch(self, **kwargs: Any):
+        self.generate_calls.append(kwargs)
+        batch_size = kwargs["input_ids"].shape[0]
+        if kwargs["use_cache"]:
+            self.prepare_inference_cache(batch_size, kwargs["max_length"])
+
+        completion_rows = [[5, 4, 0] if idx % 2 == 0 else [5, 6, 0] for idx in range(batch_size)]
+        generated_rows = (
+            completion_rows
+            if kwargs["completions_only"]
+            else [
+                [*kwargs["input_ids"][idx].tolist(), *completion_rows[idx]]
+                for idx in range(batch_size)
+            ]
+        )
+        logprob_rows = [
+            [-0.1, -0.2, -9.0] if idx % 2 == 0 else [-0.3, -0.4, -9.0] for idx in range(batch_size)
+        ]
+        return FakeTensorRows(generated_rows), None, FakeTensorRows(logprob_rows)
+
+    def prepare_inference_cache(self, batch_size: int, max_seq_len: int) -> None:
+        self.prepare_calls.append((batch_size, max_seq_len))
+        self.cache_allocated = True
+
+    def free_inference_cache(self) -> None:
+        self.cache_allocated = False
+        self.free_calls += 1
+
+
+def _write_raw_checkpoint(
+    checkpoint_dir: Path,
+    *,
+    model: dict[str, Any] | None = None,
+) -> None:
+    checkpoint_dir.mkdir(parents=True, exist_ok=True)
+    (checkpoint_dir / "config.json").write_text(
+        json.dumps(
+            {
+                "model": model if model is not None else {"d_model": 8},
+                "dataset": {
+                    "tokenizer": {
+                        "identifier": "fake-tokenizer",
+                        "vocab_size": 16,
+                        "pad_token_id": 0,
+                        "eos_token_id": 2,
+                    }
+                },
+            }
+        )
+    )
+    (checkpoint_dir / ".metadata").write_text("fake")
+
+
+def _metadata_reader(path: str | Path) -> SimpleNamespace:
+    path_obj = path if isinstance(path, Path) else Path(path)
+    if (path_obj / ".metadata").exists():
+        return SimpleNamespace(state_dict_metadata={"model.transformer.wte.weight": object()})
+    raise FileNotFoundError(path)
+
+
+def _fake_olmo_core_imports(
+    *,
+    cuda_available: bool = False,
+    auto_tokenizer: type[Any] = FakeAutoTokenizer,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        AutoTokenizer=auto_tokenizer,
+        AttentionBackendName=str,
+        GenerationConfig=lambda **kwargs: SimpleNamespace(**kwargs),
+        TokenizerConfig=FakeTokenizerConfig,
+        TransformerGenerationModule=FakeGenerationModule,
+        cached_path=None,
+        get_checkpoint_metadata=_metadata_reader,
+        torch=SimpleNamespace(
+            cuda=SimpleNamespace(
+                get_device_capability=lambda: (9, 0),
+                is_available=lambda: cuda_available,
+            ),
+            device=lambda device: device,
+        ),
+    )
+
+
+@pytest.fixture
+def fake_provider() -> tuple[OlmoCoreProvider, FakeGenerationModule, FakeTokenizer]:
+    provider = OlmoCoreProvider.__new__(OlmoCoreProvider)
+    tokenizer = FakeTokenizer()
+    module = FakeGenerationModule()
+    provider.model_name = "fake-model"
+    provider.tokenizer = tokenizer
+    provider.generation_module = module
+    provider.pad_token_id = tokenizer.pad_token_id
+    provider.eos_token_id = tokenizer.eos_token_id
+    provider.use_cache = True
+    provider.add_bos_token = False
+    provider.batch_size = None
+    provider.chat_template = None
+    provider.max_length = 32
+
+    def left_pad(sequences: list[list[int]]) -> tuple[FakeTensorRows, FakeTensorRows]:
+        max_len = max(max((len(seq) for seq in sequences), default=0), 1)
+        rows = []
+        masks = []
+        for seq in sequences:
+            pad_len = max_len - len(seq)
+            rows.append([tokenizer.pad_token_id] * pad_len + seq)
+            masks.append([0] * pad_len + [1] * len(seq))
+        return FakeTensorRows(rows), FakeTensorRows(masks)
+
+    provider._left_pad = left_pad
+    return provider, module, tokenizer
+
+
+def test_provider_loads_checkpoint_with_olmes_defaults(tmp_path, monkeypatch) -> None:
+    checkpoint_dir = tmp_path / "step1000"
+    _write_raw_checkpoint(checkpoint_dir, model={"d_model": 8, "max_sequence_length": 4096})
+    monkeypatch.setattr(
+        olmo_core_utils,
+        "_import_olmo_core",
+        lambda: _fake_olmo_core_imports(auto_tokenizer=MissingSpecialTokenAutoTokenizer),
+    )
+
+    provider = OlmoCoreProvider(str(checkpoint_dir))
+
+    checkpoint_kwargs = provider.generation_module.checkpoint_kwargs
+    generation_config = checkpoint_kwargs["generation_config"]
+    assert provider.max_length == 4096
+    assert provider.add_bos_token is False
+    assert provider.pad_token_id == 0
+    assert provider.eos_token_id == 2
+    assert provider.tokenizer.pad_token_id == 0
+    assert provider.tokenizer.eos_token_id == 2
+    assert checkpoint_kwargs["dtype"] == "bfloat16"
+    assert "attention_backend" not in checkpoint_kwargs
+    assert generation_config.pad_token_id == 0
+    assert generation_config.eos_token_id == 2
+    assert generation_config.use_cache is True
+
+
+def test_provider_passes_explicit_attention_backend(tmp_path, monkeypatch) -> None:
+    checkpoint_dir = tmp_path / "step1000"
+    _write_raw_checkpoint(checkpoint_dir, model={"d_model": 8, "max_sequence_length": 4096})
+    monkeypatch.setattr(
+        olmo_core_utils,
+        "_import_olmo_core",
+        lambda: _fake_olmo_core_imports(cuda_available=True),
+    )
+
+    provider = OlmoCoreProvider(
+        str(checkpoint_dir),
+        attention_backend="torch",
+    )
+
+    assert provider.generation_module.checkpoint_kwargs["attention_backend"] == "torch"
+
+
+def test_generate_uses_olmes_batch_contract(
+    fake_provider: tuple[OlmoCoreProvider, FakeGenerationModule, FakeTokenizer],
+) -> None:
+    provider, module, _ = fake_provider
+
+    outputs = provider.generate(
+        [
+            LMRequest(request_type=RequestType.COMPLETION, prompt="Prompt"),
+            LMRequest(request_type=RequestType.COMPLETION, prompt="Other"),
+        ],
+        SamplingParams(
+            max_tokens=3,
+            num_samples=2,
+            temperature=0.7,
+            top_p=None,
+            top_k=None,
+            stop_sequences=(" STOP", "!"),
+        ),
+    )
+
+    call = module.generate_calls[0]
+    assert call["input_ids"].tolist() == [
+        [10, 11],
+        [10, 11],
+        [0, 12],
+        [0, 12],
+    ]
+    assert call["attention_mask"].tolist() == [
+        [1, 1],
+        [1, 1],
+        [0, 1],
+        [0, 1],
+    ]
+    assert call["return_logprobs"] is True
+    assert call["completions_only"] is False
+    assert call["max_length"] == 5
+    assert "max_new_tokens" not in call
+    assert "stop_token_ids" not in call
+    assert module.prepare_calls == [(4, 5)]
+    assert [output.text for output in outputs[0]] == ["hello", "hello"]
+    assert outputs[0][0].metadata["sum_logits"] == pytest.approx(-0.3)
+    assert outputs[1][1].metadata["num_tokens"] == 2
+    assert module.cache_allocated is False
+    assert module.free_calls == 1
+
+
+def test_generate_left_truncates_to_leave_completion_room(
+    fake_provider: tuple[OlmoCoreProvider, FakeGenerationModule, FakeTokenizer],
+) -> None:
+    provider, module, _ = fake_provider
+    provider.max_length = 4
+
+    provider.generate(
+        [LMRequest(request_type=RequestType.COMPLETION, prompt="Prompt")],
+        SamplingParams(max_tokens=3),
+    )
+
+    call = module.generate_calls[0]
+    assert call["input_ids"].tolist() == [[11]]
+    assert call["attention_mask"].tolist() == [[1]]
+    assert call["max_length"] == 4
+
+    module.generate_calls.clear()
+    provider.max_length = 3
+    with pytest.raises(ValueError, match=r"max_tokens \(3\) is greater than or equal"):
+        provider.generate(
+            [LMRequest(request_type=RequestType.COMPLETION, prompt="Prompt")],
+            SamplingParams(max_tokens=3),
+        )
+    assert module.generate_calls == []
+
+
+def test_generation_encoding_uses_provider_bos_flag(
+    fake_provider: tuple[OlmoCoreProvider, FakeGenerationModule, FakeTokenizer],
+) -> None:
+    provider, _, tokenizer = fake_provider
+    tokenizer.add_bos_token = True
+
+    assert provider._encode_prompt("Prompt") == [10, 11]
+    assert tokenizer.encode_calls[-1] == {
+        "text": "Prompt",
+        "add_special_tokens": False,
+    }
+
+    provider.add_bos_token = True
+    assert provider._encode_prompt("Prompt") == [1, 10, 11]
+    assert tokenizer.encode_calls[-1] == {
+        "text": "Prompt",
+        "add_special_tokens": False,
+    }
+
+
+def test_logprob_encoding_uses_provider_bos_flag(
+    fake_provider: tuple[OlmoCoreProvider, FakeGenerationModule, FakeTokenizer],
+) -> None:
+    provider, _, tokenizer = fake_provider
+    tokenizer.add_bos_token = True
+
+    rows = provider._logprob_inputs_for_request(
+        LMRequest(
+            request_type=RequestType.LOGLIKELIHOOD,
+            prompt="Prompt",
+            continuations=("!",),
+        )
+    )
+    assert rows[0].input_ids == [10, 11]
+    assert rows[0].continuation_token_ids == [6]
+
+    provider.add_bos_token = True
+    rows = provider._logprob_inputs_for_request(
+        LMRequest(
+            request_type=RequestType.LOGLIKELIHOOD,
+            prompt="Prompt",
+            continuations=("!",),
+        )
+    )
+    assert rows[0].input_ids == [1, 10, 11]
+    assert rows[0].continuation_token_ids == [6]
+
+
+def test_logprob_encoding_adds_prefix_when_context_tokenizes_empty(
+    fake_provider: tuple[OlmoCoreProvider, FakeGenerationModule, FakeTokenizer],
+) -> None:
+    provider, _, _ = fake_provider
+
+    rows = provider._logprob_inputs_for_request(
+        LMRequest(
+            request_type=RequestType.LOGLIKELIHOOD,
+            prompt=" ",
+            continuations=("!",),
+        )
+    )
+
+    assert rows[0].input_ids == [1, 13]
+    assert rows[0].continuation_token_ids == [13, 6]
+    assert rows[0].input_length == 2
+    assert rows[0].num_tokens_all == 3
+
+
+def test_stop_text_postprocessing_matches_olmes(
+    fake_provider: tuple[OlmoCoreProvider, FakeGenerationModule, FakeTokenizer],
+) -> None:
+    provider, _, tokenizer = fake_provider
+
+    token_ids = [7, 7, 8, 9, 7]
+    token_logprobs = [-0.01] * len(token_ids)
+    normalized_ids, normalized_logprobs, text = provider._normalize_generation_output(
+        token_ids,
+        token_logprobs,
+        ("STOP",),
+    )
+    assert normalized_ids == token_ids
+    assert normalized_logprobs == token_logprobs
+    assert text == "xx"
+
+    tokenizer.id_to_text[13] = tokenizer.decode(
+        [tokenizer.eos_token_id],
+        skip_special_tokens=False,
+    )
+    normalized_ids, normalized_logprobs, text = provider._normalize_generation_output(
+        [5, 13, 7],
+        [-0.1, -0.2, -0.3],
+        provider._stop_sequences_with_eos(None),
+    )
+    assert normalized_ids == [5, 13, 7]
+    assert normalized_logprobs == [-0.1, -0.2, -0.3]
+    assert text == "hello"
+
+
+def test_logprobs_clears_generation_cache_before_forward(
+    fake_provider: tuple[OlmoCoreProvider, FakeGenerationModule, FakeTokenizer],
+) -> None:
+    provider, module, _ = fake_provider
+    module.cache_allocated = True
+    cache_states: list[bool] = []
+
+    def logprobs_chunk(requests: list[LMRequest]) -> list[list[LMOutput]]:
+        cache_states.append(module.cache_allocated)
+        return [[] for _ in requests]
+
+    provider._logprobs_chunk = logprobs_chunk
+    provider.logprobs(
+        [
+            LMRequest(
+                request_type=RequestType.LOGLIKELIHOOD,
+                prompt="Prompt",
+                continuations=("!",),
+            )
+        ]
+    )
+
+    assert cache_states == [False]
+    assert module.cache_allocated is False
+    assert module.free_calls == 1

--- a/tests/runners/test_async_worker_flow.py
+++ b/tests/runners/test_async_worker_flow.py
@@ -9,7 +9,7 @@ from olmo_eval.harness.config import HarnessConfig, ProviderConfig
 from olmo_eval.inference.provider_manager import ProviderManager
 
 
-class _FakeProcess:
+class FakeProcess:
     def __init__(self, target: Any, args: tuple[Any, ...]) -> None:
         self.target = target
         self.args = args
@@ -19,18 +19,18 @@ class _FakeProcess:
         self.started = True
 
 
-class _FakeContext:
+class FakeContext:
     def __init__(self) -> None:
-        self.processes: list[_FakeProcess] = []
+        self.processes: list[FakeProcess] = []
 
-    def Process(self, target: Any, args: tuple[Any, ...]) -> _FakeProcess:
-        process = _FakeProcess(target, args)
+    def Process(self, target: Any, args: tuple[Any, ...]) -> FakeProcess:
+        process = FakeProcess(target, args)
         self.processes.append(process)
         return process
 
 
 def test_provider_manager_passes_start_event_to_each_worker() -> None:
-    ctx = _FakeContext()
+    ctx = FakeContext()
     init_queue = object()
     start_event = object()
     manager = ProviderManager(

--- a/tests/storage/test_queries.py
+++ b/tests/storage/test_queries.py
@@ -6,13 +6,13 @@ from olmo_eval.common.types import EvalResult, StoredTaskResult
 from olmo_eval.storage.backends.postgres.queries import QueryHelper
 
 
-class _FakeExperimentRepository:
+class FakeExperimentRepository:
     def save(self, result: EvalResult) -> int:
         self.saved_result = result
         return 17
 
 
-class _FakeInstancePredictionRepository:
+class FakeInstancePredictionRepository:
     def __init__(self) -> None:
         self.calls: list[dict[str, object]] = []
 
@@ -37,8 +37,8 @@ class _FakeInstancePredictionRepository:
 
 def test_save_with_instances_normalizes_old_style_mc_predictions_before_insert() -> None:
     helper = QueryHelper(session=None)  # type: ignore[arg-type]
-    helper.experiment_repo = _FakeExperimentRepository()
-    helper.instance_repo = _FakeInstancePredictionRepository()
+    helper.experiment_repo = FakeExperimentRepository()
+    helper.instance_repo = FakeInstancePredictionRepository()
 
     result = EvalResult(
         experiment_id="exp-123",
@@ -108,8 +108,8 @@ def test_save_with_instances_normalizes_flat_instance_metrics_when_task_metrics_
     None
 ):
     helper = QueryHelper(session=None)  # type: ignore[arg-type]
-    helper.experiment_repo = _FakeExperimentRepository()
-    helper.instance_repo = _FakeInstancePredictionRepository()
+    helper.experiment_repo = FakeExperimentRepository()
+    helper.instance_repo = FakeInstancePredictionRepository()
 
     result = EvalResult(
         experiment_id="exp-123",

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -38,7 +38,7 @@ def make_harness_config(model_name: str = "llama3.1-8b") -> HarnessConfig:
 
 
 @dataclass(frozen=True, slots=True)
-class _DefaultProcessScorer(ProcessScorer):
+class DefaultProcessScorer(ProcessScorer):
     name: str = "default_process"
 
     def process_score(self, instance: Instance, output: LMOutput) -> float:
@@ -46,7 +46,7 @@ class _DefaultProcessScorer(ProcessScorer):
 
 
 @dataclass(frozen=True, slots=True)
-class _NamedProcessScorer(ProcessScorer):
+class NamedProcessScorer(ProcessScorer):
     name: str = "named_process"
     process_pool_name: ClassVar[str] = "math"
 
@@ -54,7 +54,7 @@ class _NamedProcessScorer(ProcessScorer):
         return 1.0
 
 
-class _ProcessTask(Task):
+class ProcessTask(Task):
     """Minimal task used for process-pool planning tests."""
 
     @property
@@ -75,7 +75,7 @@ def _make_process_tracker(
     total_instances: int,
 ) -> TaskTracker:
     metric = AccuracyMetric(scorer=scorer_cls)
-    task = _ProcessTask(
+    task = ProcessTask(
         TaskConfig(
             name=spec.replace(":", "_"),
             data_source="test/dataset",
@@ -566,7 +566,7 @@ class TestProcessPoolPlanning:
         trackers = {
             "process:test": _make_process_tracker(
                 "process:test",
-                _DefaultProcessScorer,
+                DefaultProcessScorer,
                 total_instances=7,
             )
         }
@@ -589,7 +589,7 @@ class TestProcessPoolPlanning:
         trackers = {
             "process:test": _make_process_tracker(
                 "process:test",
-                _DefaultProcessScorer,
+                DefaultProcessScorer,
                 total_instances=2,
             )
         }
@@ -608,7 +608,7 @@ class TestProcessPoolPlanning:
         trackers = {
             "process:named": _make_process_tracker(
                 "process:named",
-                _NamedProcessScorer,
+                NamedProcessScorer,
                 total_instances=4,
             )
         }
@@ -636,7 +636,7 @@ class TestProcessPoolPlanning:
         trackers = {
             "process:named": _make_process_tracker(
                 "process:named",
-                _NamedProcessScorer,
+                NamedProcessScorer,
                 total_instances=3,
             )
         }
@@ -653,7 +653,7 @@ class TestProcessPoolPlanning:
         trackers = {
             "process:test": _make_process_tracker(
                 "process:test",
-                _DefaultProcessScorer,
+                DefaultProcessScorer,
                 total_instances=3,
             )
         }
@@ -668,17 +668,17 @@ class TestProcessPoolPlanning:
 
     def test_rejects_non_reconstructible_process_scorer_during_planning(self):
         @dataclass(frozen=True, slots=True)
-        class _LocalProcessScorer(ProcessScorer):
+        class LocalProcessScorer(ProcessScorer):
             name: str = "local_process"
 
             def process_score(self, instance: Instance, output: LMOutput) -> float:
                 return 1.0
 
-        task = _ProcessTask(
+        task = ProcessTask(
             TaskConfig(
                 name="process_bad",
                 data_source="test/dataset",
-                metrics=(AccuracyMetric(scorer=_LocalProcessScorer),),
+                metrics=(AccuracyMetric(scorer=LocalProcessScorer),),
             )
         )
         trackers = {
@@ -702,7 +702,7 @@ class TestProcessPoolPlanning:
         trackers = {
             "process:test": _make_process_tracker(
                 "process:test",
-                _DefaultProcessScorer,
+                DefaultProcessScorer,
                 total_instances=3,
             )
         }
@@ -725,7 +725,7 @@ class TestProcessPoolPlanning:
         trackers = {
             "process:test": _make_process_tracker(
                 "process:test",
-                _DefaultProcessScorer,
+                DefaultProcessScorer,
                 total_instances=3,
             )
         }
@@ -750,7 +750,7 @@ class TestProcessPoolPlanning:
         assert context_limit == 4
 
     def test_shutdown_logs_confirmation(self, monkeypatch):
-        class _Manager:
+        class Manager:
             def __init__(self) -> None:
                 self.shutdown_called = False
 
@@ -759,7 +759,7 @@ class TestProcessPoolPlanning:
 
         import olmo_eval.runners.asynq.runner as runner_module
 
-        manager = _Manager()
+        manager = Manager()
         fake_logger = MagicMock()
         monkeypatch.setattr(runner_module, "runner_logger", fake_logger)
 
@@ -772,7 +772,7 @@ class TestProcessPoolPlanning:
         fake_logger.warning.assert_not_called()
 
     def test_shutdown_logs_warning_on_failure(self, monkeypatch):
-        class _Manager:
+        class Manager:
             def shutdown(self) -> None:
                 raise RuntimeError("boom")
 
@@ -781,7 +781,7 @@ class TestProcessPoolPlanning:
         fake_logger = MagicMock()
         monkeypatch.setattr(runner_module, "runner_logger", fake_logger)
 
-        _shutdown_process_scoring_pools(_Manager())
+        _shutdown_process_scoring_pools(Manager())
 
         fake_logger.info.assert_called_once_with("Stopping process scoring pools...")
         fake_logger.warning.assert_called_once_with(

--- a/uv.lock
+++ b/uv.lock
@@ -19,6 +19,9 @@ conflicts = [[
     { package = "olmo-eval", extra = "openhands" },
     { package = "olmo-eval", extra = "vllm" },
 ], [
+    { package = "olmo-eval", extra = "olmo-core" },
+    { package = "olmo-eval", extra = "openhands" },
+], [
     { package = "olmo-eval", extra = "clients" },
     { package = "olmo-eval", extra = "openhands" },
 ]]
@@ -30,6 +33,36 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/64/c7/8de93764ad66968d19329a7e0c147a2bb3c7054c554d4a119111b8f9440f/absl_py-2.4.0.tar.gz", hash = "sha256:8c6af82722b35cf71e0f4d1d47dcaebfff286e27110a99fc359349b247dfb5d4", size = 116543, upload-time = "2026-01-28T10:17:05.322Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/a6/907a406bb7d359e6a63f99c313846d9eec4f7e6f7437809e03aa00fa3074/absl_py-2.4.0-py3-none-any.whl", hash = "sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d", size = 135750, upload-time = "2026-01-28T10:17:04.19Z" },
+]
+
+[[package]]
+name = "ai2-olmo-core"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "bettermap" },
+    { name = "cached-path" },
+    { name = "importlib-resources" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-vllm') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra != 'extra-9-olmo-eval-vllm') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "omegaconf" },
+    { name = "packaging" },
+    { name = "requests" },
+    { name = "rich", version = "13.9.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "safetensors" },
+    { name = "torch" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/88/8b/9cae912f67625116d8fda3e979f84173249b257fdd014c66a17904d322b7/ai2_olmo_core-2.4.0.tar.gz", hash = "sha256:25f48abeedb3befddfe5c711138b094c151801f0b8fcde42c57677ddf932b6e6", size = 496584, upload-time = "2025-11-20T19:15:10.62Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/16/d85b676c5ab5fec197e1c9de6d990a24d16ba3f94e04bbb784929cec62dd/ai2_olmo_core-2.4.0-py3-none-any.whl", hash = "sha256:82a61146c49d41ebe42b6a3d7611bdbf6f50973e085feb62267bc31a9517f5d6", size = 582441, upload-time = "2025-11-20T19:15:08.393Z" },
+]
+
+[package.optional-dependencies]
+torchao = [
+    { name = "torchao" },
+]
+transformers = [
+    { name = "transformers" },
 ]
 
 [[package]]
@@ -153,7 +186,7 @@ version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "frozenlist" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/61/62/06741b579156360248d1ec624842ad0edf697050bbaf7c3e46394e106ad1/aiosignal-1.4.0.tar.gz", hash = "sha256:f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7", size = 25007, upload-time = "2025-07-03T22:54:43.528Z" }
 wheels = [
@@ -241,7 +274,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "idna" },
     { name = "sniffio" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/95/7d/4c1bd541d4dffa1b52bd83fb8527089e097a106fc90b467a7313b105f840/anyio-4.9.0.tar.gz", hash = "sha256:673c0c244e15788651a4ff38710fea9675823028a6f08a5eda409e0c9840a028", size = 190949, upload-time = "2025-03-17T00:02:54.77Z" }
 wheels = [
@@ -558,7 +591,8 @@ dependencies = [
     { name = "petname" },
     { name = "pyyaml" },
     { name = "requests" },
-    { name = "rich" },
+    { name = "rich", version = "13.9.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-olmo-core' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "rich", version = "14.3.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands' or extra != 'extra-9-olmo-eval-olmo-core'" },
     { name = "tomli" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/94/79/b5a94a955fcef4dc614fbc9a40a0d5509268de87cb736bf9b69c0ecca6f0/beaker_gantry-3.7.0.tar.gz", hash = "sha256:4304c406a4d47fcef9b00c623a9b1ced2e00fe67c037f6c8dd75750d9ab6623c", size = 64174, upload-time = "2026-04-08T23:44:25.324Z" }
@@ -603,6 +637,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b0/1c6a16426d389813b48d95e26898aff79abbde42ad353958ad95cc8c9b21/beautifulsoup4-4.14.3.tar.gz", hash = "sha256:6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86", size = 627737, upload-time = "2025-11-30T15:08:26.084Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl", hash = "sha256:0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb", size = 107721, upload-time = "2025-11-30T15:08:24.087Z" },
+]
+
+[[package]]
+name = "bettermap"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dill" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/80/b4/1d74b7740723c1b85f3ae15d7b8d4a3d869f614fb1aa1982ed0055daf0ba/bettermap-1.3.1.tar.gz", hash = "sha256:e25cdaf85c1190eb84e7b1d462fc7ba20c85121d6a6e49178c63491929f6e152", size = 7602, upload-time = "2023-01-05T18:55:08.801Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a1/8d/84c67a7245e018111d1bcd0e253b37df813ac5d4404716dff43d76dd923e/bettermap-1.3.1-py3-none-any.whl", hash = "sha256:eaf5190cb3f1eadafdbbfef30f0379f9a80a2be93085c5acdfb55e37344305a6", size = 7690, upload-time = "2023-01-05T18:55:07.189Z" },
 ]
 
 [[package]]
@@ -777,7 +823,7 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "reportlab" },
     { name = "requests" },
-    { name = "rich" },
+    { name = "rich", version = "14.3.4", source = { registry = "https://pypi.org/simple" } },
     { name = "screeninfo", marker = "platform_system != 'darwin'" },
     { name = "typing-extensions" },
     { name = "uuid7" },
@@ -868,6 +914,24 @@ filecache = [
 ]
 
 [[package]]
+name = "cached-path"
+version = "1.8.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "boto3" },
+    { name = "filelock" },
+    { name = "google-cloud-storage" },
+    { name = "huggingface-hub" },
+    { name = "packaging" },
+    { name = "requests" },
+    { name = "rich", version = "13.9.4", source = { registry = "https://pypi.org/simple" } },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9b/da/59aa2a3f5d92415d1c072a35c94c7ada2251679b3bca3cf69d420ea95ac4/cached_path-1.8.10.tar.gz", hash = "sha256:ce80db439e25619800330dcbf1f0516c0ee70a27bd65ffca33aac9f55a56ef1c", size = 33249, upload-time = "2026-03-20T17:52:08.713Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/db/ccb08109c7056b0670384fc5042be5eacd1391eb12485188e92ca97ced21/cached_path-1.8.10-py3-none-any.whl", hash = "sha256:a7a80c4a77859e40080ed3450bc1ca5434a74fc51566361677a75fd2f5b8fea8", size = 37932, upload-time = "2026-03-20T17:52:07.747Z" },
+]
+
+[[package]]
 name = "cachetools"
 version = "5.5.2"
 source = { registry = "https://pypi.org/simple" }
@@ -955,7 +1019,7 @@ name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser", marker = "implementation_name != 'PyPy' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "pycparser", marker = "implementation_name != 'PyPy' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
@@ -1138,7 +1202,7 @@ name = "click"
 version = "8.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/bb/63/f9e1ea081ce35720d8b92acde70daaedace594dc93b693c869e0d5910718/click-8.3.3.tar.gz", hash = "sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2", size = 328061, upload-time = "2026-04-22T15:11:27.506Z" }
 wheels = [
@@ -1237,7 +1301,7 @@ name = "contourpy"
 version = "1.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands')" },
     { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands' or extra != 'extra-9-olmo-eval-vllm'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
@@ -1397,7 +1461,7 @@ name = "cryptography"
 version = "46.0.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "platform_python_implementation != 'PyPy' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/47/93/ac8f3d5ff04d54bc814e961a43ae5b0b146154c89c61b47bb07557679b18/cryptography-46.0.7.tar.gz", hash = "sha256:e4cfd68c5f3e0bfdad0d38e023239b96a2fe84146481852dffbcca442c245aa5", size = 750652, upload-time = "2026-04-08T01:57:54.692Z" }
 wheels = [
@@ -1450,7 +1514,7 @@ name = "cuda-bindings"
 version = "12.9.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder" },
+    { name = "cuda-pathfinder", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-9-olmo-eval-olmo-core') or (sys_platform == 'emscripten' and extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (sys_platform == 'emscripten' and extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-vllm') or (sys_platform == 'emscripten' and extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (sys_platform == 'emscripten' and extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-vllm') or (sys_platform == 'emscripten' and extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands') or (sys_platform == 'emscripten' and extra != 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm') or (sys_platform == 'win32' and extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (sys_platform == 'win32' and extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-vllm') or (sys_platform == 'win32' and extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (sys_platform == 'win32' and extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-vllm') or (sys_platform == 'win32' and extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands') or (sys_platform == 'win32' and extra != 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm') or (extra != 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-vllm') or (extra == 'extra-9-olmo-eval-agents' and extra != 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra != 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/c2/65bfd79292b8ff18be4dd7f7442cea37bcbc1a228c1886f1dea515c45b67/cuda_bindings-12.9.4-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:694ba35023846625ef471257e6b5a4bc8af690f961d197d77d34b1d1db393f56", size = 11760260, upload-time = "2025-10-21T14:51:40.79Z" },
@@ -1505,7 +1569,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
     { name = "docstring-parser" },
-    { name = "rich" },
+    { name = "rich", version = "14.3.4", source = { registry = "https://pypi.org/simple" } },
     { name = "rich-rst" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f9/fa/eff8f1abae783bade9b5e9bafafd0040d4dbf51988f9384bfdc0326ba1fc/cyclopts-4.11.0.tar.gz", hash = "sha256:1ffcb9990dbd56b90da19980d31596de9e99019980a215a5d76cf88fe452e94d", size = 170690, upload-time = "2026-04-23T00:23:36.858Z" }
@@ -1567,10 +1631,10 @@ dependencies = [
     { name = "httpx" },
     { name = "huggingface-hub" },
     { name = "multiprocess" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands')" },
     { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands' or extra != 'extra-9-olmo-eval-vllm'" },
     { name = "packaging" },
-    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and extra == 'extra-9-olmo-eval-vllm') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm') or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands')" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and extra == 'extra-9-olmo-eval-vllm') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm') or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands')" },
     { name = "pandas", version = "3.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' or extra == 'extra-9-olmo-eval-openhands' or extra != 'extra-9-olmo-eval-vllm'" },
     { name = "pyarrow" },
     { name = "pyyaml" },
@@ -1886,7 +1950,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
     { name = "pydantic" },
-    { name = "starlette", version = "0.52.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands')" },
+    { name = "starlette", version = "0.52.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands')" },
     { name = "starlette", version = "1.0.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands' or extra != 'extra-9-olmo-eval-vllm'" },
     { name = "typing-extensions" },
     { name = "typing-inspection" },
@@ -1899,14 +1963,14 @@ wheels = [
 [package.optional-dependencies]
 standard = [
     { name = "email-validator" },
-    { name = "fastapi-cli", extra = ["standard"], marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands')" },
+    { name = "fastapi-cli", extra = ["standard"], marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands')" },
     { name = "fastar" },
     { name = "httpx" },
     { name = "jinja2" },
     { name = "pydantic-extra-types" },
     { name = "pydantic-settings" },
     { name = "python-multipart" },
-    { name = "uvicorn", extra = ["standard"], marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands')" },
+    { name = "uvicorn", extra = ["standard"], marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands')" },
 ]
 
 [[package]]
@@ -1916,7 +1980,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "rich-toolkit" },
     { name = "typer" },
-    { name = "uvicorn", extra = ["standard"], marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands')" },
+    { name = "uvicorn", extra = ["standard"], marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6e/58/74797ae9e4610cfa0c6b34c8309096d3b20bb29be3b8b5fbf1004d10fa5f/fastapi_cli-0.0.24.tar.gz", hash = "sha256:1afc9c9e21d7ebc8a3ca5e31790cd8d837742be7e4f8b9236e99cb3451f0de00", size = 19043, upload-time = "2026-02-24T10:45:10.476Z" }
 wheels = [
@@ -1926,7 +1990,7 @@ wheels = [
 [package.optional-dependencies]
 standard = [
     { name = "fastapi-cloud-cli" },
-    { name = "uvicorn", extra = ["standard"], marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands')" },
+    { name = "uvicorn", extra = ["standard"], marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands')" },
 ]
 
 [[package]]
@@ -1936,12 +2000,12 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fastar" },
     { name = "httpx" },
-    { name = "pydantic", extra = ["email"], marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands')" },
+    { name = "pydantic", extra = ["email"], marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands')" },
     { name = "rich-toolkit" },
     { name = "rignore" },
     { name = "sentry-sdk" },
     { name = "typer" },
-    { name = "uvicorn", extra = ["standard"], marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands')" },
+    { name = "uvicorn", extra = ["standard"], marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/67/79/66567c39c5fab6dbebf9e40b3a3fcb0e2ec359517c87a67434c76b06e60b/fastapi_cloud_cli-0.17.0.tar.gz", hash = "sha256:2b6c241b63427023bd1e23b3251f23234aba4b05428b245a050e92db1389823c", size = 47276, upload-time = "2026-04-15T13:17:56.402Z" }
 wheels = [
@@ -2051,7 +2115,7 @@ dependencies = [
     { name = "pyperclip" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
-    { name = "rich" },
+    { name = "rich", version = "14.3.4", source = { registry = "https://pypi.org/simple" } },
     { name = "uncalled-for" },
     { name = "uvicorn" },
     { name = "watchfiles" },
@@ -2977,7 +3041,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
     { name = "fsspec" },
-    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
     { name = "httpx" },
     { name = "packaging" },
     { name = "pyyaml" },
@@ -3127,6 +3191,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107, upload-time = "2025-12-21T10:00:19.278Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fa/5e/f8e9a1d23b9c20a551a8a02ea3637b4642e22c2626e3a13a9a29cdea99eb/importlib_metadata-8.7.1-py3-none-any.whl", hash = "sha256:5a1f80bf1daa489495071efbb095d75a634cf28a8bc299581244063b53176151", size = 27865, upload-time = "2025-12-21T10:00:18.329Z" },
+]
+
+[[package]]
+name = "importlib-resources"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/06/b56dfa750b44e86157093bc8fca0ab81dccbf5260510de4eaf1cb69b5b99/importlib_resources-7.1.0.tar.gz", hash = "sha256:0722d4c6212489c530f2a145a34c0a7a3b4721bc96a15fada5930e2a0b760708", size = 44985, upload-time = "2026-04-12T16:36:09.232Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/db/55a262f3606bebcae07cc14095338471ad7c0bbcaa37707e6f0ee49725b7/importlib_resources-7.1.0-py3-none-any.whl", hash = "sha256:1bd7b48b4088eddb2cd16382150bb515af0bd2c70128194392725f82ad2c96a1", size = 37232, upload-time = "2026-04-12T16:36:08.219Z" },
 ]
 
 [[package]]
@@ -3868,7 +3941,7 @@ dependencies = [
     { name = "jinja2" },
     { name = "jsonschema" },
     { name = "openai", version = "2.8.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands'" },
-    { name = "openai", version = "2.21.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-agents' or extra == 'extra-9-olmo-eval-clients' or extra != 'extra-9-olmo-eval-openhands' or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "openai", version = "2.21.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-agents' or extra == 'extra-9-olmo-eval-clients' or extra == 'extra-9-olmo-eval-olmo-core' or extra != 'extra-9-olmo-eval-openhands' or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "tiktoken" },
@@ -4087,6 +4160,9 @@ wheels = [
 linkify = [
     { name = "linkify-it-py" },
 ]
+plugins = [
+    { name = "mdit-py-plugins", marker = "extra == 'extra-9-olmo-eval-olmo-core' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+]
 
 [[package]]
 name = "markdownify"
@@ -4173,7 +4249,7 @@ dependencies = [
     { name = "cycler" },
     { name = "fonttools" },
     { name = "kiwisolver" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands')" },
     { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands' or extra != 'extra-9-olmo-eval-vllm'" },
     { name = "packaging" },
     { name = "pillow" },
@@ -4255,7 +4331,7 @@ dependencies = [
     { name = "python-multipart" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
     { name = "sse-starlette" },
-    { name = "starlette", version = "0.52.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands')" },
+    { name = "starlette", version = "0.52.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands')" },
     { name = "starlette", version = "1.0.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands' or (extra == 'extra-9-olmo-eval-agents' and extra != 'extra-9-olmo-eval-vllm')" },
     { name = "typing-extensions" },
     { name = "typing-inspection" },
@@ -4308,7 +4384,7 @@ dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
     { name = "pillow" },
     { name = "pydantic" },
-    { name = "pydantic-extra-types", extra = ["pycountry"], marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands')" },
+    { name = "pydantic-extra-types", extra = ["pycountry"], marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands')" },
     { name = "requests" },
     { name = "tiktoken" },
     { name = "typing-extensions" },
@@ -4343,7 +4419,8 @@ dependencies = [
     { name = "click" },
     { name = "grpclib" },
     { name = "protobuf" },
-    { name = "rich" },
+    { name = "rich", version = "13.9.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-olmo-core' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "rich", version = "14.3.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands' or extra != 'extra-9-olmo-eval-olmo-core'" },
     { name = "synchronicity" },
     { name = "toml" },
     { name = "typer" },
@@ -4399,7 +4476,7 @@ version = "1.36.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
-    { name = "pyjwt", extra = ["crypto"], marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands')" },
+    { name = "pyjwt", extra = ["crypto"], marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands')" },
     { name = "requests" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/de/cb/b02b0f748ac668922364ccb3c3bff5b71628a05f5adfec2ba2a5c3031483/msal-1.36.0.tar.gz", hash = "sha256:3f6a4af2b036b476a4215111c4297b4e6e236ed186cd804faefba23e4990978b", size = 174217, upload-time = "2026-04-09T10:20:33.525Z" }
@@ -4930,7 +5007,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.10.2.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fa/41/e79269ce215c857c935fd86bcfe91a451a584dfc27f1e068f568b9ad1ab7/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:c9132cc3f8958447b4910a1720036d9eff5928cc3179b0a51fb6d167c6cc87d8", size = 705026878, upload-time = "2025-06-06T21:52:51.348Z" },
@@ -4959,7 +5036,7 @@ name = "nvidia-cufft-cu12"
 version = "11.3.3.83"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/60/bc/7771846d3a0272026c416fbb7e5f4c1f146d6d80704534d0b187dd6f4800/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:848ef7224d6305cdb2a4df928759dca7b1201874787083b6e7550dd6765ce69a", size = 193109211, upload-time = "2025-03-07T01:44:56.873Z" },
@@ -4991,9 +5068,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.3.90"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
-    { name = "nvidia-cusparse-cu12" },
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cusparse-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/32/f7cd6ce8a7690544d084ea21c26e910a97e077c9b7f07bf5de623ee19981/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:db9ed69dbef9715071232caa9b69c52ac7de3a95773c2db65bdba85916e4e5c0", size = 267229841, upload-time = "2025-03-07T01:46:54.356Z" },
@@ -5006,7 +5083,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.8.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bc/f7/cd777c4109681367721b00a106f491e0d0d15cfa1fd59672ce580ce42a97/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:9b6c161cb130be1a07a27ea6923df8141f3c295852f4b260c65f18f3e0a091dc", size = 288117129, upload-time = "2025-03-07T01:47:40.407Z" },
@@ -5124,18 +5201,19 @@ wheels = [
 
 [[package]]
 name = "olmo-eval"
-version = "0.1.0"
+version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "antlr4-python3-runtime" },
     { name = "click" },
     { name = "datasets" },
     { name = "ifbench" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands')" },
     { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands' or extra != 'extra-9-olmo-eval-vllm'" },
     { name = "omegaconf" },
     { name = "prometheus-client" },
-    { name = "rich" },
+    { name = "rich", version = "13.9.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-olmo-core' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "rich", version = "14.3.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands' or extra != 'extra-9-olmo-eval-olmo-core'" },
     { name = "setuptools" },
     { name = "sympy" },
     { name = "textual-plot" },
@@ -5161,13 +5239,16 @@ clients = [
     { name = "openai", version = "2.21.0", source = { registry = "https://pypi.org/simple" } },
 ]
 gpu = [
-    { name = "nvidia-ml-py", marker = "sys_platform != 'darwin' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "nvidia-ml-py", marker = "sys_platform != 'darwin' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
 ]
 hf = [
     { name = "transformers" },
 ]
 litellm = [
     { name = "litellm" },
+]
+olmo-core = [
+    { name = "ai2-olmo-core", extra = ["torchao", "transformers"], marker = "extra == 'extra-9-olmo-eval-olmo-core' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
 ]
 openhands = [
     { name = "openhands-ai" },
@@ -5194,7 +5275,7 @@ storage = [
 vllm = [
     { name = "opencv-python-headless", marker = "sys_platform != 'darwin'" },
     { name = "torch-c-dlpack-ext", marker = "sys_platform != 'darwin'" },
-    { name = "vllm", extra = ["runai"], marker = "(sys_platform != 'darwin' and extra == 'extra-9-olmo-eval-vllm') or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "vllm", extra = ["runai"], marker = "(sys_platform != 'darwin' and extra == 'extra-9-olmo-eval-vllm') or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
 ]
 
 [package.dev-dependencies]
@@ -5211,11 +5292,12 @@ dev = [
 ]
 vllm = [
     { name = "olmo-eval" },
-    { name = "olmo-eval", extra = ["vllm"], marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands')" },
+    { name = "olmo-eval", extra = ["vllm"], marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands')" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "ai2-olmo-core", extras = ["torchao", "transformers"], marker = "extra == 'olmo-core'", specifier = "==2.4.0" },
     { name = "alembic", marker = "extra == 'postgres'", specifier = ">=1.18.1" },
     { name = "antlr4-python3-runtime", specifier = ">=4.11,<4.12" },
     { name = "beaker-gantry", marker = "extra == 'beaker'", specifier = ">=3.2.0,<4" },
@@ -5237,7 +5319,7 @@ requires-dist = [
     { name = "openhands-ai", marker = "extra == 'openhands'", specifier = "~=1.4.0" },
     { name = "prometheus-client", specifier = ">=0.21.0" },
     { name = "psycopg", extras = ["binary"], marker = "extra == 'postgres'", specifier = ">=3.1.0" },
-    { name = "rich", specifier = "~=14.3.4" },
+    { name = "rich", specifier = ">=13.7,<15" },
     { name = "scipy", marker = "extra == 'analysis'", specifier = "~=1.17.1" },
     { name = "seaborn", marker = "extra == 'analysis'", specifier = "~=0.13.2" },
     { name = "setuptools", specifier = "<81" },
@@ -5252,7 +5334,7 @@ requires-dist = [
     { name = "tree-sitter-python", specifier = ">=0.23.0,<0.26.0" },
     { name = "vllm", extras = ["runai"], marker = "sys_platform != 'darwin' and extra == 'vllm'", specifier = "==0.19.1" },
 ]
-provides-extras = ["hf", "vllm", "litellm", "agents", "analysis", "openhands", "sandbox", "beaker", "s3", "postgres", "gpu", "clients", "storage"]
+provides-extras = ["hf", "olmo-core", "vllm", "litellm", "agents", "analysis", "openhands", "sandbox", "beaker", "s3", "postgres", "gpu", "clients", "storage"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -5326,14 +5408,14 @@ resolution-markers = [
     "python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "anyio", marker = "extra == 'extra-9-olmo-eval-agents' or extra == 'extra-9-olmo-eval-clients' or extra != 'extra-9-olmo-eval-openhands' or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
-    { name = "distro", marker = "extra == 'extra-9-olmo-eval-agents' or extra == 'extra-9-olmo-eval-clients' or extra != 'extra-9-olmo-eval-openhands' or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
-    { name = "httpx", marker = "extra == 'extra-9-olmo-eval-agents' or extra == 'extra-9-olmo-eval-clients' or extra != 'extra-9-olmo-eval-openhands' or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
-    { name = "jiter", marker = "extra == 'extra-9-olmo-eval-agents' or extra == 'extra-9-olmo-eval-clients' or extra != 'extra-9-olmo-eval-openhands' or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
-    { name = "pydantic", marker = "extra == 'extra-9-olmo-eval-agents' or extra == 'extra-9-olmo-eval-clients' or extra != 'extra-9-olmo-eval-openhands' or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
-    { name = "sniffio", marker = "extra == 'extra-9-olmo-eval-agents' or extra == 'extra-9-olmo-eval-clients' or extra != 'extra-9-olmo-eval-openhands' or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
-    { name = "tqdm", marker = "extra == 'extra-9-olmo-eval-agents' or extra == 'extra-9-olmo-eval-clients' or extra != 'extra-9-olmo-eval-openhands' or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
-    { name = "typing-extensions", marker = "extra == 'extra-9-olmo-eval-agents' or extra == 'extra-9-olmo-eval-clients' or extra != 'extra-9-olmo-eval-openhands' or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "anyio", marker = "extra == 'extra-9-olmo-eval-agents' or extra == 'extra-9-olmo-eval-clients' or extra == 'extra-9-olmo-eval-olmo-core' or extra != 'extra-9-olmo-eval-openhands' or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "distro", marker = "extra == 'extra-9-olmo-eval-agents' or extra == 'extra-9-olmo-eval-clients' or extra == 'extra-9-olmo-eval-olmo-core' or extra != 'extra-9-olmo-eval-openhands' or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "httpx", marker = "extra == 'extra-9-olmo-eval-agents' or extra == 'extra-9-olmo-eval-clients' or extra == 'extra-9-olmo-eval-olmo-core' or extra != 'extra-9-olmo-eval-openhands' or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "jiter", marker = "extra == 'extra-9-olmo-eval-agents' or extra == 'extra-9-olmo-eval-clients' or extra == 'extra-9-olmo-eval-olmo-core' or extra != 'extra-9-olmo-eval-openhands' or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "pydantic", marker = "extra == 'extra-9-olmo-eval-agents' or extra == 'extra-9-olmo-eval-clients' or extra == 'extra-9-olmo-eval-olmo-core' or extra != 'extra-9-olmo-eval-openhands' or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "sniffio", marker = "extra == 'extra-9-olmo-eval-agents' or extra == 'extra-9-olmo-eval-clients' or extra == 'extra-9-olmo-eval-olmo-core' or extra != 'extra-9-olmo-eval-openhands' or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "tqdm", marker = "extra == 'extra-9-olmo-eval-agents' or extra == 'extra-9-olmo-eval-clients' or extra == 'extra-9-olmo-eval-olmo-core' or extra != 'extra-9-olmo-eval-openhands' or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "typing-extensions", marker = "extra == 'extra-9-olmo-eval-agents' or extra == 'extra-9-olmo-eval-clients' or extra == 'extra-9-olmo-eval-olmo-core' or extra != 'extra-9-olmo-eval-openhands' or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/92/e5/3d197a0947a166649f566706d7a4c8f7fe38f1fa7b24c9bcffe4c7591d44/openai-2.21.0.tar.gz", hash = "sha256:81b48ce4b8bbb2cc3af02047ceb19561f7b1dc0d4e52d1de7f02abfd15aa59b7", size = 644374, upload-time = "2026-02-14T00:12:01.577Z" }
 wheels = [
@@ -5864,10 +5946,10 @@ resolution-markers = [
     "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and extra == 'extra-9-olmo-eval-vllm') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm') or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands')" },
-    { name = "python-dateutil", marker = "(python_full_version >= '3.14' and extra == 'extra-9-olmo-eval-vllm') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm') or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands')" },
-    { name = "pytz", marker = "(python_full_version >= '3.14' and extra == 'extra-9-olmo-eval-vllm') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm') or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands')" },
-    { name = "tzdata", marker = "(python_full_version >= '3.14' and extra == 'extra-9-olmo-eval-vllm') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm') or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and extra == 'extra-9-olmo-eval-vllm') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm') or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands')" },
+    { name = "python-dateutil", marker = "(python_full_version >= '3.14' and extra == 'extra-9-olmo-eval-vllm') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm') or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands')" },
+    { name = "pytz", marker = "(python_full_version >= '3.14' and extra == 'extra-9-olmo-eval-vllm') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm') or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands')" },
+    { name = "tzdata", marker = "(python_full_version >= '3.14' and extra == 'extra-9-olmo-eval-vllm') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm') or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/01/d40b85317f86cf08d853a4f495195c73815fdf205eef3993821720274518/pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b", size = 4495223, upload-time = "2025-09-29T23:34:51.853Z" }
 wheels = [
@@ -5922,10 +6004,10 @@ resolution-markers = [
     "python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and extra == 'extra-9-olmo-eval-vllm') or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and extra == 'extra-9-olmo-eval-vllm') or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
     { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands' or extra != 'extra-9-olmo-eval-vllm'" },
-    { name = "python-dateutil" },
-    { name = "tzdata", marker = "(python_full_version < '3.14' and sys_platform == 'emscripten') or (python_full_version < '3.14' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm') or (sys_platform == 'emscripten' and extra == 'extra-9-olmo-eval-openhands') or (sys_platform == 'emscripten' and extra != 'extra-9-olmo-eval-vllm') or (sys_platform == 'win32' and extra == 'extra-9-olmo-eval-openhands') or (sys_platform == 'win32' and extra != 'extra-9-olmo-eval-vllm')" },
+    { name = "python-dateutil", marker = "python_full_version < '3.14' or extra == 'extra-9-olmo-eval-openhands' or extra != 'extra-9-olmo-eval-vllm'" },
+    { name = "tzdata", marker = "(python_full_version < '3.14' and sys_platform == 'emscripten') or (python_full_version < '3.14' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands') or (sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm') or (sys_platform == 'emscripten' and extra == 'extra-9-olmo-eval-openhands') or (sys_platform == 'emscripten' and extra != 'extra-9-olmo-eval-vllm') or (sys_platform == 'win32' and extra == 'extra-9-olmo-eval-openhands') or (sys_platform == 'win32' and extra != 'extra-9-olmo-eval-vllm')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/da/99/b342345300f13440fe9fe385c3c481e2d9a595ee3bab4d3219247ac94e9a/pandas-3.0.2.tar.gz", hash = "sha256:f4753e73e34c8d83221ba58f232433fca2748be8b18dbca02d242ed153945043", size = 4645855, upload-time = "2026-03-31T06:48:30.816Z" }
 wheels = [
@@ -6474,8 +6556,8 @@ name = "psycopg"
 version = "3.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
-    { name = "tzdata", marker = "sys_platform == 'win32' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "tzdata", marker = "sys_platform == 'win32' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d3/b6/379d0a960f8f435ec78720462fd94c4863e7a31237cf81bf76d0af5883bf/psycopg-3.3.3.tar.gz", hash = "sha256:5e9a47458b3c1583326513b2556a2a9473a1001a56c9efe9e587245b43148dd9", size = 165624, upload-time = "2026-02-18T16:52:16.546Z" }
 wheels = [
@@ -6484,7 +6566,7 @@ wheels = [
 
 [package.optional-dependencies]
 binary = [
-    { name = "psycopg-binary", marker = "implementation_name != 'pypy' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "psycopg-binary", marker = "implementation_name != 'pypy' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
 ]
 
 [[package]]
@@ -9793,7 +9875,7 @@ name = "pytest"
 version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
     { name = "iniconfig" },
     { name = "packaging" },
     { name = "pluggy" },
@@ -10233,7 +10315,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
     { name = "rpds-py" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
 wheels = [
@@ -10416,11 +10498,46 @@ wheels = [
 
 [[package]]
 name = "rich"
+version = "13.9.4"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.13' and sys_platform == 'win32'",
+    "python_full_version < '3.13' and sys_platform == 'emscripten'",
+    "python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "markdown-it-py", marker = "extra == 'extra-9-olmo-eval-olmo-core' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "pygments", marker = "extra == 'extra-9-olmo-eval-olmo-core' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ab/3a/0316b28d0761c6734d6bc14e770d85506c986c85ffb239e688eeaab2c2bc/rich-13.9.4.tar.gz", hash = "sha256:439594978a49a09530cff7ebc4b5c7103ef57baf48d5ea3184f21d9a2befa098", size = 223149, upload-time = "2024-11-01T16:43:57.873Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/71/39c7c0d87f8d4e6c020a393182060eaefeeae6c01dab6a84ec346f2567df/rich-13.9.4-py3-none-any.whl", hash = "sha256:6049d5e6ec054bf2779ab3358186963bac2ea89175919d699e378b99738c2a90", size = 242424, upload-time = "2024-11-01T16:43:55.817Z" },
+]
+
+[[package]]
+name = "rich"
 version = "14.3.4"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.13' and sys_platform == 'win32'",
+    "python_full_version < '3.13' and sys_platform == 'emscripten'",
+    "python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
 dependencies = [
-    { name = "markdown-it-py" },
-    { name = "pygments" },
+    { name = "markdown-it-py", marker = "extra == 'extra-9-olmo-eval-openhands' or extra != 'extra-9-olmo-eval-olmo-core'" },
+    { name = "pygments", marker = "extra == 'extra-9-olmo-eval-openhands' or extra != 'extra-9-olmo-eval-olmo-core'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e9/67/cae617f1351490c25a4b8ac3b8b63a4dda609295d8222bad12242dfdc629/rich-14.3.4.tar.gz", hash = "sha256:817e02727f2b25b40ef56f5aa2217f400c8489f79ca8f46ea2b70dd5e14558a9", size = 230524, upload-time = "2026-04-11T02:57:45.419Z" }
 wheels = [
@@ -10433,7 +10550,7 @@ version = "1.3.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "docutils" },
-    { name = "rich" },
+    { name = "rich", version = "14.3.4", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/bc/6d/a506aaa4a9eaa945ed8ab2b7347859f53593864289853c5d6d62b77246e0/rich_rst-1.3.2.tar.gz", hash = "sha256:a1196fdddf1e364b02ec68a05e8ff8f6914fee10fbca2e6b6735f166bb0da8d4", size = 14936, upload-time = "2025-10-14T16:49:45.332Z" }
 wheels = [
@@ -10446,7 +10563,8 @@ version = "0.19.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
-    { name = "rich" },
+    { name = "rich", version = "13.9.4", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-vllm') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "rich", version = "14.3.4", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands') or (extra != 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-vllm')" },
     { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/ba/dae9e3096651042754da419a4042bc1c75e07d615f9b15066d738838e4df/rich_toolkit-0.19.7.tar.gz", hash = "sha256:133c0915872da91d4c25d85342d5ec1dfacc69b63448af1a08a0d4b4f23ef46e", size = 195877, upload-time = "2026-02-24T16:06:20.555Z" }
@@ -10755,7 +10873,7 @@ name = "scipy"
 version = "1.17.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands')" },
     { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands' or extra != 'extra-9-olmo-eval-vllm'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
@@ -10843,9 +10961,9 @@ version = "0.13.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "matplotlib" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands')" },
     { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands' or extra != 'extra-9-olmo-eval-vllm'" },
-    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and extra == 'extra-9-olmo-eval-vllm') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm') or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands')" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and extra == 'extra-9-olmo-eval-vllm') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm') or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands')" },
     { name = "pandas", version = "3.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' or extra == 'extra-9-olmo-eval-openhands' or extra != 'extra-9-olmo-eval-vllm'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/86/59/a451d7420a77ab0b98f7affa3a1d78a313d2f7281a57afb1a34bae8ab412/seaborn-0.13.2.tar.gz", hash = "sha256:93e60a40988f4d65e9f4885df477e2fdaff6b73a9ded434c1ab356dd57eefff7", size = 1457696, upload-time = "2024-01-25T13:21:52.551Z" }
@@ -11096,7 +11214,7 @@ name = "sqlalchemy"
 version = "2.0.49"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
     { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/09/45/461788f35e0364a8da7bda51a1fe1b09762d0c32f12f63727998d85a873b/sqlalchemy-2.0.49.tar.gz", hash = "sha256:d15950a57a210e36dd4cec1aac22787e2a4d57ba9318233e2ef8b2daf9ff2d5f", size = 9898221, upload-time = "2026-04-03T16:38:11.704Z" }
@@ -11148,7 +11266,7 @@ version = "3.3.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "starlette", version = "0.52.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands')" },
+    { name = "starlette", version = "0.52.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands')" },
     { name = "starlette", version = "1.0.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands' or (extra == 'extra-9-olmo-eval-agents' and extra != 'extra-9-olmo-eval-vllm')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/26/8c/f9290339ef6d79badbc010f067cd769d6601ec11a57d78569c683fb4dd87/sse_starlette-3.3.4.tar.gz", hash = "sha256:aaf92fc067af8a5427192895ac028e947b484ac01edbc3caf00e7e7137c7bef1", size = 32427, upload-time = "2026-03-29T09:00:23.307Z" }
@@ -11208,8 +11326,8 @@ resolution-markers = [
     "python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "anyio", marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands')" },
-    { name = "typing-extensions", marker = "(python_full_version < '3.13' and extra == 'extra-9-olmo-eval-vllm') or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "anyio", marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands')" },
+    { name = "typing-extensions", marker = "(python_full_version < '3.13' and extra == 'extra-9-olmo-eval-vllm') or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c4/68/79977123bb7be889ad680d79a40f339082c1978b5cfcf62c2d8d196873ac/starlette-0.52.1.tar.gz", hash = "sha256:834edd1b0a23167694292e94f597773bc3f89f362be6effee198165a35d62933", size = 2653702, upload-time = "2026-01-18T13:34:11.062Z" }
 wheels = [
@@ -11233,7 +11351,7 @@ resolution-markers = [
 ]
 dependencies = [
     { name = "anyio", marker = "extra == 'extra-9-olmo-eval-openhands' or extra != 'extra-9-olmo-eval-vllm'" },
-    { name = "typing-extensions", marker = "(python_full_version < '3.13' and extra == 'extra-9-olmo-eval-openhands') or (python_full_version < '3.13' and extra != 'extra-9-olmo-eval-vllm') or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "typing-extensions", marker = "(python_full_version < '3.13' and extra == 'extra-9-olmo-eval-openhands') or (python_full_version < '3.13' and extra != 'extra-9-olmo-eval-vllm') or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
 wheels = [
@@ -11260,7 +11378,8 @@ dependencies = [
     { name = "pydantic" },
     { name = "python-multipart" },
     { name = "requests" },
-    { name = "rich" },
+    { name = "rich", version = "13.9.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-olmo-core' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "rich", version = "14.3.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands' or extra != 'extra-9-olmo-eval-olmo-core'" },
     { name = "uvicorn" },
 ]
 
@@ -11346,15 +11465,53 @@ wheels = [
 
 [[package]]
 name = "textual"
+version = "6.2.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.13' and sys_platform == 'win32'",
+    "python_full_version < '3.13' and sys_platform == 'emscripten'",
+    "python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "markdown-it-py", extra = ["linkify", "plugins"], marker = "extra == 'extra-9-olmo-eval-olmo-core' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "platformdirs", marker = "extra == 'extra-9-olmo-eval-olmo-core' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "pygments", marker = "extra == 'extra-9-olmo-eval-olmo-core' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "rich", version = "13.9.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-olmo-core' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "typing-extensions", marker = "extra == 'extra-9-olmo-eval-olmo-core' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a2/30/38b615f7d4b16f6fdd73e4dcd8913e2d880bbb655e68a076e3d91181a7ee/textual-6.2.1.tar.gz", hash = "sha256:4699d8dfae43503b9c417bd2a6fb0da1c89e323fe91c4baa012f9298acaa83e1", size = 1570645, upload-time = "2025-10-01T16:11:24.467Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/93/02c7adec57a594af28388d85da9972703a4af94ae1399542555cd9581952/textual-6.2.1-py3-none-any.whl", hash = "sha256:3c7190633cd4d8bfe6049ae66808b98da91ded2edb85cef54e82bf77b03d2a54", size = 710702, upload-time = "2025-10-01T16:11:22.161Z" },
+]
+
+[[package]]
+name = "textual"
 version = "8.2.4"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.13' and sys_platform == 'win32'",
+    "python_full_version < '3.13' and sys_platform == 'emscripten'",
+    "python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
 dependencies = [
-    { name = "markdown-it-py", extra = ["linkify"] },
-    { name = "mdit-py-plugins" },
-    { name = "platformdirs" },
-    { name = "pygments" },
-    { name = "rich" },
-    { name = "typing-extensions" },
+    { name = "markdown-it-py", extra = ["linkify"], marker = "extra == 'extra-9-olmo-eval-openhands' or extra != 'extra-9-olmo-eval-olmo-core'" },
+    { name = "mdit-py-plugins", marker = "extra == 'extra-9-olmo-eval-openhands' or extra != 'extra-9-olmo-eval-olmo-core'" },
+    { name = "platformdirs", marker = "extra == 'extra-9-olmo-eval-openhands' or extra != 'extra-9-olmo-eval-olmo-core'" },
+    { name = "pygments", marker = "extra == 'extra-9-olmo-eval-openhands' or extra != 'extra-9-olmo-eval-olmo-core'" },
+    { name = "rich", version = "14.3.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands' or extra != 'extra-9-olmo-eval-olmo-core'" },
+    { name = "typing-extensions", marker = "extra == 'extra-9-olmo-eval-openhands' or extra != 'extra-9-olmo-eval-olmo-core'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/19/89/bec5709fb759f9c784bbcb30b2e3497df3f901691d13c2b864dbf6694a17/textual-8.2.4.tar.gz", hash = "sha256:d4e2b2ddd7157191d00b228592b7c739ea080b7d792fd410f23ca75f05ea76c4", size = 1848933, upload-time = "2026-04-19T04:20:45.845Z" }
 wheels = [
@@ -11366,9 +11523,10 @@ name = "textual-hires-canvas"
 version = "0.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands')" },
     { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands' or extra != 'extra-9-olmo-eval-vllm'" },
-    { name = "textual" },
+    { name = "textual", version = "6.2.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-olmo-core' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "textual", version = "8.2.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands' or extra != 'extra-9-olmo-eval-olmo-core'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/20/f0/13f2a30ab7950cc3d5d5a2c893fbe3d40b4d129fd2cd30313260181578c4/textual_hires_canvas-0.14.0.tar.gz", hash = "sha256:0fa512492ddd2cd6c2a970a6beea58f5350f4cf25f40ad14ffd9fa86c6458769", size = 1251440, upload-time = "2026-01-10T22:16:56.708Z" }
 wheels = [
@@ -11380,9 +11538,10 @@ name = "textual-plot"
 version = "0.10.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands')" },
     { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands' or extra != 'extra-9-olmo-eval-vllm'" },
-    { name = "textual" },
+    { name = "textual", version = "6.2.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-olmo-core' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "textual", version = "8.2.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands' or extra != 'extra-9-olmo-eval-olmo-core'" },
     { name = "textual-hires-canvas" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a0/c2/13f9f747e83cd0b740d1bf310e89a006316cfb5acb4e5a4136c12f96340b/textual_plot-0.10.1.tar.gz", hash = "sha256:503db96d849134293228419324eb15efbadf1f1927a2e0a229b54e7a7e5d5292", size = 2451096, upload-time = "2026-02-01T13:27:43.658Z" }
@@ -11640,6 +11799,15 @@ wheels = [
 ]
 
 [[package]]
+name = "torchao"
+version = "0.17.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/fe/a4036a8e80fa800c92dbcbf75f541cd4c106248b6b579db6dab1800f616a/torchao-0.17.0-cp310-abi3-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:87a418ce0ec064a821ceab83c921b501acef0ce9a6ccd1be358fcd16c3ae8c58", size = 3206172, upload-time = "2026-03-30T22:25:52.974Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/37/ef37ca885265e5f79a168616767dd416a3cea1cc3b28bb6b503ce4a5b652/torchao-0.17.0-py3-none-any.whl", hash = "sha256:02eba449036715b9ae784fbaa1a6f97994bb7b0421ce92d1d5d1c08e5bd6d349", size = 1200680, upload-time = "2026-03-30T22:25:54.457Z" },
+]
+
+[[package]]
 name = "torchaudio"
 version = "2.10.0"
 source = { registry = "https://pypi.org/simple" }
@@ -11723,7 +11891,7 @@ name = "tqdm"
 version = "4.67.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
 wheels = [
@@ -11745,7 +11913,7 @@ version = "5.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "huggingface-hub" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands')" },
     { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands' or extra != 'extra-9-olmo-eval-vllm'" },
     { name = "packaging" },
     { name = "pyyaml" },
@@ -11922,7 +12090,8 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
     { name = "click" },
-    { name = "rich" },
+    { name = "rich", version = "13.9.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-olmo-core' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "rich", version = "14.3.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands' or extra != 'extra-9-olmo-eval-olmo-core'" },
     { name = "shellingham" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/83/b8/9ebb531b6c2d377af08ac6746a5df3425b21853a5d2260876919b58a2a4a/typer-0.24.2.tar.gz", hash = "sha256:ec070dcfca1408e85ee203c6365001e818c3b7fffe686fd07ff2d68095ca0480", size = 119849, upload-time = "2026-04-22T17:45:34.413Z" }
@@ -12168,7 +12337,7 @@ dependencies = [
     { name = "depyf" },
     { name = "diskcache" },
     { name = "einops" },
-    { name = "fastapi", extra = ["standard"], marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands')" },
+    { name = "fastapi", extra = ["standard"], marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands')" },
     { name = "filelock" },
     { name = "flashinfer-cubin" },
     { name = "flashinfer-python" },
@@ -12178,7 +12347,7 @@ dependencies = [
     { name = "llguidance", marker = "platform_machine == 'aarch64' or platform_machine == 'arm64' or platform_machine == 'ppc64le' or platform_machine == 's390x' or platform_machine == 'x86_64'" },
     { name = "lm-format-enforcer" },
     { name = "mcp" },
-    { name = "mistral-common", extra = ["image"], marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands')" },
+    { name = "mistral-common", extra = ["image"], marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands')" },
     { name = "model-hosting-container-standards" },
     { name = "msgspec" },
     { name = "ninja" },
@@ -12232,7 +12401,7 @@ wheels = [
 
 [package.optional-dependencies]
 runai = [
-    { name = "runai-model-streamer", extra = ["azure", "gcs", "s3"], marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands')" },
+    { name = "runai-model-streamer", extra = ["azure", "gcs", "s3"], marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands')" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Brings `main` into `vision` so vision is no longer behind main — adds the experimental **olmo-core
inference** backend (#218) and the **torch 2.10** default (#226). Clean merge of `main` into
`vision`; vision's existing work (Molmo2 image-QA #219, image-pointing, MMMU-Pro #232) is preserved.

## ⚠️ Merge method: "Create a merge commit" — NOT squash

Please merge this PR via **Create a merge commit**, not squash. A squash would copy main's content
but leave main's commits out of vision's history, so `vision` would still report as *behind main*.
A merge commit makes `main` a true ancestor → **vision becomes 0-behind-main**.

## Included

- **#218** — olmo-core inference (`inference/providers/olmo_core.py` + `olmo_core_utils.py`, provider
  registry/config updates, `tests/providers/test_olmo_core_provider.py`).
- **#226** — torch 2.10 default (`Dockerfile`, build/beaker scripts, `common/constants/infrastructure.py`).
- Only `uv.lock` conflicted (a generated lockfile); resolved by regenerating it from the
  cleanly-merged `pyproject.toml` (union of the `hf`-extra deps + main's new `olmo_core` extra). No
  source conflicts.

## Verification

The merged tree is byte-identical to the already-validated state: ruff clean, ty clean on the new
files, full suite **1795 passed / 5 skipped** on torch 2.10 (including the olmo-core provider tests,
which pass via mocks since `ai2-olmo-core` is an opt-in extra).
