### PR TITLE
Add an in-process crawl4ai browse_webpage tool (+ presets, configurable fetch truncation)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,9 @@ Repository = "https://github.com/allenai/olmo-eval"
 Issues = "https://github.com/allenai/olmo-eval/issues"
 
 [project.optional-dependencies]
+crawl4ai = [
+    "crawl4ai>=0.8",
+]
 hf = [
     "transformers>=5.4.0",
 ]
@@ -239,6 +242,7 @@ allowed-unresolved-imports = [
     "cached_path.**",
     "instructions_registry.**",
     "instructions.**",
+    "crawl4ai.**",
 ]
 
 [tool.gantry]

--- a/src/olmo_eval/harness/presets.py
+++ b/src/olmo_eval/harness/presets.py
@@ -123,6 +123,34 @@ class HarnessPresets:
         )
 
     @lazy
+    def dr_tulu_crawl4ai(name: str) -> HarnessConfig:
+        """Dr. Tulu-style S2 plus web-search harness that browses with in-process
+        crawl4ai.
+
+        Install with ``pip install 'olmo-eval[crawl4ai]'``, then run
+        ``crawl4ai-setup`` once to provision the headless browser. ``S2_API_KEY``
+        is not required but is strongly recommended for throughput because
+        keyless S2 is rate-limited to about 1 request/second process-wide.
+        """
+        from .tools.search import crawl4ai_browse, semantic_scholar_search, serper_web_search
+
+        return HarnessConfig(
+            name=name,
+            provider=ProviderConfig(
+                kind=ProviderKind.VLLM_SERVER,
+                kwargs={"timeout": 120},
+            ),
+            tools=(semantic_scholar_search, serper_web_search, crawl4ai_browse),
+            system_prompt=DR_TULU_SYSTEM_PROMPT,
+            # Agentic paper search needs more turns than the dr_tulu default of 10.
+            max_turns=20,
+            max_concurrency=4,
+            scaffold="openai_agents",
+            required_secrets=("SERPER_API_KEY",),
+            batching=BatchConfig.streaming(),
+        )
+
+    @lazy
     def paper_search_agent(name: str) -> HarnessConfig:
         """Agentic harness exposing only Semantic Scholar paper search.
 
@@ -164,6 +192,43 @@ class HarnessPresets:
             ),
             tools=(serper_web_search, serper_fetch_page),
             system_prompt=WEB_SEARCH_SYSTEM_PROMPT,
+            max_turns=30,
+            max_concurrency=4,
+            scaffold="openai_agents",
+            required_secrets=("SERPER_API_KEY",),
+            batching=BatchConfig.streaming(),
+        )
+
+    @lazy
+    def web_search_agent_crawl4ai(name: str) -> HarnessConfig:
+        """Web search via Serper + in-process crawl4ai browsing (no hosted scrape service).
+
+        Install with ``pip install 'olmo-eval[crawl4ai]'``, then run
+        ``crawl4ai-setup`` once to provision the headless browser.
+        """
+        from .tools.search import crawl4ai_browse, serper_web_search
+
+        return HarnessConfig(
+            name=name,
+            provider=ProviderConfig(
+                kind=ProviderKind.VLLM_SERVER,
+                kwargs={"timeout": 120},
+            ),
+            tools=(serper_web_search, crawl4ai_browse),
+            system_prompt="""\
+You are a helpful assistant that can search and browse webpages to answer questions accurately.
+
+You have access to these tools:
+- serper_google_webpage_search: Search the web for relevant webpages.
+- browse_webpage: Fetch and extract a webpage's content as clean markdown.
+
+When answering questions:
+1. Use serper_google_webpage_search to find relevant sources when needed.
+2. Use browse_webpage to inspect promising URLs.
+3. Provide concise, accurate answers based on the information you find.
+4. If you cannot find reliable information, say so rather than guessing.
+
+Always strive to give factually correct answers.""",
             max_turns=30,
             max_concurrency=4,
             scaffold="openai_agents",

--- a/src/olmo_eval/harness/tools/search.py
+++ b/src/olmo_eval/harness/tools/search.py
@@ -4,6 +4,7 @@ This module provides search tools that can be used with the Harness:
 - semantic_scholar_search: Search academic papers via Semantic Scholar API
 - serper_web_search: Search the web via Serper/Google API
 - serper_fetch_page: Fetch and extract webpage content
+- crawl4ai_browse: Fetch and extract webpage content via crawl4ai
 
 These tools are pre-registered in the global registry.
 Import the tool objects and use .name for HarnessConfig.tool_names.
@@ -21,6 +22,7 @@ from collections.abc import Awaitable, Callable, Iterator
 from contextlib import contextmanager
 from contextvars import ContextVar
 from datetime import date
+from urllib.parse import urlsplit
 
 import httpx
 
@@ -38,6 +40,8 @@ _RETRYABLE_STATUS = frozenset({429, 500, 502, 503, 504})
 _MAX_RETRIES = 5
 _BASE_BACKOFF_S = 1.0
 _MAX_BACKOFF_S = 16.0
+_WEBPAGE_CONTENT_LIMIT = 4000
+_WEBPAGE_TRUNCATION_NOTICE = "\n\n[Content truncated...]"
 
 # Semantic Scholar's introductory plan allows ~1 request/second cumulative across
 # all endpoints, which several concurrent agents exhaust immediately. All S2
@@ -82,6 +86,23 @@ def _parse_cutoff(raw: str | None) -> tuple[int, str, str] | None:
         f"{month_text}/{day_text}/{year_text}",
         f"{year_text}-{month_text}-{day_text}",
     )
+
+
+def _truncate_webpage_content(text: str) -> str:
+    limit_value = os.environ.get("OLMO_WEBPAGE_CONTENT_LIMIT")
+    if limit_value is None:
+        limit = _WEBPAGE_CONTENT_LIMIT
+    else:
+        try:
+            limit = int(limit_value)
+        except ValueError:
+            limit = _WEBPAGE_CONTENT_LIMIT
+
+    if limit <= 0:
+        return text
+    if len(text) > limit:
+        return text[:limit] + _WEBPAGE_TRUNCATION_NOTICE
+    return text
 
 
 async def _s2_rate_gate() -> None:
@@ -416,8 +437,57 @@ async def serper_fetch_page(url: str) -> str:
     if not text:
         return "No content extracted from webpage."
 
-    # Truncate if too long
-    if len(text) > 4000:
-        text = text[:4000] + "\n\n[Content truncated...]"
+    text = _truncate_webpage_content(text)
+
+    return text
+
+
+@registered_tool(
+    name="browse_webpage",
+    description="Fetch and extract a webpage's content as clean markdown (via crawl4ai).",
+)
+async def crawl4ai_browse(url: str) -> str:
+    """Fetch and extract a webpage's content as clean markdown via crawl4ai.
+
+    Args:
+        url: The URL of the webpage to fetch.
+
+    Returns:
+        Extracted markdown content from the webpage.
+    """
+    if not url or not url.strip():
+        return "Error: Empty URL."
+
+    sanitized_url = url.strip()
+    if urlsplit(sanitized_url).scheme.lower() not in {"http", "https"}:
+        return "Error: Only http(s) URLs are supported."
+
+    try:
+        from crawl4ai import AsyncWebCrawler
+    except ImportError:
+        return "Error: crawl4ai is not installed."
+
+    try:
+        async with AsyncWebCrawler() as crawler:
+            result = await crawler.arun(sanitized_url)
+    except Exception as e:
+        logger.exception(f"crawl4ai browse error: url={sanitized_url!r}")
+        return f"Error fetching webpage: {e}"
+
+    if not getattr(result, "success", False):
+        error_message = getattr(result, "error_message", None)
+        if error_message:
+            return f"Error fetching webpage: {error_message}"
+        status_code = getattr(result, "status_code", None)
+        if status_code is not None:
+            return f"Error fetching webpage: HTTP {status_code}"
+        return "Error fetching webpage: unknown error"
+
+    markdown = getattr(result, "markdown", None)
+    text = getattr(markdown, "raw_markdown", None) or str(markdown or "")
+    if not text.strip():
+        return "No content extracted from webpage."
+
+    text = _truncate_webpage_content(text)
 
     return text

--- a/tests/core/harness/test_crawl4ai_browse_tool.py
+++ b/tests/core/harness/test_crawl4ai_browse_tool.py
@@ -1,0 +1,303 @@
+"""Tests for the crawl4ai-backed browse_webpage tool."""
+
+from __future__ import annotations
+
+import builtins
+import sys
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+
+def _install_fake_crawl4ai(monkeypatch: pytest.MonkeyPatch, result: object):
+    class FakeCrawler:
+        instances = []
+
+        def __init__(self):
+            self.arun_urls = []
+            FakeCrawler.instances.append(self)
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def arun(self, url: str):
+            self.arun_urls.append(url)
+            if isinstance(result, Exception):
+                raise result
+            return result
+
+    module = ModuleType("crawl4ai")
+    module.AsyncWebCrawler = FakeCrawler
+    monkeypatch.setitem(sys.modules, "crawl4ai", module)
+    return FakeCrawler
+
+
+def test_truncate_webpage_content_uses_default_when_env_unset(monkeypatch):
+    from olmo_eval.harness.tools import search
+
+    monkeypatch.delenv("OLMO_WEBPAGE_CONTENT_LIMIT", raising=False)
+
+    result = search._truncate_webpage_content("x" * 4001)
+
+    assert result == ("x" * 4000) + "\n\n[Content truncated...]"
+
+
+def test_truncate_webpage_content_uses_env_limit(monkeypatch):
+    from olmo_eval.harness.tools import search
+
+    monkeypatch.setenv("OLMO_WEBPAGE_CONTENT_LIMIT", "8000")
+
+    result = search._truncate_webpage_content("x" * 8001)
+
+    assert result == ("x" * 8000) + "\n\n[Content truncated...]"
+
+
+def test_truncate_webpage_content_zero_disables_truncation(monkeypatch):
+    from olmo_eval.harness.tools import search
+
+    text = "x" * 8001
+    monkeypatch.setenv("OLMO_WEBPAGE_CONTENT_LIMIT", "0")
+
+    result = search._truncate_webpage_content(text)
+
+    assert result == text
+    assert "\n\n[Content truncated...]" not in result
+
+
+def test_truncate_webpage_content_invalid_env_uses_default(monkeypatch):
+    from olmo_eval.harness.tools import search
+
+    monkeypatch.setenv("OLMO_WEBPAGE_CONTENT_LIMIT", "abc")
+
+    result = search._truncate_webpage_content("x" * 4001)
+
+    assert result == ("x" * 4000) + "\n\n[Content truncated...]"
+
+
+def test_truncate_webpage_content_negative_limit_disables_truncation(monkeypatch):
+    from olmo_eval.harness.tools import search
+
+    text = "x" * 8001
+    monkeypatch.setenv("OLMO_WEBPAGE_CONTENT_LIMIT", "-5")
+
+    result = search._truncate_webpage_content(text)
+
+    assert result == text
+    assert "\n\n[Content truncated...]" not in result
+
+
+def test_truncate_webpage_content_at_limit_is_unchanged(monkeypatch):
+    from olmo_eval.harness.tools import search
+
+    text = "x" * 4000
+    monkeypatch.delenv("OLMO_WEBPAGE_CONTENT_LIMIT", raising=False)
+
+    result = search._truncate_webpage_content(text)
+
+    assert result == text
+    assert "\n\n[Content truncated...]" not in result
+
+
+def test_truncate_webpage_content_empty_env_uses_default(monkeypatch):
+    from olmo_eval.harness.tools import search
+
+    monkeypatch.setenv("OLMO_WEBPAGE_CONTENT_LIMIT", "")
+
+    result = search._truncate_webpage_content("x" * 4001)
+
+    assert result == ("x" * 4000) + "\n\n[Content truncated...]"
+
+
+@pytest.mark.anyio
+async def test_crawl4ai_browse_returns_markdown(monkeypatch):
+    from olmo_eval.harness.tools import search
+
+    markdown = SimpleNamespace(raw_markdown="# Page\ntext...")
+    crawler_cls = _install_fake_crawl4ai(
+        monkeypatch,
+        SimpleNamespace(success=True, status_code=200, markdown=markdown, cleaned_html=""),
+    )
+
+    result = await search.crawl4ai_browse(url=" https://example.com/page ")
+
+    assert result == "# Page\ntext..."
+    assert crawler_cls.instances[0].arun_urls == ["https://example.com/page"]
+
+
+@pytest.mark.anyio
+async def test_crawl4ai_browse_empty_url():
+    from olmo_eval.harness.tools import search
+
+    result = await search.crawl4ai_browse(url="  ")
+
+    assert result == "Error: Empty URL."
+
+
+@pytest.mark.anyio
+async def test_crawl4ai_browse_rejects_file_url_before_import(monkeypatch):
+    from olmo_eval.harness.tools import search
+
+    real_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "crawl4ai":
+            raise AssertionError("crawl4ai import attempted")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    result = await search.crawl4ai_browse(url="file:///etc/passwd")
+
+    assert result == "Error: Only http(s) URLs are supported."
+
+
+@pytest.mark.anyio
+async def test_crawl4ai_browse_rejects_ftp_url_before_import(monkeypatch):
+    from olmo_eval.harness.tools import search
+
+    real_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "crawl4ai":
+            raise AssertionError("crawl4ai import attempted")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    result = await search.crawl4ai_browse(url="ftp://x")
+
+    assert result == "Error: Only http(s) URLs are supported."
+
+
+@pytest.mark.anyio
+async def test_crawl4ai_browse_missing_package(monkeypatch):
+    from olmo_eval.harness.tools import search
+
+    real_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "crawl4ai":
+            raise ImportError("missing crawl4ai")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    result = await search.crawl4ai_browse(url="https://example.com")
+
+    assert result == "Error: crawl4ai is not installed."
+
+
+@pytest.mark.anyio
+async def test_crawl4ai_browse_unsuccessful_fetch(monkeypatch):
+    from olmo_eval.harness.tools import search
+
+    _install_fake_crawl4ai(
+        monkeypatch,
+        SimpleNamespace(success=False, status_code=503, markdown="", cleaned_html=""),
+    )
+
+    result = await search.crawl4ai_browse(url="https://example.com")
+
+    assert result == "Error fetching webpage: HTTP 503"
+
+
+@pytest.mark.anyio
+async def test_crawl4ai_browse_unsuccessful_fetch_uses_error_message(monkeypatch):
+    from olmo_eval.harness.tools import search
+
+    _install_fake_crawl4ai(
+        monkeypatch,
+        SimpleNamespace(
+            success=False,
+            status_code=None,
+            error_message="net::ERR_CONNECTION_RESET",
+            markdown="",
+            cleaned_html="",
+        ),
+    )
+
+    result = await search.crawl4ai_browse(url="https://example.com")
+
+    assert "net::ERR_CONNECTION_RESET" in result
+
+
+@pytest.mark.anyio
+async def test_crawl4ai_browse_unsuccessful_fetch_without_details_is_unknown(monkeypatch):
+    from olmo_eval.harness.tools import search
+
+    _install_fake_crawl4ai(
+        monkeypatch,
+        SimpleNamespace(success=False, status_code=None, markdown="", cleaned_html=""),
+    )
+
+    result = await search.crawl4ai_browse(url="https://example.com")
+
+    assert result == "Error fetching webpage: unknown error"
+
+
+@pytest.mark.anyio
+async def test_crawl4ai_browse_arun_exception(monkeypatch):
+    from olmo_eval.harness.tools import search
+
+    _install_fake_crawl4ai(monkeypatch, RuntimeError("crawl failed"))
+
+    result = await search.crawl4ai_browse(url="https://example.com")
+
+    assert result.startswith("Error fetching webpage:")
+
+
+@pytest.mark.anyio
+async def test_crawl4ai_browse_falls_back_to_string_markdown(monkeypatch):
+    from olmo_eval.harness.tools import search
+
+    class StringCompatibleMarkdown:
+        raw_markdown = ""
+
+        def __str__(self):
+            return "# Page\nfrom string"
+
+    _install_fake_crawl4ai(
+        monkeypatch,
+        SimpleNamespace(
+            success=True,
+            status_code=200,
+            markdown=StringCompatibleMarkdown(),
+            cleaned_html="",
+        ),
+    )
+
+    result = await search.crawl4ai_browse(url="https://example.com")
+
+    assert result == "# Page\nfrom string"
+
+
+@pytest.mark.anyio
+async def test_crawl4ai_browse_empty_markdown(monkeypatch):
+    from olmo_eval.harness.tools import search
+
+    _install_fake_crawl4ai(
+        monkeypatch,
+        SimpleNamespace(success=True, status_code=200, markdown="", cleaned_html=""),
+    )
+
+    result = await search.crawl4ai_browse(url="https://example.com")
+
+    assert result == "No content extracted from webpage."
+
+
+@pytest.mark.anyio
+async def test_crawl4ai_browse_truncates_markdown(monkeypatch):
+    from olmo_eval.harness.tools import search
+
+    monkeypatch.delenv("OLMO_WEBPAGE_CONTENT_LIMIT", raising=False)
+    _install_fake_crawl4ai(
+        monkeypatch,
+        SimpleNamespace(success=True, status_code=200, markdown="x" * 4001, cleaned_html=""),
+    )
+
+    result = await search.crawl4ai_browse(url="https://example.com")
+
+    assert result == ("x" * 4000) + "\n\n[Content truncated...]"

--- a/tests/core/harness/test_presets.py
+++ b/tests/core/harness/test_presets.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 
+from olmo_eval.common.types import ProviderKind
 from olmo_eval.harness import clear_registry
 from olmo_eval.harness.config import HarnessConfig
 from olmo_eval.harness.presets import (
@@ -91,6 +92,39 @@ class TestHarnessPresets:
         assert "S2_API_KEY" in config.required_secrets
         assert "SERPER_API_KEY" in config.required_secrets
 
+    def test_get_dr_tulu_crawl4ai_preset(self):
+        """Test the Dr. Tulu S2 + Serper search + crawl4ai browse preset."""
+        config = get_harness_preset("dr_tulu_crawl4ai")
+
+        assert isinstance(config, HarnessConfig)
+        assert config.name == "dr_tulu_crawl4ai"
+        assert config.tool_names == (
+            "semantic_scholar_snippet_search",
+            "serper_google_webpage_search",
+            "browse_webpage",
+        )
+        assert config.max_turns == 20
+        assert config.required_secrets == ("SERPER_API_KEY",)
+
+    def test_get_web_search_agent_crawl4ai_preset(self):
+        """Test the Serper search + crawl4ai browse preset."""
+        config = get_harness_preset("web_search_agent_crawl4ai")
+
+        assert isinstance(config, HarnessConfig)
+        assert config.name == "web_search_agent_crawl4ai"
+        assert config.tool_names == ("serper_google_webpage_search", "browse_webpage")
+        assert config.required_secrets == ("SERPER_API_KEY",)
+        assert config.provider.kind == ProviderKind.VLLM_SERVER
+        assert config.provider.kwargs["timeout"] == 120
+        assert config.max_turns == 30
+        assert config.max_concurrency == 4
+        assert config.scaffold == "openai_agents"
+        assert config.batching is not None
+        assert config.batching.strategy == "streaming"
+        assert config.system_prompt is not None
+        assert "serper_google_webpage_search" in config.system_prompt
+        assert "browse_webpage" in config.system_prompt
+
     def test_direct_preset_access(self):
         """Test accessing presets directly via HarnessPresets class."""
         config = HarnessPresets.default
@@ -130,6 +164,7 @@ class TestSearchTools:
         register_tool(search.semantic_scholar_search)
         register_tool(search.serper_web_search)
         register_tool(search.serper_fetch_page)
+        register_tool(search.crawl4ai_browse)
 
     def test_search_tools_registered(self):
         """Test that search tools are registered when preset is loaded."""
@@ -139,6 +174,7 @@ class TestSearchTools:
         assert "semantic_scholar_snippet_search" in tools
         assert "serper_google_webpage_search" in tools
         assert "serper_fetch_webpage_content" in tools
+        assert "browse_webpage" in tools
 
     def test_search_tools_have_schemas(self):
         """Test that search tools have valid schemas."""


### PR DESCRIPTION
## What

- New `browse_webpage` tool backed by [crawl4ai](https://docs.crawl4ai.com) (in-process headless browser, no hosted scrape service): lazy import, http(s)-only URL guard (rejects `file://` and other schemes before the browser starts), error sentinels mirroring `serper_fetch_webpage_content`, and the crawler's `error_message` surfaced on failures.
- Two presets: `dr_tulu_crawl4ai` (S2 + Serper search + crawl4ai browse) and `web_search_agent_crawl4ai` (Serper search + crawl4ai browse). Serper is still used for search; crawl4ai replaces only the fetch step and needs no API key.
- `OLMO_WEBPAGE_CONTENT_LIMIT` env var makes the fetched-page truncation limit configurable for BOTH fetch tools (default 4000 chars, `0` disables truncation).
- Packaging: `crawl4ai` optional extra; `crawl4ai.**` added to ty `allowed-unresolved-imports` so CI type-checking passes without the optional package installed.

## Why crawl4ai

- **Parity with DR Tulu's actual tool stack**: [open-instruct](https://github.com/allenai/open-instruct) ships `Crawl4AIBrowseTool`, exposing a `browse_webpage` tool backed by crawl4ai for DR Tulu. This PR mirrors that tool (same name, same backend), so models trained against open-instruct's agentic stack see the tool they were trained with at eval time.
- **No hosted-scrape dependency for fetch**: `serper_fetch_webpage_content` is credit-metered; we observed a mid-run quota exhaustion silently zeroing 33/50 instances of a baseline. crawl4ai fetches in-process with no key and no per-page cost.
- **Better page content**: real browser rendering (JS pages work) plus clean markdown extraction, instead of raw scrape text.
- **Enables fetch-length ablations**: with `OLMO_WEBPAGE_CONTENT_LIMIT`, on ExpertQA 32K-char fetches improved citation grounding for every searching model vs 8K (Gemma-4-26B +0.115 global_avg).

## Usage

```bash
pip install 'olmo-eval[crawl4ai]'
crawl4ai-setup   # one-time: provisions the headless browser

OLMO_WEBPAGE_CONTENT_LIMIT=32000 \
olmo-eval run -m Qwen/Qwen3.5-9B -H web_search_agent_crawl4ai -t expertqa -o limit=50
```

`SERPER_API_KEY` is still required (search); `S2_API_KEY` is recommended for `dr_tulu_crawl4ai` (keyless S2 is rate-limited to ~1 req/s process-wide).

## Tests

31 passing; crawl4ai fully mocked so CI needs no browser. Covers scheme rejection, error fidelity, truncation default/env/disable/invalid/boundary, and preset wiring.

## Note

Full SSRF hardening (DNS/redirect validation for private ranges) is out of scope; the scheme guard removes the local-file vector. Companion to #238/#239; used by the ExpertQA rewrite PR (linked next).

cc @donovanr