### PR TITLE
Preserve agent work on max_turns: keep partial trajectory and force a tool-free final answer

### DIFF
--- a/src/olmo_eval/harness/scaffolds/openai_agents.py
+++ b/src/olmo_eval/harness/scaffolds/openai_agents.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Sequence
 from contextvars import ContextVar
+from dataclasses import replace
 from typing import TYPE_CHECKING, Any
 
 from olmo_eval.common.types import LMOutput, LMRequest, SamplingParams
@@ -22,6 +23,10 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 _current_binding: ContextVar[ExecutorBinding | None] = ContextVar("_current_binding", default=None)
+FORCED_FINAL_ANSWER_INSTRUCTION = (
+    "You have reached the maximum number of steps. Based on the information gathered so far, "
+    "provide your final answer now. Do not call any tools."
+)
 
 
 @register_scaffold("openai_agents")
@@ -335,11 +340,32 @@ class OpenAIAgentsScaffold(Scaffold):
             except Exception as e:
                 # Handle MaxTurnsExceeded - return a result with the error instead of raising
                 if type(e).__name__ == "MaxTurnsExceeded":
+                    partial_result = getattr(e, "run_data", None)
+                    trajectory = self._convert_trajectory(partial_result)
+                    try:
+                        final_text = await self._force_final_answer(
+                            Runner=Runner,
+                            agent=agent,
+                            partial_result=partial_result,
+                            original_input=input_text,
+                        )
+                    except Exception:
+                        logger.warning(
+                            "Forced final answer after max_turns failed; using fallback result",
+                            exc_info=True,
+                        )
+                        return HarnessResult(
+                            trajectory=AgentTrajectory(turns=()),
+                            final_output=LMOutput(text="[Max turns exceeded]"),
+                            max_turns_reached=True,
+                            error=f"Max turns ({max_turns}) exceeded",
+                        )
+
                     return HarnessResult(
-                        trajectory=AgentTrajectory(turns=()),
-                        final_output=LMOutput(text="[Max turns exceeded]"),
+                        trajectory=trajectory,
+                        final_output=LMOutput(text=final_text),
                         max_turns_reached=True,
-                        error=f"Max turns ({max_turns}) exceeded",
+                        error=None,
                     )
 
                 # Log full traceback for debugging connection issues
@@ -366,6 +392,66 @@ class OpenAIAgentsScaffold(Scaffold):
             error="Max turns exceeded" if max_turns_reached else None,
         )
 
+    async def _force_final_answer(
+        self,
+        *,
+        Runner: Any,
+        agent: Any,
+        partial_result: Any,
+        original_input: str,
+    ) -> str:
+        """Run one no-tool model call to produce a final answer after max_turns."""
+        final_input = self._build_forced_final_input(partial_result, original_input)
+        model_settings = replace(agent.model_settings, tool_choice="none")
+        final_agent = replace(
+            agent,
+            tools=[],
+            handoffs=[],
+            mcp_servers=[],
+            model_settings=model_settings,
+        )
+        final_result = await Runner.run(
+            starting_agent=final_agent,
+            input=final_input,
+            max_turns=1,
+        )
+        final_text = getattr(final_result, "final_output", "")
+        return str(final_text or "")
+
+    def _build_forced_final_input(
+        self,
+        partial_result: Any,
+        original_input: str,
+    ) -> list[Any]:
+        """Build model input from the partial run plus a final-answer instruction."""
+        input_list: list[Any] = []
+
+        if partial_result is not None and hasattr(partial_result, "to_input_list"):
+            try:
+                input_list = list(partial_result.to_input_list())
+            except Exception:
+                input_list = []
+
+        if not input_list and partial_result is not None:
+            original = getattr(partial_result, "input", original_input)
+            if isinstance(original, list):
+                input_list.extend(original)
+            elif original:
+                input_list.append({"role": "user", "content": str(original)})
+
+            for item in getattr(partial_result, "new_items", None) or []:
+                if hasattr(item, "to_input_item"):
+                    try:
+                        input_list.append(item.to_input_item())
+                    except Exception:
+                        continue
+
+        if not input_list and original_input:
+            input_list.append({"role": "user", "content": original_input})
+
+        input_list.append({"role": "user", "content": FORCED_FINAL_ANSWER_INSTRUCTION})
+        return input_list
+
     def _convert_trajectory(self, result: Any) -> AgentTrajectory:
         """Convert agents SDK result to AgentTrajectory.
 
@@ -376,6 +462,8 @@ class OpenAIAgentsScaffold(Scaffold):
             AgentTrajectory with converted turns.
         """
         turns: list[AgentTurn] = []
+        if result is None:
+            return AgentTrajectory(turns=tuple(turns))
 
         # Get items from new_items (primary source in agents SDK)
         items = getattr(result, "new_items", None) or []
@@ -426,7 +514,15 @@ class OpenAIAgentsScaffold(Scaffold):
                 # Extract tool_call_id from raw_item
                 tool_call_id = ""
                 if raw is not None:
-                    tool_call_id = getattr(raw, "call_id", "") or getattr(raw, "id", "") or ""
+                    if isinstance(raw, dict):
+                        tool_call_id = (
+                            raw.get("call_id", "")
+                            or raw.get("tool_call_id", "")
+                            or raw.get("id", "")
+                            or ""
+                        )
+                    else:
+                        tool_call_id = getattr(raw, "call_id", "") or getattr(raw, "id", "") or ""
                 content = str(output) if output is not None else ""
                 tool_result = ToolResult(
                     tool_call_id=tool_call_id,

--- a/tests/core/harness/test_openai_agents_scaffold.py
+++ b/tests/core/harness/test_openai_agents_scaffold.py
@@ -1,0 +1,203 @@
+"""Tests for the OpenAI Agents scaffold (requires the optional agents deps)."""
+
+import contextlib
+from types import SimpleNamespace
+
+import pytest
+
+from olmo_eval.common.types import LMRequest, RequestType
+from olmo_eval.harness.config import HarnessConfig
+from olmo_eval.harness.scaffolds.openai_agents import (
+    FORCED_FINAL_ANSWER_INSTRUCTION,
+    OpenAIAgentsScaffold,
+)
+
+pytest.importorskip("agents")
+
+
+def _function_call(name: str, arguments: str = "{}"):
+    from openai.types.responses import ResponseFunctionToolCall
+
+    return ResponseFunctionToolCall(
+        arguments=arguments,
+        call_id=f"call_{name}",
+        name=name,
+        type="function_call",
+    )
+
+
+def _tool_turn_items(agent, output: str = "Search result text"):
+    from agents.items import ToolCallItem, ToolCallOutputItem
+
+    call = _function_call("search", '{"query":"olmo"}')
+    return [
+        ToolCallItem(agent=agent, raw_item=call),
+        ToolCallOutputItem(
+            agent=agent,
+            raw_item={
+                "type": "function_call_output",
+                "call_id": call.call_id,
+                "output": output,
+            },
+            output=output,
+        ),
+    ]
+
+
+class _FakeRunData:
+    def __init__(self, *, new_items, final_output=None):
+        self.new_items = new_items
+        self.final_output = final_output
+
+
+def _max_turns_exceeded_with_run_data(run_data, message: str = "Max turns (1) exceeded"):
+    from agents.exceptions import MaxTurnsExceeded
+
+    exc = MaxTurnsExceeded(message)
+    exc.run_data = run_data
+    return exc
+
+
+def _agent_request():
+    return LMRequest(
+        request_type=RequestType.CHAT,
+        messages=({"role": "user", "content": "What did you find?"},),
+    )
+
+
+def _patch_scaffold_agent(monkeypatch, agent):
+    import agents
+
+    monkeypatch.setattr(
+        OpenAIAgentsScaffold,
+        "_get_or_create_agent",
+        lambda self, provider, config, sandbox_manager=None: agent,
+    )
+    monkeypatch.setattr(agents, "trace", lambda *args, **kwargs: contextlib.nullcontext())
+
+
+class TestOpenAIAgentsMaxTurns:
+    @pytest.mark.anyio
+    async def test_max_turns_preserves_trajectory_and_forces_final_answer(self, monkeypatch):
+        from agents import Agent, Runner
+
+        agent = Agent(name="test-agent", instructions="Use tools.")
+        partial_run_data = _FakeRunData(
+            new_items=_tool_turn_items(agent, output="Tool result before cap"),
+        )
+        run_calls = []
+
+        def fail_run_streamed(**kwargs):
+            raise AssertionError("Runner.run_streamed should not be used")
+
+        async def fake_run(**kwargs):
+            run_calls.append(kwargs)
+            if len(run_calls) == 1:
+                raise _max_turns_exceeded_with_run_data(partial_run_data)
+            return SimpleNamespace(final_output="Forced final answer")
+
+        _patch_scaffold_agent(monkeypatch, agent)
+        monkeypatch.setattr(Runner, "run_streamed", staticmethod(fail_run_streamed))
+        monkeypatch.setattr(Runner, "run", staticmethod(fake_run))
+
+        result = await OpenAIAgentsScaffold().run(
+            provider=SimpleNamespace(),
+            config=HarnessConfig(name="test", max_turns=1),
+            request=_agent_request(),
+            enable_compaction=False,
+        )
+
+        assert result.max_turns_reached is True
+        assert result.error is None
+        assert result.final_output.text == "Forced final answer"
+        assert result.trajectory is not None
+        assert result.trajectory.total_tool_calls == 1
+        assert result.trajectory.tool_result_sequence[0].content == "Tool result before cap"
+        assert result.trajectory.tool_result_sequence[0].tool_call_id == "call_search"
+
+        assert len(run_calls) == 2
+        assert run_calls[0]["max_turns"] == 1
+        final_call = run_calls[1]
+        assert final_call["max_turns"] == 1
+        assert final_call["starting_agent"].tools == []
+        assert final_call["starting_agent"].handoffs == []
+        assert final_call["starting_agent"].mcp_servers == []
+        assert final_call["starting_agent"].model_settings.tool_choice == "none"
+        assert final_call["input"][-1] == {
+            "role": "user",
+            "content": FORCED_FINAL_ANSWER_INSTRUCTION,
+        }
+
+    @pytest.mark.anyio
+    async def test_forced_final_answer_failure_falls_back_to_old_result(self, monkeypatch):
+        from agents import Agent, Runner
+
+        agent = Agent(name="test-agent", instructions="Use tools.")
+        partial_run_data = _FakeRunData(
+            new_items=_tool_turn_items(agent),
+        )
+        run_calls = []
+
+        def fail_run_streamed(**kwargs):
+            raise AssertionError("Runner.run_streamed should not be used")
+
+        async def fake_run(**kwargs):
+            run_calls.append(kwargs)
+            if len(run_calls) == 1:
+                raise _max_turns_exceeded_with_run_data(partial_run_data)
+            raise RuntimeError("connection failed")
+
+        _patch_scaffold_agent(monkeypatch, agent)
+        monkeypatch.setattr(Runner, "run_streamed", staticmethod(fail_run_streamed))
+        monkeypatch.setattr(Runner, "run", staticmethod(fake_run))
+
+        result = await OpenAIAgentsScaffold().run(
+            provider=SimpleNamespace(),
+            config=HarnessConfig(name="test", max_turns=1),
+            request=_agent_request(),
+            enable_compaction=False,
+        )
+
+        assert result.max_turns_reached is True
+        assert result.final_output.text == "[Max turns exceeded]"
+        assert result.trajectory is not None
+        assert result.trajectory.turns == ()
+        assert result.error == "Max turns (1) exceeded"
+        assert len(run_calls) == 2
+
+    @pytest.mark.anyio
+    async def test_normal_completion_does_not_force_final_answer(self, monkeypatch):
+        from agents import Agent, Runner
+
+        agent = Agent(name="test-agent", instructions="Use tools.")
+        run_result = _FakeRunData(
+            new_items=_tool_turn_items(agent, output="Normal tool result"),
+            final_output="Normal final answer",
+        )
+        run_calls = []
+
+        def fail_run_streamed(**kwargs):
+            raise AssertionError("Runner.run_streamed should not be used")
+
+        async def fake_run(**kwargs):
+            run_calls.append(kwargs)
+            return run_result
+
+        _patch_scaffold_agent(monkeypatch, agent)
+        monkeypatch.setattr(Runner, "run_streamed", staticmethod(fail_run_streamed))
+        monkeypatch.setattr(Runner, "run", staticmethod(fake_run))
+
+        result = await OpenAIAgentsScaffold().run(
+            provider=SimpleNamespace(),
+            config=HarnessConfig(name="test", max_turns=3),
+            request=_agent_request(),
+            enable_compaction=False,
+        )
+
+        assert result.max_turns_reached is False
+        assert result.error is None
+        assert result.final_output.text == "Normal final answer"
+        assert result.trajectory is not None
+        assert result.trajectory.total_tool_calls == 1
+        assert result.trajectory.tool_result_sequence[0].content == "Normal tool result"
+        assert len(run_calls) == 1


### PR DESCRIPTION
## Problem

When an agent hits its `max_turns` budget, the `openai_agents` scaffold catches `MaxTurnsExceeded` and returns an **empty trajectory** plus `"[Max turns exceeded]"`. Every search and tool result the model actually produced is discarded, so the instance auto-scores 0 regardless of how much correct work was done. A model that searched hard for the full budget but did not finalize scores the same as one that did nothing.

Measured prevalence (share of instances that hit the cap and were zeroed): LitSearch 11-13% for the Qwen models; SAGE short_form 22-39% across Qwen3.5-9B/35B and Gemma.

## Fix

On `MaxTurnsExceeded`:
1. **Preserve the partial trajectory** from the exception's `run_data.new_items` (the SDK attaches `RunErrorDetails`), so scorers that read tool results (e.g. litsearch) see the searches that actually happened.
2. **Force a final answer**: run one tool-free generation (`tools=[]`, `tool_choice="none"`, `max_turns=1`) on the accumulated conversation plus an instruction to answer now from the gathered evidence, and use that text as `final_output` (for scorers that read the answer, e.g. sage/expertqa).
3. `max_turns_reached=True` is kept so downstream still knows the cap was hit.

**Never worse than before:** if the finalization call raises for any reason, the handler falls back to the previous empty result unchanged. The normal (non-capped) path is untouched and stays on non-streaming `Runner.run`.

## Validation

- Unit tests (new `tests/core/harness/test_openai_agents_scaffold.py`): capped run preserves tool results in the trajectory and returns the forced answer; finalization failure falls back to the old result; normal completion unchanged.
- End-to-end: re-ran only the capped instances of prior LitSearch/SAGE runs with this fix and merged by instance id. Recovered scores: LitSearch found_rate 9B 0.310 -> 0.356, 35B 0.320 -> 0.358; SAGE short_form exact_match 9B 0.45 -> 0.69, 35B 0.56 -> 0.76 (finished-run accuracy was ~90% all along; the cap discard was hiding it). SAGE open_ended barely moves (few caps), as expected.
- `ruff check` / `ruff format --check` clean; `ty` reports only pre-existing diagnostics.

cc @donovanr