### PR TITLE
Fix Hugging Face dataset paths and worker startup diagnostics

### DIFF
--- a/src/olmo_eval/data/ruler_loader.py
+++ b/src/olmo_eval/data/ruler_loader.py
@@ -13,7 +13,11 @@ from typing import Any
 import numpy as np
 from huggingface_hub import hf_hub_download
 from huggingface_hub.utils import disable_progress_bars as disable_hf_hub_progress_bars
-from huggingface_hub.utils import silent_tqdm
+
+try:
+    from huggingface_hub.utils import silent_tqdm
+except ImportError:
+    from tqdm.auto import tqdm as silent_tqdm
 
 logger = logging.getLogger(__name__)
 

--- a/src/olmo_eval/evals/tasks/csqa.py
+++ b/src/olmo_eval/evals/tasks/csqa.py
@@ -23,7 +23,7 @@ from olmo_eval.evals.tasks.constants.csqa import CSQA_FIXED_FEWSHOT
 
 @register("csqa")
 class CommonsenseQA(Task):
-    data_source = DataSource(path="commonsense_qa", split="validation")
+    data_source = DataSource(path="tau/commonsense_qa", split="validation")
     split = Split.VALIDATION
     metrics = (LogprobMCAccuracyMetric(),)
     num_fewshot = 0
@@ -157,7 +157,7 @@ register_variant(
     "olmo3base",
     num_fewshot=5,
     fewshot_source="olmes_csqa_fixed",
-    data_source=DataSource(path="commonsense_qa", split="validation"),
+    data_source=DataSource(path="tau/commonsense_qa", split="validation"),
     metrics=(LogprobUncondMCAccuracyMetric(),),
 )
 register_variant(
@@ -166,14 +166,14 @@ register_variant(
     formatter=MultipleChoiceFormatter(),
     num_fewshot=5,
     fewshot_source="olmes_csqa_fixed",
-    data_source=DataSource(path="commonsense_qa", split="validation+train"),
+    data_source=DataSource(path="tau/commonsense_qa", split="validation+train"),
     limit=10000,
     seed=1234,
 )
 register_variant(
     "csqa",
     "xlarge",
-    data_source=DataSource(path="commonsense_qa", split="validation+train"),
+    data_source=DataSource(path="tau/commonsense_qa", split="validation+train"),
     num_fewshot=5,
     limit=10000,
     seed=1234,

--- a/src/olmo_eval/evals/tasks/gsm8k.py
+++ b/src/olmo_eval/evals/tasks/gsm8k.py
@@ -32,7 +32,7 @@ def _clean_short_answer(text: str) -> str:
 
 @register("gsm8k")
 class GSM8K(Task):
-    data_source = DataSource(path="gsm8k", subset="main")
+    data_source = DataSource(path="openai/gsm8k", subset="main")
     metrics = (AccuracyMetric(scorer=ExactMatchScorer),)
     num_fewshot = 8
     sampling_params = SamplingParams(

--- a/src/olmo_eval/evals/tasks/humaneval.py
+++ b/src/olmo_eval/evals/tasks/humaneval.py
@@ -28,7 +28,7 @@ class CodeExecutionScorer3s(CodeExecutionScorer):
 class HumanEval(Task):
     """HumanEval code generation task."""
 
-    data_source = DataSource(path="openai_humaneval")
+    data_source = DataSource(path="openai/openai_humaneval")
     sampling_params = SamplingParams(
         max_tokens=1024,
         temperature=0.0,

--- a/src/olmo_eval/evals/tasks/piqa.py
+++ b/src/olmo_eval/evals/tasks/piqa.py
@@ -18,7 +18,7 @@ from olmo_eval.evals.tasks.constants.piqa import PIQA_FIXED_FEWSHOT
 
 @register("piqa")
 class PiQA(Task):
-    data_source = DataSource(path="piqa", split="validation", revision="refs/convert/parquet")
+    data_source = DataSource(path="ybisk/piqa", split="validation", revision="refs/convert/parquet")
     split = Split.VALIDATION
     metrics = (LogprobPerTokenMCAccuracyMetric(),)
     num_fewshot = 0

--- a/src/olmo_eval/evals/tasks/socialiqa.py
+++ b/src/olmo_eval/evals/tasks/socialiqa.py
@@ -21,7 +21,7 @@ from olmo_eval.evals.tasks.constants.socialiqa import SOCIALIQA_FIXED_FEWSHOT
 @register("socialiqa")
 class SocialIQA(Task):
     data_source = DataSource(
-        path="social_i_qa", split="validation", revision="refs/convert/parquet"
+        path="allenai/social_i_qa", split="validation", revision="refs/convert/parquet"
     )
     split = Split.VALIDATION
     metrics = (LogprobPerCharMCAccuracyMetric(),)
@@ -158,7 +158,7 @@ register_variant(
     "mc_olmo3base",
     formatter=MultipleChoiceFormatter(),
     data_source=DataSource(
-        path="social_i_qa", split="train+validation", revision="refs/convert/parquet"
+        path="allenai/social_i_qa", split="train+validation", revision="refs/convert/parquet"
     ),
     num_fewshot=5,
     limit=10000,
@@ -168,7 +168,7 @@ register_variant(
     "socialiqa",
     "xlarge",
     data_source=DataSource(
-        path="social_i_qa", split="train+validation", revision="refs/convert/parquet"
+        path="allenai/social_i_qa", split="train+validation", revision="refs/convert/parquet"
     ),
     num_fewshot=5,
     limit=10000,

--- a/src/olmo_eval/evals/tasks/winogrande.py
+++ b/src/olmo_eval/evals/tasks/winogrande.py
@@ -64,7 +64,7 @@ def _format_mc(sentence: str, options: tuple[str, ...], answer: str | None = Non
 
 @register("winogrande")
 class Winogrande(Task):
-    data_source = DataSource(path="winogrande", subset="winogrande_xl", split="validation")
+    data_source = DataSource(path="allenai/winogrande", subset="winogrande_xl", split="validation")
     split = Split.VALIDATION
     metrics = (LogprobMCAccuracyMetric(),)
     num_fewshot = 0

--- a/src/olmo_eval/inference/providers/vllm.py
+++ b/src/olmo_eval/inference/providers/vllm.py
@@ -131,6 +131,7 @@ class VLLMProvider(InferenceProvider):
         if worker_id:
             _configure_vllm_logger(worker_id)
 
+        logger.info("Importing vLLM LLM class")
         try:
             from vllm import LLM
         except ImportError as e:
@@ -139,6 +140,7 @@ class VLLMProvider(InferenceProvider):
             logger.error(f"Failed to import vllm: {e}")
             logger.error(traceback.format_exc())
             raise ImportError("vllm is required for VLLMProvider") from e
+        logger.info("Imported vLLM LLM class")
 
         super().__init__(model_name)
         self._worker_id = worker_id
@@ -181,7 +183,12 @@ class VLLMProvider(InferenceProvider):
         # matching the old framework's behavior (tokenizer(text, add_special_tokens=False)).
         self._add_bos_token: bool | None = engine_kwargs.pop("add_bos_token", None)
 
+        logger.info(
+            "Calling vllm.LLM(...) "
+            "(loads weights, initializes engine, profiles KV cache, and may compile kernels)"
+        )
         self.llm: LLM = LLM(model=model_name, **engine_kwargs)
+        logger.info("vllm.LLM(...) returned")
 
     @property
     def max_length(self) -> int:

--- a/src/olmo_eval/runners/asynq/workers.py
+++ b/src/olmo_eval/runners/asynq/workers.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import multiprocessing as mp
 import os
+import sys
 import time
 from typing import Any
 
@@ -15,6 +16,76 @@ from olmo_eval.runners.asynq.types import (
 )
 
 logger = get_logger(__name__)
+
+
+def _configure_hf_modules_cache_for_worker(
+    worker_id: str,
+    output_dir: str | None,
+    trust_remote_code: bool,
+    worker_logger: Any,
+) -> None:
+    """Avoid concurrent writes to Transformers' dynamic remote-code cache.
+
+    Local checkpoints with ``trust_remote_code=True`` are copied into
+    Hugging Face's modules cache before import. When many eval workers cold-start
+    the same checkpoint at once, they can observe a partially populated package.
+    Give each worker its own tiny modules cache while keeping the large model
+    and dataset caches shared.
+    """
+    if not trust_remote_code:
+        return
+    if os.environ.get("HF_MODULES_CACHE"):
+        return
+
+    base_dir = output_dir or os.path.join("/tmp", "olmo_eval")
+    safe_worker_id = "".join(c if c.isalnum() or c in "._-" else "_" for c in worker_id)
+    modules_cache = os.path.join(base_dir, ".hf_modules_cache", safe_worker_id)
+    os.makedirs(modules_cache, exist_ok=True)
+    os.environ["HF_MODULES_CACHE"] = modules_cache
+
+    # These constants are computed at import time. If Transformers was imported
+    # before this worker initialized, update the already-imported modules too.
+    for module_name in ("transformers.utils.hub", "transformers.dynamic_module_utils"):
+        module = sys.modules.get(module_name)
+        if module is not None and hasattr(module, "HF_MODULES_CACHE"):
+            module.HF_MODULES_CACHE = modules_cache
+
+    worker_logger.info(f"  HF modules cache: {modules_cache}")
+
+
+def _configure_torch_threads_for_worker(worker_logger: Any) -> None:
+    """Optionally cap PyTorch CPU thread pools inside inference workers."""
+    torch_threads = os.environ.get("OLMO_EVAL_TORCH_NUM_THREADS")
+    if not torch_threads:
+        return
+
+    try:
+        intra_op_threads = int(torch_threads)
+        inter_op_threads = int(os.environ.get("OLMO_EVAL_TORCH_INTEROP_THREADS", "1"))
+    except ValueError:
+        worker_logger.warning(
+            "Ignoring invalid OLMO_EVAL_TORCH_NUM_THREADS/OLMO_EVAL_TORCH_INTEROP_THREADS"
+        )
+        return
+
+    if intra_op_threads < 1 or inter_op_threads < 1:
+        worker_logger.warning(
+            "Ignoring non-positive OLMO_EVAL_TORCH_NUM_THREADS/OLMO_EVAL_TORCH_INTEROP_THREADS"
+        )
+        return
+
+    try:
+        import torch
+
+        torch.set_num_threads(intra_op_threads)
+        torch.set_num_interop_threads(inter_op_threads)
+    except Exception as exc:
+        worker_logger.warning(f"Failed to configure PyTorch CPU threads: {exc}")
+        return
+
+    worker_logger.info(
+        f"  Torch CPU threads: intra_op={intra_op_threads}, inter_op={inter_op_threads}"
+    )
 
 
 def inference_worker(
@@ -47,8 +118,6 @@ def inference_worker(
         num_workers: Number of parallel workers sharing the work.
         start_event: Optional event used to hold all ready workers at a start gate.
     """
-    import sys
-
     from olmo_eval.common.logging import configure_logging, configure_worker_logging
 
     configure_logging()
@@ -83,6 +152,13 @@ def inference_worker(
             worker_logger.info(f"  Tokenizer: {tokenizer}")
         if gpu_ids:
             worker_logger.info(f"  GPUs: {gpu_ids}")
+        _configure_torch_threads_for_worker(worker_logger)
+        _configure_hf_modules_cache_for_worker(
+            worker_id,
+            output_dir,
+            provider_config.trust_remote_code,
+            worker_logger,
+        )
 
         init_start = time.time()
 
@@ -123,19 +199,30 @@ def inference_worker(
             )
             harness_config = harness_config.with_metrics(updated_metrics)
 
+        worker_logger.info("Building harness")
         harness = Harness(harness_config)
+        worker_logger.info("Harness built")
 
         # Force provider creation to catch import errors early
+        worker_logger.info(
+            "Creating provider via harness.provider "
+            "(vLLM may load weights, profile KV cache, and compile kernels)"
+        )
         _ = harness.provider
+        worker_logger.info("Provider object created")
 
         # Validate scaffold requirements early to fail fast
         if harness_config.scaffold:
             from olmo_eval.harness.scaffolds import validate_scaffold
 
+            worker_logger.info("Validating scaffold")
             validate_scaffold(harness_config.scaffold)
+            worker_logger.info("Scaffold validated")
 
         # Initialize metrics reporters early to establish database connections
+        worker_logger.info("Initializing metrics reporters")
         harness.initialize_reporters()
+        worker_logger.info("Metrics reporters initialized")
 
         init_time = time.time() - init_start
         worker_logger.info(f"Provider ready ({init_time:.1f}s)")
@@ -149,7 +236,9 @@ def inference_worker(
 
             # Initialize scaffold resources (e.g., sandbox manager) before processing
             if harness_config.scaffold:
+                worker_logger.info("Initializing scaffold resources")
                 asyncio.run(harness.scaffold.initialize(harness_config))
+                worker_logger.info("Scaffold resources initialized")
 
             # Get batching strategy from config
             from olmo_eval.runners.asynq.batching import BatchConfig, get_strategy
@@ -174,8 +263,11 @@ def inference_worker(
                 init_queue.put((worker_id, init_time))
 
             if start_event is not None:
+                worker_logger.info("Waiting for worker start gate")
                 start_event.wait()
+                worker_logger.info("Worker start gate released")
 
+            worker_logger.info("Starting inference processing loop")
             asyncio.run(
                 strategy.run(
                     item_queue,
@@ -187,15 +279,19 @@ def inference_worker(
                     num_workers,
                 )
             )
+            worker_logger.info("Inference processing loop returned")
 
             worker_logger.info("Processing complete")
         finally:
             # Clean up harness resources (including sandbox manager)
+            worker_logger.info("Cleaning up harness resources")
             asyncio.run(harness.cleanup())
             # Clean up provider
+            worker_logger.info("Closing provider if supported")
             close_fn = getattr(harness.provider, "close", None)
             if callable(close_fn):
                 close_fn()
+            worker_logger.info("Worker cleanup complete")
 
     except Exception as e:
         import traceback


### PR DESCRIPTION
## Summary
- update task DataSource paths to fully qualified Hugging Face dataset repo IDs and add a fallback for `silent_tqdm`
- give `trust_remote_code` workers isolated Hugging Face modules caches to avoid concurrent dynamic-code cache writes
- add optional PyTorch worker thread limits and more detailed worker/vLLM startup and cleanup logging

## Testing
- Not run; PR opened from the existing remote branch without a local checkout.