### PR TITLE
Rewrite ExpertQA as agentic web-grounded attributed QA (JSON + cite-tag formats)

### DIFF
--- a/src/olmo_eval/common/scorers/citation.py
+++ b/src/olmo_eval/common/scorers/citation.py
@@ -11,6 +11,7 @@ Ported from astabench citation_eval.py (https://github.com/allenai/asta-bench).
 from __future__ import annotations
 
 import asyncio
+import copy
 import json
 import logging
 import re
@@ -47,6 +48,80 @@ JUST_HAS_A_TITLE = "Paper content unavailable. The paper's title is: "
 SEMANTIC_SCHOLAR_BAD_SNIPPET = (
     "Please click on the paper title to read the abstract on Semantic Scholar."
 )
+
+
+def _normalize_grounding_text(text: str) -> str:
+    """Normalize text for source-grounding substring checks."""
+    return re.sub(r"[^a-z0-9]", "", text.lower())
+
+
+def ground_citations_in_sources(
+    parsed_response: dict[str, Any], source_text: str
+) -> tuple[dict[str, Any], dict[str, float]]:
+    """Filter fabricated citation evidence against retrieved source text.
+
+    This is the anti-fabrication layer for agentic attributed-QA tasks such as
+    ExpertQA, and is reusable by ScholarQA later. ``source_text`` is the
+    concatenated tool output the agent saw during its trajectory.
+
+    Citations with an ``id`` keep only snippets found verbatim in the source
+    text. If no snippet remains, the citation is kept only when its title is
+    also source-grounded, preserving the title-only half-credit path. Citations
+    without an ``id`` are left untouched and excluded from snippet counts, since
+    they are ignored by citation judging.
+    """
+    grounded_response = copy.deepcopy(parsed_response)
+    normalized_source = _normalize_grounding_text(source_text)
+    n_snippets = 0
+    n_grounded = 0
+
+    for section in grounded_response.get("sections", []):
+        sec_iter = [section]
+        if section.get("table") and isinstance(section["table"], dict):
+            sec_iter.append(section["table"])
+
+        for curr_sec in sec_iter:
+            if "citations" not in curr_sec:
+                continue
+
+            grounded_citations = []
+            for citation in curr_sec.get("citations", []):
+                if not citation.get("id"):
+                    grounded_citations.append(citation)
+                    continue
+
+                raw_snippets = citation.get("snippets", [])
+                if isinstance(raw_snippets, str):
+                    raw_snippets = [raw_snippets]
+                elif not isinstance(raw_snippets, list):
+                    raw_snippets = []
+
+                grounded_snippets = []
+                for snippet in raw_snippets:
+                    snippet_text = str(snippet)
+                    if not snippet_text.strip():
+                        continue
+                    n_snippets += 1
+                    normalized_snippet = _normalize_grounding_text(snippet_text)
+                    if len(normalized_snippet) >= 20 and normalized_snippet in normalized_source:
+                        grounded_snippets.append(snippet)
+                        n_grounded += 1
+
+                citation["snippets"] = grounded_snippets
+                title = citation.get("title", "")
+                normalized_title = _normalize_grounding_text(str(title))
+                title_grounded = bool(normalized_title) and normalized_title in normalized_source
+                if grounded_snippets or title_grounded:
+                    grounded_citations.append(citation)
+            curr_sec["citations"] = grounded_citations
+
+    rate = n_grounded / n_snippets if n_snippets else 0.0
+    return grounded_response, {
+        "n_snippets": float(n_snippets),
+        "n_grounded": float(n_grounded),
+        "snippet_grounding_rate": rate,
+    }
+
 
 # from astabench citation_eval.py:CitationEval.score_citation_group
 CITATION_GROUP_PROMPT = """You are a claim validator. For each claim made in the following text you will determine if it is supported by the quote from it's corresponding inline citations. As is typically done in academic writing, assume that consecutive sentences can share citations. Make sure to also include claims presented in table format. For references with only the title available (ie no quotes from the reference are included), judge them as `supporting` if the title indicates that the paper is likely relevant to the claim being considered. Return a JSON object with a single key `claims` which is a list of `claim` objects, one for each sentence in the text. Each `claim` object contains the claim itself (`text`), a list of `supporting` inline citations and `non_supporting` inline citations and finally a boolean `is_fully_supported` which indicates if the claim is entirely supported by the quotations in the associated citations. Each inline citation corresponding to that claim should appear in either `supporting` or `non_supporting`, but not both. Each claim made in the text should appear in your output, but you should skip sentences covering high level introductory information.

--- a/src/olmo_eval/common/scorers/citation.py
+++ b/src/olmo_eval/common/scorers/citation.py
@@ -49,10 +49,61 @@ SEMANTIC_SCHOLAR_BAD_SNIPPET = (
     "Please click on the paper title to read the abstract on Semantic Scholar."
 )
 
+_CITE_TAG_RE = re.compile(
+    r"<\s*cite\b(?=[^>]*(?<![\w-])url\s*=)[^>]*(?<![\w-])url\s*=\s*"
+    r"(?:\"(?P<url_d>[^\"<>]*\S[^\"<>]*)\"|'(?P<url_s>[^'<>]*\S[^'<>]*)')"
+    r"[^>]*>(?P<claim>.*?)<\s*/\s*cite\s*>",
+    re.DOTALL | re.IGNORECASE,
+)
+
 
 def _normalize_grounding_text(text: str) -> str:
     """Normalize text for source-grounding substring checks."""
     return re.sub(r"[^a-z0-9]", "", text.lower())
+
+
+def _normalize_grounding_url(url: str) -> str:
+    """Normalize URL strings for cite-mode trajectory lookup."""
+    return str(url).strip().rstrip("/.,;:)]}'\"")
+
+
+def parse_cite_tag_response(text: str) -> dict[str, Any] | None:
+    """Parse prose with ``<cite url="...">claim</cite>`` tags into report JSON."""
+    citations: list[dict[str, Any]] = []
+    citation_ids_by_url: dict[str, str] = {}
+
+    def replace_cite_tag(match: re.Match[str]) -> str:
+        url = (match.group("url_d") or match.group("url_s") or "").strip()
+        if not url:
+            return match.group(0)
+        claim_text = match.group("claim").strip()
+        citation_id = citation_ids_by_url.get(url)
+        if citation_id is None:
+            citation_id = f"[{len(citations) + 1}]"
+            citation_ids_by_url[url] = citation_id
+            citations.append(
+                {
+                    "id": citation_id,
+                    "url": url,
+                    "title": "",
+                    "snippets": [],
+                }
+            )
+        return f"{claim_text} {citation_id}"
+
+    prose, count = _CITE_TAG_RE.subn(replace_cite_tag, text)
+    if count == 0:
+        return None
+
+    return {
+        "sections": [
+            {
+                "title": "",
+                "text": prose.strip(),
+                "citations": citations,
+            }
+        ]
+    }
 
 
 def ground_citations_in_sources(
@@ -119,6 +170,78 @@ def ground_citations_in_sources(
     return grounded_response, {
         "n_snippets": float(n_snippets),
         "n_grounded": float(n_grounded),
+        "snippet_grounding_rate": rate,
+    }
+
+
+def ground_citations_by_url(
+    parsed_response: dict[str, Any],
+    url_to_content: dict[str, str],
+    max_evidence_chars: int = 1500,
+) -> tuple[dict[str, Any], dict[str, float]]:
+    """Ground cite-tag citations by URL against trajectory-observed content.
+
+    This is the cite-mode counterpart of ``ground_citations_in_sources``.
+    ``url_to_content`` should contain every URL observed in the trajectory:
+    fetched pages map to their fetched content, while search-result-only URLs map
+    to an empty string and receive title-only half-credit handling downstream.
+    Rates are not comparable across modes because cite mode counts URL citations
+    while JSON mode counts quoted snippets.
+    """
+    grounded_response = copy.deepcopy(parsed_response)
+    normalized_content: dict[str, str] = {}
+    for url, content in url_to_content.items():
+        normalized_url = _normalize_grounding_url(url)
+        if not normalized_url:
+            continue
+        content_text = str(content or "")
+        if normalized_url not in normalized_content or content_text:
+            normalized_content[normalized_url] = content_text
+
+    n_citations = 0
+    n_grounded = 0
+    n_half = 0
+
+    for section in grounded_response.get("sections", []):
+        sec_iter = [section]
+        if section.get("table") and isinstance(section["table"], dict):
+            sec_iter.append(section["table"])
+
+        for curr_sec in sec_iter:
+            if "citations" not in curr_sec:
+                continue
+
+            grounded_citations = []
+            for citation in curr_sec.get("citations", []):
+                raw_url = citation.get("url")
+                if not raw_url:
+                    continue
+
+                citation_url = str(raw_url).strip()
+                normalized_url = _normalize_grounding_url(citation_url)
+                if not normalized_url:
+                    continue
+
+                n_citations += 1
+                if normalized_url not in normalized_content:
+                    continue
+
+                content = normalized_content[normalized_url]
+                if content:
+                    citation["snippets"] = [content[:max_evidence_chars]]
+                    n_grounded += 1
+                else:
+                    citation["snippets"] = []
+                    citation["title"] = citation_url
+                    n_half += 1
+                grounded_citations.append(citation)
+            curr_sec["citations"] = grounded_citations
+
+    rate = n_grounded / n_citations if n_citations else 0.0
+    return grounded_response, {
+        "n_citations": float(n_citations),
+        "n_grounded": float(n_grounded),
+        "n_half": float(n_half),
         "snippet_grounding_rate": rate,
     }
 

--- a/src/olmo_eval/evals/suites/science.py
+++ b/src/olmo_eval/evals/suites/science.py
@@ -156,9 +156,11 @@ SCIENCE_RESEARCH = make_suite(
 
 # The members of science:research measure different things; read the per-metric
 # tiers rather than the aggregate:
-# - expertqa: attribution and on-topic precision of cited long-form answers
-#   (citation precision/recall + answer precision), not factual correctness
-#   against a reference. A high score means well-cited, on-topic prose.
+# - expertqa: agentic web-grounded attribution and on-topic precision of cited
+#   long-form answers, not factual correctness against a reference. Like
+#   litsearch, it needs a tool-providing harness (web_search_agent), so it sits
+#   only in science:research, not science:judge / science:nojudge / science:all.
+#   Its citation metrics additionally require the OpenAI judge at scoring time.
 # - litsearch: an agentic retrieval smoke test (does a gold paper surface in live
 #   Semantic Scholar results), distinct from the published fixed-corpus Recall@k.
 # - litsearch_rerank: fixed-corpus reranking. The model reranks a frozen pool of
@@ -205,10 +207,7 @@ SCIENCE_NOJUDGE = make_suite(
 
 SCIENCE_JUDGE = make_suite(
     "science:judge",
-    (
-        "expertqa",
-        get_suite("astabench"),
-    ),
+    (get_suite("astabench"),),
     aggregation=AggregationStrategy.AVERAGE_OF_AVERAGES,
     description="Current science tasks that require external LLM-as-judge scoring.",
 )

--- a/src/olmo_eval/evals/tasks/expertqa.py
+++ b/src/olmo_eval/evals/tasks/expertqa.py
@@ -20,18 +20,26 @@ they cannot grade a fresh model answer directly. We therefore score a model
 under test on citation_precision, citation_recall, answer_precision, and a
 separate snippet_grounding_rate that reports how much quoted evidence was found
 in retrieved tool text.
+
+Answer formats: `expertqa` is the primary/official JSON-schema task.
+`expertqa:cite` is prose with cite tags. Both feed the same metrics, but numbers
+are not comparable across modes; pick one mode for any comparison table.
 """
 
 from __future__ import annotations
 
+import json
 import logging
+import re
 from collections.abc import Iterator, Sequence
 from dataclasses import dataclass
 from typing import Any
 
 from olmo_eval.common.scorers.citation import (
     extract_json_from_response,
+    ground_citations_by_url,
     ground_citations_in_sources,
+    parse_cite_tag_response,
     score_citations_for_sections,
 )
 from olmo_eval.common.scorers.llm_judge import JudgeFn, build_default_judge_fn
@@ -60,6 +68,11 @@ from olmo_eval.evals.tasks.common import Task, register
 logger = logging.getLogger(__name__)
 
 EXPERTQA_REPO = "cmalaviya/expertqa"
+EXPERTQA_WEB_SEARCH_TOOL = "serper_google_webpage_search"
+EXPERTQA_WEB_FETCH_TOOL = "serper_fetch_webpage_content"
+EXPERTQA_FETCH_EMPTY_CONTENT = "No content extracted from webpage."
+_URL_RE = re.compile(r"https?://[^\s<>()\]\"']+")
+
 EXPERTQA_GENERATION_PROMPT = """Answer the following expert question as a well-cited report.
 
 You have exactly two tools available, and only these tool names exist:
@@ -78,7 +91,28 @@ has keys `id`, `url`, `title`, and `snippets`:
 - `snippets` is a list of VERBATIM excerpts copied exactly from fetched content.
 Do not paraphrase snippets and do not invent quotes.
 
+Your final answer must consist of ONLY a single JSON object.
+The first character of your final answer must be '{' and the last must be '}'.
+Do not use Markdown, code fences, headings, or any text outside the JSON.
 If no supporting source was found for a claim, do not attach a fabricated citation.
+Do not create a References section.
+
+Question: """
+
+EXPERTQA_CITE_PROMPT = """Answer the following expert question in plain prose. Markdown is allowed.
+
+You have exactly two tools available, and only these tool names exist:
+- serper_google_webpage_search
+- serper_fetch_webpage_content
+
+Use those names verbatim. Search first with serper_google_webpage_search, then fetch
+promising pages with serper_fetch_webpage_content before answering.
+
+Do not return JSON.
+For every source-based claim, wrap the exact claim text in a cite tag:
+<cite url="https://example.com/page">claim text</cite>.
+Use the exact URL of a page you fetched or a search result you relied on. Do not
+invent URLs. Every factual claim needs a citation.
 Do not create a References section.
 
 Question: """
@@ -120,6 +154,95 @@ def _trajectory_source_text(response: Response) -> str:
     if response.trajectory is None:
         return ""
     return "\n\n".join(result.content or "" for result in response.trajectory.tool_result_sequence)
+
+
+def _strip_think_block(text: str) -> str:
+    """Strip leading chain-of-thought block emitted by some reasoning models."""
+    think_end = text.find("</think>")
+    if think_end >= 0:
+        return text[think_end + len("</think>") :]
+    return text
+
+
+def _extract_urls(text: str) -> list[str]:
+    """Extract URL-like strings from search result text."""
+    return [url.strip().rstrip("/.,;:)]}'\"") for url in _URL_RE.findall(text or "")]
+
+
+def _tool_call_arguments(tool_call: Any) -> dict[str, Any]:
+    """Decode a trajectory tool call's JSON arguments."""
+    try:
+        parsed = json.loads(tool_call.function.arguments)
+    except (TypeError, json.JSONDecodeError):
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _fetch_result_is_error(result: Any, content: str) -> bool:
+    """Return whether a fetch result should be treated as unfetched."""
+    return bool(
+        getattr(result, "is_error", False)
+        or content.startswith("Error")
+        or content.strip() == EXPERTQA_FETCH_EMPTY_CONTENT
+    )
+
+
+def _trajectory_url_content(response: Response) -> dict[str, str]:
+    """Map trajectory-observed URLs to fetched content, or empty text if only seen."""
+    if response.trajectory is None:
+        return {}
+
+    url_to_content: dict[str, str] = {}
+    pending_tool_calls: list[Any] = []
+    pending_tool_calls_by_id: dict[str, Any] = {}
+
+    def pop_tool_call(result: Any) -> Any | None:
+        result_tool_call_id = str(getattr(result, "tool_call_id", "") or "")
+        if result_tool_call_id:
+            tool_call = pending_tool_calls_by_id.pop(result_tool_call_id, None)
+            if tool_call is not None:
+                for idx, pending_tool_call in enumerate(pending_tool_calls):
+                    if pending_tool_call is tool_call:
+                        del pending_tool_calls[idx]
+                        break
+                return tool_call
+
+        # Saved trajectories carry empty tool_call_id on results; fall back to order.
+        tool_call = pending_tool_calls.pop(0) if pending_tool_calls else None
+        if tool_call is not None:
+            pending_tool_calls_by_id.pop(getattr(tool_call, "id", ""), None)
+        return tool_call
+
+    for turn in response.trajectory.turns:
+        if turn.role == "assistant":
+            for tool_call in turn.tool_calls:
+                pending_tool_calls.append(tool_call)
+                if tool_call.id:
+                    pending_tool_calls_by_id[tool_call.id] = tool_call
+            continue
+        if turn.role != "tool":
+            continue
+
+        for result in turn.tool_results:
+            tool_call = pop_tool_call(result)
+            content = result.content or ""
+            if tool_call is None:
+                continue
+
+            tool_name = tool_call.function.name
+            if tool_name == EXPERTQA_WEB_SEARCH_TOOL:
+                for url in _extract_urls(content):
+                    url_to_content.setdefault(url, "")
+            elif tool_name == EXPERTQA_WEB_FETCH_TOOL:
+                url = str(_tool_call_arguments(tool_call).get("url", "")).strip()
+                if url:
+                    if _fetch_result_is_error(result, content):
+                        url_to_content.setdefault(url, "")
+                    elif content:
+                        url_to_content[url] = content
+                    else:
+                        url_to_content.setdefault(url, "")
+    return url_to_content
 
 
 @register("expertqa")
@@ -167,11 +290,8 @@ class ExpertQA(Task):
 
     def extract_answer(self, output: LMOutput) -> Any:
         """Parse JSON from model output and store the structured response."""
-        text = output.text
         # Strip <think>...</think> blocks so JSON extraction ignores reasoning braces.
-        think_end = text.find("</think>")
-        if think_end >= 0:
-            text = text[think_end + len("</think>") :]
+        text = _strip_think_block(output.text)
         parsed = extract_json_from_response(text)
         if parsed is not None:
             parsed = normalize_agent_response_dict(parsed)
@@ -192,7 +312,6 @@ class ExpertQA(Task):
         for response in responses:
             if response.trajectory is None:
                 missing_trajectory += 1
-            source_text = _trajectory_source_text(response)
             per_label: dict[str, dict[int, float]] = {label: {} for label in EXPERTQA_OUTPUT_LABELS}
 
             for out_idx, output in enumerate(response.outputs):
@@ -200,7 +319,6 @@ class ExpertQA(Task):
                     response=response,
                     output=output,
                     judge_fn=judge_fn,
-                    source_text=source_text,
                 )
                 for label in EXPERTQA_OUTPUT_LABELS:
                     score = scores.get(label, 0.0)
@@ -230,7 +348,6 @@ class ExpertQA(Task):
         response: Response,
         output: LMOutput,
         judge_fn: JudgeFn,
-        source_text: str,
     ) -> dict[str, float]:
         zeros = {k: 0.0 for k in EXPERTQA_OUTPUT_LABELS}
         parsed = output.metadata.get("parsed_response")
@@ -238,7 +355,7 @@ class ExpertQA(Task):
             output.metadata["grounding_stats"] = dict(ZERO_GROUNDING_STATS)
             return zeros
 
-        grounded, grounding_stats = ground_citations_in_sources(parsed, source_text)
+        grounded, grounding_stats = self._ground(parsed, response)
         output.metadata["grounding_stats"] = grounding_stats
 
         answer_text = format_report(grounded)
@@ -254,6 +371,12 @@ class ExpertQA(Task):
             "snippet_grounding_rate": grounding_stats["snippet_grounding_rate"],
         }
 
+    def _ground(
+        self, parsed: dict[str, Any], response: Response
+    ) -> tuple[dict[str, Any], dict[str, float]]:
+        """Ground parsed JSON citation snippets against trajectory tool text."""
+        return ground_citations_in_sources(parsed, _trajectory_source_text(response))
+
     async def _score_precision(self, judge_fn: JudgeFn, question: str, answer: str) -> float:
         """Answer precision via the irrelevant-paragraph judge (astabench precision_eval)."""
         prompt = PRECISION_EVAL_PROMPT.format(query=question, answer=answer)
@@ -264,3 +387,28 @@ class ExpertQA(Task):
 
         score, _ = compute_precision_score(parsed, answer)
         return score
+
+
+@register("expertqa:cite")
+class ExpertQACite(ExpertQA):
+    """ExpertQA prose cite-tag variant, sharing ExpertQA scoring."""
+
+    def format_request(self, instance: Instance) -> LMRequest:
+        prompt_text = EXPERTQA_CITE_PROMPT + instance.question
+        return LMRequest(
+            request_type=RequestType.CHAT,
+            messages=({"role": "user", "content": prompt_text},),
+        )
+
+    def extract_answer(self, output: LMOutput) -> Any:
+        """Parse cite-tag prose into the structured response shape."""
+        text = _strip_think_block(output.text)
+        parsed = parse_cite_tag_response(text)
+        output.metadata["parsed_response"] = parsed
+        return parsed
+
+    def _ground(
+        self, parsed: dict[str, Any], response: Response
+    ) -> tuple[dict[str, Any], dict[str, float]]:
+        """Ground parsed cite-tag citations by trajectory-observed URL."""
+        return ground_citations_by_url(parsed, _trajectory_url_content(response))

--- a/src/olmo_eval/evals/tasks/expertqa.py
+++ b/src/olmo_eval/evals/tasks/expertqa.py
@@ -1,31 +1,37 @@
-"""ExpertQA: multi-domain expert-curated attributed long-form QA.
+"""ExpertQA: agentic, grounded attributed long-form QA.
 
 2,177 expert-written questions across 32 fields (Malaviya et al., NAACL 2024,
 arXiv 2309.07852). The model generates a well-cited long-form answer, which is
 graded for attribution and on-topic precision.
 
+This implementation is AGENTIC: the model is expected to use web search/fetch
+tools, and citation snippets are graded only when grounded in content the agent
+actually retrieved. Before judging, each quoted snippet is checked verbatim
+against `response.trajectory` tool output (with normalization), and fabricated
+snippets are removed from the judge input.
+
+Requirements: this task only measures grounded attribution when run through a
+tool-providing agentic harness with web search/fetch available, e.g. the
+`web_search_agent` preset. Run without tools, every snippet is ungrounded and
+citation scores collapse toward zero; that is by design, not a bug.
+
 ExpertQA's human annotations grade the dataset's own pre-generated answers, so
 they cannot grade a fresh model answer directly. We therefore score a model
-under test on the axes the shared judges support without a reference:
-
-- citation_precision / citation_recall: claim-level attribution, via the shared
-  citation scorer (olmo_eval.common.scorers.citation).
-- answer_precision: fraction of paragraphs the judge finds on-topic, via the
-  irrelevant-paragraph judge reused from astabench_sqa.
-
-The generation prompt, response parsing, precision judge, and the score-reading
-metric classes are reused from astabench_sqa; ExpertQA drops the SQA rubric
-(ingredient_recall), which has no per-question analogue here.
+under test on citation_precision, citation_recall, answer_precision, and a
+separate snippet_grounding_rate that reports how much quoted evidence was found
+in retrieved tool text.
 """
 
 from __future__ import annotations
 
 import logging
 from collections.abc import Iterator, Sequence
+from dataclasses import dataclass
 from typing import Any
 
 from olmo_eval.common.scorers.citation import (
     extract_json_from_response,
+    ground_citations_in_sources,
     score_citations_for_sections,
 )
 from olmo_eval.common.scorers.llm_judge import JudgeFn, build_default_judge_fn
@@ -41,7 +47,6 @@ from olmo_eval.common.types import (
 from olmo_eval.data import DataSource
 from olmo_eval.evals.tasks.astabench_sqa import (
     PRECISION_EVAL_PROMPT,
-    SQA_GENERATION_PROMPT,
     AnswerPrecisionMetric,
     CitationPrecisionMetric,
     CitationRecallMetric,
@@ -55,16 +60,66 @@ from olmo_eval.evals.tasks.common import Task, register
 logger = logging.getLogger(__name__)
 
 EXPERTQA_REPO = "cmalaviya/expertqa"
+EXPERTQA_GENERATION_PROMPT = """Answer the following expert question as a well-cited report.
+
+You have exactly two tools available, and only these tool names exist:
+- serper_google_webpage_search
+- serper_fetch_webpage_content
+
+Use those names verbatim. Search first with serper_google_webpage_search, then fetch
+promising pages with serper_fetch_webpage_content before answering.
+
+Return valid JSON with a single key `sections`, whose value is a list of section
+objects. Each section has keys `title`, `text`, and `citations`. Each citation
+has keys `id`, `url`, `title`, and `snippets`:
+- `id` is the inline marker exactly as it appears in `text`.
+- `url` is the source page.
+- `title` is the source page title when available.
+- `snippets` is a list of VERBATIM excerpts copied exactly from fetched content.
+Do not paraphrase snippets and do not invent quotes.
+
+If no supporting source was found for a claim, do not attach a fabricated citation.
+Do not create a References section.
+
+Question: """
+
+ZERO_GROUNDING_STATS = {
+    "n_snippets": 0.0,
+    "n_grounded": 0.0,
+    "snippet_grounding_rate": 0.0,
+}
+
+# Metrics averaged into global_avg (ingredient_recall excluded, no rubric here).
+EXPERTQA_METRIC_LABELS = ["citation_precision", "citation_recall", "answer_precision"]
+EXPERTQA_OUTPUT_LABELS = EXPERTQA_METRIC_LABELS + ["snippet_grounding_rate"]
+
+
+@dataclass(frozen=True)
+class SnippetGroundingMetric(AnswerPrecisionMetric):
+    """Mean fraction of model citation snippets grounded in trajectory tool text."""
+
+    name: str = "snippet_grounding_rate"
+
 
 EXPERTQA_METRICS = (
     GlobalAvgMetric(),
     CitationPrecisionMetric(),
     CitationRecallMetric(),
     AnswerPrecisionMetric(),
+    SnippetGroundingMetric(),
 )
 
-# Metrics averaged into global_avg (ingredient_recall excluded, no rubric here).
-EXPERTQA_METRIC_LABELS = ["citation_precision", "citation_recall", "answer_precision"]
+
+def _build_judge_fn() -> JudgeFn:
+    """Build the ExpertQA judge function; kept as a small test hook."""
+    return build_default_judge_fn(scorer_name="ExpertQA")
+
+
+def _trajectory_source_text(response: Response) -> str:
+    """Concatenate all tool result content visible to the agent."""
+    if response.trajectory is None:
+        return ""
+    return "\n\n".join(result.content or "" for result in response.trajectory.tool_result_sequence)
 
 
 @register("expertqa")
@@ -104,7 +159,7 @@ class ExpertQA(Task):
         )
 
     def format_request(self, instance: Instance) -> LMRequest:
-        prompt_text = SQA_GENERATION_PROMPT + instance.question
+        prompt_text = EXPERTQA_GENERATION_PROMPT + instance.question
         return LMRequest(
             request_type=RequestType.CHAT,
             messages=({"role": "user", "content": prompt_text},),
@@ -131,39 +186,73 @@ class ExpertQA(Task):
         """Score responses for citation precision/recall and answer precision."""
         self._extract_answers(responses)
 
-        judge_fn = build_default_judge_fn(scorer_name="ExpertQA")
+        judge_fn = _build_judge_fn()
+        missing_trajectory = 0
 
         for response in responses:
-            response.scores.update(await self._score_single(response, judge_fn))
+            if response.trajectory is None:
+                missing_trajectory += 1
+            source_text = _trajectory_source_text(response)
+            per_label: dict[str, dict[int, float]] = {label: {} for label in EXPERTQA_OUTPUT_LABELS}
 
+            for out_idx, output in enumerate(response.outputs):
+                scores = await self._score_output(
+                    response=response,
+                    output=output,
+                    judge_fn=judge_fn,
+                    source_text=source_text,
+                )
+                for label in EXPERTQA_OUTPUT_LABELS:
+                    score = scores.get(label, 0.0)
+                    output.metadata[f"score:{label}"] = score
+                    per_label[label][out_idx] = score
+
+            for label, output_scores in per_label.items():
+                response.scores[label] = self._aggregate_output_scores(output_scores)
+
+            response.scores["global_avg"] = sum(
+                response.scores.get(label, 0.0) for label in EXPERTQA_METRIC_LABELS
+            ) / len(EXPERTQA_METRIC_LABELS)
+
+        if missing_trajectory:
+            logger.warning(
+                "ExpertQA scored %d/%d responses with no trajectory; this task needs an "
+                "agentic harness exposing web search/fetch tools, e.g. web_search_agent. "
+                "Without trajectory tool text, every snippet is ungrounded and citation "
+                "scores collapse toward zero.",
+                missing_trajectory,
+                len(responses),
+            )
         return responses
 
-    async def _score_single(self, response: Response, judge_fn: JudgeFn) -> dict[str, float]:
-        zeros = {k: 0.0 for k in EXPERTQA_METRIC_LABELS + ["global_avg"]}
-
-        output = response.outputs[0] if response.outputs else None
-        if output is None:
-            return zeros
-
+    async def _score_output(
+        self,
+        response: Response,
+        output: LMOutput,
+        judge_fn: JudgeFn,
+        source_text: str,
+    ) -> dict[str, float]:
+        zeros = {k: 0.0 for k in EXPERTQA_OUTPUT_LABELS}
         parsed = output.metadata.get("parsed_response")
         if not parsed or not parsed.get("sections"):
+            output.metadata["grounding_stats"] = dict(ZERO_GROUNDING_STATS)
             return zeros
 
-        answer_text = format_report(parsed)
+        grounded, grounding_stats = ground_citations_in_sources(parsed, source_text)
+        output.metadata["grounding_stats"] = grounding_stats
+
+        answer_text = format_report(grounded)
         precision_score = await self._score_precision(
             judge_fn, response.instance.question, answer_text
         )
-        citation_scores = await score_citations_for_sections(judge_fn, parsed)
+        citation_scores = await score_citations_for_sections(judge_fn, grounded)
 
-        scores = {
+        return {
             "citation_precision": citation_scores.get("citation_precision", 0.0),
             "citation_recall": citation_scores.get("citation_recall", 0.0),
             "answer_precision": precision_score,
+            "snippet_grounding_rate": grounding_stats["snippet_grounding_rate"],
         }
-        scores["global_avg"] = sum(scores[k] for k in EXPERTQA_METRIC_LABELS) / len(
-            EXPERTQA_METRIC_LABELS
-        )
-        return scores
 
     async def _score_precision(self, judge_fn: JudgeFn, question: str, answer: str) -> float:
         """Answer precision via the irrelevant-paragraph judge (astabench precision_eval)."""

--- a/src/olmo_eval/evals/tasks/expertqa.py
+++ b/src/olmo_eval/evals/tasks/expertqa.py
@@ -97,6 +97,13 @@ Do not use Markdown, code fences, headings, or any text outside the JSON.
 If no supporting source was found for a claim, do not attach a fabricated citation.
 Do not create a References section.
 
+Workflow (follow in order):
+1. Call serper_google_webpage_search to find relevant pages.
+2. Call serper_fetch_webpage_content to read the most promising pages.
+3. Only after you have gathered evidence from fetched pages, write your final answer.
+Do not answer from memory. You must search before answering and read pages before answering.
+When you answer, output only the single JSON object described above.
+
 Question: """
 
 EXPERTQA_CITE_PROMPT = """Answer the following expert question in plain prose. Markdown is allowed.
@@ -114,6 +121,13 @@ For every source-based claim, wrap the exact claim text in a cite tag:
 Use the exact URL of a page you fetched or a search result you relied on. Do not
 invent URLs. Every factual claim needs a citation.
 Do not create a References section.
+
+Workflow (follow in order):
+1. Call serper_google_webpage_search to find relevant pages.
+2. Call serper_fetch_webpage_content to read the most promising pages.
+3. Only after you have gathered evidence from fetched pages, write your final answer.
+Do not answer from memory. You must search before answering and read pages before answering.
+When you answer, write prose with <cite url="..."> tags as described above.
 
 Question: """
 

--- a/src/olmo_eval/evals/tasks/expertqa.py
+++ b/src/olmo_eval/evals/tasks/expertqa.py
@@ -70,17 +70,21 @@ logger = logging.getLogger(__name__)
 EXPERTQA_REPO = "cmalaviya/expertqa"
 EXPERTQA_WEB_SEARCH_TOOL = "serper_google_webpage_search"
 EXPERTQA_WEB_FETCH_TOOL = "serper_fetch_webpage_content"
+EXPERTQA_CRAWL4AI_FETCH_TOOL = "browse_webpage"
+EXPERTQA_WEB_FETCH_TOOLS = frozenset({EXPERTQA_WEB_FETCH_TOOL, EXPERTQA_CRAWL4AI_FETCH_TOOL})
 EXPERTQA_FETCH_EMPTY_CONTENT = "No content extracted from webpage."
 _URL_RE = re.compile(r"https?://[^\s<>()\]\"']+")
 
 EXPERTQA_GENERATION_PROMPT = """Answer the following expert question as a well-cited report.
 
-You have exactly two tools available, and only these tool names exist:
+You have a web search tool and one page-fetch tool available. The possible tool names are:
 - serper_google_webpage_search
 - serper_fetch_webpage_content
+- browse_webpage
 
-Use those names verbatim. Search first with serper_google_webpage_search, then fetch
-promising pages with serper_fetch_webpage_content before answering.
+Use the available tool names verbatim. Search first with serper_google_webpage_search,
+then fetch promising pages with serper_fetch_webpage_content or browse_webpage before
+answering.
 
 Return valid JSON with a single key `sections`, whose value is a list of section
 objects. Each section has keys `title`, `text`, and `citations`. Each citation
@@ -99,7 +103,7 @@ Do not create a References section.
 
 Workflow (follow in order):
 1. Call serper_google_webpage_search to find relevant pages.
-2. Call serper_fetch_webpage_content to read the most promising pages.
+2. Call serper_fetch_webpage_content or browse_webpage to read the most promising pages.
 3. Only after you have gathered evidence from fetched pages, write your final answer.
 Do not answer from memory. You must search before answering and read pages before answering.
 When you answer, output only the single JSON object described above.
@@ -108,12 +112,14 @@ Question: """
 
 EXPERTQA_CITE_PROMPT = """Answer the following expert question in plain prose. Markdown is allowed.
 
-You have exactly two tools available, and only these tool names exist:
+You have a web search tool and one page-fetch tool available. The possible tool names are:
 - serper_google_webpage_search
 - serper_fetch_webpage_content
+- browse_webpage
 
-Use those names verbatim. Search first with serper_google_webpage_search, then fetch
-promising pages with serper_fetch_webpage_content before answering.
+Use the available tool names verbatim. Search first with serper_google_webpage_search,
+then fetch promising pages with serper_fetch_webpage_content or browse_webpage before
+answering.
 
 Do not return JSON.
 For every source-based claim, wrap the exact claim text in a cite tag:
@@ -124,7 +130,7 @@ Do not create a References section.
 
 Workflow (follow in order):
 1. Call serper_google_webpage_search to find relevant pages.
-2. Call serper_fetch_webpage_content to read the most promising pages.
+2. Call serper_fetch_webpage_content or browse_webpage to read the most promising pages.
 3. Only after you have gathered evidence from fetched pages, write your final answer.
 Do not answer from memory. You must search before answering and read pages before answering.
 When you answer, write prose with <cite url="..."> tags as described above.
@@ -164,10 +170,31 @@ def _build_judge_fn() -> JudgeFn:
 
 
 def _trajectory_source_text(response: Response) -> str:
-    """Concatenate all tool result content visible to the agent."""
+    """Concatenate fetched-page content visible to the agent."""
     if response.trajectory is None:
         return ""
-    return "\n\n".join(result.content or "" for result in response.trajectory.tool_result_sequence)
+
+    source_chunks: list[str] = []
+    for tool_call, result in _iter_trajectory_tool_results(response):
+        content = result.content or ""
+        tool_name = tool_call.function.name
+        if (
+            tool_name in EXPERTQA_WEB_FETCH_TOOLS
+            and content
+            and not _fetch_result_is_error(result, content)
+        ):
+            source_chunks.append(content)
+
+    if source_chunks:
+        return "\n\n".join(source_chunks)
+
+    # Older tests and saved traces may contain tool results without tool-call
+    # metadata; keep those usable when there is no call sequence to pair.
+    if not response.trajectory.tool_call_sequence:
+        return "\n\n".join(
+            result.content or "" for result in response.trajectory.tool_result_sequence
+        )
+    return ""
 
 
 def _strip_think_block(text: str) -> str:
@@ -201,12 +228,11 @@ def _fetch_result_is_error(result: Any, content: str) -> bool:
     )
 
 
-def _trajectory_url_content(response: Response) -> dict[str, str]:
-    """Map trajectory-observed URLs to fetched content, or empty text if only seen."""
+def _iter_trajectory_tool_results(response: Response) -> Iterator[tuple[Any, Any]]:
+    """Yield trajectory tool results paired with their originating tool call."""
     if response.trajectory is None:
-        return {}
+        return
 
-    url_to_content: dict[str, str] = {}
     pending_tool_calls: list[Any] = []
     pending_tool_calls_by_id: dict[str, Any] = {}
 
@@ -239,23 +265,31 @@ def _trajectory_url_content(response: Response) -> dict[str, str]:
 
         for result in turn.tool_results:
             tool_call = pop_tool_call(result)
-            content = result.content or ""
-            if tool_call is None:
-                continue
+            if tool_call is not None:
+                yield tool_call, result
 
-            tool_name = tool_call.function.name
-            if tool_name == EXPERTQA_WEB_SEARCH_TOOL:
-                for url in _extract_urls(content):
+
+def _trajectory_url_content(response: Response) -> dict[str, str]:
+    """Map trajectory-observed URLs to fetched content, or empty text if only seen."""
+    if response.trajectory is None:
+        return {}
+
+    url_to_content: dict[str, str] = {}
+    for tool_call, result in _iter_trajectory_tool_results(response):
+        content = result.content or ""
+        tool_name = tool_call.function.name
+        if tool_name == EXPERTQA_WEB_SEARCH_TOOL:
+            for url in _extract_urls(content):
+                url_to_content.setdefault(url, "")
+        elif tool_name in EXPERTQA_WEB_FETCH_TOOLS:
+            url = str(_tool_call_arguments(tool_call).get("url", "")).strip()
+            if url:
+                if _fetch_result_is_error(result, content):
                     url_to_content.setdefault(url, "")
-            elif tool_name == EXPERTQA_WEB_FETCH_TOOL:
-                url = str(_tool_call_arguments(tool_call).get("url", "")).strip()
-                if url:
-                    if _fetch_result_is_error(result, content):
-                        url_to_content.setdefault(url, "")
-                    elif content:
-                        url_to_content[url] = content
-                    else:
-                        url_to_content.setdefault(url, "")
+                elif content:
+                    url_to_content[url] = content
+                else:
+                    url_to_content.setdefault(url, "")
     return url_to_content
 
 

--- a/src/olmo_eval/harness/presets.py
+++ b/src/olmo_eval/harness/presets.py
@@ -22,6 +22,17 @@ from .constants import (
     DR_TULU_SYSTEM_PROMPT,
 )
 
+WEB_SEARCH_SYSTEM_PROMPT = """\
+You are a web-search assistant for open-domain attributed question answering.
+
+Only these tool names exist; use them verbatim:
+- serper_google_webpage_search
+- serper_fetch_webpage_content
+
+Search first with serper_google_webpage_search, then fetch promising pages with
+serper_fetch_webpage_content before answering. Quote only text copied from
+fetched page content, and do not invent citations."""
+
 
 # TODO(undfined): Remove reference to beaker
 def _get_logs_dir() -> str:
@@ -132,6 +143,31 @@ class HarnessPresets:
             max_turns=10,
             max_concurrency=4,
             scaffold="openai_agents",
+            batching=BatchConfig.streaming(),
+        )
+
+    @lazy
+    def web_search_agent(name: str) -> HarnessConfig:
+        """Agentic harness exposing only web search/fetch tools.
+
+        For open-domain attributed-QA tasks (e.g. expertqa). Web-only search
+        keeps non-science domains searchable and prevents models from
+        substituting paper search for general evidence.
+        """
+        from .tools.search import serper_fetch_page, serper_web_search
+
+        return HarnessConfig(
+            name=name,
+            provider=ProviderConfig(
+                kind=ProviderKind.VLLM_SERVER,
+                kwargs={"timeout": 120},
+            ),
+            tools=(serper_web_search, serper_fetch_page),
+            system_prompt=WEB_SEARCH_SYSTEM_PROMPT,
+            max_turns=30,
+            max_concurrency=4,
+            scaffold="openai_agents",
+            required_secrets=("SERPER_API_KEY",),
             batching=BatchConfig.streaming(),
         )
 

--- a/tests/core/test_citation_grounding.py
+++ b/tests/core/test_citation_grounding.py
@@ -6,7 +6,11 @@ import copy
 
 import pytest
 
-from olmo_eval.common.scorers.citation import ground_citations_in_sources
+from olmo_eval.common.scorers.citation import (
+    ground_citations_by_url,
+    ground_citations_in_sources,
+    parse_cite_tag_response,
+)
 
 
 def test_grounded_snippet_kept():
@@ -222,3 +226,217 @@ def test_input_dict_not_mutated():
     ground_citations_in_sources(response, "unrelated source")
 
     assert response == original
+
+
+class TestParseCiteTagResponse:
+    def test_parse_well_formed_tag(self):
+        parsed = parse_cite_tag_response(
+            'Intro <cite url="https://example.com/page">Alpha claim.</cite> Outro.'
+        )
+
+        assert parsed == {
+            "sections": [
+                {
+                    "title": "",
+                    "text": "Intro Alpha claim. [1] Outro.",
+                    "citations": [
+                        {
+                            "id": "[1]",
+                            "url": "https://example.com/page",
+                            "title": "",
+                            "snippets": [],
+                        }
+                    ],
+                }
+            ]
+        }
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "No citation tags here.",
+            '<cite url="https://example.com/page">Missing close tag.',
+            "<cite>Missing URL.</cite>",
+            '<cite data-url="https://example.com/page">Wrong attr.</cite>',
+        ],
+    )
+    def test_parse_none_or_malformed_returns_none(self, text):
+        assert parse_cite_tag_response(text) is None
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            '<cite url="">Empty URL claim.</cite>',
+            '<cite url="   ">Blank URL claim.</cite>',
+        ],
+    )
+    def test_empty_url_tag_returns_none(self, text):
+        assert parse_cite_tag_response(text) is None
+
+    def test_single_and_double_quotes_with_whitespace(self):
+        parsed = parse_cite_tag_response(
+            "<cite  url = 'https://example.com/a' >Claim A.</cite> "
+            '<cite url="https://example.com/b">Claim B.</cite>'
+        )
+
+        assert parsed is not None
+        section = parsed["sections"][0]
+        assert section["text"] == "Claim A. [1] Claim B. [2]"
+        assert [c["url"] for c in section["citations"]] == [
+            "https://example.com/a",
+            "https://example.com/b",
+        ]
+
+    def test_duplicate_urls_share_id(self):
+        parsed = parse_cite_tag_response(
+            '<cite url="https://example.com/a">Claim A.</cite> '
+            '<cite url="https://example.com/a">Claim B.</cite>'
+        )
+
+        assert parsed is not None
+        section = parsed["sections"][0]
+        assert section["text"] == "Claim A. [1] Claim B. [1]"
+        assert section["citations"] == [
+            {
+                "id": "[1]",
+                "url": "https://example.com/a",
+                "title": "",
+                "snippets": [],
+            }
+        ]
+
+
+class TestGroundCitationsByUrl:
+    def test_content_grounded_citation_gets_excerpt(self):
+        response = {
+            "sections": [
+                {
+                    "text": "Grounded claim [1].",
+                    "citations": [{"id": "[1]", "url": "https://example.com/a"}],
+                }
+            ]
+        }
+
+        grounded, stats = ground_citations_by_url(
+            response,
+            {"https://example.com/a": "Fetched content supports the claim."},
+            max_evidence_chars=15,
+        )
+
+        citation = grounded["sections"][0]["citations"][0]
+        assert citation["snippets"] == ["Fetched content"]
+        assert stats == {
+            "n_citations": 1.0,
+            "n_grounded": 1.0,
+            "n_half": 0.0,
+            "snippet_grounding_rate": 1.0,
+        }
+
+    def test_seen_no_content_citation_kept_for_half_credit(self):
+        response = {
+            "sections": [
+                {
+                    "text": "Search-result claim [1].",
+                    "citations": [{"id": "[1]", "url": "https://example.com/a"}],
+                }
+            ]
+        }
+
+        grounded, stats = ground_citations_by_url(response, {"https://example.com/a": ""})
+
+        citation = grounded["sections"][0]["citations"][0]
+        assert citation["snippets"] == []
+        assert citation["title"] == "https://example.com/a"
+        assert stats["n_citations"] == 1
+        assert stats["n_grounded"] == 0
+        assert stats["n_half"] == 1
+        assert stats["snippet_grounding_rate"] == pytest.approx(0.0)
+
+    def test_url_less_citations_dropped(self):
+        response = {
+            "sections": [
+                {
+                    "text": "Missing-url claims [1][2].",
+                    "citations": [{"id": "[1]", "url": ""}, {"id": "[2]"}],
+                }
+            ]
+        }
+
+        grounded, stats = ground_citations_by_url(
+            response,
+            {"https://example.com/a": "Fetched content."},
+        )
+
+        assert grounded["sections"][0]["citations"] == []
+        assert stats == {
+            "n_citations": 0.0,
+            "n_grounded": 0.0,
+            "n_half": 0.0,
+            "snippet_grounding_rate": 0.0,
+        }
+
+    def test_never_seen_citation_dropped(self):
+        response = {
+            "sections": [
+                {
+                    "text": "Seen claim [1]. Invented claim [2].",
+                    "citations": [
+                        {"id": "[1]", "url": "https://example.com/a"},
+                        {"id": "[2]", "url": "https://invented.example/missing"},
+                    ],
+                }
+            ]
+        }
+
+        grounded, stats = ground_citations_by_url(
+            response, {"https://example.com/a": "Fetched content."}
+        )
+
+        citations = grounded["sections"][0]["citations"]
+        assert [c["id"] for c in citations] == ["[1]"]
+        assert stats["n_citations"] == 2
+        assert stats["n_grounded"] == 1
+        assert stats["n_half"] == 0
+        assert stats["snippet_grounding_rate"] == pytest.approx(0.5)
+
+    def test_rate_math_counts_grounded_half_and_dropped_urls(self):
+        response = {
+            "sections": [
+                {
+                    "text": "Grounded [1]. Half [2]. Dropped [3].",
+                    "citations": [
+                        {"id": "[1]", "url": "https://example.com/a/"},
+                        {"id": "[2]", "url": "https://example.com/b."},
+                        {"id": "[3]", "url": "https://example.com/c"},
+                    ],
+                }
+            ]
+        }
+
+        _, stats = ground_citations_by_url(
+            response,
+            {
+                "https://example.com/a": "Fetched content.",
+                "https://example.com/b": "",
+            },
+        )
+
+        assert stats["n_citations"] == 3
+        assert stats["n_grounded"] == 1
+        assert stats["n_half"] == 1
+        assert stats["snippet_grounding_rate"] == pytest.approx(1 / 3)
+
+    def test_input_dict_not_mutated(self):
+        response = {
+            "sections": [
+                {
+                    "text": "Invented claim [1].",
+                    "citations": [{"id": "[1]", "url": "https://invented.example"}],
+                }
+            ]
+        }
+        original = copy.deepcopy(response)
+
+        ground_citations_by_url(response, {})
+
+        assert response == original

--- a/tests/core/test_citation_grounding.py
+++ b/tests/core/test_citation_grounding.py
@@ -1,0 +1,224 @@
+"""Tests for trajectory-source grounding of citation snippets."""
+
+from __future__ import annotations
+
+import copy
+
+import pytest
+
+from olmo_eval.common.scorers.citation import ground_citations_in_sources
+
+
+def test_grounded_snippet_kept():
+    snippet = "The Eiffel Tower opened in 1889 for the world's fair."
+    response = {
+        "sections": [
+            {
+                "text": "The Eiffel Tower opened in 1889 [1].",
+                "citations": [{"id": "[1]", "snippets": [snippet], "title": "Tower"}],
+            }
+        ]
+    }
+
+    grounded, stats = ground_citations_in_sources(response, f"Source says: {snippet}")
+
+    assert grounded["sections"][0]["citations"][0]["snippets"] == [snippet]
+    assert stats["n_snippets"] == 1
+    assert stats["n_grounded"] == 1
+    assert stats["snippet_grounding_rate"] == pytest.approx(1.0)
+
+
+def test_fabricated_only_citation_removed():
+    response = {
+        "sections": [
+            {
+                "text": "The answer cites a fabricated quote [1].",
+                "citations": [
+                    {
+                        "id": "[1]",
+                        "snippets": ["This fabricated passage is not present in sources."],
+                        "title": "Missing Title",
+                    }
+                ],
+            }
+        ]
+    }
+
+    grounded, stats = ground_citations_in_sources(response, "The source has unrelated text.")
+
+    assert grounded["sections"][0]["citations"] == []
+    assert stats["n_snippets"] == 1
+    assert stats["n_grounded"] == 0
+    assert stats["snippet_grounding_rate"] == pytest.approx(0.0)
+
+
+def test_mixed_citation_keeps_only_grounded_snippets():
+    grounded_snippet = "Grounded evidence appears verbatim in the fetched page."
+    fabricated_snippet = "Fabricated evidence does not appear anywhere."
+    response = {
+        "sections": [
+            {
+                "text": "Only one quote is grounded [1].",
+                "citations": [
+                    {
+                        "id": "[1]",
+                        "snippets": [grounded_snippet, fabricated_snippet],
+                        "title": "Fetched Page",
+                    }
+                ],
+            }
+        ]
+    }
+
+    grounded, stats = ground_citations_in_sources(response, grounded_snippet)
+
+    assert grounded["sections"][0]["citations"][0]["snippets"] == [grounded_snippet]
+    assert stats["n_snippets"] == 2
+    assert stats["n_grounded"] == 1
+    assert stats["snippet_grounding_rate"] == pytest.approx(0.5)
+
+
+def test_normalization_allows_case_punctuation_and_whitespace_differences():
+    response = {
+        "sections": [
+            {
+                "text": "Normalization should ground this [1].",
+                "citations": [
+                    {
+                        "id": "[1]",
+                        "snippets": ["Alpha beta gamma delta evidence string"],
+                    }
+                ],
+            }
+        ]
+    }
+    source = "ALPHA-beta,\ngamma    delta evidence string!"
+
+    grounded, stats = ground_citations_in_sources(response, source)
+
+    assert grounded["sections"][0]["citations"][0]["snippets"] == [
+        "Alpha beta gamma delta evidence string"
+    ]
+    assert stats["snippet_grounding_rate"] == pytest.approx(1.0)
+
+
+def test_short_snippet_removed_and_counted():
+    response = {
+        "sections": [
+            {
+                "text": "The city is Paris [1].",
+                "citations": [{"id": "[1]", "snippets": ["Paris"], "title": "Paris"}],
+            }
+        ]
+    }
+
+    grounded, stats = ground_citations_in_sources(response, "Paris")
+
+    assert grounded["sections"][0]["citations"][0]["snippets"] == []
+    assert grounded["sections"][0]["citations"][0]["title"] == "Paris"
+    assert stats["n_snippets"] == 1
+    assert stats["n_grounded"] == 0
+    assert stats["snippet_grounding_rate"] == pytest.approx(0.0)
+
+
+def test_grounded_title_only_citation_retained():
+    response = {
+        "sections": [
+            {
+                "text": "Title-only citations get filtered [1][2].",
+                "citations": [
+                    {"id": "[1]", "snippets": [], "title": "Important Study Title"},
+                    {"id": "[2]", "snippets": [], "title": "Absent Study Title"},
+                ],
+            }
+        ]
+    }
+
+    grounded, stats = ground_citations_in_sources(response, "Important Study Title appears here.")
+
+    citations = grounded["sections"][0]["citations"]
+    assert len(citations) == 1
+    assert citations[0]["id"] == "[1]"
+    assert citations[0]["title"] == "Important Study Title"
+    assert stats["n_snippets"] == 0
+    assert stats["snippet_grounding_rate"] == pytest.approx(0.0)
+
+
+def test_idless_citation_left_untouched_and_not_counted():
+    idless_snippet = "Idless evidence appears verbatim in source text."
+    grounded_snippet = "Grounded cited evidence appears verbatim in source text."
+    response = {
+        "sections": [
+            {
+                "text": "Only id-bearing snippets count [1].",
+                "citations": [
+                    {"snippets": [idless_snippet], "title": "Idless Title"},
+                    {"id": "[1]", "snippets": [grounded_snippet], "title": "Cited Title"},
+                ],
+            }
+        ]
+    }
+
+    grounded, stats = ground_citations_in_sources(response, f"{idless_snippet} {grounded_snippet}")
+
+    citations = grounded["sections"][0]["citations"]
+    assert citations[0] == {"snippets": [idless_snippet], "title": "Idless Title"}
+    assert citations[1]["snippets"] == [grounded_snippet]
+    assert stats["n_snippets"] == 1
+    assert stats["n_grounded"] == 1
+    assert stats["snippet_grounding_rate"] == pytest.approx(1.0)
+
+
+def test_table_sub_section_is_grounded():
+    snippet = "Table evidence value was copied from fetched content."
+    response = {
+        "sections": [
+            {
+                "text": "Main text.",
+                "citations": [],
+                "table": {
+                    "text": "A table claim [1].",
+                    "citations": [{"id": "[1]", "snippets": [snippet], "title": "Table"}],
+                },
+            }
+        ]
+    }
+
+    grounded, stats = ground_citations_in_sources(response, snippet)
+
+    table_citation = grounded["sections"][0]["table"]["citations"][0]
+    assert table_citation["snippets"] == [snippet]
+    assert stats["snippet_grounding_rate"] == pytest.approx(1.0)
+
+
+def test_empty_sections_rate_zero():
+    grounded, stats = ground_citations_in_sources({"sections": []}, "source")
+
+    assert grounded == {"sections": []}
+    assert stats == {
+        "n_snippets": 0.0,
+        "n_grounded": 0.0,
+        "snippet_grounding_rate": 0.0,
+    }
+
+
+def test_input_dict_not_mutated():
+    response = {
+        "sections": [
+            {
+                "text": "Fabricated citation [1].",
+                "citations": [
+                    {
+                        "id": "[1]",
+                        "snippets": ["This fabricated passage is not in sources."],
+                        "title": "Missing Title",
+                    }
+                ],
+            }
+        ]
+    }
+    original = copy.deepcopy(response)
+
+    ground_citations_in_sources(response, "unrelated source")
+
+    assert response == original

--- a/tests/evals/suites/test_science.py
+++ b/tests/evals/suites/test_science.py
@@ -80,4 +80,4 @@ def test_science_nojudge_excludes_judge_tasks():
 
 def test_science_judge_contains_judge_tasks():
     expanded = get_suite("science:judge").expand()
-    assert set(expanded) == {"astabench_scholarqa", "expertqa"}
+    assert set(expanded) == {"astabench_scholarqa"}

--- a/tests/evals/tasks/test_expertqa.py
+++ b/tests/evals/tasks/test_expertqa.py
@@ -146,6 +146,8 @@ class TestFormatRequest:
         assert "well-cited report" in content
         assert "serper_google_webpage_search" in content
         assert "serper_fetch_webpage_content" in content
+        assert "browse_webpage" in content
+        assert "serper_fetch_webpage_content or browse_webpage" in content
         assert "`url` is the source page" in content
         assert "Your final answer must consist of ONLY a single JSON object" in content
         assert "The first character of your final answer must be '{'" in content
@@ -166,6 +168,8 @@ class TestFormatRequest:
         assert '<cite url="https://example.com/page">claim text</cite>' in content
         assert "serper_google_webpage_search" in content
         assert "serper_fetch_webpage_content" in content
+        assert "browse_webpage" in content
+        assert "serper_fetch_webpage_content or browse_webpage" in content
         assert "Do not answer from memory. You must search before answering" in content
         workflow_start = content.index("Workflow (follow in order):")
         assert workflow_start > content.index("Do not return JSON.")
@@ -260,6 +264,52 @@ class TestScoreResponses:
             "snippet_grounding_rate": 1.0,
         }
         assert response.outputs[0].metadata["score:snippet_grounding_rate"] == pytest.approx(1.0)
+        assert response.scores["snippet_grounding_rate"] == pytest.approx(1.0)
+
+    @pytest.mark.anyio
+    async def test_browse_webpage_grounded_snippet_reaches_judge(self, task, monkeypatch):
+        url = "https://example.com/crawl4ai-source"
+        snippet = "Crawl4ai fetched passage exactly supports the grounded ExpertQA answer."
+        page_content = f"Fetched text: {snippet}"
+        judge = _RecordingJudge()
+        monkeypatch.setattr(expertqa_module, "_build_judge_fn", lambda: judge)
+        parsed = {
+            "sections": [
+                {
+                    "text": "Grounded crawl4ai claim [1].",
+                    "citations": [
+                        {
+                            "id": "[1]",
+                            "url": url,
+                            "title": "Fetched Source",
+                            "snippets": [snippet],
+                        }
+                    ],
+                }
+            ]
+        }
+        response = self._response(
+            parsed,
+            _trajectory_with_search_and_fetch(
+                fetch_url=url,
+                fetch_content=page_content,
+                search_content=f"URL: {url}",
+                fetch_tool_name="browse_webpage",
+            ),
+        )
+
+        assert expertqa_module._trajectory_source_text(response) == page_content
+
+        await task.score_responses([response])
+
+        citation_prompts = [p for p in judge.prompts if "References:" in p]
+        assert citation_prompts
+        assert snippet in citation_prompts[0]
+        assert response.outputs[0].metadata["grounding_stats"] == {
+            "n_snippets": 1.0,
+            "n_grounded": 1.0,
+            "snippet_grounding_rate": 1.0,
+        }
         assert response.scores["snippet_grounding_rate"] == pytest.approx(1.0)
 
     @pytest.mark.anyio
@@ -514,6 +564,20 @@ class TestSuiteMembership:
 
 
 class TestTrajectoryUrlContent:
+    def test_browse_webpage_fetch_content_maps_url(self):
+        url = "https://example.com/crawl4ai-source"
+        fetch_content = "Crawl4ai fetched page evidence belongs to the cited URL."
+        trajectory = _trajectory_with_search_and_fetch(
+            fetch_url=url,
+            fetch_content=fetch_content,
+            search_content=f"URL: {url}",
+            fetch_tool_name="browse_webpage",
+        )
+
+        url_to_content = expertqa_module._trajectory_url_content(_cite_response("", trajectory))
+
+        assert url_to_content[url] == fetch_content
+
     def test_good_fetch_content_survives_later_error_refetch(self):
         url = "https://example.com/source"
         good_content = "Fetched page evidence that should remain mapped."
@@ -698,6 +762,7 @@ def _trajectory_with_search_and_fetch(
     fetch_content,
     search_content,
     fetch_is_error=False,
+    fetch_tool_name="serper_fetch_webpage_content",
 ):
     return AgentTrajectory(
         turns=(
@@ -722,7 +787,7 @@ def _trajectory_with_search_and_fetch(
                 tool_calls=[
                     ToolCall.create(
                         "",
-                        "serper_fetch_webpage_content",
+                        fetch_tool_name,
                         {"url": fetch_url},
                     )
                 ]

--- a/tests/evals/tasks/test_expertqa.py
+++ b/tests/evals/tasks/test_expertqa.py
@@ -1,11 +1,24 @@
 """Tests for the ExpertQA attributed long-form QA task."""
 
 import json
+import logging
 
 import pytest
 
-from olmo_eval.common.types import Instance, LMOutput, LMRequest, RequestType, Response
+from olmo_eval.common.types import (
+    AgentTrajectory,
+    AgentTurn,
+    Instance,
+    LMOutput,
+    LMRequest,
+    RequestType,
+    Response,
+    ToolResult,
+)
+from olmo_eval.evals.suites import get_suite
+from olmo_eval.evals.tasks import expertqa as expertqa_module
 from olmo_eval.evals.tasks.common import get_task, list_tasks
+from olmo_eval.evals.tasks.expertqa import EXPERTQA_OUTPUT_LABELS
 
 
 @pytest.fixture(autouse=True)
@@ -29,6 +42,7 @@ class TestRegistration:
             "citation_precision",
             "citation_recall",
             "answer_precision",
+            "snippet_grounding_rate",
         }
 
     def test_primary_metric(self, task):
@@ -102,51 +116,242 @@ class TestFormatRequest:
         assert len(request.messages) == 1
         content = request.messages[0]["content"]
         assert "What is attention?" in content
-        assert "Generate a report" in content
+        assert "well-cited report" in content
+        assert "serper_google_webpage_search" in content
+        assert "serper_fetch_webpage_content" in content
+        assert "`url` is the source page" in content
+        assert "Do not create a References section" in content
 
 
-class TestScoreSingle:
-    def _response(self, parsed):
+class TestScoreResponses:
+    def _response(self, parsed, trajectory):
         instance = Instance(question="What causes X?", metadata={})
-        output = LMOutput(text="", metadata={"parsed_response": parsed})
+        text = json.dumps(parsed) if parsed is not None else "not json at all"
+        output = LMOutput(text=text)
         return Response(
             instance=instance,
             request=LMRequest(request_type=RequestType.CHAT, messages=()),
             outputs=[output],
             scores={},
+            trajectory=trajectory,
         )
 
     @pytest.mark.anyio
-    async def test_no_parsed_response_scores_zero(self, task):
-        response = self._response(None)
-        scores = await task._score_single(response, _unused_judge)
-        assert scores == {
+    async def test_no_parsed_response_scores_zero(self, task, monkeypatch):
+        monkeypatch.setattr(expertqa_module, "_build_judge_fn", lambda: _unused_judge)
+        response = self._response(None, _trajectory_with_source(""))
+
+        await task.score_responses([response])
+
+        assert response.scores == {
             "citation_precision": 0.0,
             "citation_recall": 0.0,
             "answer_precision": 0.0,
+            "snippet_grounding_rate": 0.0,
             "global_avg": 0.0,
         }
+        assert response.outputs[0].metadata["grounding_stats"]["snippet_grounding_rate"] == 0.0
 
     @pytest.mark.anyio
-    async def test_global_avg_is_mean_of_three_axes(self, task):
+    async def test_global_avg_is_mean_of_three_axes(self, task, monkeypatch):
+        monkeypatch.setattr(expertqa_module, "_build_judge_fn", lambda: _citation_split_judge)
+        snippet = "Evidence from a fetched source supports the first claim."
         parsed = {
             "sections": [
                 {
                     "text": "Claim A [1]. Claim B [1].",
-                    "citations": [
-                        {"id": "[1]", "snippets": ["evidence from paper"], "title": "Paper"}
-                    ],
+                    "citations": [{"id": "[1]", "snippets": [snippet], "title": "Paper"}],
                 }
             ]
         }
-        response = self._response(parsed)
-        scores = await task._score_single(response, _citation_split_judge)
+        response = self._response(parsed, _trajectory_with_source(snippet))
+
+        await task.score_responses([response])
+
+        scores = response.scores
         # One of two claims attributable -> recall 0.5; precision averages 0.5;
         # no irrelevant paragraphs -> answer_precision 1.0.
         assert scores["citation_recall"] == pytest.approx(0.5)
         assert scores["citation_precision"] == pytest.approx(0.5)
         assert scores["answer_precision"] == pytest.approx(1.0)
+        assert scores["snippet_grounding_rate"] == pytest.approx(1.0)
         assert scores["global_avg"] == pytest.approx((0.5 + 0.5 + 1.0) / 3)
+
+    @pytest.mark.anyio
+    async def test_grounded_snippet_reaches_judge(self, task, monkeypatch):
+        snippet = "This fetched passage exactly supports the grounded ExpertQA answer."
+        judge = _RecordingJudge()
+        monkeypatch.setattr(expertqa_module, "_build_judge_fn", lambda: judge)
+        parsed = {
+            "sections": [
+                {
+                    "text": "Grounded claim [1].",
+                    "citations": [
+                        {
+                            "id": "[1]",
+                            "url": "https://example.com/source",
+                            "title": "Fetched Source",
+                            "snippets": [snippet],
+                        }
+                    ],
+                }
+            ]
+        }
+        response = self._response(parsed, _trajectory_with_source(f"Fetched text: {snippet}"))
+
+        await task.score_responses([response])
+
+        citation_prompts = [p for p in judge.prompts if "References:" in p]
+        assert citation_prompts
+        assert snippet in citation_prompts[0]
+        assert response.outputs[0].metadata["grounding_stats"] == {
+            "n_snippets": 1.0,
+            "n_grounded": 1.0,
+            "snippet_grounding_rate": 1.0,
+        }
+        assert response.outputs[0].metadata["score:snippet_grounding_rate"] == pytest.approx(1.0)
+        assert response.scores["snippet_grounding_rate"] == pytest.approx(1.0)
+
+    @pytest.mark.anyio
+    async def test_fabricated_snippet_removed_before_judging(self, task, monkeypatch):
+        grounded_snippet = "Fetched evidence appears verbatim in the trajectory source text."
+        fabricated_snippet = "Fabricated evidence never appeared in any fetched page."
+        judge = _RecordingJudge()
+        monkeypatch.setattr(expertqa_module, "_build_judge_fn", lambda: judge)
+        parsed = {
+            "sections": [
+                {
+                    "text": "One grounded claim [1]. One fabricated citation [2].",
+                    "citations": [
+                        {"id": "[1]", "snippets": [grounded_snippet], "title": "Fetched"},
+                        {"id": "[2]", "snippets": [fabricated_snippet], "title": "Missing"},
+                    ],
+                }
+            ]
+        }
+        response = self._response(parsed, _trajectory_with_source(grounded_snippet))
+
+        await task.score_responses([response])
+
+        citation_prompts = [p for p in judge.prompts if "References:" in p]
+        assert citation_prompts
+        assert grounded_snippet in citation_prompts[0]
+        assert fabricated_snippet not in citation_prompts[0]
+        assert response.outputs[0].metadata["grounding_stats"]["n_snippets"] == 2.0
+        assert response.outputs[0].metadata["grounding_stats"]["n_grounded"] == 1.0
+        assert response.scores["snippet_grounding_rate"] == pytest.approx(0.5)
+
+    @pytest.mark.anyio
+    async def test_fully_fabricated_citation_scores_zero_with_supporting_judge(
+        self, task, monkeypatch
+    ):
+        fabricated_snippet = "Fabricated ExpertQA evidence never appeared in retrieved sources."
+        judge = _EverythingSupportingJudge()
+        monkeypatch.setattr(expertqa_module, "_build_judge_fn", lambda: judge)
+        parsed = {
+            "sections": [
+                {
+                    "text": "A fully fabricated citation should not receive credit [1].",
+                    "citations": [
+                        {
+                            "id": "[1]",
+                            "snippets": [fabricated_snippet],
+                            "title": "Invented Source Title",
+                        }
+                    ],
+                }
+            ]
+        }
+        response = self._response(
+            parsed, _trajectory_with_source("Retrieved unrelated source text.")
+        )
+
+        await task.score_responses([response])
+
+        assert response.scores["citation_precision"] == pytest.approx(0.0)
+        assert response.scores["citation_recall"] == pytest.approx(0.0)
+        assert response.scores["snippet_grounding_rate"] == pytest.approx(0.0)
+        assert response.outputs[0].metadata["grounding_stats"] == {
+            "n_snippets": 1.0,
+            "n_grounded": 0.0,
+            "snippet_grounding_rate": 0.0,
+        }
+        assert [p for p in judge.prompts if "References:" in p] == []
+
+    @pytest.mark.anyio
+    async def test_missing_trajectory_warns_and_ungrounds_snippets(self, task, monkeypatch, caplog):
+        monkeypatch.setattr(expertqa_module, "_build_judge_fn", lambda: _citation_split_judge)
+        caplog.set_level(logging.WARNING, logger=expertqa_module.__name__)
+        parsed = {
+            "sections": [
+                {
+                    "text": "Claim with missing trajectory [1].",
+                    "citations": [
+                        {
+                            "id": "[1]",
+                            "snippets": ["This snippet is long enough but has no source text."],
+                            "title": "Missing",
+                        }
+                    ],
+                }
+            ]
+        }
+        response = self._response(parsed, trajectory=None)
+
+        await task.score_responses([response])
+
+        assert response.scores["snippet_grounding_rate"] == pytest.approx(0.0)
+        assert "web_search_agent" in caplog.text
+        assert "no trajectory" in caplog.text
+
+    @pytest.mark.anyio
+    async def test_multi_output_scores_metadata_and_uses_configured_aggregation(self, monkeypatch):
+        task = get_task("expertqa", config_overrides={"output_score_aggregation": "first"})
+        monkeypatch.setattr(expertqa_module, "_build_judge_fn", lambda: _citation_split_judge)
+        grounded_snippet = "Grounded multi-output evidence appears in fetched content."
+        fabricated = {
+            "sections": [
+                {
+                    "text": "Ungrounded first output [1].",
+                    "citations": [
+                        {
+                            "id": "[1]",
+                            "snippets": ["This first output quote is not in trajectory text."],
+                        }
+                    ],
+                }
+            ]
+        }
+        grounded = {
+            "sections": [
+                {
+                    "text": "Grounded second output [1].",
+                    "citations": [{"id": "[1]", "snippets": [grounded_snippet]}],
+                }
+            ]
+        }
+        response = Response(
+            instance=Instance(question="What causes X?", metadata={}),
+            request=LMRequest(request_type=RequestType.CHAT, messages=()),
+            outputs=[LMOutput(text=json.dumps(fabricated)), LMOutput(text=json.dumps(grounded))],
+            scores={},
+            trajectory=_trajectory_with_source(grounded_snippet),
+        )
+
+        await task.score_responses([response])
+
+        for output in response.outputs:
+            for label in EXPERTQA_OUTPUT_LABELS:
+                assert f"score:{label}" in output.metadata
+        assert response.outputs[0].metadata["score:snippet_grounding_rate"] == pytest.approx(0.0)
+        assert response.outputs[1].metadata["score:snippet_grounding_rate"] == pytest.approx(1.0)
+        assert response.scores["snippet_grounding_rate"] == pytest.approx(0.0)
+
+
+class TestSuiteMembership:
+    def test_expertqa_research_only_for_science_execution_split(self):
+        assert "expertqa" in get_suite("science:research").expand()
+        assert "expertqa" not in get_suite("science:judge").expand()
 
 
 async def _unused_judge(prompt, **kwargs):
@@ -174,4 +379,63 @@ async def _citation_split_judge(prompt, **kwargs):
                 },
             ]
         }
+    )
+
+
+class _RecordingJudge:
+    def __init__(self):
+        self.prompts = []
+
+    async def __call__(self, prompt, **kwargs):
+        self.prompts.append(prompt)
+        if "irrelevant paragraphs" in prompt:
+            return json.dumps({"irrelevant_paragraphs": []})
+        return json.dumps(
+            {
+                "claims": [
+                    {
+                        "text": "Claim",
+                        "supporting": ["[1]"],
+                        "non_supporting": [],
+                        "is_fully_supported": True,
+                    }
+                ]
+            }
+        )
+
+
+class _EverythingSupportingJudge:
+    def __init__(self):
+        self.prompts = []
+
+    async def __call__(self, prompt, **kwargs):
+        self.prompts.append(prompt)
+        if "irrelevant paragraphs" in prompt:
+            return json.dumps({"irrelevant_paragraphs": []})
+        return json.dumps(
+            {
+                "claims": [
+                    {
+                        "text": "Claim",
+                        "supporting": ["[1]"],
+                        "non_supporting": [],
+                        "is_fully_supported": True,
+                    }
+                ]
+            }
+        )
+
+
+def _trajectory_with_source(source_text):
+    return AgentTrajectory(
+        turns=(
+            AgentTurn.tool(
+                [
+                    ToolResult(
+                        tool_call_id="call_1",
+                        content=source_text,
+                    )
+                ]
+            ),
+        )
     )

--- a/tests/evals/tasks/test_expertqa.py
+++ b/tests/evals/tasks/test_expertqa.py
@@ -143,7 +143,6 @@ class TestFormatRequest:
         assert request.request_type == RequestType.CHAT
         assert len(request.messages) == 1
         content = request.messages[0]["content"]
-        assert "What is attention?" in content
         assert "well-cited report" in content
         assert "serper_google_webpage_search" in content
         assert "serper_fetch_webpage_content" in content
@@ -152,19 +151,26 @@ class TestFormatRequest:
         assert "The first character of your final answer must be '{'" in content
         assert "Do not use Markdown, code fences, headings" in content
         assert "Do not create a References section" in content
+        assert "Do not answer from memory. You must search before answering" in content
+        workflow_start = content.index("Workflow (follow in order):")
+        assert workflow_start > content.index("Your final answer must consist")
+        assert content.endswith("Question: What is attention?")
 
     def test_cite_request_uses_cite_prompt(self, cite_task):
         instance = Instance(question="What is attention?", metadata={})
         request = cite_task.format_request(instance)
         assert request.request_type == RequestType.CHAT
         content = request.messages[0]["content"]
-        assert "What is attention?" in content
         assert "Markdown is allowed" in content
         assert "Do not return JSON." in content
         assert '<cite url="https://example.com/page">claim text</cite>' in content
         assert "serper_google_webpage_search" in content
         assert "serper_fetch_webpage_content" in content
+        assert "Do not answer from memory. You must search before answering" in content
+        workflow_start = content.index("Workflow (follow in order):")
+        assert workflow_start > content.index("Do not return JSON.")
         assert "Return valid JSON" not in content
+        assert content.endswith("Question: What is attention?")
 
 
 class TestScoreResponses:

--- a/tests/evals/tasks/test_expertqa.py
+++ b/tests/evals/tasks/test_expertqa.py
@@ -13,6 +13,7 @@ from olmo_eval.common.types import (
     LMRequest,
     RequestType,
     Response,
+    ToolCall,
     ToolResult,
 )
 from olmo_eval.evals.suites import get_suite
@@ -31,9 +32,17 @@ def task():
     return get_task("expertqa")
 
 
+@pytest.fixture
+def cite_task():
+    return get_task("expertqa:cite")
+
+
 class TestRegistration:
     def test_task_registered(self):
         assert "expertqa" in list_tasks()
+
+    def test_cite_task_registered(self):
+        assert "expertqa:cite" in list_tasks()
 
     def test_metrics_exclude_ingredient_recall(self, task):
         metric_names = {m.name for m in task.config.metrics}
@@ -107,6 +116,25 @@ class TestExtractAnswer:
         assert result is not None
         assert "sections" in result
 
+    def test_cite_extract_answer_parses_tags(self, cite_task):
+        text = (
+            "<think>\nplan\n</think>\n"
+            'Intro <cite url="https://example.com/source">Grounded claim.</cite>'
+        )
+        output = LMOutput(text=text)
+        result = cite_task.extract_answer(output)
+        assert result is not None
+        assert result["sections"][0]["text"] == "Intro Grounded claim. [1]"
+        assert result["sections"][0]["citations"] == [
+            {
+                "id": "[1]",
+                "url": "https://example.com/source",
+                "title": "",
+                "snippets": [],
+            }
+        ]
+        assert output.metadata["parsed_response"] == result
+
 
 class TestFormatRequest:
     def test_chat_request_embeds_question(self, task):
@@ -120,7 +148,23 @@ class TestFormatRequest:
         assert "serper_google_webpage_search" in content
         assert "serper_fetch_webpage_content" in content
         assert "`url` is the source page" in content
+        assert "Your final answer must consist of ONLY a single JSON object" in content
+        assert "The first character of your final answer must be '{'" in content
+        assert "Do not use Markdown, code fences, headings" in content
         assert "Do not create a References section" in content
+
+    def test_cite_request_uses_cite_prompt(self, cite_task):
+        instance = Instance(question="What is attention?", metadata={})
+        request = cite_task.format_request(instance)
+        assert request.request_type == RequestType.CHAT
+        content = request.messages[0]["content"]
+        assert "What is attention?" in content
+        assert "Markdown is allowed" in content
+        assert "Do not return JSON." in content
+        assert '<cite url="https://example.com/page">claim text</cite>' in content
+        assert "serper_google_webpage_search" in content
+        assert "serper_fetch_webpage_content" in content
+        assert "Return valid JSON" not in content
 
 
 class TestScoreResponses:
@@ -347,11 +391,203 @@ class TestScoreResponses:
         assert response.outputs[1].metadata["score:snippet_grounding_rate"] == pytest.approx(1.0)
         assert response.scores["snippet_grounding_rate"] == pytest.approx(0.0)
 
+    @pytest.mark.anyio
+    async def test_cite_grounded_fetched_url_reaches_judge(self, cite_task, monkeypatch):
+        page_excerpt = "Fetched page evidence supports the cite-tag ExpertQA claim."
+        judge = _RecordingJudge()
+        monkeypatch.setattr(expertqa_module, "_build_judge_fn", lambda: judge)
+        response = _cite_response(
+            '<cite url="https://example.com/source">Grounded cite claim.</cite>',
+            _trajectory_with_search_and_fetch(
+                fetch_url="https://example.com/source",
+                fetch_content=page_excerpt,
+                search_content="URL: https://example.com/source\nURL: https://example.com/other",
+            ),
+        )
+
+        await cite_task.score_responses([response])
+
+        citation_prompts = [p for p in judge.prompts if "References:" in p]
+        assert citation_prompts
+        assert page_excerpt in citation_prompts[0]
+        assert response.outputs[0].metadata["grounding_stats"] == {
+            "n_citations": 1.0,
+            "n_grounded": 1.0,
+            "n_half": 0.0,
+            "snippet_grounding_rate": 1.0,
+        }
+        assert response.scores["snippet_grounding_rate"] == pytest.approx(1.0)
+
+    @pytest.mark.anyio
+    async def test_cite_invented_url_scores_zero_with_supporting_judge(
+        self, cite_task, monkeypatch
+    ):
+        judge = _EverythingSupportingJudge()
+        monkeypatch.setattr(expertqa_module, "_build_judge_fn", lambda: judge)
+        response = _cite_response(
+            '<cite url="https://invented.example/missing">Invented cite claim.</cite>',
+            _trajectory_with_search_and_fetch(
+                fetch_url="https://example.com/source",
+                fetch_content="Fetched content for a different source.",
+                search_content="URL: https://example.com/source",
+            ),
+        )
+
+        await cite_task.score_responses([response])
+
+        assert response.scores["citation_precision"] == pytest.approx(0.0)
+        assert response.scores["citation_recall"] == pytest.approx(0.0)
+        assert response.scores["snippet_grounding_rate"] == pytest.approx(0.0)
+        assert response.outputs[0].metadata["grounding_stats"] == {
+            "n_citations": 1.0,
+            "n_grounded": 0.0,
+            "n_half": 0.0,
+            "snippet_grounding_rate": 0.0,
+        }
+        assert [p for p in judge.prompts if "References:" in p] == []
+
+    @pytest.mark.anyio
+    async def test_cite_empty_url_scores_zero_with_supporting_judge(self, cite_task, monkeypatch):
+        judge = _EverythingSupportingJudge()
+        monkeypatch.setattr(expertqa_module, "_build_judge_fn", lambda: judge)
+        response = _cite_response(
+            '<cite url="">Empty-url cite claim.</cite>',
+            _trajectory_with_search_and_fetch(
+                fetch_url="https://example.com/source",
+                fetch_content="Fetched content for a source.",
+                search_content="URL: https://example.com/source",
+            ),
+        )
+
+        await cite_task.score_responses([response])
+
+        assert response.outputs[0].metadata["parsed_response"] is None
+        assert response.scores["citation_precision"] == pytest.approx(0.0)
+        assert response.scores["citation_recall"] == pytest.approx(0.0)
+        assert response.scores["snippet_grounding_rate"] == pytest.approx(0.0)
+        assert response.outputs[0].metadata["grounding_stats"] == {
+            "n_snippets": 0.0,
+            "n_grounded": 0.0,
+            "snippet_grounding_rate": 0.0,
+        }
+        assert [p for p in judge.prompts if "References:" in p] == []
+
+    @pytest.mark.anyio
+    async def test_cite_fetch_error_routes_to_half_credit(self, cite_task, monkeypatch):
+        judge = _RecordingJudge()
+        monkeypatch.setattr(expertqa_module, "_build_judge_fn", lambda: judge)
+        response = _cite_response(
+            '<cite url="https://example.com/source">Error-fetch cite claim.</cite>',
+            _trajectory_with_search_and_fetch(
+                fetch_url="https://example.com/source",
+                fetch_content="Error fetching webpage: timed out",
+                search_content="URL: https://example.com/source",
+                fetch_is_error=True,
+            ),
+        )
+
+        await cite_task.score_responses([response])
+
+        citation_prompts = [p for p in judge.prompts if "References:" in p]
+        assert citation_prompts
+        assert "Paper content unavailable" in citation_prompts[0]
+        assert "The paper's title is: https://example.com/source" in citation_prompts[0]
+        assert "Error fetching webpage" not in citation_prompts[0]
+        assert response.outputs[0].metadata["grounding_stats"] == {
+            "n_citations": 1.0,
+            "n_grounded": 0.0,
+            "n_half": 1.0,
+            "snippet_grounding_rate": 0.0,
+        }
+
 
 class TestSuiteMembership:
     def test_expertqa_research_only_for_science_execution_split(self):
         assert "expertqa" in get_suite("science:research").expand()
         assert "expertqa" not in get_suite("science:judge").expand()
+
+
+class TestTrajectoryUrlContent:
+    def test_good_fetch_content_survives_later_error_refetch(self):
+        url = "https://example.com/source"
+        good_content = "Fetched page evidence that should remain mapped."
+        trajectory = AgentTrajectory(
+            turns=(
+                AgentTurn.assistant(
+                    tool_calls=[
+                        ToolCall.create(
+                            "fetch_1",
+                            "serper_fetch_webpage_content",
+                            {"url": url},
+                        )
+                    ]
+                ),
+                AgentTurn.tool(
+                    [
+                        ToolResult(
+                            tool_call_id="fetch_1",
+                            content=good_content,
+                        )
+                    ]
+                ),
+                AgentTurn.assistant(
+                    tool_calls=[
+                        ToolCall.create(
+                            "fetch_2",
+                            "serper_fetch_webpage_content",
+                            {"url": url},
+                        )
+                    ]
+                ),
+                AgentTurn.tool(
+                    [
+                        ToolResult(
+                            tool_call_id="fetch_2",
+                            content="Error fetching webpage: timed out",
+                            is_error=True,
+                        )
+                    ]
+                ),
+            )
+        )
+
+        url_to_content = expertqa_module._trajectory_url_content(_cite_response("", trajectory))
+
+        assert url_to_content[url] == good_content
+
+    def test_two_tool_calls_pair_results_by_order_when_ids_empty(self):
+        fetch_url = "https://example.com/source"
+        search_content = f"URL: {fetch_url}\nSearch result text should not be fetch evidence."
+        fetch_content = "Fetched page evidence belongs to the fetch call."
+        trajectory = AgentTrajectory(
+            turns=(
+                AgentTurn.assistant(
+                    tool_calls=[
+                        ToolCall.create(
+                            "",
+                            "serper_google_webpage_search",
+                            {"query": "expertqa source"},
+                        ),
+                        ToolCall.create(
+                            "",
+                            "serper_fetch_webpage_content",
+                            {"url": fetch_url},
+                        ),
+                    ]
+                ),
+                AgentTurn.tool(
+                    [
+                        ToolResult(tool_call_id="", content=search_content),
+                        ToolResult(tool_call_id="", content=fetch_content),
+                    ]
+                ),
+            )
+        )
+
+        url_to_content = expertqa_module._trajectory_url_content(_cite_response("", trajectory))
+
+        assert url_to_content[fetch_url] == fetch_content
+        assert url_to_content[fetch_url] != search_content
 
 
 async def _unused_judge(prompt, **kwargs):
@@ -434,6 +670,63 @@ def _trajectory_with_source(source_text):
                     ToolResult(
                         tool_call_id="call_1",
                         content=source_text,
+                    )
+                ]
+            ),
+        )
+    )
+
+
+def _cite_response(text, trajectory):
+    return Response(
+        instance=Instance(question="What causes X?", metadata={}),
+        request=LMRequest(request_type=RequestType.CHAT, messages=()),
+        outputs=[LMOutput(text=text)],
+        scores={},
+        trajectory=trajectory,
+    )
+
+
+def _trajectory_with_search_and_fetch(
+    fetch_url,
+    fetch_content,
+    search_content,
+    fetch_is_error=False,
+):
+    return AgentTrajectory(
+        turns=(
+            AgentTurn.assistant(
+                tool_calls=[
+                    ToolCall.create(
+                        "",
+                        "serper_google_webpage_search",
+                        {"query": "expertqa source"},
+                    )
+                ]
+            ),
+            AgentTurn.tool(
+                [
+                    ToolResult(
+                        tool_call_id="",
+                        content=search_content,
+                    )
+                ]
+            ),
+            AgentTurn.assistant(
+                tool_calls=[
+                    ToolCall.create(
+                        "",
+                        "serper_fetch_webpage_content",
+                        {"url": fetch_url},
+                    )
+                ]
+            ),
+            AgentTurn.tool(
+                [
+                    ToolResult(
+                        tool_call_id="",
+                        content=fetch_content,
+                        is_error=fetch_is_error,
                     )
                 ]
             ),


### PR DESCRIPTION
## Problem

ExpertQA as shipped was closed-book: models answered from memory and were judged against their own self-cited claims, so it measured self-consistency rather than attribution (same issue as scholar-qa).

## Redesign

An agentic task: the model must search the web (`serper_google_webpage_search`), read pages (`serper_fetch_webpage_content` or `browse_webpage`), and produce a cited report. Two answer formats, one per evaluation:
- `expertqa` (official JSON): `sections[].citations[].snippets` with VERBATIM excerpts from fetched pages
- `expertqa:cite` (DR-Tulu-style `<cite url="...">` tags)

Key mechanics:
- **Anti-fabrication grounding**: a citation only reaches the judge if its snippet appears verbatim in trajectory tool output (JSON mode) or its URL was actually fetched (cite mode); fabricated citations are dropped.
- **Metrics**: `citation_precision`, `citation_recall`, `answer_precision` (LLM judge, default `gpt-5.5:medium`, overridable via `OLMO_EVAL_JUDGE`), plus `snippet_grounding_rate`; `global_avg` = mean of the three judge metrics.
- Grounding recognizes both fetch tools (`serper_fetch_webpage_content` and crawl4ai's `browse_webpage`, added in #250), so the task runs under serper or crawl4ai presets.
- Prompts are ordered so the search-first workflow has recency; weak instruction-followers otherwise skip tools under the strict output-format rules.

## Validation (4 models x 50 questions, crawl4ai preset, gpt-5-mini judge)

| model | global_avg 8K fetch | global_avg 32K fetch |
|---|---|---|
| Gemma-4-26B-A4B | 0.595 | 0.710 |
| Qwen3.5-35B-A3B | 0.614 | 0.662 |
| Qwen3.5-9B | 0.495 | 0.525 |
| Olmo-3-7B | 0.280 | 0.300 |

Olmo-3-7B writes fluent prose (answer_precision 0.84) but emits zero tool calls under the strict-JSON prompt and fabricates citations, so its citation metrics ground to 0; documented as a known behavior.

## Reproducing the reported numbers

Scores depend on three settings; to match the table exactly:

```bash
# needs #239 (Qwen tool parser inference), #249 (max-turns finalization), #250 (crawl4ai tool)
OLMO_EVAL_JUDGE=gpt-5-mini OLMO_WEBPAGE_CONTENT_LIMIT=32000 \
olmo-eval run -m Qwen/Qwen3.5-9B -H web_search_agent_crawl4ai \
  -o provider.max_model_len=65536 -t expertqa -o limit=50
```

Moving pieces that shift absolute numbers: fetch backend/length (serper caps pages at 4K chars; 8K vs 32K crawl4ai above), judge model (`OLMO_EVAL_JUDGE`), and the Qwen `qwen3_coder` tool parser (auto-inferred in #239).

## Tests

56 passing (grounding both formats, prompts, judge parsing). Related: #238 (SAGE), #239 (harness robustness), #249 (max-turns finalization), #250 (crawl4ai tool; optional companion, no hard dependency).

cc @donovanr