### PR TITLE
Add ResearchQA scholarly-QA benchmark (survey-mined rubric coverage)

### DIFF
--- a/src/olmo_eval/evals/tasks/researchqa.py
+++ b/src/olmo_eval/evals/tasks/researchqa.py
@@ -1,0 +1,461 @@
+"""ResearchQA agentic scholarly question answering (arXiv 2509.00496).
+
+The model searches the scholarly web and writes an approximately 250-word
+answer. Coverage is judged with the verbatim prompt from the official
+``compute_coverage.py`` scorer: rubric items are sent in batches of at most
+eight and receive one of five ordinal labels, normalized onto a 0--1 scale.
+The primary metric is an unweighted mean of per-answer rubric means. The paper
+reports this value multiplied by 100; for example, its best system's 75.29%
+coverage is ``0.7529`` here. Per-type metrics pool rubric items across answers,
+so answers with more items of a type receive proportionally more weight.
+
+Unlike the official scorer, which drops an entire answer after three malformed
+judge outputs, this task assigns the affected rubric items 0.0 and keeps the
+answer in the denominator. This prevents parse failures from inflating scores.
+
+The deliberate project default, ``gpt-5.4-mini``, deviates from the paper's
+official ``gpt-4.1-mini`` judge at temperature 0. To reproduce the published
+leaderboard exactly, set ``OLMO_EVAL_JUDGE=gpt-4.1-mini``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from abc import ABC
+from collections.abc import Iterator, Sequence
+from dataclasses import dataclass
+from typing import Any, cast
+
+from olmo_eval.common.metrics import Metric
+from olmo_eval.common.scorers.base import Scorer
+from olmo_eval.common.scorers.llm_judge import JudgeFn, build_openai_judge_fn
+from olmo_eval.common.types import (
+    Instance,
+    LMOutput,
+    LMRequest,
+    RequestType,
+    Response,
+    SamplingParams,
+    Split,
+)
+from olmo_eval.data import DataSource
+from olmo_eval.evals.tasks.common import Task, register, register_variant
+
+logger = logging.getLogger(__name__)
+
+RESEARCHQA_REPO = "realliyifei/ResearchQA"
+RESEARCHQA_DEFAULT_JUDGE_SPEC = "gpt-5.4-mini"
+RESEARCHQA_RUBRIC_BATCH_SIZE = 8
+RESEARCHQA_JUDGE_ATTEMPTS = 3
+
+RESEARCHQA_TYPE_METRICS = {
+    "coverage_citation": "Citation",
+    "coverage_limitation": "Limitation",
+    "coverage_comparison": "Comparison",
+    "coverage_example": "Example",
+    "coverage_impact": "Impact",
+    "coverage_other": "Other",
+}
+
+RESEARCHQA_LABEL_SCORES = {
+    "Not at all": 1,
+    "Barely": 2,
+    "Moderately": 3,
+    "Mostly": 4,
+    "Completely": 5,
+}
+
+RESEARCHQA_GENERATION_PROMPT = (
+    "You are answering a scholarly research question. Use the available research tools "
+    "to find reliable sources that support your answer.\n\n"
+    "Available tools:\n"
+    "- semantic_scholar_snippet_search\n"
+    "- serper_google_webpage_search\n"
+    "- serper_fetch_webpage_content\n\n"
+    "Format and length requirements:\n"
+    "- Write a well-organized, citation-supported answer in about 250 words.\n"
+    "- Synthesize the evidence directly around the question and cite the sources you use.\n\n"
+    "{date_cutoff}"
+    "Workflow (follow this order):\n"
+    "1. Search for relevant scholarly sources using semantic_scholar_snippet_search and "
+    "serper_google_webpage_search.\n"
+    "2. Fetch and read promising source content using serper_fetch_webpage_content.\n"
+    "3. Only after searching, fetching, and reading, write the answer.\n"
+    "Search first, then fetch and read, and only then answer. Do not answer from memory.\n\n"
+    "Question: "
+)
+
+# Verbatim from ResearchQA's official compute_coverage.py:build_prompt().
+RESEARCHQA_COVERAGE_JUDGE_PROMPT = (
+    "Please judge the following questions based on the response below.\n"
+    "For each question, select one of the following ratings to indicate the extent to which "
+    "the response addresses the question:\n"
+    "Not at all, Barely, Moderately, Mostly, Completely\n\n"
+    "Definitions:\n"
+    "- Not at all: *totally uninferable*\n"
+    "- Barely: *unmentioned but inferrable*\n"
+    "- Moderately: *mentioned but misses important details*\n"
+    "- Mostly: *mentioned but misses some details*\n"
+    "- Completely: *mentioned with sufficient details*\n\n"
+    "Only output one of the five phrases for each question, separated by newlines, and "
+    "nothing else.\n\n"
+    "Response: {answer}\n"
+    "Questions:\n"
+    "{questions}\n\n"
+    "Output:"
+)
+
+
+def normalize_coverage_label(label: str) -> float:
+    """Map an official ResearchQA judge label onto the 0--1 coverage scale."""
+    return (RESEARCHQA_LABEL_SCORES[label] - 1) / 4
+
+
+def build_coverage_judge_prompt(answer: str, rubric_items: Sequence[str]) -> str:
+    """Format one official coverage-judge batch with raw newline-separated items."""
+    questions = "\n".join(rubric_items)
+    return RESEARCHQA_COVERAGE_JUDGE_PROMPT.format(answer=answer, questions=questions)
+
+
+def parse_coverage_labels(raw: str, expected_count: int) -> list[str] | None:
+    """Parse the official newline-separated output, rejecting malformed batches."""
+    labels = [line.strip() for line in raw.splitlines() if line.strip()]
+    if len(labels) != expected_count:
+        return None
+    if any(label not in RESEARCHQA_LABEL_SCORES for label in labels):
+        return None
+    return labels
+
+
+def build_researchqa_judge_fn() -> JudgeFn:
+    """Build the task-local judge from ``$OLMO_EVAL_JUDGE`` or its own default."""
+    spec = os.getenv("OLMO_EVAL_JUDGE", RESEARCHQA_DEFAULT_JUDGE_SPEC)
+    model, separator, effort = spec.partition(":")
+    return build_openai_judge_fn(
+        model=model,
+        temperature=0.0,
+        # A reasoning judge can spend this budget and truncate the label list; that batch scores 0.
+        max_tokens=4096,
+        scorer_name="ResearchQA",
+        reasoning_effort=(effort if separator else None),
+    )
+
+
+def _type_item_count(response: Response, rubric_type: str) -> int:
+    rubric = response.instance.metadata.get("rubric", [])
+    if not isinstance(rubric, list):
+        return 0
+    return sum(
+        1
+        for item in rubric
+        if isinstance(item, dict)
+        and isinstance(item.get("type"), list)
+        and rubric_type in item["type"]
+    )
+
+
+@dataclass(frozen=True)
+class ResearchQAScorer(Scorer):
+    """Placeholder scorer; ResearchQA scores are computed in ``score_responses``."""
+
+    name: str = "researchqa"
+    score_key: str = "rubric_coverage"
+
+    def score(self, instance: Instance, output: LMOutput) -> float:
+        return (output.metadata or {}).get(self.score_key, 0.0)
+
+
+class ResearchQAMetricBase(Metric, ABC):
+    """Base for ResearchQA metrics precomputed by the task."""
+
+    scorer: type[Scorer] = ResearchQAScorer
+
+    def pairwise_display_format(self) -> str:
+        return "percentage"
+
+    def pairwise_unit(self) -> str:
+        return "proportion"
+
+
+@dataclass(frozen=True)
+class RubricCoverageMetric(ResearchQAMetricBase):
+    """Mean per-answer rubric coverage, matching the official aggregation."""
+
+    name: str = "rubric_coverage"
+    scorer: type[Scorer] = ResearchQAScorer
+
+    def compute(self, responses: Sequence[Response]) -> float:
+        if not responses:
+            return 0.0
+        return sum(response.scores.get(self.name, 0.0) for response in responses) / len(responses)
+
+
+@dataclass(frozen=True)
+class CoverageTypeMetric(ResearchQAMetricBase):
+    """Coverage pooled over all rubric items carrying one type label."""
+
+    name: str = ""
+    scorer: type[Scorer] = ResearchQAScorer
+    rubric_type: str = ""
+
+    def compute(self, responses: Sequence[Response]) -> float:
+        weighted_score = 0.0
+        item_count = 0
+        for response in responses:
+            response_item_count = _type_item_count(response, self.rubric_type)
+            weighted_score += response.scores.get(self.name, 0.0) * response_item_count
+            item_count += response_item_count
+        return weighted_score / item_count if item_count else 0.0
+
+    def supports_pairwise_scorer_fallback(self) -> bool:
+        return False
+
+
+RUBRIC_COVERAGE_METRIC = RubricCoverageMetric()
+RESEARCHQA_METRICS = (
+    RUBRIC_COVERAGE_METRIC,
+    *(
+        CoverageTypeMetric(name=metric_name, rubric_type=rubric_type)
+        for metric_name, rubric_type in RESEARCHQA_TYPE_METRICS.items()
+    ),
+)
+
+
+def _validated_rubric(doc: dict[str, Any]) -> list[dict[str, Any]] | None:
+    """Validate the nested HF schema without normalizing scientific text."""
+    raw_rubric = doc.get("rubric")
+    if not isinstance(raw_rubric, list) or not raw_rubric:
+        return None
+
+    rubric: list[dict[str, Any]] = []
+    for item_index, raw_item in enumerate(raw_rubric):
+        if not isinstance(raw_item, dict):
+            raise TypeError(f"rubric[{item_index}] must be a mapping")
+        item = cast(dict[str, Any], raw_item)
+
+        rubric_item = item.get("rubric_item")
+        if not isinstance(rubric_item, str) or not rubric_item:
+            raise ValueError(f"rubric[{item_index}].rubric_item must be a non-empty string")
+
+        rubric_types = item.get("type")
+        if not isinstance(rubric_types, list) or not all(
+            isinstance(rubric_type, str) for rubric_type in rubric_types
+        ):
+            raise TypeError(f"rubric[{item_index}].type must be a list of strings")
+
+        citation_metadata = item.get("citation_metadata")
+        if citation_metadata is not None and not isinstance(citation_metadata, dict):
+            raise TypeError(f"rubric[{item_index}].citation_metadata must be a mapping or None")
+
+        rubric.append(
+            {
+                "rubric_item": rubric_item,
+                "type": list(rubric_types),
+                "citation_metadata": (
+                    dict(citation_metadata) if citation_metadata is not None else None
+                ),
+            }
+        )
+    return rubric
+
+
+@register("researchqa")
+class ResearchQA(Task):
+    """ResearchQA generation with a deliberately non-paper-default coverage judge.
+
+    The default is ``gpt-5.4-mini``; the paper's official judge is
+    ``gpt-4.1-mini`` at temperature 0. Set
+    ``OLMO_EVAL_JUDGE=gpt-4.1-mini`` for exact published-leaderboard
+    reproduction.
+    """
+
+    split = Split.TEST
+    data_source = DataSource(path=RESEARCHQA_REPO, subset="default", split="test")
+    metrics = RESEARCHQA_METRICS
+    primary_metric = RUBRIC_COVERAGE_METRIC
+    sampling_params = SamplingParams(temperature=0.0, max_tokens=4096)
+    required_secrets = ("OPENAI_API_KEY",)
+
+    @property
+    def instances(self) -> Iterator[Instance]:
+        split = (
+            self.config.data_source.split
+            if isinstance(self.config.data_source, DataSource)
+            else None
+        )
+        yield from self._load_instances_cached(split=split)
+
+    def process_doc(self, doc: dict[str, Any], index: int = 0) -> Instance | None:
+        query = doc.get("query")
+        if not isinstance(query, str) or not query:
+            return None
+
+        rubric = _validated_rubric(doc)
+        if rubric is None:
+            return None
+
+        researchqa_id = doc.get("id")
+        if not isinstance(researchqa_id, str) or not researchqa_id:
+            researchqa_id = f"researchqa_{index}"
+
+        date = doc.get("date")
+        return Instance(
+            question=query,
+            metadata={
+                "id": researchqa_id,
+                "case_id": researchqa_id,
+                "general_domain": doc.get("general_domain", ""),
+                "subdomain": doc.get("subdomain", ""),
+                "field": doc.get("field", ""),
+                "date": None if date is None else str(date),
+                "retrieval_date_cutoff": None if date is None else str(date),
+                "rubric": rubric,
+                "index": index,
+            },
+        )
+
+    def format_request(self, instance: Instance) -> LMRequest:
+        date = instance.metadata.get("date")
+        date_cutoff = (
+            f"Prefer sources available on or before {date}.\n\n"
+            if isinstance(date, str) and date
+            else ""
+        )
+        generation_prompt = RESEARCHQA_GENERATION_PROMPT.format(date_cutoff=date_cutoff)
+        return LMRequest(
+            request_type=RequestType.CHAT,
+            messages=(
+                {
+                    "role": "user",
+                    "content": generation_prompt + instance.question,
+                },
+            ),
+        )
+
+    def extract_answer(self, output: LMOutput) -> Any:
+        """Strip a leading ``<think>...</think>`` reasoning block before scoring."""
+        text = output.text
+        think_end = text.find("</think>")
+        if think_end >= 0:
+            text = text[think_end + len("</think>") :]
+        return text.strip()
+
+    async def score_responses(
+        self,
+        responses: Sequence[Response],
+        context: Any = None,
+    ) -> Sequence[Response]:
+        """Judge rubric coverage, retaining zero-scored parse failures."""
+        self._extract_answers(responses)
+        judge_fn = build_researchqa_judge_fn()
+
+        failed_batches = 0
+        failed_items = 0
+        affected_instances = 0
+        for response in responses:
+            scores, labels, item_scores, response_failed_batches = await self._score_single(
+                response, judge_fn
+            )
+            response.scores.update(scores)
+            failed_batches += response_failed_batches
+            if response_failed_batches:
+                affected_instances += 1
+                failed_items += sum(label is None for label in labels)
+
+            if response.outputs:
+                output = response.outputs[0]
+                output.metadata["researchqa_rubric_labels"] = labels
+                output.metadata["researchqa_rubric_scores"] = item_scores
+                for metric_name, score in scores.items():
+                    output.metadata[f"score:{metric_name}"] = score
+
+        if failed_batches:
+            logger.warning(
+                "ResearchQA judge had %d unparseable batch(es) covering %d rubric item(s) "
+                "across %d instance(s) after %d attempts; assigned those items 0.0 and "
+                "kept every instance in the denominator.",
+                failed_batches,
+                failed_items,
+                affected_instances,
+                RESEARCHQA_JUDGE_ATTEMPTS,
+            )
+        return responses
+
+    async def _score_single(
+        self,
+        response: Response,
+        judge_fn: JudgeFn,
+    ) -> tuple[dict[str, float], list[str | None], list[float], int]:
+        """Score one answer and return metrics plus per-rubric judge details."""
+        rubric = response.instance.metadata.get("rubric", [])
+        if not isinstance(rubric, list) or not rubric:
+            return self._scores_from_items([], []), [], [], 0
+
+        output = response.outputs[0] if response.outputs else None
+        if output is None:
+            zeros = [0.0] * len(rubric)
+            return self._scores_from_items(rubric, zeros), [None] * len(rubric), zeros, 0
+
+        answer = output.extracted_answer
+        if not isinstance(answer, str):
+            answer = output.text
+
+        all_labels: list[str | None] = []
+        all_scores: list[float] = []
+        failed_batches = 0
+        for start in range(0, len(rubric), RESEARCHQA_RUBRIC_BATCH_SIZE):
+            batch = rubric[start : start + RESEARCHQA_RUBRIC_BATCH_SIZE]
+            rubric_items = [item["rubric_item"] for item in batch]
+            prompt = build_coverage_judge_prompt(answer, rubric_items)
+
+            labels = None
+            for attempt in range(RESEARCHQA_JUDGE_ATTEMPTS):
+                raw = await judge_fn(prompt)
+                labels = parse_coverage_labels(raw, len(batch))
+                if labels is not None:
+                    break
+                if attempt < RESEARCHQA_JUDGE_ATTEMPTS - 1:
+                    await asyncio.sleep(2**attempt)
+
+            if labels is None:
+                failed_batches += 1
+                all_labels.extend([None] * len(batch))
+                all_scores.extend([0.0] * len(batch))
+            else:
+                all_labels.extend(labels)
+                all_scores.extend(normalize_coverage_label(label) for label in labels)
+
+        return (
+            self._scores_from_items(rubric, all_scores),
+            all_labels,
+            all_scores,
+            failed_batches,
+        )
+
+    @staticmethod
+    def _scores_from_items(
+        rubric: Sequence[dict[str, Any]], item_scores: Sequence[float]
+    ) -> dict[str, float]:
+        primary = sum(item_scores) / len(rubric) if rubric else 0.0
+        scores = {"rubric_coverage": primary}
+        for metric_name, rubric_type in RESEARCHQA_TYPE_METRICS.items():
+            type_scores = [
+                score
+                for item, score in zip(rubric, item_scores, strict=True)
+                if rubric_type in item["type"]
+            ]
+            scores[metric_name] = sum(type_scores) / len(type_scores) if type_scores else 0.0
+        return scores
+
+
+register_variant(
+    "researchqa",
+    "mini",
+    data_source=DataSource(
+        path=RESEARCHQA_REPO,
+        subset="default",
+        split="test_mini",
+    ),
+)

--- a/tests/evals/tasks/test_researchqa.py
+++ b/tests/evals/tasks/test_researchqa.py
@@ -1,0 +1,388 @@
+"""Tests for the ResearchQA agentic scholarly-QA task."""
+
+import logging
+from collections.abc import Sequence
+
+import pytest
+
+from olmo_eval.common.types import Instance, LMOutput, LMRequest, RequestType, Response
+from olmo_eval.evals.tasks import researchqa
+from olmo_eval.evals.tasks.common import get_task, task_exists
+from olmo_eval.evals.tasks.researchqa import (
+    RESEARCHQA_GENERATION_PROMPT,
+    RESEARCHQA_LABEL_SCORES,
+    build_coverage_judge_prompt,
+    build_researchqa_judge_fn,
+    normalize_coverage_label,
+    parse_coverage_labels,
+)
+
+
+@pytest.fixture
+def task():
+    return get_task("researchqa")
+
+
+def _rubric_item(
+    text: str,
+    types: Sequence[str] = ("Other",),
+    citation_metadata=None,
+):
+    return {
+        "rubric_item": text,
+        "type": list(types),
+        "citation_metadata": citation_metadata,
+    }
+
+
+def _doc(rubric=None, query="How does TiO₂ photocatalysis remove pollutants?"):
+    return {
+        "id": "174539438139989436-s6",
+        "general_domain": "Physical & Theoretical Sciences",
+        "subdomain": "Chemical Sciences",
+        "field": "Materials Chemistry",
+        "query": query,
+        "date": "2021-11-03",
+        "rubric": rubric
+        if rubric is not None
+        else [
+            _rubric_item(
+                "Does the response compare TiO₂ with ZnO?",
+                ("Comparison", "Example"),
+            ),
+            _rubric_item(
+                "Does the response cite Alestalo (1971)?",
+                ("Citation",),
+                {
+                    "first_author": "Alestalo",
+                    "title": "Dendrochronological interpretation of geomorphic processes",
+                    "url": "http://fennia.journal.fi/article/view/40757",
+                    "year": 1971,
+                },
+            ),
+        ],
+    }
+
+
+def _response(instance: Instance, text: str = "A researched answer.") -> Response:
+    return Response(
+        instance=instance,
+        request=LMRequest(request_type=RequestType.CHAT, messages=()),
+        outputs=[LMOutput(text=text)],
+        scores={},
+    )
+
+
+def _instance_with_rubric(rubric) -> Instance:
+    return Instance(question="A research question?", metadata={"rubric": rubric})
+
+
+class TestRegistration:
+    def test_both_splits_are_registered(self):
+        assert task_exists("researchqa")
+        assert task_exists("researchqa:mini")
+
+        full = get_task("researchqa")
+        mini = get_task("researchqa:mini")
+        assert full.config.data_source.path == "realliyifei/ResearchQA"
+        assert full.config.data_source.subset == "default"
+        assert full.config.data_source.split == "test"
+        assert mini.config.data_source.split == "test_mini"
+
+    def test_primary_and_secondary_metrics(self, task):
+        assert task.config.get_primary_metric().name == "rubric_coverage"
+        assert {metric.name for metric in task.config.metrics} == {
+            "rubric_coverage",
+            "coverage_citation",
+            "coverage_limitation",
+            "coverage_comparison",
+            "coverage_example",
+            "coverage_impact",
+            "coverage_other",
+        }
+
+
+class TestProcessDoc:
+    def test_maps_real_schema_and_preserves_unicode(self, task):
+        doc = _doc()
+        instance = task.process_doc(doc, index=7)
+
+        assert instance is not None
+        assert instance.question == "How does TiO₂ photocatalysis remove pollutants?"
+        assert instance.metadata["id"] == "174539438139989436-s6"
+        assert instance.metadata["case_id"] == "174539438139989436-s6"
+        assert instance.metadata["general_domain"] == "Physical & Theoretical Sciences"
+        assert instance.metadata["subdomain"] == "Chemical Sciences"
+        assert instance.metadata["field"] == "Materials Chemistry"
+        assert instance.metadata["date"] == "2021-11-03"
+        assert instance.metadata["index"] == 7
+
+        rubric = instance.metadata["rubric"]
+        assert rubric[0]["rubric_item"] == "Does the response compare TiO₂ with ZnO?"
+        assert rubric[0]["type"] == ["Comparison", "Example"]
+        assert rubric[0]["citation_metadata"] is None
+        assert rubric[1]["citation_metadata"] == doc["rubric"][1]["citation_metadata"]
+
+    def test_accepts_one_item_rubric_and_nullable_citation_fields(self, task):
+        citation = {
+            "first_author": None,
+            "title": "A scientific paper",
+            "url": "https://example.test/paper",
+            "year": None,
+        }
+        instance = task.process_doc(
+            _doc([_rubric_item("Does the response cite the paper?", ("Citation",), citation)])
+        )
+
+        assert instance is not None
+        assert len(instance.metadata["rubric"]) == 1
+        assert instance.metadata["rubric"][0]["citation_metadata"] == citation
+
+    def test_rejects_scalar_type_from_incorrect_loader_schema(self, task):
+        doc = _doc([_rubric_item("Does it explain the effect?")])
+        doc["rubric"][0]["type"] = "Impact"
+
+        with pytest.raises(TypeError, match=r"rubric\[0\]\.type must be a list"):
+            task.process_doc(doc)
+
+    def test_skips_missing_query_or_empty_rubric(self, task):
+        assert task.process_doc(_doc(query="")) is None
+        assert task.process_doc(_doc(rubric=[])) is None
+
+
+class TestPrompts:
+    def test_generation_prompt_invariants_and_ordering(self, task):
+        query = "What limits solid-state batteries?"
+        instance = task.process_doc(_doc(query=query))
+        assert instance is not None
+        request = task.format_request(instance)
+        content = request.messages[0]["content"]
+
+        assert request.request_type == RequestType.CHAT
+        assert "semantic_scholar_snippet_search" in content
+        assert "serper_google_webpage_search" in content
+        assert "serper_fetch_webpage_content" in content
+        assert "about 250 words" in content
+        assert "Prefer sources available on or before 2021-11-03." in content
+        assert "Search first, then fetch and read, and only then answer" in content
+        assert "Do not answer from memory" in content
+        assert content.endswith(query)
+        assert content.index("Format and length requirements") < content.index(
+            "Workflow (follow this order)"
+        )
+        assert content.index("Prefer sources available on or before 2021-11-03.") < content.index(
+            "Workflow (follow this order)"
+        )
+        assert RESEARCHQA_GENERATION_PROMPT.endswith("Question: ")
+
+    def test_generation_prompt_omits_cutoff_when_date_is_missing(self, task):
+        doc = _doc()
+        doc["date"] = None
+        instance = task.process_doc(doc)
+
+        assert instance is not None
+        content = task.format_request(instance).messages[0]["content"]
+        assert "Prefer sources available on or before" not in content
+
+    def test_coverage_prompt_matches_official_rendering_byte_for_byte(self):
+        expected = (
+            "Please judge the following questions based on the response below.\n"
+            "For each question, select one of the following ratings to indicate the extent "
+            "to which the response addresses the question:\n"
+            "Not at all, Barely, Moderately, Mostly, Completely\n\n"
+            "Definitions:\n"
+            "- Not at all: *totally uninferable*\n"
+            "- Barely: *unmentioned but inferrable*\n"
+            "- Moderately: *mentioned but misses important details*\n"
+            "- Mostly: *mentioned but misses some details*\n"
+            "- Completely: *mentioned with sufficient details*\n\n"
+            "Only output one of the five phrases for each question, separated by newlines, "
+            "and nothing else.\n\n"
+            "Response: A\n"
+            "Questions:\n"
+            "q1?\n"
+            "q2?\n\n"
+            "Output:"
+        )
+
+        assert build_coverage_judge_prompt("A", ["q1?", "q2?"]) == expected
+
+
+class TestExtractAnswer:
+    def test_strips_think_block(self, task):
+        output = LMOutput(
+            text="<think>\nplanning noise\n</think>\n\nThe real answer covers X and Y."
+        )
+        assert task.extract_answer(output) == "The real answer covers X and Y."
+
+        output = LMOutput(text="A clean answer.")
+        assert task.extract_answer(output) == "A clean answer."
+
+
+class TestParsingAndScoring:
+    def test_label_map_and_normalization_are_exact(self):
+        assert RESEARCHQA_LABEL_SCORES == {
+            "Not at all": 1,
+            "Barely": 2,
+            "Moderately": 3,
+            "Mostly": 4,
+            "Completely": 5,
+        }
+        assert [
+            normalize_coverage_label(label)
+            for label in ["Not at all", "Barely", "Moderately", "Mostly", "Completely"]
+        ] == [0.0, 0.25, 0.5, 0.75, 1.0]
+        assert parse_coverage_labels("Barely\n\nCompletely\n", 2) == [
+            "Barely",
+            "Completely",
+        ]
+        assert parse_coverage_labels("Unknown", 1) is None
+
+    @pytest.mark.anyio
+    async def test_chunks_nine_items_into_two_judge_calls(self, task, monkeypatch):
+        rubric = [_rubric_item(f"Does it cover item {index}?") for index in range(9)]
+        response = _response(_instance_with_rubric(rubric))
+        prompts = []
+        outputs = iter(["\n".join(["Completely"] * 8), "Not at all"])
+
+        async def judge(prompt):
+            prompts.append(prompt)
+            return next(outputs)
+
+        monkeypatch.setattr(researchqa, "build_researchqa_judge_fn", lambda: judge)
+        await task.score_responses([response])
+
+        assert len(prompts) == 2
+        assert prompts[0].endswith(
+            "Questions:\n"
+            + "\n".join(f"Does it cover item {index}?" for index in range(8))
+            + "\n\nOutput:"
+        )
+        assert prompts[1].endswith("Questions:\nDoes it cover item 8?\n\nOutput:")
+        assert response.scores["rubric_coverage"] == pytest.approx(8 / 9)
+        assert response.outputs[0].metadata["researchqa_rubric_scores"] == [1.0] * 8 + [0.0]
+
+    @pytest.mark.anyio
+    async def test_primary_aggregation_means_instances_not_pooled_items(self, task, monkeypatch):
+        responses = [
+            _response(_instance_with_rubric([_rubric_item("One?")])),
+            _response(
+                _instance_with_rubric(
+                    [_rubric_item("Two?"), _rubric_item("Three?"), _rubric_item("Four?")]
+                )
+            ),
+        ]
+        outputs = iter(["Completely", "Not at all\nNot at all\nNot at all"])
+
+        async def judge(_prompt):
+            return next(outputs)
+
+        monkeypatch.setattr(researchqa, "build_researchqa_judge_fn", lambda: judge)
+        await task.score_responses(responses)
+
+        primary = task.config.get_primary_metric()
+        assert [response.scores["rubric_coverage"] for response in responses] == [1.0, 0.0]
+        assert primary.compute(responses) == 0.5
+
+    @pytest.mark.anyio
+    async def test_per_type_metrics_pool_items_and_multilabel_counts_twice(self, task, monkeypatch):
+        first_rubric = [
+            _rubric_item("A?", ("Comparison", "Example")),
+            _rubric_item("B?", ("Comparison",)),
+            _rubric_item("C?", ("Citation",)),
+            _rubric_item("D?", ("Other", "Impact", "Limitation")),
+        ]
+        second_rubric = [_rubric_item("E?", ("Comparison",))]
+        responses = [
+            _response(_instance_with_rubric(first_rubric)),
+            _response(_instance_with_rubric(second_rubric)),
+        ]
+        outputs = iter(["Completely\nModerately\nBarely\nMostly", "Not at all"])
+
+        async def judge(_prompt):
+            return next(outputs)
+
+        monkeypatch.setattr(researchqa, "build_researchqa_judge_fn", lambda: judge)
+        await task.score_responses(responses)
+
+        assert responses[0].scores["coverage_comparison"] == 0.75
+        assert responses[0].scores["coverage_example"] == 1.0
+        assert responses[0].scores["coverage_citation"] == 0.25
+        assert responses[0].scores["coverage_limitation"] == 0.75
+        assert responses[0].scores["coverage_impact"] == 0.75
+        assert responses[0].scores["coverage_other"] == 0.75
+
+        metrics = {metric.name: metric.compute(responses) for metric in task.config.metrics}
+        assert metrics["coverage_comparison"] == 0.5
+        assert metrics["coverage_example"] == 1.0
+        assert metrics["coverage_citation"] == 0.25
+        assert metrics["coverage_limitation"] == 0.75
+        assert metrics["coverage_impact"] == 0.75
+        assert metrics["coverage_other"] == 0.75
+
+    @pytest.mark.anyio
+    async def test_parse_failure_retries_three_times_keeps_zero_instance(
+        self, task, monkeypatch, caplog
+    ):
+        response = _response(
+            _instance_with_rubric([_rubric_item("Does the response explain it?", ("Impact",))])
+        )
+        calls = 0
+        delays = []
+
+        async def judge(_prompt):
+            nonlocal calls
+            calls += 1
+            return "garbage"
+
+        async def sleep(delay):
+            delays.append(delay)
+
+        monkeypatch.setattr(researchqa, "build_researchqa_judge_fn", lambda: judge)
+        monkeypatch.setattr(researchqa.asyncio, "sleep", sleep)
+        with caplog.at_level(logging.WARNING, logger=researchqa.__name__):
+            scored = await task.score_responses([response])
+
+        assert calls == 3
+        assert delays == [1, 2]
+        assert scored == [response]
+        assert response.scores["rubric_coverage"] == 0.0
+        assert response.scores["coverage_impact"] == 0.0
+        assert task.config.get_primary_metric().compute(scored) == 0.0
+        assert response.outputs[0].metadata["researchqa_rubric_labels"] == [None]
+        assert "1 unparseable batch(es) covering 1 rubric item(s)" in caplog.text
+        assert "kept every instance in the denominator" in caplog.text
+
+
+@pytest.mark.parametrize(
+    ("env_spec", "expected_model", "expected_effort"),
+    [
+        (None, "gpt-5.4-mini", None),
+        ("judge-override", "judge-override", None),
+        ("gpt-5.4-mini:high", "gpt-5.4-mini", "high"),
+    ],
+)
+def test_judge_spec_resolution(monkeypatch, env_spec, expected_model, expected_effort):
+    captured = {}
+
+    async def sentinel(_prompt):
+        return ""
+
+    def fake_builder(**kwargs):
+        captured.update(kwargs)
+        return sentinel
+
+    if env_spec is None:
+        monkeypatch.delenv("OLMO_EVAL_JUDGE", raising=False)
+    else:
+        monkeypatch.setenv("OLMO_EVAL_JUDGE", env_spec)
+    monkeypatch.setattr(researchqa, "build_openai_judge_fn", fake_builder)
+
+    assert build_researchqa_judge_fn() is sentinel
+    assert captured == {
+        "model": expected_model,
+        "temperature": 0.0,
+        "max_tokens": 4096,
+        "scorer_name": "ResearchQA",
+        "reasoning_effort": expected_effort,
+    }


### PR DESCRIPTION
## What
Adds ResearchQA as an agentic long-form scholarly-QA task. The model searches + reads sources,
then answers a research question (~250 words); the answer is scored by per-answer rubric
Coverage % against survey-mined rubric items. Registers `researchqa` (test) and `researchqa:mini`
(test_mini, 776 domain-balanced instances). Two new files only: `researchqa.py` (+461),
`test_researchqa.py` (+388).

- Paper: https://arxiv.org/abs/2509.00496
- Dataset: https://huggingface.co/datasets/realliyifei/ResearchQA
- Official code: https://github.com/realliyifei/ResearchQA

## Scoring (faithful port of the official scorer)
- Each rubric item rated by an LLM judge on the official 5-point ordinal {Not at all..Completely}
  using the verbatim official prompt, normalized `(x-1)/4`; items batched <=8/call; per-answer mean,
  then mean over instances. Per-rubric-type coverage tiers also reported.
- Deliberate deviation: an unparseable judge batch scores its items 0.0 and the instance is KEPT
  (official drops it), for a stable denominator.

## Answer extraction
- `extract_answer` strips a leading `<think>...</think>` reasoning block before judging (mirrors
  ExpertQA). Reasoning models (Qwen family) emit the block in the answer channel; without stripping
  the judge scored ~250 words of planning scaffold as part of the answer. On a 4-model smoke this
  corrected a model-order artifact (pre-strip the reasoning scaffold and max_turns caps understated
  the Qwen models specifically).

## Judge default
Defaults to `gpt-5.4-mini`; set `OLMO_EVAL_JUDGE=gpt-4.1-mini` to reproduce the paper's leaderboard.
Documented on the task class.

## Date-constrained retrieval
Each instance exposes `retrieval_date_cutoff`; when the date-constrained-retrieval harness change is
present, retrieval is limited to sources on/before the survey date (the paper uses date-constrained
Google Scholar). Harmless no-op without that change.

## Validation
Real-data smoke on `researchqa:mini` (4 models): schema/rubric parse over all 776 instances; judge
sanity (strong->1.0, garbage->0.0, 0 parse failures); agentic runs search + answer; one instance
independently re-judged and recomputed by hand (matched to one ordinal notch). Gates: ruff/format/ty
+ pytest 18.