### PR TITLE
Multimodal OLMo-core checkpoint eval: olmo_core_vlm provider, HF-provider export support, dense-caption conformance fixes

### DIFF
--- a/src/olmo_eval/common/image_qa/prompt_templates.py
+++ b/src/olmo_eval/common/image_qa/prompt_templates.py
@@ -24,7 +24,12 @@ import string
 import numpy as np
 
 EVAL_LOADER_SEED = 691203
-"""DataLoaderConfig seed used by mm_olmo's eval pipeline."""
+"""DataLoaderConfig seed used by mm_olmo's image-QA eval pipeline (``olmo/eval/eval_utils.py``)."""
+
+DENSE_CAPTION_LOADER_SEED = 6198
+"""DataLoaderConfig seed used by mm_olmo's dense-caption generation pipeline
+(``launch_scripts/eval.py``, the ``eval_captioner.sh`` path). Verified against a real
+mm_olmo prediction dump: ``_getter_seed == (6198 * 195172 + idx) % (2**32 - 1)``."""
 
 POINT_COUNT_TEMPLATES: list[str] = [
     "How many {label} are there?",
@@ -136,7 +141,7 @@ def pixmo_count_question(label: str, arrow_idx: int, seed: int = EVAL_LOADER_SEE
     return _apply_label(template, label.lower())
 
 
-def dense_caption_question(idx: int, seed: int = EVAL_LOADER_SEED) -> str:
+def dense_caption_question(idx: int, seed: int = DENSE_CAPTION_LOADER_SEED) -> str:
     """Reproduce mm_olmo's per-example PixMo-Cap dense-caption prompt.
 
     The released Molmo2-4B uses ``prompt_templates="uber_model_v2"`` +
@@ -145,7 +150,14 @@ def dense_caption_question(idx: int, seed: int = EVAL_LOADER_SEED) -> str:
     per-example pick from :data:`LONG_CAPTION_TEMPLATES` (``apply_keyword_prompt``'s
     ``rng.randint``).  ``idx`` is the example's raw line position in
     ``dense-caption-eval/test.jsonl``; the seed arithmetic matches
-    ``DeterministicDataset.get`` (epoch 0), same as :func:`pixmo_count_question`.
+    ``DeterministicDataset.get`` (epoch 0), same as :func:`pixmo_count_question` — but with
+    :data:`DENSE_CAPTION_LOADER_SEED` (6198), the ``launch_scripts/eval.py`` loader seed,
+    not the image-QA loader seed used for :func:`pixmo_count_question`.
+
+    Checkpoints trained with ``prompt_templates="none"`` + ``system_prompt=
+    "style_and_length_v2"`` (mm_olmo's captioner family) do not sample a template at all —
+    their eval prompt is the constant ``"long_caption {default_inference_len}:"``; see the
+    ``dense_caption_captioner`` task.
     """
     rng = np.random.RandomState((seed * 195172 + idx) % (2**32 - 1))
     return LONG_CAPTION_TEMPLATES[rng.randint(0, len(LONG_CAPTION_TEMPLATES))]

--- a/src/olmo_eval/common/scorers/dense_caption_judge.py
+++ b/src/olmo_eval/common/scorers/dense_caption_judge.py
@@ -339,6 +339,10 @@ class DenseCaptionJudgeScorer(ContextScorer):
                 consistency_valid = num_valid > 0
                 result["consistency"] = num_consistent / num_valid if consistency_valid else 0.0
                 result["num_consistent"] = num_consistent
+                # mm_olmo's reported `num_statements` is this consistency-side count:
+                # the canonical statements GPT derived from the *model caption*
+                # (ConsistencyEval.num_statements), not the recall-side mturk count.
+                result["consistency_num_statements"] = num_valid
                 result["consistency_valid"] = consistency_valid
             except Exception as exc:
                 logger.warning(
@@ -346,7 +350,12 @@ class DenseCaptionJudgeScorer(ContextScorer):
                     instance.metadata.get("url", "?"),
                     exc,
                 )
-                result.update(consistency=0.0, num_consistent=0, consistency_valid=False)
+                result.update(
+                    consistency=0.0,
+                    num_consistent=0,
+                    consistency_num_statements=0,
+                    consistency_valid=False,
+                )
 
         if output.metadata is None:
             output.metadata = {}

--- a/src/olmo_eval/common/types/literals.py
+++ b/src/olmo_eval/common/types/literals.py
@@ -11,11 +11,14 @@ class ProviderKind(StrEnum):
     VLLM_SERVER = "vllm_server"
     HF = "hf"
     OLMO_CORE = "olmo_core"
+    OLMO_CORE_VLM = "olmo_core_vlm"
     MOCK = "mock"
     LITELLM = "litellm"
 
 
-ProviderLiteral = Literal["vllm", "vllm_server", "hf", "olmo_core", "mock", "litellm"]
+ProviderLiteral = Literal[
+    "vllm", "vllm_server", "hf", "olmo_core", "olmo_core_vlm", "mock", "litellm"
+]
 DtypeLiteral = Literal["auto", "float16", "bfloat16", "float32"]
 PriorityLiteral = Literal["low", "normal", "high", "urgent"]
 LoadFormatLiteral = Literal[

--- a/src/olmo_eval/evals/tasks/dense_caption.py
+++ b/src/olmo_eval/evals/tasks/dense_caption.py
@@ -103,19 +103,26 @@ class DenseCaptionRecallAt10Metric(Metric):
 
 @dataclass(frozen=True, slots=True)
 class DenseCaptionNumStatementsMetric(Metric):
-    """Mean number of mturk statements per valid example (raw, not ×100)."""
+    """Mean number of canonical statements per valid example (raw, not ×100).
+
+    Matches mm_olmo's reported ``num_statements``: the count of canonical
+    statements GPT derives from the *model caption* during the consistency
+    judge (``ConsistencyEval.num_statements``), averaged over
+    consistency-valid examples — a caption-informativeness proxy, not the
+    recall-side mturk statement count.
+    """
 
     name: str = "num_statements"
     scorer: type[Scorer] | Scorer = _JUDGE
 
     def compute(self, responses: Sequence[Response]) -> float:
         vals = [
-            o.metadata["dense_caption_result"]["num_statements"]
+            o.metadata["dense_caption_result"]["consistency_num_statements"]
             for r in responses
             for o in r.outputs
             if o.metadata
             and "dense_caption_result" in o.metadata
-            and o.metadata["dense_caption_result"].get("recall_valid")
+            and o.metadata["dense_caption_result"].get("consistency_valid")
         ]
         return (sum(vals) / len(vals)) if vals else 0.0
 
@@ -260,3 +267,20 @@ class DenseCaptionEval(Task):
 
 # "pixmo_cap" is an alias for "dense_caption" with no overrides.
 register_variant("dense_caption", "pixmo_cap")
+
+
+@register("dense_caption_captioner")
+class DenseCaptionCaptionerEval(DenseCaptionEval):
+    """Dense-caption eval prompt for mm_olmo's captioner-family checkpoints.
+
+    Checkpoints trained with ``prompt_templates="none"`` + ``system_prompt=
+    "style_and_length_v2"`` (mm_olmo ``train_captioner.py``; e.g. the
+    siglip2-cap-stage1 runs) see a constant eval prompt: an empty user question
+    with the style/length prefix ``"long_caption {default_inference_len}:"``
+    (``default_inference_len`` defaults to 65). Verified verbatim against an
+    mm_olmo ``DenseCaptionEval-test`` prediction dump. Use ``dense_caption``
+    for released-Molmo2-family (``uber_model_v2``) checkpoints, which sample a
+    seeded natural-language instruction instead.
+    """
+
+    caption_prompt: str | None = "long_caption 65:"

--- a/src/olmo_eval/inference/__init__.py
+++ b/src/olmo_eval/inference/__init__.py
@@ -18,6 +18,7 @@ __all__ = [
     "VLLMProvider",
     "VLLMServerProvider",
     "OlmoCoreProvider",
+    "OlmoCoreVLMProvider",
     "LiteLLMProvider",
     "create_provider",
     # Tokenizer utilities
@@ -129,9 +130,20 @@ def create_provider(
             )
             return VLLMServerProvider(model_name, **kwargs)
         case "olmo_core":
+            from .providers.olmo_core_vlm_utils import is_multimodal_checkpoint
+
+            if is_multimodal_checkpoint(model_name):
+                from .providers.olmo_core_vlm import OlmoCoreVLMProvider
+
+                return OlmoCoreVLMProvider(model_name, **kwargs)
+
             from .providers.olmo_core import OlmoCoreProvider
 
             return OlmoCoreProvider(model_name, **kwargs)
+        case "olmo_core_vlm":
+            from .providers.olmo_core_vlm import OlmoCoreVLMProvider
+
+            return OlmoCoreVLMProvider(model_name, **kwargs)
         case "litellm":
             from .providers.litellm import LiteLLMProvider
 
@@ -162,6 +174,10 @@ def __getattr__(name: str):
         from .providers.olmo_core import OlmoCoreProvider
 
         return OlmoCoreProvider
+    if name == "OlmoCoreVLMProvider":
+        from .providers.olmo_core_vlm import OlmoCoreVLMProvider
+
+        return OlmoCoreVLMProvider
     if name == "LiteLLMProvider":
         from .providers.litellm import LiteLLMProvider
 

--- a/src/olmo_eval/inference/providers/__init__.py
+++ b/src/olmo_eval/inference/providers/__init__.py
@@ -11,6 +11,7 @@ if TYPE_CHECKING:
     from .litellm import LiteLLMProvider
     from .mock import MockProvider
     from .olmo_core import OlmoCoreProvider
+    from .olmo_core_vlm import OlmoCoreVLMProvider
     from .vllm import VLLMProvider
     from .vllm_server import VLLMServerProvider
 
@@ -19,6 +20,7 @@ __all__ = [
     "LiteLLMProvider",
     "MockProvider",
     "OlmoCoreProvider",
+    "OlmoCoreVLMProvider",
     "ProviderConfig",
     "VLLMProvider",
     "VLLMServerProvider",
@@ -42,6 +44,10 @@ def __getattr__(name: str):
         from .olmo_core import OlmoCoreProvider
 
         return OlmoCoreProvider
+    if name == "OlmoCoreVLMProvider":
+        from .olmo_core_vlm import OlmoCoreVLMProvider
+
+        return OlmoCoreVLMProvider
     if name == "VLLMProvider":
         from .vllm import VLLMProvider
 

--- a/src/olmo_eval/inference/providers/config.py
+++ b/src/olmo_eval/inference/providers/config.py
@@ -61,7 +61,9 @@ class ProviderConfig:
     kwargs: Mapping[str, Any] = field(default_factory=dict)
 
     # Providers that require GPU resources for local inference
-    _GPU_PROVIDERS: ClassVar[frozenset[str]] = frozenset({"vllm", "vllm_server", "hf", "olmo_core"})
+    _GPU_PROVIDERS: ClassVar[frozenset[str]] = frozenset(
+        {"vllm", "vllm_server", "hf", "olmo_core", "olmo_core_vlm"}
+    )
 
     @property
     def requires_gpu(self) -> bool:
@@ -108,6 +110,14 @@ class ProviderConfig:
         "litellm": ("base_url", "api_base", "max_concurrency"),
         "hf": ("tokenizer", "revision", "force_download", "trust_remote_code", "dtype"),
         "olmo_core": (
+            "tokenizer",
+            "revision",
+            "force_download",
+            "trust_remote_code",
+            "dtype",
+            "max_model_len",
+        ),
+        "olmo_core_vlm": (
             "tokenizer",
             "revision",
             "force_download",

--- a/src/olmo_eval/inference/providers/huggingface.py
+++ b/src/olmo_eval/inference/providers/huggingface.py
@@ -269,6 +269,11 @@ class HuggingFaceProvider(InferenceProvider):
             model_kwargs.pop(key, None)
 
         super().__init__(model_name)
+        if not multimodal:
+            from .olmo_core_vlm_utils import is_olmo_core_hf_export
+
+            if is_olmo_core_hf_export(model_name):
+                multimodal = True
         self.is_multimodal = bool(multimodal)
         self.max_crops = int(max_crops)
         self.autocast_dtype = autocast_dtype
@@ -318,11 +323,75 @@ class HuggingFaceProvider(InferenceProvider):
 
         _ensure_default_rope_registered()
         _patch_processor_optional_attribute_kwargs()
+
+        from .olmo_core_vlm_utils import is_olmo_core_hf_export
+
+        if is_olmo_core_hf_export(model_name):
+            self._init_multimodal_from_olmo_core_export(model_name, model_kwargs)
+            return
+
         processor_kwargs = {
             key: value for key, value in model_kwargs.items() if key in self._TOKENIZER_KWARGS
         }
         self.processor = AutoProcessor.from_pretrained(model_name, **processor_kwargs)
         self.model = AutoModelForImageTextToText.from_pretrained(model_name, **model_kwargs)
+        _reinit_rope_buffers(self.model)
+        _patch_molmo2_generation_cache_position(self.model)
+        self.tokenizer = self.processor.tokenizer
+
+    def _init_multimodal_from_olmo_core_export(
+        self, model_name: str, model_kwargs: dict[str, Any]
+    ) -> None:
+        """Load a consolidated OLMo-core multimodal export through the HF stack.
+
+        Such a directory (``olmo_core_config.json`` + ``model.safetensors`` with
+        OLMo-core key names) has no HF config/processor/modeling files, so this
+        borrows them from a *reference* released repo — the ``reference_model``
+        kwarg, or the export's recorded ``model_id`` (e.g.
+        ``allenai/Molmo2-4B``) — builds the remote-code model from that config,
+        and loads the weights converted back to released-Molmo2 naming (the
+        bit-exact inverse of OLMo-core's HF loader mapping). Everything
+        downstream (processor, ``model.generate``, transformers-5 shims) is the
+        verified released-Molmo2 path.
+        """
+        from pathlib import Path
+
+        from transformers import AutoConfig, AutoModelForImageTextToText, AutoProcessor
+
+        from .olmo_core_vlm_utils import (
+            convert_olmo_core_to_molmo2_hf_state_dict,
+            olmo_core_export_reference_model,
+        )
+
+        reference = model_kwargs.pop("reference_model", None) or olmo_core_export_reference_model(
+            model_name
+        )
+        processor_kwargs = {
+            key: value for key, value in model_kwargs.items() if key in self._TOKENIZER_KWARGS
+        }
+        self.processor = AutoProcessor.from_pretrained(reference, **processor_kwargs)
+        config = AutoConfig.from_pretrained(reference, **processor_kwargs)
+
+        from safetensors.torch import load_file
+
+        state_dict = load_file(str(Path(model_name) / "model.safetensors"))
+        converted = convert_olmo_core_to_molmo2_hf_state_dict(
+            state_dict,
+            base_vocab_size=config.text_config.vocab_size,
+            patch_size=config.vit_config.image_patch_size,
+        )
+        del state_dict
+
+        self.model = AutoModelForImageTextToText.from_config(
+            config, trust_remote_code=bool(model_kwargs.get("trust_remote_code"))
+        )
+        self.model.load_state_dict(converted)
+        del converted
+
+        dtype = model_kwargs.get("dtype") or model_kwargs.get("torch_dtype")
+        if dtype and dtype != "auto":
+            self.model.to(_to_torch_dtype(str(dtype)))
+
         _reinit_rope_buffers(self.model)
         _patch_molmo2_generation_cache_position(self.model)
         self.tokenizer = self.processor.tokenizer

--- a/src/olmo_eval/inference/providers/olmo_core_vlm.py
+++ b/src/olmo_eval/inference/providers/olmo_core_vlm.py
@@ -1,0 +1,676 @@
+"""Multimodal (vision-language) OLMo-core inference provider.
+
+Runs OLMo-core ``MultimodalLM`` checkpoints (vision encoder + connector + LM)
+for image+text generation. Unlike the text-only :class:`OlmoCoreProvider`,
+which wraps ``TransformerGenerationModule``, this provider builds the
+``MultimodalLM`` directly and drives its own decode loop: the vision branch of
+OLMo-core has no multimodal generation module, and the attention backends that
+support the bidirectional image-token mask (``torch`` / ``flex``) do not
+support KV caching. The vision tower runs once per request (image features are
+spliced into the prompt embeddings at prefill); each decode step re-runs the LM
+over the growing sequence with ``logits_to_keep=1``.
+
+Supported checkpoint formats (see ``olmo_core_vlm_utils``): raw OLMo-core
+multimodal trainer checkpoints, consolidated OLMo-core safetensors exports, and
+mm_olmo (Molmo2 ``video_olmo``) trainer checkpoints, which are key-remapped into
+the OLMo-core layout at load time.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import dataclasses
+import gc
+import logging
+import threading
+from typing import TYPE_CHECKING, Any
+
+import olmo_eval.inference.providers.olmo_core_vlm_utils as vlm_utils
+from olmo_eval.common.debug import is_debug_requests
+from olmo_eval.common.types import LMOutput, LMRequest, RequestType, SamplingParams
+from olmo_eval.inference.base import InferenceProvider
+
+if TYPE_CHECKING:
+    import torch
+
+logger = logging.getLogger(__name__)
+
+# Provider-foreign kwargs silently accepted for config compatibility.
+_IGNORED_KWARGS = frozenset(
+    {
+        "tensor_parallel_size",
+        "gpu_memory_utilization",
+        "use_tqdm_on_load",
+        "add_bos_token",
+        "load_format",
+        "model_loader_extra_config",
+        "enable_auto_tool_choice",
+        "token",
+        "cache_dir",
+        "local_files_only",
+    }
+)
+
+
+def _to_torch_dtype(name: str) -> Any:
+    import torch
+
+    return {
+        "bfloat16": torch.bfloat16,
+        "float16": torch.float16,
+        "float32": torch.float32,
+    }[name]
+
+
+class OlmoCoreVLMProvider(InferenceProvider):
+    """Provider for multimodal OLMo-core (``MultimodalLM``) checkpoints."""
+
+    def __init__(
+        self,
+        model_name: str,
+        tokenizer: str | None = None,
+        *,
+        dtype: str = "float32",
+        autocast_dtype: str | None = "bfloat16",
+        max_crops: int | None = None,
+        max_model_len: int | None = None,
+        device: str | None = None,
+        bidirectional_image_attention: bool = True,
+        use_cache: bool = True,
+        trust_remote_code: bool = False,
+        revision: str | None = None,
+        force_download: bool = False,
+        **kwargs: Any,
+    ) -> None:
+        import torch
+        from transformers import AutoTokenizer
+
+        max_model_len = self._resolve_max_model_len_alias(max_model_len, kwargs)
+        for key in list(kwargs):
+            if key in _IGNORED_KWARGS:
+                kwargs.pop(key)
+        if kwargs:
+            unsupported = ", ".join(sorted(kwargs))
+            raise ValueError(f"Unsupported OlmoCoreVLMProvider kwargs: {unsupported}")
+        if dtype == "auto":
+            dtype = "float32"
+
+        super().__init__(model_name)
+
+        self.checkpoint_info = vlm_utils.detect_checkpoint_format(model_name)
+        logger.info(
+            "Detected multimodal checkpoint format %r for %s",
+            self.checkpoint_info.format,
+            model_name,
+        )
+
+        tokenizer_path = vlm_utils.resolve_tokenizer_path(self.checkpoint_info, tokenizer)
+        tokenizer_kwargs = {
+            key: value
+            for key, value in {
+                "revision": revision,
+                "force_download": force_download,
+                "trust_remote_code": trust_remote_code,
+            }.items()
+            if value
+        }
+        self.tokenizer = AutoTokenizer.from_pretrained(tokenizer_path, **tokenizer_kwargs)
+        self._resolve_special_token_ids(tokenizer_path)
+
+        self.model_config = vlm_utils.build_model_config(
+            self.checkpoint_info, image_patch_token_id=self.image_patch_token_id
+        )
+        if self.model_config.image_patch_token_id != self.image_patch_token_id:
+            raise ValueError(
+                f"Checkpoint image_patch_token_id ({self.model_config.image_patch_token_id}) "
+                f"does not match the tokenizer's <im_patch> id ({self.image_patch_token_id}); "
+                f"pass a matching tokenizer (e.g. tokenizer={vlm_utils.DEFAULT_TOKENIZER!r})."
+            )
+
+        self.device = torch.device(device or ("cuda" if torch.cuda.is_available() else "cpu"))
+        self.param_dtype = _to_torch_dtype(dtype)
+        self.autocast_dtype = autocast_dtype
+        self.bidirectional_image_attention = bidirectional_image_attention
+        self.max_crops = vlm_utils.resolve_max_crops(self.checkpoint_info, max_crops)
+        self.max_length = vlm_utils.resolve_max_length(self.checkpoint_info, max_model_len)
+
+        logger.info("Building MultimodalLM and loading weights from %s", model_name)
+        model = self.model_config.build(init_device="cpu")
+        vlm_utils.load_checkpoint_weights(self.checkpoint_info, model_name, model)
+        model = model.to(dtype=self.param_dtype).to(self.device)
+        model.eval()
+        model.requires_grad_(False)
+        self.model = model
+
+        self.use_cache = use_cache and vlm_utils.enable_kv_cache(model)
+        if use_cache and not self.use_cache:
+            logger.warning(
+                "KV-cached decoding unavailable for this model's attention backend; "
+                "falling back to full re-forward decoding."
+            )
+        # KV-cached decoding mutates per-block cache state on the shared model,
+        # so concurrent agenerate/alogprobs threads must take turns.
+        self._model_lock = threading.Lock()
+
+    @staticmethod
+    def _resolve_max_model_len_alias(
+        max_model_len: int | None, kwargs: dict[str, Any]
+    ) -> int | None:
+        max_length = kwargs.pop("max_length", None)
+        if max_length is None:
+            return max_model_len
+        if not isinstance(max_length, int):
+            raise ValueError("OlmoCoreVLMProvider max_length must be an integer when set")
+        if max_model_len is not None and max_model_len != max_length:
+            raise ValueError(
+                "OlmoCoreVLMProvider received both max_model_len and max_length "
+                "with different values"
+            )
+        return max_length
+
+    def _resolve_special_token_ids(self, tokenizer_path: str) -> None:
+        """Resolve Molmo2 image special-token IDs through the tokenizer."""
+        ids = self.tokenizer.convert_tokens_to_ids(list(vlm_utils.IMAGE_SPECIAL_TOKENS))
+        unk_id = getattr(self.tokenizer, "unk_token_id", None)
+        if any(token_id is None or token_id == unk_id for token_id in ids):
+            raise ValueError(
+                f"Tokenizer {tokenizer_path!r} does not define the Molmo2 image special tokens "
+                f"{vlm_utils.IMAGE_SPECIAL_TOKENS}; pass tokenizer={vlm_utils.DEFAULT_TOKENIZER!r} "
+                "or another Molmo2-family tokenizer."
+            )
+        by_name = dict(zip(vlm_utils.IMAGE_SPECIAL_TOKENS, ids, strict=True))
+        self.image_patch_token_id = by_name["<im_patch>"]
+        self.image_structural_token_ids = tuple(ids)
+
+        placeholder = self.tokenizer.convert_tokens_to_ids(vlm_utils.IMAGE_PLACEHOLDER_TOKEN)
+        if placeholder is None or placeholder == unk_id:
+            raise ValueError(
+                f"Tokenizer {tokenizer_path!r} does not define "
+                f"{vlm_utils.IMAGE_PLACEHOLDER_TOKEN!r}"
+            )
+        self.image_placeholder_id = placeholder
+
+        stop_ids = {self.tokenizer.eos_token_id}
+        end_of_turn = self.tokenizer.convert_tokens_to_ids(vlm_utils.END_OF_TURN_TOKEN)
+        if end_of_turn is not None and end_of_turn != unk_id:
+            stop_ids.add(end_of_turn)
+        self.stop_token_ids = frozenset(token_id for token_id in stop_ids if token_id is not None)
+
+    def get_tokenizer(self) -> Any:
+        return self.tokenizer
+
+    # ------------------------------------------------------------------
+    # Request preparation
+    # ------------------------------------------------------------------
+
+    def _chat_text(self, request: LMRequest, num_images: int) -> str:
+        """Render the request as chat-templated text with ``<|image|>`` markers.
+
+        Passes structured content parts so the Molmo2 chat template itself
+        hoists the image markers in front of the conversation (with ``Image N``
+        prefixes for multi-image requests), exactly like the released
+        processor's ``apply_chat_template``.
+        """
+        messages = list(request.messages or ({"role": "user", "content": request.prompt},))
+        chat: list[dict[str, Any]] = []
+        attached = False
+        for msg in messages:
+            role = msg.get("role", "user")
+            text = msg.get("content", "") or ""
+            content: Any = [{"type": "text", "text": text}]
+            if role == "user" and not attached and num_images:
+                content = [{"type": "image"} for _ in range(num_images)] + content
+                attached = True
+            chat.append({"role": role, "content": content})
+        if not attached and num_images:
+            chat.insert(
+                0, {"role": "user", "content": [{"type": "image"} for _ in range(num_images)]}
+            )
+        return self.tokenizer.apply_chat_template(chat, tokenize=False, add_generation_prompt=True)
+
+    def _preprocess_images(
+        self, images: tuple[Any, ...]
+    ) -> tuple[torch.Tensor, torch.Tensor, list[list[int]]]:
+        """Patchify images and build their expanded token sequences.
+
+        Multiple images are concatenated along the crop axis; each image's
+        pooled-patch indices are offset into the combined flat patch axis so a
+        single ``pooled_patches_idx`` covers the whole request.
+
+        :returns: ``(images, pooled_patches_idx, per_image_token_ids)``.
+        """
+        import torch
+        from olmo_core.nn.vision.molmo2_image_processor import preprocess_image_molmo2
+        from olmo_core.nn.vision.molmo2_tokens import build_image_token_ids
+
+        image_size = int(self.model_config.vision.image_default_input_size[0])
+        patch_size = int(self.model_config.vision.image_patch_size)
+
+        crop_tensors: list[torch.Tensor] = []
+        pooling_tensors: list[torch.Tensor] = []
+        token_sequences: list[list[int]] = []
+        crop_offset = 0
+        for image in images:
+            if hasattr(image, "mode") and image.mode != "RGB":
+                image = image.convert("RGB")
+            crops, pooling, grid = preprocess_image_molmo2(
+                image,
+                self.param_dtype,
+                self.device,
+                image_size=image_size,
+                patch_size=patch_size,
+                max_crops=self.max_crops,
+            )
+            n_patches_per_crop = crops.shape[2]
+            offset_pooling = pooling.clone()
+            offset_pooling[offset_pooling >= 0] += crop_offset * n_patches_per_crop
+            crop_offset += crops.shape[1]
+
+            crop_tensors.append(crops)
+            pooling_tensors.append(offset_pooling)
+            token_sequences.append(
+                build_image_token_ids(int(grid[0]), int(grid[1]), int(grid[2]), int(grid[3]))
+            )
+
+        return (
+            torch.cat(crop_tensors, dim=1),
+            torch.cat(pooling_tensors, dim=1),
+            token_sequences,
+        )
+
+    def _encode_request(self, request: LMRequest) -> tuple[list[int], Any, Any]:
+        """Tokenize a request, splicing expanded image tokens at each placeholder.
+
+        :returns: ``(token_ids, images, pooled_patches_idx)`` where the tensors
+            are ``None`` for text-only requests.
+        """
+        images = tuple(request.images or ())
+        image_tensor = pooling_tensor = None
+        token_sequences: list[list[int]] = []
+        if images:
+            image_tensor, pooling_tensor, token_sequences = self._preprocess_images(images)
+
+        text = self._chat_text(request, len(images))
+        token_ids: list[int] = self.tokenizer.encode(text, add_special_tokens=False)
+
+        for image_tokens in token_sequences:
+            position = token_ids.index(self.image_placeholder_id)
+            token_ids = token_ids[:position] + image_tokens + token_ids[position + 1 :]
+        if self.image_placeholder_id in token_ids:
+            raise ValueError("Prompt contains more <|image|> placeholders than provided images")
+
+        # The released Molmo2 processor prepends a BOS token (falling back to
+        # EOS, matching `Molmo2Processor.insert_bos`).
+        bos = self.tokenizer.bos_token_id or self.tokenizer.eos_token_id
+        if bos is not None and (not token_ids or token_ids[0] != bos):
+            token_ids = [bos, *token_ids]
+        return token_ids, image_tensor, pooling_tensor
+
+    # ------------------------------------------------------------------
+    # Model forward helpers
+    # ------------------------------------------------------------------
+
+    def _autocast(self) -> Any:
+        import torch
+
+        if self.autocast_dtype and self.device.type in ("cuda", "cpu"):
+            return torch.autocast(
+                device_type=self.device.type, dtype=_to_torch_dtype(self.autocast_dtype)
+            )
+        return contextlib.nullcontext()
+
+    def _embed(self, token_ids: torch.Tensor) -> torch.Tensor:
+        """LM token embeddings with the model's configured scale/norm applied.
+
+        Mirrors ``MultimodalLM.forward``'s embedding stage so image features
+        can be spliced in once at prefill and cheap per-token embeddings can be
+        appended during decode.
+        """
+        import torch.nn.functional as F
+
+        lm = self.model.lm
+        h = F.embedding(token_ids, lm.embeddings.weight, padding_idx=lm.embeddings.padding_idx)
+        if lm.embed_scale is not None:
+            h = h * lm.embed_scale
+        if lm.embedding_norm is not None:
+            h = lm.embedding_norm(h)
+        return h
+
+    def _prefill(
+        self,
+        token_ids: list[int],
+        image_tensor: torch.Tensor | None,
+        pooling_tensor: torch.Tensor | None,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
+        """Build prompt embeddings with image features spliced in.
+
+        :returns: ``(input_ids (1, S), embeddings (1, S, d), is_image (S,) or None)``.
+        """
+        import torch
+
+        ids = torch.tensor([token_ids], dtype=torch.long, device=self.device)
+        h = self._embed(ids)
+
+        if image_tensor is not None:
+            assert pooling_tensor is not None
+            features = self.model._encode_images(image_tensor, pooling_tensor)  # (1, P, d)
+            valid_rows = (pooling_tensor >= 0).any(dim=-1)
+            features = features[valid_rows]  # (P_valid, d)
+            is_patch = ids[0] == self.image_patch_token_id
+            n_patches = int(is_patch.sum())
+            if n_patches != features.shape[0]:
+                raise ValueError(
+                    f"Number of <im_patch> tokens ({n_patches}) does not match the number of "
+                    f"pooled image features ({features.shape[0]})"
+                )
+            h = h.clone()
+            h[0, is_patch] = h[0, is_patch] + features.to(h.dtype)
+
+        is_image = None
+        if self.bidirectional_image_attention and image_tensor is not None:
+            import torch
+
+            structural = torch.tensor(
+                self.image_structural_token_ids, dtype=torch.long, device=self.device
+            )
+            is_image = torch.isin(ids[0], structural)
+        return ids, h, is_image
+
+    def _step_logits(
+        self,
+        ids: torch.Tensor,
+        h: torch.Tensor,
+        is_image: torch.Tensor | None,
+    ) -> torch.Tensor:
+        """One full LM forward over the current sequence; returns last-position logits."""
+        or_mask = None
+        if is_image is not None:
+            or_mask = (is_image[None, :, None] & is_image[None, None, :]).unsqueeze(1)
+        logits = self.model.lm(ids, input_embeddings=h, or_mask=or_mask, logits_to_keep=1)
+        return logits[:, -1, :].float()
+
+    def _select_token(self, logits: torch.Tensor, params: SamplingParams) -> int:
+        from olmo_core.generate.sampling import select_next_token
+
+        do_sample = params.do_sample and params.temperature > 0
+        return int(
+            select_next_token(
+                logits,
+                do_sample=do_sample,
+                temperature=params.temperature if do_sample else 0.0,
+                top_k=params.top_k if do_sample and params.top_k is not None else -1,
+                top_p=params.top_p if do_sample and params.top_p is not None else 1.0,
+            )[0].item()
+        )
+
+    def _decode_loop(
+        self,
+        ids: torch.Tensor,
+        h: torch.Tensor,
+        is_image: torch.Tensor | None,
+        params: SamplingParams,
+    ) -> list[int]:
+        if self.use_cache:
+            return self._decode_loop_cached(ids, h, is_image, params)
+        return self._decode_loop_uncached(ids, h, is_image, params)
+
+    def _decode_loop_cached(
+        self,
+        ids: torch.Tensor,
+        h: torch.Tensor,
+        is_image: torch.Tensor | None,
+        params: SamplingParams,
+    ) -> list[int]:
+        """KV-cached decode: one prefill over the prompt, then one token per step.
+
+        Uses the cache-capable dense-SDPA backend installed by
+        ``vlm_utils.enable_kv_cache``. Caches are freed afterwards so any other
+        forward (e.g. ``logprobs``) runs uncached.
+        """
+        import torch
+
+        or_mask = None
+        if is_image is not None:
+            or_mask = (is_image[None, :, None] & is_image[None, None, :]).unsqueeze(1)
+
+        generated: list[int] = []
+        vlm_utils.prepare_kv_caches(self.model, ids.shape[0], ids.shape[1] + params.max_tokens)
+        try:
+            logits = self.model.lm(ids, input_embeddings=h, or_mask=or_mask, logits_to_keep=1)
+            logits = logits[:, -1, :].float()
+            for step in range(params.max_tokens):
+                next_id = self._select_token(logits, params)
+                generated.append(next_id)
+                if next_id in self.stop_token_ids or step == params.max_tokens - 1:
+                    break
+                next_tensor = torch.tensor([[next_id]], dtype=torch.long, device=self.device)
+                logits = self.model.lm(
+                    next_tensor, input_embeddings=self._embed(next_tensor), logits_to_keep=1
+                )
+                logits = logits[:, -1, :].float()
+        finally:
+            vlm_utils.free_kv_caches(self.model)
+        return generated
+
+    def _decode_loop_uncached(
+        self,
+        ids: torch.Tensor,
+        h: torch.Tensor,
+        is_image: torch.Tensor | None,
+        params: SamplingParams,
+    ) -> list[int]:
+        """Autoregressive decode re-running the LM over the full sequence per step."""
+        import torch
+
+        generated: list[int] = []
+        for _ in range(params.max_tokens):
+            logits = self._step_logits(ids, h, is_image)
+            next_id = self._select_token(logits, params)
+            generated.append(next_id)
+            if next_id in self.stop_token_ids:
+                break
+            next_tensor = torch.tensor([[next_id]], dtype=torch.long, device=self.device)
+            ids = torch.cat([ids, next_tensor], dim=1)
+            h = torch.cat([h, self._embed(next_tensor)], dim=1)
+            if is_image is not None:
+                is_image = torch.cat(
+                    [is_image, torch.zeros(1, dtype=torch.bool, device=self.device)]
+                )
+        return generated
+
+    # ------------------------------------------------------------------
+    # Provider interface
+    # ------------------------------------------------------------------
+
+    def _text_before_stop(self, text: str, stop_sequences: tuple[str, ...] | None) -> str:
+        for stop in stop_sequences or ():
+            if stop and stop in text:
+                text = text.split(stop)[0]
+        return text
+
+    def generate(
+        self,
+        requests: list[LMRequest],
+        sampling_params: SamplingParams | None = None,
+    ) -> list[list[LMOutput]]:
+        import torch
+
+        params = self._default_sampling_params(sampling_params)
+        if params.max_tokens <= 0:
+            raise ValueError("OlmoCoreVLMProvider requires sampling max_tokens > 0")
+        if params.num_samples <= 0:
+            raise ValueError("OlmoCoreVLMProvider requires sampling num_samples > 0")
+
+        results: list[list[LMOutput]] = []
+        for request in requests:
+            token_ids, image_tensor, pooling_tensor = self._encode_request(request)
+            if is_debug_requests():
+                logger.info("Prompt:\n%s", self.tokenizer.decode(token_ids))
+
+            # Multimodal prompts cannot be truncated (that would corrupt the
+            # image-token layout), so clamp the generation budget instead and
+            # skip requests whose prompt alone exceeds the window.
+            request_params = params
+            if len(token_ids) >= self.max_length:
+                logger.warning(
+                    "Skipping request: prompt length (%d) >= max_length (%d)",
+                    len(token_ids),
+                    self.max_length,
+                )
+                results.append(
+                    [
+                        LMOutput(
+                            text="",
+                            logprobs=None,
+                            metadata={
+                                "num_tokens": 0,
+                                "num_tokens_all": 0,
+                                "skipped": "prompt_too_long",
+                            },
+                        )
+                        for _ in range(params.num_samples)
+                    ]
+                )
+                continue
+            if len(token_ids) + params.max_tokens > self.max_length:
+                clamped = self.max_length - len(token_ids)
+                logger.warning(
+                    "Clamping max_tokens from %d to %d for a %d-token prompt (max_length %d)",
+                    params.max_tokens,
+                    clamped,
+                    len(token_ids),
+                    self.max_length,
+                )
+                request_params = dataclasses.replace(params, max_tokens=clamped)
+
+            request_outputs: list[LMOutput] = []
+            with self._model_lock, torch.inference_mode(), self._autocast():
+                ids, h, is_image = self._prefill(token_ids, image_tensor, pooling_tensor)
+                for _ in range(request_params.num_samples):
+                    generated = self._decode_loop(ids, h, is_image, request_params)
+                    if generated and generated[-1] in self.stop_token_ids:
+                        generated = generated[:-1]
+                    text = self.tokenizer.decode(generated, skip_special_tokens=True)
+                    text = self._text_before_stop(text, params.stop_sequences)
+                    request_outputs.append(
+                        LMOutput(
+                            text=text.strip(),
+                            logprobs=None,
+                            metadata={
+                                "num_tokens": len(generated),
+                                "num_tokens_all": len(generated),
+                            },
+                        )
+                    )
+            results.append(request_outputs)
+        return results
+
+    def logprobs(
+        self,
+        requests: list[LMRequest],
+        sampling_params: SamplingParams | None = None,
+    ) -> list[list[LMOutput]]:
+        del sampling_params
+        if any(request.images for request in requests):
+            raise NotImplementedError(
+                "OlmoCoreVLMProvider does not support loglikelihood scoring of image requests"
+            )
+
+        import torch
+        import torch.nn.functional as F
+
+        from olmo_eval.inference.tokenizer_utils import encode_context_and_continuation
+
+        results: list[list[LMOutput]] = []
+        for request in requests:
+            request_outputs: list[LMOutput] = []
+            cont_prompts = request.continuation_prompts
+            for i, continuation in enumerate(request.continuations or ()):
+                prompt = cont_prompts[i] if cont_prompts else request.prompt
+                context_ids, continuation_ids = encode_context_and_continuation(
+                    self.tokenizer, prompt, continuation
+                )
+                if not context_ids:
+                    context_ids = [self.tokenizer.eos_token_id]
+                full_ids = (context_ids + continuation_ids)[-(self.max_length + 1) :]
+                model_input = full_ids[:-1]
+                with self._model_lock, torch.inference_mode(), self._autocast():
+                    ids = torch.tensor([model_input], dtype=torch.long, device=self.device)
+                    logits = self.model.lm(ids, input_embeddings=self._embed(ids)).float()
+                n_cont = len(continuation_ids)
+                cont_logits = logits[0, -n_cont:]
+                log_probs = F.log_softmax(cont_logits, dim=-1)
+                cont_tensor = torch.tensor(
+                    continuation_ids, dtype=torch.long, device=log_probs.device
+                )
+                token_log_probs = torch.gather(log_probs, 1, cont_tensor.unsqueeze(-1)).squeeze(-1)
+                is_greedy = bool((log_probs.argmax(dim=-1) == cont_tensor).all().item())
+                total = float(token_log_probs.sum().item())
+                request_outputs.append(
+                    LMOutput(
+                        text=continuation,
+                        logprobs=[
+                            {
+                                "token": self.tokenizer.decode([token_id]),
+                                "logprob": float(logprob),
+                            }
+                            for token_id, logprob in zip(
+                                continuation_ids, token_log_probs.tolist(), strict=True
+                            )
+                        ],
+                        metadata={
+                            "total_logprob": total,
+                            "sum_logits": total,
+                            "num_tokens": n_cont,
+                            "num_tokens_all": len(full_ids),
+                            "is_greedy": is_greedy,
+                        },
+                    )
+                )
+            results.append(request_outputs)
+        return results
+
+    def describe_request(
+        self,
+        request: LMRequest,
+        sampling_params: SamplingParams | None = None,
+    ) -> dict[str, Any] | None:
+        trace = super().describe_request(request, sampling_params)
+        if trace is None:
+            return None
+        trace["provider"] = "OlmoCoreVLMProvider"
+        if request.request_type != RequestType.LOGLIKELIHOOD:
+            trace["endpoint"] = "multimodal_lm.decode_loop"
+            trace["input_mode"] = "input_ids+images"
+        return trace
+
+    async def agenerate(
+        self,
+        requests: list[LMRequest],
+        sampling_params: SamplingParams | None = None,
+    ) -> list[list[LMOutput]]:
+        return await asyncio.to_thread(self.generate, requests, sampling_params)
+
+    async def alogprobs(
+        self,
+        requests: list[LMRequest],
+        sampling_params: SamplingParams | None = None,
+    ) -> list[list[LMOutput]]:
+        return await asyncio.to_thread(self.logprobs, requests, sampling_params)
+
+    def close(self) -> None:
+        if hasattr(self, "model"):
+            del self.model
+        gc.collect()
+        try:
+            import torch
+
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
+        except Exception:
+            logger.debug("Failed to clear CUDA cache", exc_info=True)
+
+    def __del__(self) -> None:
+        with contextlib.suppress(Exception):
+            self.close()

--- a/src/olmo_eval/inference/providers/olmo_core_vlm_utils.py
+++ b/src/olmo_eval/inference/providers/olmo_core_vlm_utils.py
@@ -1,0 +1,832 @@
+"""Utilities for the multimodal OLMo-core inference provider.
+
+Handles the three on-disk flavors of OLMo-core ``MultimodalLM`` weights:
+
+1. ``olmo_core_dcp`` — a raw OLMo-core trainer checkpoint directory
+   (``config.json`` with a serialized ``MultimodalLMConfig`` under ``model``
+   plus a torch distributed checkpoint at ``model_and_optim/``).
+2. ``olmo_core_unsharded`` — a consolidated export: ``olmo_core_config.json``
+   (the full OLMo-core ``ExperimentConfig``) next to a single
+   ``model.safetensors`` whose tensor keys use OLMo-core naming
+   (``lm.*`` / ``vision.*`` / ``connector.*``).
+3. ``mm_olmo_dcp`` — a checkpoint saved by the mm_olmo (Molmo2 ``video_olmo``)
+   trainer: ``config.yaml`` plus a torch distributed checkpoint at
+   ``model_and_optim/`` with legacy key naming (``model.transformer.*`` with
+   fused ``att_proj`` / ``ff_proj``, ``model.vision_backbone.*``). These are
+   translated into the OLMo-core ``MultimodalLM`` layout at load time by
+   reusing OLMo-core's HF-Molmo2 converter.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+import types
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Literal
+
+if TYPE_CHECKING:
+    import torch
+
+logger = logging.getLogger(__name__)
+
+CheckpointFormat = Literal["olmo_core_dcp", "olmo_core_unsharded", "mm_olmo_dcp"]
+
+_EXPECTED_FORMATS = (
+    "expected one of: a raw OLMo-core multimodal checkpoint (config.json with a "
+    "MultimodalLMConfig under 'model' + model_and_optim/.metadata), a consolidated "
+    "OLMo-core export (olmo_core_config.json + model.safetensors with lm.*/vision.*/"
+    "connector.* keys), or an mm_olmo/Molmo2-trainer checkpoint (config.yaml + "
+    "model_and_optim/.metadata with model.transformer.*/model.vision_backbone.* keys)"
+)
+
+# Old name of MultimodalLMConfig kept by earlier vision-branch checkpoints.
+_LEGACY_MULTIMODAL_CLASS_NAMES = {
+    "olmo_core.nn.vision.multimodal.MultimodalTransformerConfig": (
+        "olmo_core.nn.vision.multimodal.MultimodalLMConfig"
+    ),
+}
+
+_MULTIMODAL_CLASS_SUFFIXES = ("MultimodalLMConfig", "MultimodalTransformerConfig")
+
+# Default tokenizer for Molmo2-family models: Qwen tokenizer + Molmo2 image
+# special tokens + the Molmo2 chat template.
+DEFAULT_TOKENIZER = "allenai/Molmo2-4B"
+
+# Molmo2 image special-token *names* — resolved to IDs through the tokenizer so
+# the provider works for any vocab layout that defines them.
+IMAGE_SPECIAL_TOKENS = (
+    "<im_start>",
+    "<im_end>",
+    "<im_patch>",
+    "<im_col>",
+    "<low_res_im_start>",
+)
+IMAGE_PLACEHOLDER_TOKEN = "<|image|>"
+END_OF_TURN_TOKEN = "<|im_end|>"
+
+
+@dataclass(frozen=True)
+class MultimodalCheckpointInfo:
+    """Resolved facts about a multimodal checkpoint directory."""
+
+    format: CheckpointFormat
+    config: dict[str, Any]
+    """The full config dict (ExperimentConfig for OLMo-core, the yaml for mm_olmo)."""
+    model_config: dict[str, Any]
+    """The model section (MultimodalLMConfig dict, or the mm_olmo model yaml)."""
+
+
+def _config_error(checkpoint_dir: str, reason: str) -> ValueError:
+    return ValueError(
+        f"Invalid multimodal OLMo-core checkpoint {checkpoint_dir!r}: {reason}. "
+        f"{_EXPECTED_FORMATS}."
+    )
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    with path.open() as f:
+        return json.load(f)
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    import yaml
+
+    with path.open() as f:
+        return yaml.safe_load(f)
+
+
+def _is_multimodal_model_config(model_config: Any) -> bool:
+    if not isinstance(model_config, dict):
+        return False
+    class_name = model_config.get("_CLASS_", "")
+    return isinstance(class_name, str) and class_name.endswith(_MULTIMODAL_CLASS_SUFFIXES)
+
+
+def _is_mm_olmo_model_config(model_config: Any) -> bool:
+    return (
+        isinstance(model_config, dict)
+        and "llm" in model_config
+        and "vision_backbone" in model_config
+    )
+
+
+def is_multimodal_checkpoint(checkpoint_dir: str) -> bool:
+    """Cheaply check whether a local directory holds multimodal OLMo-core weights.
+
+    Used to route ``provider.kind=olmo_core`` requests to the multimodal
+    provider. Returns ``False`` on any read error so callers can fall back to
+    the text provider's own validation.
+    """
+    try:
+        detect_checkpoint_format(checkpoint_dir)
+        return True
+    except Exception:
+        return False
+
+
+def detect_checkpoint_format(checkpoint_dir: str) -> MultimodalCheckpointInfo:
+    """Identify which multimodal checkpoint flavor ``checkpoint_dir`` holds.
+
+    :raises ValueError: if the directory matches none of the known formats.
+    """
+    root = Path(checkpoint_dir)
+    if not root.is_dir():
+        raise _config_error(checkpoint_dir, "not a local directory")
+
+    unsharded_config = root / "olmo_core_config.json"
+    if unsharded_config.is_file() and (root / "model.safetensors").is_file():
+        config = _load_json(unsharded_config)
+        model_config = config.get("model")
+        if not (isinstance(model_config, dict) and _is_multimodal_model_config(model_config)):
+            raise _config_error(
+                checkpoint_dir,
+                "olmo_core_config.json 'model' is not a MultimodalLMConfig",
+            )
+        return MultimodalCheckpointInfo(
+            format="olmo_core_unsharded", config=config, model_config=model_config
+        )
+
+    has_dcp = (root / "model_and_optim" / ".metadata").is_file()
+    json_config = root / "config.json"
+    yaml_config = root / "config.yaml"
+
+    if json_config.is_file() and has_dcp:
+        config = _load_json(json_config)
+        model_config = config.get("model")
+        if isinstance(model_config, dict) and _is_multimodal_model_config(model_config):
+            return MultimodalCheckpointInfo(
+                format="olmo_core_dcp", config=config, model_config=model_config
+            )
+        raise _config_error(
+            checkpoint_dir,
+            "config.json 'model' is not a MultimodalLMConfig (text-only OLMo-core "
+            "checkpoints should use the 'olmo_core' provider)",
+        )
+
+    if yaml_config.is_file() and has_dcp:
+        config = _load_yaml(yaml_config)
+        model_config = config.get("model")
+        if isinstance(model_config, dict) and _is_mm_olmo_model_config(model_config):
+            return MultimodalCheckpointInfo(
+                format="mm_olmo_dcp", config=config, model_config=model_config
+            )
+        raise _config_error(
+            checkpoint_dir,
+            "config.yaml 'model' does not look like an mm_olmo multimodal model "
+            "(missing 'llm'/'vision_backbone')",
+        )
+
+    raise _config_error(checkpoint_dir, "no recognizable config/weights layout found")
+
+
+# ---------------------------------------------------------------------------
+# Config building
+# ---------------------------------------------------------------------------
+
+
+def _rewrite_legacy_class_names(config: Any) -> Any:
+    """Recursively map renamed ``_CLASS_`` names to their current spelling."""
+    if isinstance(config, dict):
+        out = {key: _rewrite_legacy_class_names(value) for key, value in config.items()}
+        class_name = out.get("_CLASS_")
+        if isinstance(class_name, str) and class_name in _LEGACY_MULTIMODAL_CLASS_NAMES:
+            out["_CLASS_"] = _LEGACY_MULTIMODAL_CLASS_NAMES[class_name]
+        return out
+    if isinstance(config, list):
+        return [_rewrite_legacy_class_names(value) for value in config]
+    return config
+
+
+def build_model_config(info: MultimodalCheckpointInfo, *, image_patch_token_id: int) -> Any:
+    """Build the OLMo-core ``MultimodalLMConfig`` for a checkpoint.
+
+    :param image_patch_token_id: The ``<im_patch>`` vocab ID resolved from the
+        tokenizer; only used for the mm_olmo format (OLMo-core configs carry
+        their own).
+    """
+    from olmo_core.nn.vision.multimodal import MultimodalLMConfig
+
+    if info.format in ("olmo_core_dcp", "olmo_core_unsharded"):
+        model_config = _rewrite_legacy_class_names(info.model_config)
+        return MultimodalLMConfig.from_dict(model_config)
+    return _mm_olmo_model_config_to_multimodal_lm_config(
+        info.model_config, image_patch_token_id=image_patch_token_id
+    )
+
+
+def _mm_olmo_model_config_to_multimodal_lm_config(
+    model_config: dict[str, Any], *, image_patch_token_id: int
+) -> Any:
+    """Translate an mm_olmo (``video_olmo``) model config into a ``MultimodalLMConfig``.
+
+    Builds lightweight HF-Molmo2-config lookalikes from the mm_olmo yaml fields
+    and reuses OLMo-core's ``molmo2_config_from_hf_config`` so the architecture
+    dispatch (qwen3_4B / qwen3_8B / olmo3_7B) and ViT-truncation logic stay in
+    one place.
+    """
+    from olmo_core.nn.vision.molmo2_loader import molmo2_config_from_hf_config
+
+    llm = model_config["llm"]
+    backbone = model_config["vision_backbone"]
+    vit = backbone["vit"]
+
+    text_config = types.SimpleNamespace(
+        hidden_size=llm["d_model"],
+        num_hidden_layers=llm["n_layers"],
+        qk_norm_type=(
+            llm.get("attention_layer_norm_type") if llm.get("attention_layer_norm") else None
+        ),
+        rope_theta=llm["rope_theta"],
+        vocab_size=llm["embedding_size"],
+        additional_vocab_size=llm["additional_vocab_size"],
+    )
+    vit_config = types.SimpleNamespace(
+        image_default_input_size=tuple(vit["image_default_input_size"]),
+        image_patch_size=vit["image_patch_size"],
+        hidden_size=vit["image_emb_dim"],
+        num_attention_heads=vit["image_num_heads"],
+        num_key_value_heads=vit["image_num_key_value_heads"],
+        num_hidden_layers=vit["image_num_layers"],
+        head_dim=vit["image_head_dim"],
+        intermediate_size=vit["image_mlp_dim"],
+        hidden_act=vit["image_mlp_activations"],
+        image_num_pos=vit["image_num_pos"],
+        layer_norm_eps=vit["image_norm_eps"],
+    )
+    # mm_olmo's image_pooling_2d reuses the ViT attention dims and half the LM's
+    # fused MLP width, matching the released Molmo2 adapter_config.
+    adapter_config = types.SimpleNamespace(
+        vit_layers=list(backbone["vit_layers"]),
+        num_attention_heads=vit["image_num_heads"],
+        num_key_value_heads=vit["image_num_key_value_heads"],
+        head_dim=vit["image_head_dim"],
+        text_hidden_size=llm["d_model"],
+        pooling_attention_mask=backbone["pooling_attention_mask"],
+        intermediate_size=llm["mlp_hidden_size"] // 2,
+    )
+    hf_like_config = types.SimpleNamespace(
+        text_config=text_config,
+        vit_config=vit_config,
+        adapter_config=adapter_config,
+        image_patch_id=image_patch_token_id,
+    )
+    if backbone.get("image_pooling_2d") != "attention_meanq":
+        raise ValueError(
+            "mm_olmo checkpoint uses unsupported image pooling "
+            f"{backbone.get('image_pooling_2d')!r}; only 'attention_meanq' is supported"
+        )
+    if backbone.get("image_projector") != "mlp":
+        raise ValueError(
+            "mm_olmo checkpoint uses unsupported image projector "
+            f"{backbone.get('image_projector')!r}; only 'mlp' is supported"
+        )
+    return molmo2_config_from_hf_config(hf_like_config)
+
+
+# ---------------------------------------------------------------------------
+# Weight loading
+# ---------------------------------------------------------------------------
+
+
+def _untie_lm_head(model: Any) -> None:
+    """Give ``lm_head.w_out`` its own storage when word embeddings are tied.
+
+    Checkpoints in the wild store *different* tensors for
+    ``lm.embeddings.weight`` and ``lm.lm_head.w_out.weight`` even when the
+    config says ``tie_word_embeddings`` (the extra image-token rows legitimately
+    differ). Loading both into a shared parameter would let one silently
+    clobber the other, so break the tie before loading.
+    """
+    import torch.nn as nn
+
+    lm = model.lm
+    if getattr(lm, "tie_word_embeddings", False):
+        lm.lm_head.w_out.weight = nn.Parameter(lm.embeddings.weight.detach().clone())
+
+
+def _ensure_mm_olmo_unpickle_shim() -> None:
+    """Register a stub ``olmo.train.remote_filesystem`` module for metadata unpickling.
+
+    mm_olmo distributed checkpoints pickle a custom ``_StorageInfo`` dataclass
+    (fields ``relative_path`` / ``offset`` / ``length``, mirroring torch's) into
+    ``model_and_optim/.metadata``. The mm_olmo package isn't installed in the
+    eval environment, so provide a minimal class with the same module path for
+    pickle to resolve. No-op when the real package (or the shim) is importable.
+    """
+    import importlib.util
+
+    try:
+        if importlib.util.find_spec("olmo.train.remote_filesystem") is not None:
+            return
+    except (ImportError, ModuleNotFoundError):
+        pass
+    if "olmo.train.remote_filesystem" in sys.modules:
+        return
+
+    from dataclasses import dataclass as _dataclass
+
+    @_dataclass
+    class _StorageInfo:
+        relative_path: str
+        offset: int
+        length: int
+
+    olmo_mod = sys.modules.setdefault("olmo", types.ModuleType("olmo"))
+    train_mod = sys.modules.setdefault("olmo.train", types.ModuleType("olmo.train"))
+    fs_mod = sys.modules.setdefault(
+        "olmo.train.remote_filesystem", types.ModuleType("olmo.train.remote_filesystem")
+    )
+    setattr(olmo_mod, "train", train_mod)  # noqa: B010
+    setattr(train_mod, "remote_filesystem", fs_mod)  # noqa: B010
+    _StorageInfo.__module__ = "olmo.train.remote_filesystem"
+    setattr(fs_mod, "_StorageInfo", _StorageInfo)  # noqa: B010
+
+
+def _mm_olmo_key_to_hf_key(key: str) -> str:
+    """Rename an mm_olmo trainer tensor key to released-Molmo2 HF naming.
+
+    The mm_olmo trainer keeps attention/MLP tensors directly on the block
+    (``blocks.N.att_proj``); the HF release nests them (``blocks.N.self_attn.
+    att_proj`` / ``blocks.N.mlp.ff_proj``). Everything else (wte, ln_f, the
+    whole vision backbone) matches HF naming already.
+    """
+    parts = key.split(".")
+    if len(parts) >= 4 and parts[:2] == ["model", "transformer"] and parts[2] == "blocks":
+        leaf = parts[4]
+        if leaf in ("att_proj", "attn_out", "q_norm", "k_norm"):
+            parts.insert(4, "self_attn")
+        elif leaf in ("ff_proj", "ff_out"):
+            parts.insert(4, "mlp")
+        return ".".join(parts)
+    return key
+
+
+def _load_mm_olmo_state_dict(checkpoint_dir: str, model_cfg: Any) -> dict[str, torch.Tensor]:
+    """Consolidate an mm_olmo distributed checkpoint into MultimodalLM keys.
+
+    Reads the (unsharded) ``model.*`` tensors, renames them to released-Molmo2
+    HF naming, synthesizes the tied ``lm_head`` when absent, and runs OLMo-core's
+    ``molmo2_hf_state_dict_to_multimodal_lm`` for the fused-weight splits and
+    patch-embedding permutation.
+    """
+    from olmo_core.distributed.checkpoint import get_checkpoint_metadata, load_keys
+    from olmo_core.nn.vision.molmo2_loader import molmo2_hf_state_dict_to_multimodal_lm
+
+    _ensure_mm_olmo_unpickle_shim()
+
+    dcp_dir = str(Path(checkpoint_dir) / "model_and_optim")
+    metadata = get_checkpoint_metadata(dcp_dir)
+    model_keys = sorted(key for key in metadata.state_dict_metadata if key.startswith("model."))
+    if not model_keys:
+        raise _config_error(checkpoint_dir, "distributed checkpoint has no 'model.*' keys")
+
+    logger.info("Loading %d unsharded tensors from %s", len(model_keys), dcp_dir)
+    hf_state_dict: dict[str, Any] = {}
+    for key, tensor in zip(model_keys, load_keys(dcp_dir, model_keys), strict=True):
+        hf_state_dict[_mm_olmo_key_to_hf_key(key)] = tensor
+
+    if "lm_head.weight" not in hf_state_dict:
+        # Weight-tied mm_olmo model (`can_predict_extra_tokens=False`): logits use
+        # the base-vocab embedding table; the converter zero-pads the extra rows.
+        base_embedding = hf_state_dict.get("model.transformer.wte.embedding")
+        if base_embedding is None:
+            raise _config_error(
+                checkpoint_dir, "missing both 'lm_head' and 'wte.embedding' tensors"
+            )
+        hf_state_dict["lm_head.weight"] = base_embedding
+
+    return molmo2_hf_state_dict_to_multimodal_lm(hf_state_dict, model_cfg)
+
+
+def load_checkpoint_weights(
+    info: MultimodalCheckpointInfo, checkpoint_dir: str, model: Any
+) -> None:
+    """Load checkpoint weights into a freshly built ``MultimodalLM`` (on CPU)."""
+    _untie_lm_head(model)
+
+    if info.format == "olmo_core_dcp":
+        from olmo_core.distributed.checkpoint import load_model_and_optim_state
+
+        load_model_and_optim_state(str(Path(checkpoint_dir) / "model_and_optim"), model)
+        return
+
+    if info.format == "olmo_core_unsharded":
+        from safetensors.torch import load_file
+
+        state_dict = load_file(str(Path(checkpoint_dir) / "model.safetensors"))
+        model.load_state_dict(state_dict)
+        return
+
+    state_dict = _load_mm_olmo_state_dict(checkpoint_dir, model.cfg)
+    model.load_state_dict(state_dict)
+
+
+# ---------------------------------------------------------------------------
+# Tokenizer / preprocessing hints
+# ---------------------------------------------------------------------------
+
+
+def resolve_tokenizer_path(info: MultimodalCheckpointInfo, explicit_tokenizer: str | None) -> str:
+    """Pick the tokenizer to load: explicit > checkpoint hint > Molmo2 default.
+
+    OLMo-core multimodal checkpoints record the HF model they were bootstrapped
+    from as ``model_id``; mm_olmo checkpoints record only the *base* tokenizer
+    (e.g. ``Qwen/Qwen3-4B``) which lacks the Molmo2 image special tokens and
+    chat template, so those fall through to the Molmo2 default.
+    """
+    if explicit_tokenizer is not None:
+        return explicit_tokenizer
+    if info.format in ("olmo_core_dcp", "olmo_core_unsharded"):
+        model_id = info.config.get("model_id")
+        if isinstance(model_id, str) and model_id:
+            return model_id
+    return DEFAULT_TOKENIZER
+
+
+def resolve_max_crops(info: MultimodalCheckpointInfo, explicit_max_crops: int | None) -> int:
+    """Pick the multi-crop budget: explicit > checkpoint hint > OLMo-core default."""
+    from olmo_core.nn.vision.molmo2_tokens import DEFAULT_MAX_CROPS
+
+    if explicit_max_crops is not None:
+        return explicit_max_crops
+    if info.format == "mm_olmo_dcp":
+        image_cfg = (info.model_config.get("mm_preprocessor") or {}).get("image") or {}
+        max_crops = image_cfg.get("max_crops")
+        if isinstance(max_crops, int) and max_crops > 0:
+            return max_crops
+    else:
+        dataset = info.config.get("dataset")
+        if isinstance(dataset, dict):
+            max_crops = dataset.get("max_crops")
+            if isinstance(max_crops, int) and max_crops > 0:
+                return max_crops
+    return DEFAULT_MAX_CROPS
+
+
+# ---------------------------------------------------------------------------
+# OLMo-core export → released-Molmo2 HF state dict (for HuggingFaceProvider)
+# ---------------------------------------------------------------------------
+
+
+def is_olmo_core_hf_export(checkpoint_dir: str) -> bool:
+    """Whether ``checkpoint_dir`` is a consolidated OLMo-core multimodal export
+    (``olmo_core_config.json`` + ``model.safetensors`` with OLMo-core key names)."""
+    try:
+        return detect_checkpoint_format(checkpoint_dir).format == "olmo_core_unsharded"
+    except Exception:
+        return False
+
+
+def olmo_core_export_reference_model(checkpoint_dir: str) -> str:
+    """The HF repo whose config/processor/modeling files match an export's weights."""
+    info = detect_checkpoint_format(checkpoint_dir)
+    model_id = info.config.get("model_id")
+    if isinstance(model_id, str) and model_id:
+        return model_id
+    return DEFAULT_TOKENIZER
+
+
+def convert_olmo_core_to_molmo2_hf_state_dict(
+    state_dict: dict[str, torch.Tensor],
+    *,
+    base_vocab_size: int,
+    patch_size: int,
+) -> dict[str, torch.Tensor]:
+    """Convert an OLMo-core ``MultimodalLM`` state dict to released-Molmo2 HF naming.
+
+    The exact inverse of OLMo-core's
+    ``molmo2_loader.molmo2_hf_state_dict_to_multimodal_lm`` (no olmo-core
+    dependency): re-fuse the split QKV / SwiGLU projections, split the token
+    embedding back into base + image-special tables, drop the extra-token
+    ``lm_head`` output rows (input-only tokens; the released architecture has no
+    columns for them), and permute the ViT patch embedding back to Molmo2's
+    spatial-first flatten order.
+
+    :param base_vocab_size: The released model's base vocab (``text_config.
+        vocab_size``, e.g. 151936) — the split point of the embedding table.
+    :param patch_size: ViT patch size (``vit_config.image_patch_size``) for the
+        patch-embedding permutation.
+    """
+    import re
+
+    import torch
+
+    sd = dict(state_dict)
+    out: dict[str, torch.Tensor] = {}
+
+    def take(key: str) -> torch.Tensor:
+        if key not in sd:
+            raise ValueError(f"OLMo-core export is missing required tensor {key!r}")
+        return sd.pop(key)
+
+    def maybe(key: str) -> torch.Tensor | None:
+        return sd.pop(key, None)
+
+    # --- LM: embeddings / head / final norm ---------------------------------
+    embeddings = take("lm.embeddings.weight")
+    if embeddings.shape[0] <= base_vocab_size:
+        raise ValueError(
+            f"lm.embeddings.weight has {embeddings.shape[0]} rows; expected more than the "
+            f"base vocab ({base_vocab_size}) to split off the image-special-token table"
+        )
+    out["model.transformer.wte.embedding"] = embeddings[:base_vocab_size].contiguous()
+    out["model.transformer.wte.new_embedding"] = embeddings[base_vocab_size:].contiguous()
+    out["model.transformer.ln_f.weight"] = take("lm.lm_head.norm.weight")
+    out["lm_head.weight"] = take("lm.lm_head.w_out.weight")[:base_vocab_size].contiguous()
+
+    def layer_indices(pattern: str) -> list[int]:
+        found = {int(m.group(1)) for key in sd if (m := re.match(pattern, key))}
+        return sorted(found)
+
+    # --- LM blocks: re-fuse QKV and SwiGLU ----------------------------------
+    for i in layer_indices(r"lm\.blocks\.(\d+)\."):
+        src, dst = f"lm.blocks.{i}", f"model.transformer.blocks.{i}"
+        out[f"{dst}.attn_norm.weight"] = take(f"{src}.attention_norm.weight")
+        out[f"{dst}.ff_norm.weight"] = take(f"{src}.feed_forward_norm.weight")
+
+        out[f"{dst}.self_attn.att_proj.weight"] = torch.cat(
+            [take(f"{src}.attention.w_{p}.weight") for p in ("q", "k", "v")], dim=0
+        )
+        biases = [maybe(f"{src}.attention.w_{p}.bias") for p in ("q", "k", "v")]
+        if all(bias is not None for bias in biases):
+            out[f"{dst}.self_attn.att_proj.bias"] = torch.cat(biases, dim=0)  # type: ignore[arg-type]
+        out[f"{dst}.self_attn.attn_out.weight"] = take(f"{src}.attention.w_out.weight")
+        for norm in ("q_norm", "k_norm"):
+            tensor = maybe(f"{src}.attention.{norm}.weight")
+            if tensor is not None:
+                out[f"{dst}.self_attn.{norm}.weight"] = tensor
+
+        # HF forward: x, gate = ff_proj.chunk(2) → rows [:H] are the multiplier
+        # branch (our w3), rows [H:] the gate branch (our w1).
+        out[f"{dst}.mlp.ff_proj.weight"] = torch.cat(
+            [take(f"{src}.feed_forward.w3.weight"), take(f"{src}.feed_forward.w1.weight")], dim=0
+        )
+        out[f"{dst}.mlp.ff_out.weight"] = take(f"{src}.feed_forward.w2.weight")
+
+    # --- Vision: patch embedding permute + blocks ---------------------------
+    patch_weight = take("vision.patch_embedding.weight")
+    d_model, total = patch_weight.shape
+    if total != 3 * patch_size * patch_size:
+        raise ValueError(
+            f"vision.patch_embedding.weight has {total} columns; expected "
+            f"{3 * patch_size * patch_size} for patch_size={patch_size}"
+        )
+    out["model.vision_backbone.image_vit.patch_embedding.weight"] = (
+        patch_weight.reshape(d_model, 3, patch_size, patch_size)
+        .permute(0, 2, 3, 1)
+        .reshape(d_model, total)
+        .contiguous()
+    )
+    out["model.vision_backbone.image_vit.patch_embedding.bias"] = take(
+        "vision.patch_embedding.bias"
+    )
+    out["model.vision_backbone.image_vit.positional_embedding"] = take(
+        "vision.positional_embedding"
+    )
+
+    for i in layer_indices(r"vision\.blocks\.(\d+)\."):
+        src = f"vision.blocks.{i}"
+        dst = f"model.vision_backbone.image_vit.transformer.resblocks.{i}"
+        for ours, hf in (("attn_norm", "attention_norm"), ("ffn_norm", "ffn_norm")):
+            for suffix in ("weight", "bias"):
+                out[f"{dst}.{hf}.{suffix}"] = take(f"{src}.{ours}.{suffix}")
+        for proj in ("wq", "wk", "wv", "wo"):
+            for suffix in ("weight", "bias"):
+                out[f"{dst}.attention.{proj}.{suffix}"] = take(f"{src}.attn.{proj}.{suffix}")
+        for proj in ("w1", "w2"):
+            for suffix in ("weight", "bias"):
+                out[f"{dst}.feed_forward.{proj}.{suffix}"] = take(f"{src}.ffn.{proj}.{suffix}")
+
+    # --- Connector -----------------------------------------------------------
+    for proj in ("wq", "wk", "wv", "wo"):
+        for suffix in ("weight", "bias"):
+            out[f"model.vision_backbone.image_pooling_2d.{proj}.{suffix}"] = take(
+                f"connector.pooling.{proj}.{suffix}"
+            )
+    for proj in ("w1", "w2", "w3"):
+        out[f"model.vision_backbone.image_projector.{proj}.weight"] = take(
+            f"connector.projector.{proj}.weight"
+        )
+
+    if sd:
+        leftover = ", ".join(sorted(sd)[:8])
+        raise ValueError(f"OLMo-core export has unconverted tensors: {leftover}")
+    return out
+
+
+# ---------------------------------------------------------------------------
+# KV-cached decoding
+# ---------------------------------------------------------------------------
+
+_CACHED_BACKEND_CLS: type | None = None
+
+
+def _cached_torch_backend_class() -> type:
+    """Build (once) a ``TorchAttentionBackend`` subclass that supports KV caching.
+
+    OLMo-core's dense ``torch`` backend is the only one that supports the
+    multimodal ``or_mask`` / ``and_mask``, but it rejects KV caching — so
+    multimodal decoding would otherwise re-run the LM over the whole sequence
+    for every generated token. The ``Attention`` module already carries all the
+    cache plumbing (``KVCacheManager``, RoPE ``start_pos`` from
+    ``current_position()``); this subclass adds the missing piece: write the
+    new K/V into the cache and run SDPA over the cached prefix.
+
+    Scope (asserted): no sliding window, no context parallelism, no
+    intra-document masking. Queries at absolute positions ``pos..pos+T-1``
+    attend keys ``0..pos+T-1`` causally; ``or_mask`` / ``and_mask`` (sized
+    ``(B, 1, T, T)`` over the current forward's tokens) are aligned to the key
+    axis by left-padding, which is exact for the prefill call (``pos == 0``,
+    the only call that passes them).
+    """
+    global _CACHED_BACKEND_CLS
+    if _CACHED_BACKEND_CLS is not None:
+        return _CACHED_BACKEND_CLS
+
+    import torch
+    import torch.nn.functional as F
+    from olmo_core.nn.attention.backend import TorchAttentionBackend, _repeat_kv
+
+    class CachedTorchAttentionBackend(TorchAttentionBackend):
+        @classmethod
+        def assert_supports_kv_cache(cls) -> None:
+            pass
+
+        def forward(  # noqa: C901
+            self,
+            qkv,
+            cu_doc_lens=None,
+            cu_doc_lens_q=None,
+            cu_doc_lens_k=None,
+            max_doc_len=None,
+            max_doc_len_q=None,
+            max_doc_len_k=None,
+            local_k_slice=None,
+            kv_cache_manager=None,
+            or_mask=None,
+            and_mask=None,
+        ):
+            if kv_cache_manager is None:
+                return super().forward(
+                    qkv,
+                    cu_doc_lens=cu_doc_lens,
+                    cu_doc_lens_q=cu_doc_lens_q,
+                    cu_doc_lens_k=cu_doc_lens_k,
+                    max_doc_len=max_doc_len,
+                    max_doc_len_q=max_doc_len_q,
+                    max_doc_len_k=max_doc_len_k,
+                    local_k_slice=local_k_slice,
+                    or_mask=or_mask,
+                    and_mask=and_mask,
+                )
+
+            if isinstance(qkv, torch.Tensor):
+                raise RuntimeError(f"'{type(self).__name__}' doesn't support packed QKV")
+            if self.window_size != (-1, -1):
+                raise RuntimeError(
+                    f"'{type(self).__name__}' doesn't support KV caching with sliding windows"
+                )
+            if any(
+                opt is not None
+                for opt in (
+                    cu_doc_lens,
+                    cu_doc_lens_q,
+                    cu_doc_lens_k,
+                    max_doc_len,
+                    max_doc_len_q,
+                    max_doc_len_k,
+                )
+            ):
+                raise RuntimeError(
+                    f"'{type(self).__name__}' doesn't support intra-document masking"
+                )
+            if self.cp_enabled:
+                raise RuntimeError(
+                    f"'{type(self).__name__}' doesn't support KV caching with context parallelism"
+                )
+
+            q, k, v = qkv
+            seq_len = q.shape[1]
+            # CPU-side mirror of ``cache_seqlens`` to avoid a GPU sync per layer
+            # per step. ``Attention.sdpa`` calls ``update_seqlen(seq_len)`` right
+            # after this forward, so advance the mirror by the same amount.
+            pos = getattr(kv_cache_manager, "_position_mirror", None)
+            if pos is None:
+                pos = int(kv_cache_manager.cache_seqlens.item())
+            kv_cache_manager._position_mirror = pos + seq_len
+            total = pos + seq_len
+
+            k_cache, v_cache = kv_cache_manager.k_cache, kv_cache_manager.v_cache
+            if total > k_cache.shape[1]:
+                raise RuntimeError(f"KV cache overflow: {total} > allocated {k_cache.shape[1]}")
+            k_cache[:, pos:total] = k.to(k_cache.dtype)
+            v_cache[:, pos:total] = v.to(v_cache.dtype)
+            k_full = k_cache[:, :total].to(q.dtype)
+            v_full = v_cache[:, :total].to(q.dtype)
+
+            attn_mask: torch.Tensor | None = None
+            if seq_len > 1 or or_mask is not None or and_mask is not None:
+                base = torch.ones(seq_len, total, device=q.device, dtype=torch.bool).tril(
+                    diagonal=pos
+                )
+
+                def _align_keys(mask: torch.Tensor, pad_value: bool) -> torch.Tensor:
+                    mask = mask.to(device=q.device, dtype=torch.bool)
+                    missing = total - mask.shape[-1]
+                    if missing > 0:
+                        pad = torch.full((*mask.shape[:-1], missing), pad_value, device=q.device)
+                        mask = torch.cat([pad, mask], dim=-1)
+                    return mask
+
+                if or_mask is not None:
+                    base = base | _align_keys(or_mask, False)
+                if and_mask is not None:
+                    base = base & _align_keys(and_mask, True)
+                attn_mask = base
+
+            n_rep = self.n_heads // self.n_kv_heads
+            k_full = _repeat_kv(k_full, n_rep)
+            v_full = _repeat_kv(v_full, n_rep)
+            q, k_full, v_full = q.transpose(1, 2), k_full.transpose(1, 2), v_full.transpose(1, 2)
+            att = F.scaled_dot_product_attention(
+                q,
+                k_full,
+                v_full,
+                attn_mask=attn_mask,
+                dropout_p=self.dropout_p,
+                is_causal=False,
+                scale=self.scale,
+            )
+            return att.transpose(1, 2).contiguous()
+
+    _CACHED_BACKEND_CLS = CachedTorchAttentionBackend
+    return CachedTorchAttentionBackend
+
+
+def _lm_attention_modules(model: Any) -> list[Any]:
+    return [
+        block.attention
+        for block in model.lm.blocks.values()
+        if getattr(block, "attention", None) is not None
+    ]
+
+
+def enable_kv_cache(model: Any) -> bool:
+    """Swap each LM attention's dense ``torch`` backend for the cached subclass.
+
+    Returns ``False`` (leaving the model untouched) when any block uses a
+    different backend, a sliding window, or has no attention module — callers
+    should then fall back to no-cache decoding.
+    """
+    from olmo_core.nn.attention.backend import TorchAttentionBackend
+
+    cached_cls = _cached_torch_backend_class()
+    attentions = _lm_attention_modules(model)
+    if len(attentions) != len(model.lm.blocks):
+        return False
+    for attention in attentions:
+        backend = getattr(attention, "backend", None)
+        if backend is None or type(backend) not in (TorchAttentionBackend, cached_cls):
+            return False
+        if backend.window_size != (-1, -1):
+            return False
+    for attention in attentions:
+        attention.backend.__class__ = cached_cls
+    return True
+
+
+def prepare_kv_caches(model: Any, batch_size: int, max_seq_len: int) -> None:
+    """Initialize (or reset) a KV cache on every LM attention block."""
+    for attention in _lm_attention_modules(model):
+        if attention.kv_cache_manager is None:
+            attention.init_kv_cache_manager(batch_size, max_seq_len)
+        else:
+            attention.kv_cache_manager.reset(batch_size, max_seq_len)
+        attention.kv_cache_manager._position_mirror = 0
+
+
+def free_kv_caches(model: Any) -> None:
+    """Drop all LM KV caches so subsequent forwards run uncached."""
+    for attention in _lm_attention_modules(model):
+        attention.kv_cache_manager = None
+
+
+def resolve_max_length(info: MultimodalCheckpointInfo, explicit_max_length: int | None) -> int:
+    """Pick the max sequence length: explicit > checkpoint hint > 4096."""
+    if explicit_max_length is not None:
+        return explicit_max_length
+    if info.format == "mm_olmo_dcp":
+        max_length = (info.model_config.get("llm") or {}).get("max_sequence_length")
+        if isinstance(max_length, int) and max_length > 0:
+            return max_length
+    else:
+        for section in ("dataset", "collator", "train_module"):
+            value = info.config.get(section)
+            if isinstance(value, dict):
+                max_length = value.get("sequence_length") or value.get("max_sequence_length")
+                if isinstance(max_length, int) and max_length > 0:
+                    return max_length
+    return 4096

--- a/tests/core/test_dense_caption_judge.py
+++ b/tests/core/test_dense_caption_judge.py
@@ -138,6 +138,7 @@ class TestDenseCaptionMetrics:
         num_covered: int = 5,
         num_statements: int = 10,
         num_consistent: int = 8,
+        consistency_num_statements: int = 10,
         consistency_valid: bool = True,
     ) -> dict:
         return dict(
@@ -148,6 +149,7 @@ class TestDenseCaptionMetrics:
             recall_valid=True,
             consistency=consistency,
             num_consistent=num_consistent,
+            consistency_num_statements=consistency_num_statements,
             consistency_valid=consistency_valid,
         )
 
@@ -190,9 +192,11 @@ class TestDenseCaptionMetrics:
         assert abs(score - 80.0) < 1e-6
 
     def test_num_statements_not_scaled(self):
+        # num_statements reports the consistency-side canonical-statement count
+        # (mm_olmo's ConsistencyEval.num_statements), not the recall-side count.
         responses = [
-            _make_response(self._valid_result(num_statements=20)),
-            _make_response(self._valid_result(num_statements=10)),
+            _make_response(self._valid_result(consistency_num_statements=20)),
+            _make_response(self._valid_result(consistency_num_statements=10)),
         ]
         score = DenseCaptionNumStatementsMetric().compute(responses)
         assert abs(score - 15.0) < 1e-6

--- a/tests/core/test_image_qa_scorers.py
+++ b/tests/core/test_image_qa_scorers.py
@@ -414,18 +414,19 @@ class TestPromptTemplates:
     def test_long_caption_template_count(self) -> None:
         assert len(LONG_CAPTION_TEMPLATES) == 23
 
-    # Pinned (line_idx -> dense-caption prompt) pairs, verified byte-for-byte against
-    # mm_olmo's DataFormatter.get_user_prompt for style="long_caption" under the released
-    # Molmo2-4B config (prompt_templates="uber_model_v2", system_prompt="demo_or_style_v2"):
-    # a seeded per-example pick from the long_caption templates, with no style prefix.
+    # Pinned (line_idx -> dense-caption prompt) pairs for mm_olmo's dense-caption
+    # generation pipeline (`launch_scripts/eval.py`, loader seed 6198 — verified against a
+    # real DenseCaptionEval-test dump's `_getter_seed`), under the released Molmo2-4B config
+    # (prompt_templates="uber_model_v2", system_prompt="demo_or_style_v2"): a seeded
+    # per-example pick from the long_caption templates, with no style prefix.
     @pytest.mark.parametrize(
         ("idx", "expected"),
         [
-            (0, "What do you see in the image?"),
-            (1, "Look at this photo carefully and then tell me about it in detail"),
-            (2, "Describe this image in detail"),
-            (3, "Caption this"),
-            (6, "describe the image"),
+            (0, "What can be seen in this image?"),
+            (1, "Construct a long caption for this image"),
+            (2, "caption the picture"),
+            (3, "Generate a long caption about this image."),
+            (6, "What do you see in the image?"),
         ],
     )
     def test_dense_caption_question_pinned(self, idx: int, expected: str) -> None:


### PR DESCRIPTION
Adds first-class eval support for **multimodal OLMo-core checkpoints** (the `MultimodalLM` vision branch models), so they can be evaluated directly from their training formats — no offline conversion to the released `allenai/Molmo2-4B` HF format required. Also carries three conformance fixes for the PixMo-Cap dense-caption eval found in a line-by-line review against mm_olmo.

## 1. New `olmo_core_vlm` provider

`ProviderKind.OLMO_CORE_VLM` (auto-routed from `olmo_core` when the checkpoint is multimodal). Loads three on-disk formats:

| Format | Layout | Loading |
|---|---|---|
| `olmo_core_dcp` | `config.json` (`MultimodalLMConfig` under `model`) + `model_and_optim/` DCP | `MultimodalLMConfig.from_dict` (legacy `MultimodalTransformerConfig` class name rewritten) + `load_model_and_optim_state` |
| `olmo_core_unsharded` | `olmo_core_config.json` + `model.safetensors` with `lm.*`/`vision.*`/`connector.*` keys | direct safetensors load |
| `mm_olmo_dcp` | `config.yaml` (`video_olmo`) + DCP with legacy fused keys | config translated + keys remapped via OLMo-core's `molmo2_loader` (fused QKV/SwiGLU splits, tied-lm_head synthesis, patch-embed permute) |

Design points:
- **Prompt construction is token-exact with the released Molmo2 processor** (chat-template image hoisting, BOS rule, expanded image-token splicing) — verified 765/765 `input_ids` and identical pooled-patch indices on a real image.
- **KV-cached decoding**: the mask-capable `torch`/`flex` attention backends reject KV caching, so the provider installs a cache-capable dense-SDPA backend subclass on the LM blocks (OLMo-core's `Attention`/`KVCacheManager` plumbing reused as-is). Token-for-token parity with no-cache decoding verified; ~10× decode speedup for caption-length outputs. `use_cache=False` falls back to full re-forward.
- The LM head is untied before loading (checkpoints store differing `embeddings`/`w_out` tensors despite `tie_word_embeddings`, and OLMo-core's tie shares storage — loading both into one parameter would silently clobber).
- Bidirectional image-token attention (`or_mask`) on by default, matching HF Molmo2 / mm_olmo `bi_directional_attn: image_tokens`.
- Over-length prompts clamp `max_tokens` (or skip with a warning) instead of raising; decode is serialized with a lock for the async harness; multi-image requests supported (crop-axis concat with offset pooled indices).
- Text-only loglikelihood implemented; image loglikelihood raises (all image tasks are CHAT), mirroring the HF multimodal provider.

## 2. `HuggingFaceProvider`: consolidated OLMo-core exports

The HF provider (the verified released-Molmo2 path) now also accepts `olmo_core_unsharded` export dirs: auto-detected, weights converted **in-memory** back to released-Molmo2 naming (`convert_olmo_core_to_molmo2_hf_state_dict`, the exact inverse of OLMo-core's HF loader mapping), config/processor/modeling code borrowed from a reference repo (`reference_model` kwarg, defaulting to the export's recorded `model_id`). Everything downstream is the stock remote-code path (`model.generate`, transformers-5 shims).

Verification: converting a real export reproduced its independently-converted released-format twin **bit-exactly (706/706 tensors)**, and end-to-end greedy generation matched the released-format checkpoint **word-for-word**. Cross-provider check: `hf` and `olmo_core_vlm` on the same export scored identically (0.8125) on a 32-example `real_world_qa` slice.

## 3. Dense-caption (PixMo-Cap) conformance fixes

From a line-by-line review against mm_olmo main (`b8bb0e79`) plus a real mm_olmo `DenseCaptionEval-test` prediction dump:

1. **Prompt seed**: `dense_caption_question` now uses `DENSE_CAPTION_LOADER_SEED = 6198` — the `launch_scripts/eval.py` dense-caption pipeline's loader seed, verified via the dump's `_getter_seed == (6198·195172 + idx) mod 2³²−1` — instead of the image-QA loader seed 691203 (which remains correct for `pixmo_count`). Per-example template picks now match mm_olmo's caption pipeline.
2. **`num_statements`** now reports mm_olmo's quantity: the mean count of canonical statements GPT derives from the *model caption* (consistency side, over consistency-valid examples), not the recall-side mturk statement count. Recall/consistency/avg were already exact and are unchanged.
3. **New task `dense_caption_captioner`**: for mm_olmo captioner-family checkpoints (`prompt_templates="none"` + `system_prompt="style_and_length_v2"`), whose eval prompt is the constant `"long_caption 65:"` with an empty user question (verified verbatim in the dump). The default `dense_caption` task keeps the released-Molmo2 (`uber_model_v2`) behavior.

Note: fix 1 changes generated captions for `uber_model_v2`-style models, so the next `dense_caption` run re-generates and re-judges (fresh GPT-judge cache entries) rather than reusing caches keyed to the old prompts.

## Tests

- Full non-integration suite: **1795 passed, 5 skipped**; `ruff check`/`format` clean.
- Test updates limited to the changed semantics: the `num_statements` synthetic-result helper and five pinned dense-caption prompt expectations (recomputed under seed 6198).
