### PR TITLE
Compose CUDA_VISIBLE_DEVICES so concurrent runs don't collide on physical GPUs

### DIFF
--- a/src/olmo_eval/inference/gpu_planner.py
+++ b/src/olmo_eval/inference/gpu_planner.py
@@ -2,11 +2,42 @@
 
 from __future__ import annotations
 
+import logging
+import os
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from olmo_eval.inference.providers.config import ProviderConfig
+
+logger = logging.getLogger(__name__)
+
+
+def resolve_visible_devices(gpu_ids: list[int]) -> str:
+    """Map planner-relative GPU indices to a physical CUDA_VISIBLE_DEVICES string.
+
+    The planner allocates indices relative to the process's visible GPU set
+    (range(torch.cuda.device_count())). If the process already has a
+    CUDA_VISIBLE_DEVICES mask, those relative indices must be composed through it
+    so a worker does not clobber an outer mask; otherwise they are physical already.
+    """
+    outer = os.environ.get("CUDA_VISIBLE_DEVICES", "").strip()
+    if not outer:
+        return ",".join(str(g) for g in gpu_ids)
+
+    outer_ids = [tok.strip() for tok in outer.split(",") if tok.strip()]
+    resolved: list[str] = []
+    for gpu_id in gpu_ids:
+        if 0 <= gpu_id < len(outer_ids):
+            resolved.append(outer_ids[gpu_id])
+        else:
+            logger.warning(
+                "GPU index %s outside CUDA_VISIBLE_DEVICES mask %r; using raw index",
+                gpu_id,
+                outer,
+            )
+            resolved.append(str(gpu_id))
+    return ",".join(resolved)
 
 
 @dataclass(frozen=True)

--- a/src/olmo_eval/inference/providers/vllm_server_utils.py
+++ b/src/olmo_eval/inference/providers/vllm_server_utils.py
@@ -20,6 +20,7 @@ from contextlib import contextmanager, suppress
 from typing import TYPE_CHECKING, Any
 
 from olmo_eval.common.debug import is_debug_provider
+from olmo_eval.inference.gpu_planner import resolve_visible_devices
 
 if TYPE_CHECKING:
     pass
@@ -466,7 +467,10 @@ class VLLMServerProcess:
         # the kernel ephemeral range.
         env["VLLM_PORT"] = str(self._vllm_port)
         if self.gpu_ids:
-            env["CUDA_VISIBLE_DEVICES"] = ",".join(str(g) for g in self.gpu_ids)
+            # Invariant: gpu_ids are relative to the external CUDA_VISIBLE_DEVICES mask.
+            # Only runner-side InferenceManager/aux servers reach this; workers pass
+            # gpu_ids=None, avoiding a second composition that would mis-map GPUs.
+            env["CUDA_VISIBLE_DEVICES"] = resolve_visible_devices(self.gpu_ids)
 
         # Allow extended max_model_len when user specifies it (e.g., with rope_scaling)
         # This is needed when max_model_len > model's max_position_embeddings

--- a/src/olmo_eval/runners/asynq/workers.py
+++ b/src/olmo_eval/runners/asynq/workers.py
@@ -9,6 +9,7 @@ import time
 from typing import Any
 
 from olmo_eval.common.logging import get_logger
+from olmo_eval.inference.gpu_planner import resolve_visible_devices
 from olmo_eval.runners.asynq.types import (
     WORKER_FATAL,
     ResultItem,
@@ -63,7 +64,7 @@ def inference_worker(
 
     try:
         if gpu_ids:
-            os.environ["CUDA_VISIBLE_DEVICES"] = ",".join(str(g) for g in gpu_ids)
+            os.environ["CUDA_VISIBLE_DEVICES"] = resolve_visible_devices(gpu_ids)
 
         provider_kind = str(provider_config.kind)
         tokenizer = provider_config.tokenizer

--- a/tests/inference/test_gpu_planner.py
+++ b/tests/inference/test_gpu_planner.py
@@ -1,0 +1,60 @@
+"""Tests for GPU planning helpers."""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from olmo_eval.inference.gpu_planner import resolve_visible_devices
+
+
+def test_resolve_visible_devices_identity_when_no_outer_mask(monkeypatch):
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+
+    assert resolve_visible_devices([0, 1]) == "0,1"
+    assert resolve_visible_devices([2, 3]) == "2,3"
+
+
+def test_resolve_visible_devices_composes_outer_mask(monkeypatch):
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "2,3")
+
+    assert resolve_visible_devices([0, 1]) == "2,3"
+
+
+def test_resolve_visible_devices_composes_outer_mask_ranges(monkeypatch):
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "4,5,6,7")
+
+    assert resolve_visible_devices([0, 1]) == "4,5"
+    assert resolve_visible_devices([2, 3]) == "6,7"
+
+
+def test_resolve_visible_devices_preserves_outer_order(monkeypatch):
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "3,2")
+
+    assert resolve_visible_devices([0, 1]) == "3,2"
+
+
+def test_resolve_visible_devices_tolerates_spaces(monkeypatch):
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "2, 3")
+
+    assert resolve_visible_devices([0, 1]) == "2,3"
+
+
+@pytest.mark.parametrize("outer", ["", "  "])
+def test_resolve_visible_devices_empty_outer_mask_is_unset(monkeypatch, outer):
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", outer)
+
+    assert resolve_visible_devices([0, 1]) == "0,1"
+
+
+def test_resolve_visible_devices_out_of_range_falls_back_with_warning(
+    monkeypatch,
+    caplog,
+):
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "4,5")
+
+    with caplog.at_level(logging.WARNING, logger="olmo_eval.inference.gpu_planner"):
+        assert resolve_visible_devices([0, 2]) == "4,2"
+
+    assert "GPU index 2 outside CUDA_VISIBLE_DEVICES mask '4,5'; using raw index" in caplog.text


### PR DESCRIPTION
## Summary

Concurrent `olmo-eval run` processes that each set a distinct external `CUDA_VISIBLE_DEVICES` collide on the same physical GPUs, so you cannot partition the machine across independent runs (e.g. 4 models, 2 GPUs each, on an 8-GPU host). This composes the planner indices through the inherited mask so each process stays on the GPUs it was given.

## Root cause

The GPU planner allocates indices relative to the process's visible set (`range(torch.cuda.device_count())`), then the worker writes them straight into the env:

```python
os.environ["CUDA_VISIBLE_DEVICES"] = ",".join(str(g) for g in gpu_ids)
```

CUDA always interprets `CUDA_VISIBLE_DEVICES` against the physical device ordering. So a process launched with an outer mask of `2,3` gets planner indices `[0,1]`, writes `"0,1"`, and lands on physical GPU 0,1 instead of 2,3. Two such processes both target physical 0,1 and one OOMs.

## Fix

New helper `resolve_visible_devices(gpu_ids)` in `gpu_planner.py`: if the process already has a `CUDA_VISIBLE_DEVICES` mask, map each relative index through it (`[0,1]` under mask `2,3` becomes `2,3`); otherwise emit the indices unchanged. Used at both sites that write `CUDA_VISIBLE_DEVICES` from planner indices (`workers.py`, `vllm_server_utils.py`).

The no-outer-mask path is byte-identical to before, so the normal single-process multi-worker allocation is unchanged.

## Verification

Two concurrent Qwen3.5-9B runs (tensor-parallel 2 each), launched with `CUDA_VISIBLE_DEVICES=0,1` and `CUDA_VISIBLE_DEVICES=2,3`:

- before: both loaded onto physical GPU 0,1; one crashed with CUDA OOM
- after: run A on physical GPU 0,1, run B on physical GPU 2,3, no collision

Tests in `tests/inference/test_gpu_planner.py` cover the identity (no-mask) non-regression, composition, reordered masks, whitespace, empty mask, and the out-of-range guard. `pytest tests/inference tests/runners` passes (99).

## Note

This touches the shared worker/server GPU setup, so flagging for your eyes. cc @roryd