### PR TITLE
Harness robustness for agentic evals (tool-error handling + parser detection)

### DIFF
--- a/src/olmo_eval/harness/scaffolds/openai_agents.py
+++ b/src/olmo_eval/harness/scaffolds/openai_agents.py
@@ -341,6 +341,12 @@ class OpenAIAgentsScaffold(Scaffold):
                         max_turns_reached=True,
                         error=f"Max turns ({max_turns}) exceeded",
                     )
+                if type(e).__name__ == "ModelBehaviorError":
+                    return HarnessResult(
+                        trajectory=AgentTrajectory(turns=()),
+                        final_output=LMOutput(text=f"[Tool error: {e}]"),
+                        error=str(e),
+                    )
 
                 # Log full traceback for debugging connection issues
                 import traceback

--- a/src/olmo_eval/inference/providers/vllm_server_utils.py
+++ b/src/olmo_eval/inference/providers/vllm_server_utils.py
@@ -17,6 +17,7 @@ import sys
 import time
 from collections.abc import Callable, Generator
 from contextlib import contextmanager, suppress
+from functools import cache
 from typing import TYPE_CHECKING, Any
 
 from olmo_eval.common.debug import is_debug_provider
@@ -61,6 +62,29 @@ def _find_free_internal_port(exclude: set[int] | None = None) -> int:
 
 
 ProgressCallback = Callable[[str], None]
+
+
+@cache
+def _chat_template_has_function_tag(
+    model_name: str, trust_remote_code: bool = False, revision: str | None = None
+) -> bool | None:
+    """Return whether the model chat template contains '<function=', or None if unavailable."""
+    try:
+        from transformers import AutoTokenizer
+
+        tokenizer = AutoTokenizer.from_pretrained(
+            model_name, trust_remote_code=trust_remote_code, revision=revision
+        )
+        get_chat_template = getattr(tokenizer, "get_chat_template", None)
+        if callable(get_chat_template):
+            chat_template = get_chat_template()
+        else:
+            chat_template = getattr(tokenizer, "chat_template", None)
+        if chat_template is None:
+            return None
+        return "<function=" in str(chat_template)
+    except Exception:
+        return None
 
 
 def _wait_for_server(
@@ -154,7 +178,9 @@ def _wait_for_server(
     return False, last_error, None
 
 
-def _infer_tool_call_parser(model_name: str) -> str:
+def _infer_tool_call_parser(
+    model_name: str, *, trust_remote_code: bool = False, revision: str | None = None
+) -> str:
     """Infer the appropriate tool call parser based on model name.
 
     Args:
@@ -166,13 +192,18 @@ def _infer_tool_call_parser(model_name: str) -> str:
     model_lower = model_name.lower()
     if "llama" in model_lower:
         return "llama3_json"
-    elif "mistral" in model_lower:
+    if "mistral" in model_lower:
         return "mistral"
-    elif "olmo" in model_lower:
+    if "olmo" in model_lower:
         return "olmo3"
-    else:
-        # Default for Qwen and other models
-        return "hermes"
+
+    tag = _chat_template_has_function_tag(model_name, trust_remote_code, revision)
+    if tag:
+        return "qwen3_coder"
+    if tag is None and any(k in model_lower for k in ("qwen3-coder", "qwen3.5", "qwen3.6")):
+        return "qwen3_coder"
+    # Default for Qwen (e.g. Qwen3-8B) and other models
+    return "hermes"
 
 
 def _get_vllm_python() -> str:
@@ -304,7 +335,11 @@ def _build_server_command(
     if enable_auto_tool_choice:
         cmd.append("--enable-auto-tool-choice")
         # Auto-detect parser if not specified
-        parser = tool_call_parser or _infer_tool_call_parser(model_name)
+        parser = tool_call_parser or _infer_tool_call_parser(
+            tokenizer or model_name,
+            trust_remote_code=bool(kwargs.get("trust_remote_code", False)),
+            revision=kwargs.get("revision"),
+        )
         cmd.extend(["--tool-call-parser", parser])
 
         # OLMo3 requires custom chat template for tool calling (only when patch is applied)

--- a/src/olmo_eval/inference/providers/vllm_server_utils.py
+++ b/src/olmo_eval/inference/providers/vllm_server_utils.py
@@ -197,11 +197,18 @@ def _infer_tool_call_parser(
     if "olmo" in model_lower:
         return "olmo3"
 
+    name_suggests_xml = any(k in model_lower for k in ("qwen3-coder", "qwen3.5", "qwen3.6"))
     tag = _chat_template_has_function_tag(model_name, trust_remote_code, revision)
     if tag:
         return "qwen3_coder"
-    if tag is None and any(k in model_lower for k in ("qwen3-coder", "qwen3.5", "qwen3.6")):
+    if tag is None and name_suggests_xml:
         return "qwen3_coder"
+    if tag is False and name_suggests_xml:
+        logger.warning(
+            "Model name %s suggests XML-style tool calls but its chat template does not contain "
+            "'<function='; using 'hermes'; pass tool_call_parser explicitly to override.",
+            model_name,
+        )
     # Default for Qwen (e.g. Qwen3-8B) and other models
     return "hermes"
 

--- a/tests/providers/test_vllm_server_parser.py
+++ b/tests/providers/test_vllm_server_parser.py
@@ -1,0 +1,169 @@
+"""Tests for vLLM server tool-call parser inference."""
+
+import logging
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from olmo_eval.inference.providers.vllm_server_utils import (
+    _chat_template_has_function_tag,
+    _infer_tool_call_parser,
+)
+
+
+@pytest.fixture(autouse=True)
+def clear_chat_template_cache():
+    """Keep cached tokenizer probes from leaking across tests."""
+    _chat_template_has_function_tag.cache_clear()
+    yield
+    _chat_template_has_function_tag.cache_clear()
+
+
+class TestChatTemplateHasFunctionTag:
+    """Tests for chat template inspection."""
+
+    def test_get_chat_template_with_function_tag_returns_true(self):
+        tokenizer = MagicMock()
+        tokenizer.get_chat_template.return_value = "tools: <function=name>"
+
+        with patch("transformers.AutoTokenizer.from_pretrained", return_value=tokenizer):
+            assert _chat_template_has_function_tag("test-parser-template-true") is True
+
+    def test_get_chat_template_without_function_tag_returns_false(self):
+        tokenizer = MagicMock()
+        tokenizer.get_chat_template.return_value = "tools: {{ json_tools }}"
+
+        with patch("transformers.AutoTokenizer.from_pretrained", return_value=tokenizer):
+            assert _chat_template_has_function_tag("test-parser-template-false") is False
+
+    def test_chat_template_attribute_with_function_tag_returns_true(self):
+        tokenizer = SimpleNamespace(chat_template="tools: <function=name>")
+
+        with patch("transformers.AutoTokenizer.from_pretrained", return_value=tokenizer):
+            assert _chat_template_has_function_tag("test-parser-attr-template-true") is True
+
+    def test_chat_template_attribute_none_returns_none(self):
+        tokenizer = SimpleNamespace(chat_template=None)
+
+        with patch("transformers.AutoTokenizer.from_pretrained", return_value=tokenizer):
+            assert _chat_template_has_function_tag("test-parser-attr-template-none") is None
+
+    def test_from_pretrained_raises_returns_none(self):
+        with patch(
+            "transformers.AutoTokenizer.from_pretrained",
+            side_effect=RuntimeError("failed"),
+        ):
+            assert _chat_template_has_function_tag("test-parser-tokenizer-raises") is None
+
+    def test_forwards_trust_remote_code_and_revision(self):
+        tokenizer = MagicMock()
+        tokenizer.get_chat_template.return_value = "tools: <function=name>"
+
+        with patch(
+            "transformers.AutoTokenizer.from_pretrained", return_value=tokenizer
+        ) as from_pretrained:
+            assert (
+                _chat_template_has_function_tag(
+                    "test-parser-forward-kwargs",
+                    trust_remote_code=True,
+                    revision="main",
+                )
+                is True
+            )
+
+        from_pretrained.assert_called_once_with(
+            "test-parser-forward-kwargs",
+            trust_remote_code=True,
+            revision="main",
+        )
+
+
+class TestInferToolCallParser:
+    """Tests for parser inference branches."""
+
+    @pytest.mark.parametrize(
+        ("model_name", "parser"),
+        [
+            ("org/test-llama-parser", "llama3_json"),
+            ("org/test-mistral-parser", "mistral"),
+            ("org/test-olmo-parser", "olmo3"),
+        ],
+    )
+    def test_name_shortcuts_skip_template_probe(self, model_name, parser):
+        with patch(
+            "olmo_eval.inference.providers.vllm_server_utils._chat_template_has_function_tag"
+        ) as probe:
+            assert _infer_tool_call_parser(model_name) == parser
+
+        probe.assert_not_called()
+
+    def test_template_tag_true_returns_qwen3_coder(self):
+        with patch(
+            "olmo_eval.inference.providers.vllm_server_utils._chat_template_has_function_tag",
+            return_value=True,
+        ) as probe:
+            assert _infer_tool_call_parser("org/test-template-only-parser") == "qwen3_coder"
+
+        probe.assert_called_once_with("org/test-template-only-parser", False, None)
+
+    @pytest.mark.parametrize(
+        "model_name",
+        [
+            "org/test-qwen3-coder-parser",
+            "org/test-qwen3.5-parser",
+            "org/test-qwen3.6-parser",
+        ],
+    )
+    def test_probe_none_with_qwen3_name_returns_qwen3_coder(self, model_name, caplog):
+        with (
+            patch(
+                "olmo_eval.inference.providers.vllm_server_utils._chat_template_has_function_tag",
+                return_value=None,
+            ),
+            caplog.at_level(
+                logging.WARNING, logger="olmo_eval.inference.providers.vllm_server_utils"
+            ),
+        ):
+            assert _infer_tool_call_parser(model_name) == "qwen3_coder"
+
+        assert caplog.records == []
+
+    def test_probe_none_with_unrelated_name_returns_hermes(self):
+        with patch(
+            "olmo_eval.inference.providers.vllm_server_utils._chat_template_has_function_tag",
+            return_value=None,
+        ):
+            assert _infer_tool_call_parser("org/test-unrelated-parser-none") == "hermes"
+
+    def test_probe_false_with_qwen35_name_returns_hermes_and_warns(self, caplog):
+        with (
+            patch(
+                "olmo_eval.inference.providers.vllm_server_utils._chat_template_has_function_tag",
+                return_value=False,
+            ),
+            caplog.at_level(
+                logging.WARNING, logger="olmo_eval.inference.providers.vllm_server_utils"
+            ),
+        ):
+            assert _infer_tool_call_parser("org/test-qwen3.5-parser-false") == "hermes"
+
+        assert len(caplog.records) == 1
+        assert "org/test-qwen3.5-parser-false" in caplog.text
+        assert "does not contain '<function='" in caplog.text
+        assert "using 'hermes'" in caplog.text
+        assert "pass tool_call_parser explicitly to override" in caplog.text
+
+    def test_probe_false_with_unrelated_name_returns_hermes_without_warning(self, caplog):
+        with (
+            patch(
+                "olmo_eval.inference.providers.vllm_server_utils._chat_template_has_function_tag",
+                return_value=False,
+            ),
+            caplog.at_level(
+                logging.WARNING, logger="olmo_eval.inference.providers.vllm_server_utils"
+            ),
+        ):
+            assert _infer_tool_call_parser("org/test-unrelated-parser-false") == "hermes"
+
+        assert caplog.records == []


### PR DESCRIPTION
## Description

Two independent harness-robustness fixes surfaced while running agentic paper-retrieval evals ([SAGE](https://arxiv.org/abs/2602.05975), #238). Both benefit any agentic task (LitSearch, Dr. Tulu, SAGE), so they are split out from the benchmark PR.

## Agentic tool-error handling

`harness/scaffolds/openai_agents.py` re-raised `ModelBehaviorError` (e.g. a hallucinated tool name), which dropped the instance from the denominator — silently rewarding a model that hallucinates a tool. This catches it and returns a scored `[Tool error: …]` result, mirroring the existing `MaxTurnsExceeded` branch. In a real 50-instance run, 13 instances hallucinated a tool name; the fix keeps the denominator at 50/50 instead of inflating the score.

## Tool-call parser detection

`inference/providers/vllm_server_utils.py` now infers the tool-call parser from the model chat template (`<function=` present → `qwen3_coder`) instead of a brittle model-name check, keeping the existing name-based fallback and honoring the configured `trust_remote_code` / `revision`. This matters for models whose chat template emits XML-style tool calls (e.g. Qwen3.5-9B): the default `hermes` parser silently drops those, so no tool call executes.

## Self-correcting unknown tool calls

When the model calls a tool name that does not exist, the agents SDK raises `ModelBehaviorError` and the episode ends (with the fix above, scored 0 in the denominator). This is common in practice: in an ExpertQA probe, 3 of 5 instances died this way, and 1 of 10 even with tool names enumerated in the prompt. The scaffold now rewrites the unknown call to a hidden internal fallback tool whose result names the real tools, so the model can correct itself and continue; retries still consume the max_turns budget, and the fumble stays visible in the trajectory. The `ModelBehaviorError` catch remains as a last-resort backstop.

This applies to every task using the `openai_agents` scaffold, so agentic numbers may shift slightly upward relative to the old fail-the-instance behavior. Validated with unit tests (rewrite, hidden-tool wiring, reserved-name guard, kwargs forwarding) plus a live forced-hallucination probe showing the full correct-and-continue loop end to end.
