### PR TITLE
Add DeepResearch Bench (RACE report quality + FACT citation trustworthiness)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,6 +178,8 @@ select = [
 # Verbatim prompt templates from asta-bench reference implementation
 "src/olmo_eval/evals/tasks/astabench_sqa.py" = ["E501"]
 "src/olmo_eval/common/scorers/citation.py" = ["E501"]
+# Verbatim bilingual prompt templates from DeepResearch Bench
+"src/olmo_eval/evals/tasks/deepresearch_bench.py" = ["E501"]
 # Verbatim prompt templates and gold snippets from scicode-bench reference implementation
 "src/olmo_eval/evals/external/benchmarks/scicode/prompts.py" = ["E501"]
 # Embedded fewshot data with long string literals

--- a/scripts/internal/build_deepresearch_bench_dataset.py
+++ b/scripts/internal/build_deepresearch_bench_dataset.py
@@ -1,0 +1,247 @@
+"""Offline builder for the DeepResearch Bench dataset mirror.
+
+Downloads the official query, criteria, and cleaned-reference JSONL files at a
+pinned upstream commit (or reads them from ``--source-dir``), joins them by task
+ID, writes local JSONL configs, and can push them to the HF Hub. This script is
+intentionally not imported or run by tests.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger("build_deepresearch_bench_dataset")
+
+DEEPRESEARCH_BENCH_REPO = "allenai/deepresearch-bench"
+UPSTREAM_COMMIT = "469cce54ea7f6a63c163d3d9fec879cf289ec484"
+UPSTREAM_RAW_ROOT = (
+    f"https://raw.githubusercontent.com/Ayanami0730/deep_research_bench/{UPSTREAM_COMMIT}"
+)
+EXPECTED_IDS = set(range(1, 101))
+
+SOURCE_FILES = {
+    "queries": Path("data/prompt_data/query.jsonl"),
+    "criteria": Path("data/criteria_data/criteria.jsonl"),
+    "references": Path("data/test_data/cleaned_data/reference.jsonl"),
+}
+
+
+def load_jsonl_lines(lines: Iterable[str], *, source: str) -> list[dict[str, Any]]:
+    """Parse JSONL records and report the source and line on malformed input."""
+    rows: list[dict[str, Any]] = []
+    for line_number, line in enumerate(lines, start=1):
+        if not line.strip():
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Invalid JSON in {source} at line {line_number}: {exc}") from exc
+        if not isinstance(row, dict):
+            raise TypeError(f"Expected an object in {source} at line {line_number}")
+        rows.append(row)
+    return rows
+
+
+def load_jsonl_path(path: Path) -> list[dict[str, Any]]:
+    with path.open(encoding="utf-8") as handle:
+        return load_jsonl_lines(handle, source=str(path))
+
+
+def download_jsonl(relative_path: Path) -> list[dict[str, Any]]:
+    """Download one official file from the immutable upstream revision."""
+    url = f"{UPSTREAM_RAW_ROOT}/{relative_path.as_posix()}"
+    logger.info("Downloading %s", url)
+    request = Request(url, headers={"User-Agent": "olmo-eval-deepresearch-builder"})
+    try:
+        with urlopen(request, timeout=120) as response:
+            text = response.read().decode("utf-8")
+    except (HTTPError, URLError) as exc:
+        raise RuntimeError(f"Could not download DeepResearch Bench data from {url}: {exc}") from exc
+    return load_jsonl_lines(text.splitlines(), source=url)
+
+
+def load_official_files(
+    source_dir: Path | None,
+) -> dict[str, list[dict[str, Any]]]:
+    """Load all three official inputs from disk or the pinned raw URLs."""
+    if source_dir is None:
+        return {name: download_jsonl(path) for name, path in SOURCE_FILES.items()}
+
+    missing = [
+        source_dir / path for path in SOURCE_FILES.values() if not (source_dir / path).is_file()
+    ]
+    if missing:
+        missing_text = "\n".join(f"- {path}" for path in missing)
+        raise FileNotFoundError(
+            "DeepResearch Bench source files are missing:\n"
+            f"{missing_text}\nOmit --source-dir to fetch the pinned official files instead."
+        )
+    return {
+        name: load_jsonl_path(source_dir / relative_path)
+        for name, relative_path in SOURCE_FILES.items()
+    }
+
+
+def index_by_id(
+    rows: list[dict[str, Any]],
+    *,
+    source_name: str,
+) -> dict[int, dict[str, Any]]:
+    """Validate the official integer IDs and reject duplicates or omissions."""
+    indexed: dict[int, dict[str, Any]] = {}
+    for row_number, row in enumerate(rows, start=1):
+        identifier = row.get("id")
+        if not isinstance(identifier, int):
+            raise TypeError(f"{source_name} row {row_number} has non-integer id {identifier!r}")
+        if identifier in indexed:
+            raise ValueError(f"Duplicate id {identifier} in {source_name}")
+        indexed[identifier] = row
+
+    actual_ids = set(indexed)
+    if actual_ids != EXPECTED_IDS:
+        missing = sorted(EXPECTED_IDS - actual_ids)
+        unexpected = sorted(actual_ids - EXPECTED_IDS)
+        raise ValueError(
+            f"{source_name} must contain exactly IDs 1..100; "
+            f"missing={missing}, unexpected={unexpected}"
+        )
+    return indexed
+
+
+def _require_string(row: dict[str, Any], key: str, *, source: str, identifier: int) -> str:
+    value = row.get(key)
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{source} id {identifier} has invalid {key!r}")
+    return value
+
+
+def build_rows(inputs: dict[str, list[dict[str, Any]]]) -> list[dict[str, Any]]:
+    """Join official inputs by ID while preserving all benchmark text verbatim."""
+    queries = index_by_id(inputs["queries"], source_name="query.jsonl")
+    criteria = index_by_id(inputs["criteria"], source_name="criteria.jsonl")
+    references = index_by_id(inputs["references"], source_name="reference.jsonl")
+
+    output: list[dict[str, Any]] = []
+    for identifier in sorted(EXPECTED_IDS):
+        query = queries[identifier]
+        criterion_row = criteria[identifier]
+        reference = references[identifier]
+
+        prompt = _require_string(query, "prompt", source="query.jsonl", identifier=identifier)
+        criterion_prompt = _require_string(
+            criterion_row, "prompt", source="criteria.jsonl", identifier=identifier
+        )
+        reference_prompt = _require_string(
+            reference, "prompt", source="reference.jsonl", identifier=identifier
+        )
+        if criterion_prompt != prompt:
+            logger.warning("Prompt mismatch between query and criteria for id %d", identifier)
+        if reference_prompt != prompt:
+            logger.warning("Prompt mismatch between query and reference for id %d", identifier)
+
+        language = query.get("language")
+        if language not in {"en", "zh"}:
+            raise ValueError(f"query.jsonl id {identifier} has invalid language {language!r}")
+        topic = _require_string(query, "topic", source="query.jsonl", identifier=identifier)
+
+        dimension_weight = criterion_row.get("dimension_weight")
+        criterions = criterion_row.get("criterions")
+        if not isinstance(dimension_weight, dict) or not isinstance(criterions, dict):
+            raise TypeError(
+                f"criteria.jsonl id {identifier} must contain mapping-valued "
+                "dimension_weight and criterions"
+            )
+
+        article = _require_string(
+            reference, "article", source="reference.jsonl", identifier=identifier
+        )
+        output.append(
+            {
+                "id": identifier,
+                "language": language,
+                "topic": topic,
+                "prompt": prompt,
+                "criteria": {
+                    "dimension_weight": dimension_weight,
+                    "criterions": criterions,
+                },
+                "reference_article": article,
+            }
+        )
+
+    language_counts = {
+        language: sum(row["language"] == language for row in output) for language in ("en", "zh")
+    }
+    if language_counts != {"en": 50, "zh": 50}:
+        raise ValueError(f"Expected 50 English and 50 Chinese rows, got {language_counts}")
+    return output
+
+
+def dataset_configs(rows: list[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
+    """Return the full dataset and its two language-specific subsets."""
+    return {
+        "default": rows,
+        "en": [row for row in rows if row["language"] == "en"],
+        "zh": [row for row in rows if row["language"] == "zh"],
+    }
+
+
+def write_local(rows: list[dict[str, Any]], output_dir: Path) -> list[Path]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    paths: list[Path] = []
+    for config_name, config_rows in dataset_configs(rows).items():
+        path = output_dir / f"{config_name}.jsonl"
+        with path.open("w", encoding="utf-8") as handle:
+            for row in config_rows:
+                handle.write(json.dumps(row, ensure_ascii=False) + "\n")
+        logger.info("Wrote %d rows to %s", len(config_rows), path)
+        paths.append(path)
+    return paths
+
+
+def push_to_hub(rows: list[dict[str, Any]], *, repo_id: str) -> None:
+    try:
+        from datasets import Dataset, DatasetDict
+    except ImportError as exc:
+        raise RuntimeError("Pushing DeepResearch Bench requires `datasets`.") from exc
+
+    for config_name, config_rows in dataset_configs(rows).items():
+        dataset = DatasetDict({"test": Dataset.from_list(config_rows)})
+        dataset.push_to_hub(repo_id, config_name=config_name)
+        logger.info("Pushed %s/test with %d rows to %s", config_name, len(config_rows), repo_id)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--source-dir",
+        type=Path,
+        help=(
+            "Read an official repository checkout instead of downloading files "
+            f"at pinned commit {UPSTREAM_COMMIT}."
+        ),
+    )
+    parser.add_argument("--repo-id", default=DEEPRESEARCH_BENCH_REPO)
+    parser.add_argument("--output-dir", type=Path, default=Path("deepresearch_bench_dataset"))
+    parser.add_argument("--push", action="store_true", help="Push all configs to the HF Hub.")
+    args = parser.parse_args()
+
+    inputs = load_official_files(args.source_dir)
+    rows = build_rows(inputs)
+    write_local(rows, args.output_dir)
+    if args.push:
+        push_to_hub(rows, repo_id=args.repo_id)
+    else:
+        logger.info("Skipping Hub push. Use --push to upload.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/olmo_eval/evals/tasks/deepresearch_bench.py
+++ b/src/olmo_eval/evals/tasks/deepresearch_bench.py
@@ -7,18 +7,17 @@ ported verbatim/faithfully from the benchmark repository.
 
 This integration deliberately deviates from the official implementation in
 six ways: (1) FACT scrapes with olmo-eval's crawl4ai-backed browsing logic
-instead of Jina Reader; (2) generated articles receive only deterministic
-``<think>`` stripping instead of the optional LLM ArticleCleaner, equivalent
-to evaluating with official cleaning skipped; (3) both judge models can be
-overridden with ``OLMO_EVAL_JUDGE``; and (4) the appended report-generation
-instruction is ours because the official benchmark leaves each deep-research
-system's generation prompting unspecified; (5) ``clean_urls`` is applied to
-every article rather than conditionally by source model, and text-fragment
-URLs are also normalized while grouping, merging citations to fragments of
-the same page; and (6) judge failures use three attempts with ``2**n``
-backoff, while the official RACE runner uses ten attempts with ``1.5**n``
-backoff. After final RACE judge/parse failure, an instance receives zero RACE
-scores and remains in every mean.
+instead of Jina Reader; (2) generated articles receive deterministic ``<think>``
+stripping and tool/channel-scaffold marker removal instead of the optional LLM
+ArticleCleaner; (3) both judge models can be overridden with
+``OLMO_EVAL_JUDGE``; and (4) the appended report-generation instruction is ours
+because the official benchmark leaves each deep-research system's generation
+prompting unspecified; (5) ``clean_urls`` is applied to every article rather
+than conditionally by source model, and text-fragment URLs are also normalized
+while grouping, merging citations to fragments of the same page; and (6) judge
+failures use three attempts with ``2**n`` backoff, while the official RACE
+runner uses ten attempts with ``1.5**n`` backoff. After final RACE judge/parse
+failure, an instance receives zero RACE scores and remains in every mean.
 """
 
 from __future__ import annotations
@@ -69,13 +68,17 @@ DEEPRESEARCH_GENERATION_INSTRUCTIONS = {
     "en": (
         "Write a comprehensive research report in English. Research the task using the "
         "available web-search and webpage-browsing tools before writing. Place an inline "
-        "Markdown citation in the exact form `[source title](url)` immediately after every "
-        "factual claim it supports. Synthesize the sources into a clear, detailed report."
+        "Markdown citation in the exact form `[<the source's actual "
+        "title>](<the source's actual URL>)` immediately after every factual claim it "
+        "supports. Replace both placeholders with the real page title and URL; never output "
+        "either placeholder itself. Synthesize the sources "
+        "into a clear, detailed report."
     ),
     "zh": (
         "请用中文撰写一份全面的研究报告。写作前请使用可用的网页搜索和网页浏览工具调研任务。"
-        "每项事实性主张后都应紧跟一个格式严格为 `[来源标题](url)` 的行内 Markdown 引用。"
-        "请综合各项来源，形成清晰、详尽的报告。"
+        "每项事实性主张后都应紧跟一个格式严格为 `[<来源的真实标题>]"
+        "(<来源的真实链接>)` 的行内 Markdown 引用。请将两个占位符替换为真实网页标题和链接，"
+        "绝不要原样输出任何一个占位符。请综合各项来源，形成清晰、详尽的报告。"
     ),
 }
 
@@ -700,7 +703,7 @@ def clean_urls(input_text: str) -> str:
 
 def clean_citation_url(url: str) -> str:
     """Apply the official ``#:~:text=`` URL cleanup to a raw URL."""
-    return url.split("#:~:text=", maxsplit=1)[0]
+    return url.strip().strip("<>").split("#:~:text=", maxsplit=1)[0]
 
 
 def remove_urls(input_text: str) -> str:
@@ -941,11 +944,128 @@ DEEPRESEARCH_METRICS = (
 
 
 def strip_think_block(text: str) -> str:
-    """Strip a leading reasoning block using the ResearchQA helper pattern."""
+    """Strip a reasoning prefix using the intentionally lossy ResearchQA pattern.
+
+    Only text after the first ``</think>`` is retained, so a mid-report closing tag
+    discards the report prefix as well. This pre-existing behavior matches ResearchQA.
+    """
     think_end = text.find("</think>")
     if think_end >= 0:
         text = text[think_end + len("</think>") :]
     return text.strip()
+
+
+_SCAFFOLD_IDENTIFIER = r"[A-Za-z_][\w.:-]*"
+_SCAFFOLD_QUOTED_VALUE = r"""(?:"[^"<>\r\n]*"|'[^'<>\r\n]*')"""
+_SCAFFOLD_VALUE = rf"(?:{_SCAFFOLD_IDENTIFIER}|{_SCAFFOLD_QUOTED_VALUE})"
+_SCAFFOLD_OPEN_WITH_ATTRIBUTES_RE = re.compile(
+    rf"<(?:tool_call|tool_response|function|parameter)(?:"
+    rf"[ \t]*=[ \t]*{_SCAFFOLD_VALUE}|"
+    rf"(?:[ \t]+{_SCAFFOLD_IDENTIFIER}[ \t]*=[ \t]*{_SCAFFOLD_VALUE})+"
+    rf")[ \t]*>",
+    flags=re.IGNORECASE,
+)
+_SCAFFOLD_TAG_RE = re.compile(
+    r"</?(?:tool_call|tool_response)[ \t]*>|</(?:function|parameter)[ \t]*>",
+    flags=re.IGNORECASE,
+)
+_SPECIAL_TOKEN_PATTERN = r"<(?:\|[A-Za-z_][\w.:-]*\|?|[A-Za-z_][\w.:-]*\|)>"
+_SPECIAL_TOKEN_RE = re.compile(_SPECIAL_TOKEN_PATTERN, flags=re.IGNORECASE)
+_CHANNEL_HEADER_RE = re.compile(
+    rf"<\|channel\|?>[ \t]*(?P<channel>analysis|commentary|final|thought|tool)"
+    rf"[ \t\r\n]*(?={_SPECIAL_TOKEN_PATTERN})",
+    flags=re.IGNORECASE,
+)
+_ASSISTANT_TURN_PREFIX_RE = re.compile(
+    r"(?:<\|start\|>|<start\|>)[ \t]*assistant\b", flags=re.IGNORECASE
+)
+_MARKDOWN_CODE_SPAN_RE = re.compile(r"```[\s\S]*?```|`[^`\n]*`")
+_PAIRED_BARE_SCAFFOLD_TAGS = ("function", "parameter")
+_BARE_SCAFFOLD_OPEN_RES = {
+    tag: re.compile(rf"<{tag}[ \t]*>", flags=re.IGNORECASE) for tag in _PAIRED_BARE_SCAFFOLD_TAGS
+}
+_BARE_SCAFFOLD_CLOSE_RES = {
+    tag: re.compile(rf"</{tag}[ \t]*>", flags=re.IGNORECASE) for tag in _PAIRED_BARE_SCAFFOLD_TAGS
+}
+_REASONING_CHANNELS = frozenset({"analysis", "commentary", "thought"})
+
+
+def _partition_markdown_code(text: str) -> list[tuple[bool, str]]:
+    """Return ``(is_code, text)`` parts without modifying protected Markdown code."""
+    parts: list[tuple[bool, str]] = []
+    cursor = 0
+    for match in _MARKDOWN_CODE_SPAN_RE.finditer(text):
+        if cursor < match.start():
+            parts.append((False, text[cursor : match.start()]))
+        parts.append((True, match.group()))
+        cursor = match.end()
+    if cursor < len(text):
+        parts.append((False, text[cursor:]))
+    return parts
+
+
+def _retain_final_channel(parts: Sequence[tuple[bool, str]]) -> list[tuple[bool, str]]:
+    """Keep pre-header and final prose when reasoning and final channels coexist."""
+    channel_names = {
+        match.group("channel").lower()
+        for is_code, part in parts
+        if not is_code
+        for match in _CHANNEL_HEADER_RE.finditer(part)
+    }
+    if "final" not in channel_names or channel_names.isdisjoint(_REASONING_CHANNELS):
+        return list(parts)
+
+    retained: list[tuple[bool, str]] = []
+    active_channel: str | None = None
+    for is_code, part in parts:
+        if is_code:
+            retained.append((True, part))
+            continue
+
+        cursor = 0
+        retained_chunks: list[str] = []
+        for match in _CHANNEL_HEADER_RE.finditer(part):
+            if active_channel in (None, "final"):
+                retained_chunks.append(part[cursor : match.start()])
+            active_channel = match.group("channel").lower()
+            cursor = match.end()
+        if active_channel in (None, "final"):
+            retained_chunks.append(part[cursor:])
+        retained.append((False, "".join(retained_chunks)))
+    return retained
+
+
+def _clean_report_segment(text: str, paired_bare_tags: frozenset[str]) -> str:
+    """Remove scaffold tokens from a non-code Markdown segment in linear passes."""
+    text = _ASSISTANT_TURN_PREFIX_RE.sub(" ", text)
+    text = _CHANNEL_HEADER_RE.sub(" ", text)
+    text = _SPECIAL_TOKEN_RE.sub(" ", text)
+    for tag in paired_bare_tags:
+        text = _BARE_SCAFFOLD_OPEN_RES[tag].sub("", text)
+    text = _SCAFFOLD_OPEN_WITH_ATTRIBUTES_RE.sub("", text)
+    return _SCAFFOLD_TAG_RE.sub("", text)
+
+
+def _clean_generated_report(text: str) -> str:
+    """Strip reasoning and tool-call scaffold while preserving report prose and code.
+
+    Explicit analysis/commentary/thought content is dropped only when an explicit final
+    channel is also present; ordinary report content before the first channel header and
+    final-channel content are retained. This intentionally limited parser infers
+    boundaries from channel headers rather than assigning semantics to every possible
+    special token; protected Markdown code spans are always retained verbatim.
+    """
+    text = strip_think_block(text)
+    parts = _retain_final_channel(_partition_markdown_code(text))
+    paired_bare_tags = frozenset(
+        tag
+        for tag, close_re in _BARE_SCAFFOLD_CLOSE_RES.items()
+        if any(not is_code and close_re.search(part) for is_code, part in parts)
+    )
+    return "".join(
+        part if is_code else _clean_report_segment(part, paired_bare_tags)
+        for is_code, part in parts
+    ).strip()
 
 
 def _validated_criteria(doc: Mapping[str, Any]) -> dict[str, Any] | None:
@@ -1025,7 +1145,7 @@ class DeepResearchBench(Task):
         )
 
     def extract_answer(self, output: LMOutput) -> str:
-        return strip_think_block(output.text)
+        return _clean_generated_report(output.text)
 
     async def score_responses(
         self,

--- a/src/olmo_eval/evals/tasks/deepresearch_bench.py
+++ b/src/olmo_eval/evals/tasks/deepresearch_bench.py
@@ -858,12 +858,20 @@ def _fact_scoring_disabled() -> bool:
 
 def build_deepresearch_race_judge_fn() -> JudgeFn:
     """Build the RACE judge with medium effort unless a spec suffix overrides it."""
-    return _build_judge_fn(DEEPRESEARCH_RACE_DEFAULT_JUDGE_SPEC, "DeepResearchBenchRACE", "medium")
+    return _build_judge_fn(
+        os.getenv("OLMO_EVAL_JUDGE", DEEPRESEARCH_RACE_DEFAULT_JUDGE_SPEC),
+        "DeepResearchBenchRACE",
+        "medium",
+    )
 
 
 def build_deepresearch_fact_judge_fn() -> JudgeFn:
     """Build the FACT judge with low effort unless a spec suffix overrides it."""
-    return _build_judge_fn(DEEPRESEARCH_FACT_DEFAULT_JUDGE_SPEC, "DeepResearchBenchFACT", "low")
+    return _build_judge_fn(
+        os.getenv("OLMO_EVAL_JUDGE", DEEPRESEARCH_FACT_DEFAULT_JUDGE_SPEC),
+        "DeepResearchBenchFACT",
+        "low",
+    )
 
 
 @dataclass(frozen=True)

--- a/src/olmo_eval/evals/tasks/deepresearch_bench.py
+++ b/src/olmo_eval/evals/tasks/deepresearch_bench.py
@@ -832,7 +832,7 @@ async def fetch_crawl4ai_page(url: str) -> str:
     return text
 
 
-def _build_judge_fn(default_spec: str, scorer_name: str) -> JudgeFn:
+def _build_judge_fn(default_spec: str, scorer_name: str, default_effort: str) -> JudgeFn:
     spec = os.getenv("OLMO_EVAL_JUDGE", default_spec)
     model, separator, effort = spec.partition(":")
     return build_openai_judge_fn(
@@ -840,18 +840,18 @@ def _build_judge_fn(default_spec: str, scorer_name: str) -> JudgeFn:
         temperature=0.0,
         max_tokens=DEEPRESEARCH_JUDGE_MAX_TOKENS,
         scorer_name=scorer_name,
-        reasoning_effort=(effort if separator else None),
+        reasoning_effort=(effort if separator else default_effort),
     )
 
 
 def build_deepresearch_race_judge_fn() -> JudgeFn:
-    """Build the RACE judge from its default or ``$OLMO_EVAL_JUDGE``."""
-    return _build_judge_fn(DEEPRESEARCH_RACE_DEFAULT_JUDGE_SPEC, "DeepResearchBenchRACE")
+    """Build the RACE judge with medium effort unless a spec suffix overrides it."""
+    return _build_judge_fn(DEEPRESEARCH_RACE_DEFAULT_JUDGE_SPEC, "DeepResearchBenchRACE", "medium")
 
 
 def build_deepresearch_fact_judge_fn() -> JudgeFn:
-    """Build the shared FACT-stage judge from its default or ``$OLMO_EVAL_JUDGE``."""
-    return _build_judge_fn(DEEPRESEARCH_FACT_DEFAULT_JUDGE_SPEC, "DeepResearchBenchFACT")
+    """Build the FACT judge with low effort unless a spec suffix overrides it."""
+    return _build_judge_fn(DEEPRESEARCH_FACT_DEFAULT_JUDGE_SPEC, "DeepResearchBenchFACT", "low")
 
 
 @dataclass(frozen=True)

--- a/src/olmo_eval/evals/tasks/deepresearch_bench.py
+++ b/src/olmo_eval/evals/tasks/deepresearch_bench.py
@@ -844,6 +844,18 @@ def _build_judge_fn(default_spec: str, scorer_name: str, default_effort: str) ->
     )
 
 
+
+def _fact_scoring_disabled() -> bool:
+    """Whether FACT scoring is switched off for this run.
+
+    FACT crawls every cited URL and judges each extracted statement, so it dominates the cost of
+    scoring this benchmark. RACE alone is often what is wanted, and there was previously no way
+    to ask for it.
+    """
+    value = os.environ.get("DEEPRESEARCH_SKIP_FACT", "")
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
 def build_deepresearch_race_judge_fn() -> JudgeFn:
     """Build the RACE judge with medium effort unless a spec suffix overrides it."""
     return _build_judge_fn(DEEPRESEARCH_RACE_DEFAULT_JUDGE_SPEC, "DeepResearchBenchRACE", "medium")
@@ -1159,6 +1171,7 @@ class DeepResearchBench(Task):
         fact_judge = build_deepresearch_fact_judge_fn()
 
         race_failures = 0
+        fact_skipped = 0
         fact_failures = 0
         for response in responses:
             output = response.outputs[0] if response.outputs else None
@@ -1174,20 +1187,29 @@ class DeepResearchBench(Task):
                 race_scores, race_details, race_failed = await self._score_race(
                     response.instance, answer, race_judge
                 )
-                try:
-                    fact_scores, fact_details = await self._score_fact(
-                        response.instance, answer, fact_judge
-                    )
-                    fact_failed = False
-                except Exception as exc:
-                    logger.warning(
-                        "DeepResearch Bench FACT scoring failed for id %r: %s",
-                        response.instance.metadata.get("id"),
-                        exc,
-                    )
+                if _fact_scoring_disabled():
+                    # Skipped, not zero. Leaving silent zeros here would be indistinguishable
+                    # from "ran and scored nothing", which is exactly the confusion that made an
+                    # earlier all-zero metrics column unreadable.
                     fact_scores = self._zero_fact_scores()
-                    fact_details = []
-                    fact_failed = True
+                    fact_details = [{"fact_scoring": "skipped"}]
+                    fact_failed = False
+                    fact_skipped += 1
+                else:
+                    try:
+                        fact_scores, fact_details = await self._score_fact(
+                            response.instance, answer, fact_judge
+                        )
+                        fact_failed = False
+                    except Exception as exc:
+                        logger.warning(
+                            "DeepResearch Bench FACT scoring failed for id %r: %s",
+                            response.instance.metadata.get("id"),
+                            exc,
+                        )
+                        fact_scores = self._zero_fact_scores()
+                        fact_details = []
+                        fact_failed = True
             else:
                 race_scores = self._zero_race_scores()
                 race_details = None
@@ -1207,6 +1229,14 @@ class DeepResearchBench(Task):
                 output.metadata["deepresearch_fact"] = fact_details
                 for metric_name, score in response.scores.items():
                     output.metadata[f"score:{metric_name}"] = score
+
+        if fact_skipped:
+            logger.warning(
+                "DeepResearch Bench FACT scoring skipped for %d instance(s) because "
+                "DEEPRESEARCH_SKIP_FACT is set; every fact_* metric below is a placeholder "
+                "and must not be read as a score of zero.",
+                fact_skipped,
+            )
 
         if race_failures:
             logger.warning(

--- a/src/olmo_eval/evals/tasks/deepresearch_bench.py
+++ b/src/olmo_eval/evals/tasks/deepresearch_bench.py
@@ -1159,6 +1159,7 @@ class DeepResearchBench(Task):
         fact_judge = build_deepresearch_fact_judge_fn()
 
         race_failures = 0
+        fact_failures = 0
         for response in responses:
             output = response.outputs[0] if response.outputs else None
             answer = ""
@@ -1173,17 +1174,30 @@ class DeepResearchBench(Task):
                 race_scores, race_details, race_failed = await self._score_race(
                     response.instance, answer, race_judge
                 )
-                fact_scores, fact_details = await self._score_fact(
-                    response.instance, answer, fact_judge
-                )
+                try:
+                    fact_scores, fact_details = await self._score_fact(
+                        response.instance, answer, fact_judge
+                    )
+                    fact_failed = False
+                except Exception as exc:
+                    logger.warning(
+                        "DeepResearch Bench FACT scoring failed for id %r: %s",
+                        response.instance.metadata.get("id"),
+                        exc,
+                    )
+                    fact_scores = self._zero_fact_scores()
+                    fact_details = []
+                    fact_failed = True
             else:
                 race_scores = self._zero_race_scores()
                 race_details = None
                 race_failed = False
                 fact_scores = self._zero_fact_scores()
                 fact_details = []
+                fact_failed = False
 
             race_failures += int(race_failed)
+            fact_failures += int(fact_failed)
             response.scores.update(race_scores)
             response.scores.update(fact_scores)
             if output is not None:
@@ -1200,6 +1214,12 @@ class DeepResearchBench(Task):
                 "attempts; assigned zero and retained them in the denominator.",
                 race_failures,
                 DEEPRESEARCH_JUDGE_ATTEMPTS,
+            )
+        if fact_failures:
+            logger.warning(
+                "DeepResearch Bench FACT scoring failed for %d instance(s); assigned zero "
+                "and retained them in the denominator.",
+                fact_failures,
             )
         return responses
 
@@ -1399,10 +1419,14 @@ class DeepResearchBench(Task):
                 raw = await judge_fn(prompt)
                 parsed = cast(list[dict[str, Any]], _json_without_fences(raw))
                 for item in parsed:
+                    if not isinstance(item, Mapping) or "idx" not in item or "result" not in item:
+                        raise ValueError(
+                            "FACT validation item must be an object containing idx and result"
+                        )
                     item["idx"] -= 1
                 assert len(parsed) == len(facts), "FACT validation result length mismatch"
                 return parsed
-            except (AssertionError, json.JSONDecodeError, KeyError, TypeError) as exc:
+            except (AssertionError, json.JSONDecodeError, KeyError, TypeError, ValueError) as exc:
                 logger.warning(
                     "FACT validation attempt %d/%d failed: %s",
                     attempt + 1,

--- a/src/olmo_eval/evals/tasks/deepresearch_bench.py
+++ b/src/olmo_eval/evals/tasks/deepresearch_bench.py
@@ -1,0 +1,1319 @@
+"""DeepResearch Bench long-form research evaluation (arXiv 2506.11763).
+
+The task generates citation-rich research reports and applies both official
+scoring frameworks: RACE for criteria-weighted report quality and FACT for
+citation trustworthiness. Official bilingual judge prompts and score math are
+ported verbatim/faithfully from the benchmark repository.
+
+This integration deliberately deviates from the official implementation in
+six ways: (1) FACT scrapes with olmo-eval's crawl4ai-backed browsing logic
+instead of Jina Reader; (2) generated articles receive only deterministic
+``<think>`` stripping instead of the optional LLM ArticleCleaner, equivalent
+to evaluating with official cleaning skipped; (3) both judge models can be
+overridden with ``OLMO_EVAL_JUDGE``; and (4) the appended report-generation
+instruction is ours because the official benchmark leaves each deep-research
+system's generation prompting unspecified; (5) ``clean_urls`` is applied to
+every article rather than conditionally by source model, and text-fragment
+URLs are also normalized while grouping, merging citations to fragments of
+the same page; and (6) judge failures use three attempts with ``2**n``
+backoff, while the official RACE runner uses ten attempts with ``1.5**n``
+backoff. After final RACE judge/parse failure, an instance receives zero RACE
+scores and remains in every mean.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import re
+from abc import ABC
+from collections.abc import Iterator, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any, cast
+from urllib.parse import urlsplit
+
+from olmo_eval.common.metrics import Metric
+from olmo_eval.common.scorers.base import Scorer
+from olmo_eval.common.scorers.llm_judge import JudgeFn, build_openai_judge_fn
+from olmo_eval.common.types import (
+    Instance,
+    LMOutput,
+    LMRequest,
+    RequestType,
+    Response,
+    SamplingParams,
+    Split,
+)
+from olmo_eval.data import DataSource
+from olmo_eval.evals.tasks.common import Task, TaskConfig, register, register_variant
+
+logger = logging.getLogger(__name__)
+
+DEEPRESEARCH_BENCH_REPO = "allenai/deepresearch-bench"
+DEEPRESEARCH_RACE_DEFAULT_JUDGE_SPEC = "gpt-5.5"
+DEEPRESEARCH_FACT_DEFAULT_JUDGE_SPEC = "gpt-5.4-mini"
+DEEPRESEARCH_JUDGE_MAX_TOKENS = 64_000
+DEEPRESEARCH_JUDGE_ATTEMPTS = 3
+DEEPRESEARCH_SCRAPE_ATTEMPTS = 3
+DEEPRESEARCH_PAGE_CONTENT_LIMIT = 200_000
+DEEPRESEARCH_DIMENSIONS = (
+    "comprehensiveness",
+    "insight",
+    "instruction_following",
+    "readability",
+)
+
+DEEPRESEARCH_GENERATION_INSTRUCTIONS = {
+    "en": (
+        "Write a comprehensive research report in English. Research the task using the "
+        "available web-search and webpage-browsing tools before writing. Place an inline "
+        "Markdown citation in the exact form `[source title](url)` immediately after every "
+        "factual claim it supports. Synthesize the sources into a clear, detailed report."
+    ),
+    "zh": (
+        "请用中文撰写一份全面的研究报告。写作前请使用可用的网页搜索和网页浏览工具调研任务。"
+        "每项事实性主张后都应紧跟一个格式严格为 `[来源标题](url)` 的行内 Markdown 引用。"
+        "请综合各项来源，形成清晰、详尽的报告。"
+    ),
+}
+
+# Verbatim from prompt/score_prompt_en.py:generate_merged_score_prompt.
+RACE_SCORE_PROMPT_EN = """
+<system_role>You are a strict, meticulous, and objective research article evaluation expert. You excel at using specific assessment criteria to deeply compare two articles on the same task, providing precise scores and clear justifications.</system_role>
+
+<user_prompt>
+**Task Background**
+There is a deep research task, and you need to evaluate two research articles written for this task. We will assess the articles across four dimensions: Comprehensiveness, Insight, Instruction Following, and Readability. The content is as follows:
+<task>
+"{task_prompt}"
+</task>
+
+**Articles to Evaluate**
+<article_1>
+"{article_1}"
+</article_1>
+
+<article_2>
+"{article_2}"
+</article_2>
+
+**Evaluation Criteria**
+Now, you need to evaluate and compare these two articles based on the following **evaluation criteria list**, providing comparative analysis and scoring each on a scale of 0-10. Each criterion includes an explanation, please understand carefully.
+
+<criteria_list>
+{criteria_list}
+</criteria_list>
+
+<Instruction>
+**Your Task**
+Please strictly evaluate and compare `<article_1>` and `<article_2>` based on **each criterion** in the `<criteria_list>`. You need to:
+1.  **Analyze Each Criterion**: Consider how each article fulfills the requirements of each criterion.
+2.  **Comparative Evaluation**: Analyze how the two articles perform on each criterion, referencing the content and criterion explanation.
+3.  **Score Separately**: Based on your comparative analysis, score each article on each criterion (0-10 points).
+
+**Scoring Rules**
+For each criterion, score both articles on a scale of 0-10 (continuous values). The score should reflect the quality of performance on that criterion:
+*   0-2 points: Very poor performance. Almost completely fails to meet the criterion requirements.
+*   2-4 points: Poor performance. Minimally meets the criterion requirements with significant deficiencies.
+*   4-6 points: Average performance. Basically meets the criterion requirements, neither good nor bad.
+*   6-8 points: Good performance. Largely meets the criterion requirements with notable strengths.
+*   8-10 points: Excellent/outstanding performance. Fully meets or exceeds the criterion requirements.
+
+**Output Format Requirements**
+Please **strictly** follow the `<output_format>` below for each criterion evaluation. **Do not include any other unrelated content, introduction, or summary**. Start with "Standard 1" and proceed sequentially through all criteria:
+</Instruction>
+
+<output_format>
+{{
+    "comprehensiveness": [
+        {{
+            "criterion": [Text content of the first comprehensiveness evaluation criterion],
+            "analysis": [Comparative analysis],
+            "article_1_score": [Continuous score 0-10],
+            "article_2_score": [Continuous score 0-10]
+}},
+{{
+            "criterion": [Text content of the second comprehensiveness evaluation criterion],
+            "analysis": [Comparative analysis],
+            "article_1_score": [Continuous score 0-10],
+            "article_2_score": [Continuous score 0-10]
+        }},
+        ...
+    ],
+    "insight": [
+        {{
+            "criterion": [Text content of the first insight evaluation criterion],
+            "analysis": [Comparative analysis],
+            "article_1_score": [Continuous score 0-10],
+            "article_2_score": [Continuous score 0-10]
+        }},
+        ...
+    ],
+    ...
+}}
+</output_format>
+
+Now, please evaluate the two articles based on the research task and criteria, providing detailed comparative analysis and scores according to the requirements above. Ensure your output follows the specified `<output_format>` and that the JSON format is parsable, with all characters that might cause JSON parsing errors properly escaped.
+</user_prompt>
+"""
+
+# Verbatim from prompt/score_prompt_zh.py:generate_merged_score_prompt.
+RACE_SCORE_PROMPT_ZH = """
+<system_role>你是一名严格、细致、客观的调研文章评估专家。你擅长根据具体的评估标准，深入比较两篇针对同一任务的文章，并给出精确的评分和清晰的理由。</system_role>
+
+<user_prompt>
+**任务背景**
+有一个深度调研任务，你需要评估针对该任务撰写的两篇调研文章。我们会从以下四个维度评估文章：全面性、洞察力、指令遵循能力和可读性。内容如下：
+<task>
+"{task_prompt}"
+</task>
+
+**待评估文章**
+<article_1>
+"{article_1}"
+</article_1>
+
+<article_2>
+"{article_2}"
+</article_2>
+
+**评估标准**
+现在，你需要根据以下**评判标准列表**，逐条评估并比较这两篇文章的表现，输出对比分析，然后给出0-10的分数。每个标准都附有其解释，请仔细理解。
+
+<criteria_list>
+{criteria_list}
+</criteria_list>
+
+<Instruction>
+**你的任务**
+请严格按照 `<criteria_list>` 中的**每一条标准**，对比评估 `<article_1>` 和 `<article_2>` 在该标准上的具体表现。你需要：
+1.  **逐条分析**：针对列表中的每一条标准，分别思考两篇文章是如何满足该标准要求的。
+2.  **对比评估**：结合文章内容与标准解释，对比分析两篇文章在每一条标准上的表现。
+3.  **分别打分**：基于你的对比分析，为两篇文章在该条标准上的表现分别打分（0-10分）。
+
+**打分规则**
+对每一条标准，分别为两篇文章打分，打分范围为 0-10 分（连续的数值）。分数高低应体现文章在该标准上表现的好坏：
+*   0-2分：表现很差。几乎完全不符合标准要求。
+*   2-4分：表现较差。少量符合标准要求，但有明显不足。
+*   4-6分：表现中等。基本符合标准要求，不好不坏。
+*   6-8分：表现较好。大部分符合标准要求，有可取之处。
+*   8-10分：表现出色/极好。完全或超预期符合标准要求。
+
+**输出格式要求**
+请**严格**按照下列`<output_format>`格式输出每一条标准的评估结果，**不要包含任何其他无关内容、引言或总结**。从"标准1"开始，按顺序输出所有标准的评估：
+</Instruction>
+
+<output_format>
+{{
+    "comprehensiveness": [
+        {{
+            "criterion": [全面性维度的第一条评判标准文本内容],
+            "analysis": [对比分析],
+            "article_1_score": [0-10连续分数],
+            "article_2_score": [0-10连续分数]
+        }},
+        {{
+            "criterion": [全面性维度的第二条评判标准文本内容],
+            "analysis": [对比分析],
+            "article_1_score": [0-10连续分数],
+            "article_2_score": [0-10连续分数]
+        }},
+        ...
+    ],
+    "insight": [
+        {{
+            "criterion": [洞察力维度的第一条评判标准文本内容],
+            "analysis": [对比分析],
+            "article_1_score": [0-10连续分数],
+            "article_2_score": [0-10连续分数]
+        }},
+        ...
+    ],
+    ...
+}}
+</output_format>
+
+现在，请根据调研任务和标准，对两篇文章进行评估，并按照上述要求给出详细的对比分析和评分，请确保输出格式遵守上述`<output_format>`，而且保证其中的json格式可以解析，注意所有可能导致json解析错误的要转义的符号。
+</user_prompt>
+"""
+
+# Verbatim from utils/extract.py:prompt_template and prompt_template_en.
+FACT_EXTRACTION_PROMPT_ZH = """你会看到一篇研究报告，研究报告正文中会有一些对参考文献的引用。
+正文中的引用可能以如下形式出现：
+1. 一段文字+空格+数字，例如："李强基于收入、教育和职业构造了一个社会经济地位指数（SES），将社会划分为7个等级 15"
+2. 一段文字+[（一个或多个)数字]，例如："李强基于收入、教育和职业构造了一个社会经济地位指数（SES），将社会划分为7个等级[15]"
+3. 一段文字+[（一个或多个)数字†(一些行号等内容)]，例如："李强基于收入、教育和职业构造了一个社会经济地位指数（SES），将社会划分为7个等级[15†L10][5L23][7†summary][9summary]"
+4. [引用来源](引用链接)，例如："根据[ChinaFile: A Guide to Social Class in Modern China](https://www.chinafile.com/reporting-opinion/media/guide-social-class-modern-china)'s分类，中国社会可分为九个阶层"
+
+请从正文中找出**所有**引用了参考文献的地方，提取出(fact, ref_idx, url)三元组，提取的时候，注意以下事项：
+1. 由于后续需要检验这些facts是否正确，你可能需要在引用的前后寻找一些上下文，以确保fact是完整可理解的，而不是简单的词组或短语
+2. 如果一个fact引用了多个文献，那么它应该对应多个三元组，例如如果引用了2个文献，则应该是(fact, ref_idx_1, url_1)和(fact, ref_idx_2, url_2)
+3. 对于第三种形式的引用，ref_idx仅考虑第一个数字部分，不考虑其他指示具体位置的内容；对于第四种形式的引用（即引用来源和链接直接出现在正文中）的情况，ref_idx统一设置为0
+4. 如果正文中没有标出引用的具体位置（比如仅在文章结尾列出了参考文献列表，而没有在正文中标出），请返回空列表
+
+你应该返回json列表格式，列表中的每一项是一个三元组，例如：
+[
+    {{
+        "fact": "原文中的文本片段，注意中文引号要用全角, 英文引号前加单个反斜杠转义",
+        "ref_idx": "该段文字引用的参考文献在参考文献列表中的索引",
+        "url": "该段文字引用的参考文献链接（从研究报告结尾的参考文献列表或引用处的括号中提取）"
+    }}
+]
+
+下面是研究报告的正文：
+{report_text}
+
+下面开始提取，直接输出json列表，不要输出任何闲聊或解释。"""
+
+FACT_EXTRACTION_PROMPT_EN = """You will be provided with a research report. The body of the report will contain some citations to references.
+
+Citations in the main text may appear in the following forms:
+1. A segment of text + space + number, for example: "Li Qiang constructed a socioeconomic status index (SES) based on income, education, and occupation, dividing society into 7 levels 15"
+2. A segment of text + [number], for example: "Li Qiang constructed a socioeconomic status index (SES) based on income, education, and occupation, dividing society into 7 levels[15]"
+3. A segment of text + [number†(some line numbers, etc.)], for example: "Li Qiang constructed a socioeconomic status index (SES) based on income, education, and occupation, dividing society into 7 levels[15†L10][5L23][7†summary]"
+4. [Citation Source](Citation Link), for example: "According to [ChinaFile: A Guide to Social Class in Modern China](https://www.chinafile.com/reporting-opinion/media/guide-social-class-modern-china)'s classification, Chinese society can be divided into nine strata"
+
+Please identify **all** instances where references are cited in the main text, and extract (fact, ref_idx, url) triplets. When extracting, pay attention to the following:
+1. Since these facts will need to be verified later, you may need to look for some context before and after the citation to ensure that the fact is complete and understandable, rather than just a simple phrase or short expression.
+2. If a fact cites multiple references, then it should correspond to two triplets: (fact, ref_idx_1, url_1) and (fact, ref_idx_2, url_2).
+3. For the third form of citation (i.e., where the citation source and link appear directly in the text), the ref_idx should be uniformly set to 0.
+4. If the main text does not specify the exact location of the citation (for example, only the reference list is listed at the end of the article, without specifying the citation point in the text), please return an empty list.
+
+You should return a JSON list format, where each item in the list is a triplet, for example:
+[
+    {{
+        "fact": "Text segment from the original document. Note that Chinese quotation marks should use full-width marks. And add a single backslash before the English quotation mark to make it a readable for python json module.",
+        "ref_idx": "The index of the cited reference in the reference list for this text segment.",
+        "url": "The URL of the cited reference for this text segment (extracted from the reference list at the end of the research report or from the parentheses at the citation point)."
+    }}
+]
+
+Here is the main text of the research report:
+{report_text}
+
+Please begin the extraction now. Output only the JSON list directly, without any chitchat or explanations."""
+
+# Verbatim from utils/deduplicate.py:prompt_template and prompt_template_en.
+FACT_DEDUPLICATION_PROMPT_ZH = """你会看到一个statement列表，你需要对其去重，并返回去重后的statement序号列表，注意：只有表达完全一致的事情时，两个statement才被认为是重复的，如果列表中没有重复的statement，则返回完整的列表。
+
+你应该返回一个List(int)，列表中的每一项是去重后留下的，不重复的statement的序号，例如：
+[1, 3, 5]
+
+下面是你需要去重的statement列表
+{statements}
+
+下面开始提取，直接输出整数列表，不要输出任何闲聊或解释。"""
+
+FACT_DEDUPLICATION_PROMPT_EN = """You will be given a list of statements. You need to de-duplicate them and return a list of indices of the unique statements. Note: Two statements are considered duplicates only if they express *exactly the same thing*. If there are no duplicate statements in the list, return the complete list of indices.
+
+You should return a List(int), where each item in the list is the index of a unique, non-duplicated statement that has been retained. For example:
+[1, 3, 5]
+
+Below is the list of statements you need to de-duplicate:
+{statements}
+
+Please begin the extraction now. Output only the integer list, without any conversational text or explanations."""
+
+# Verbatim from utils/validate.py:prompt_template and prompt_template_en.
+FACT_VALIDATION_PROMPT_ZH = """你会看到一个参考资料和一些statement，请你判断对于参考资料来说statement是supported、unsupported、或者unknown，注意：
+首先判断参考资料是否存在有效内容，如果参考资料中没有任何有效信息，如"page not found"页面，则认为所有statement的状态都是unknown。
+除此之外，参考资料有效的情况下，对于一个statement来说，如果它包含的事实或数据在参考资料中可以全部或部分找到，就认为它是supported的（数据接受四舍五入）；如果statement中所有的事实和数据在参考资料中都找不到，认为它是unsupported的。
+
+你应该返回json列表格式，列表中的每一项包含statement的序号和判断结果，例如：
+[
+    {{
+        "idx": 1,
+        "result": "supported"
+    }},
+    {{
+        "idx": 2,
+        "result": "unsupported"
+    }}
+]
+
+下面是参考资料和statements：
+<reference>
+{reference}
+</reference>
+
+<statements>
+{statements}
+</statements>
+
+下面开始判断，直接输出json列表，不要输出任何闲聊或解释。"""
+
+FACT_VALIDATION_PROMPT_EN = """You will be provided with a reference and some statements. Please determine whether each statement is 'supported', 'unsupported', or 'unknown' with respect to the reference. Please note:
+First, assess whether the reference contains any valid content. If the reference contains no valid information, such as a 'page not found' message, then all statements should be considered 'unknown'.
+If the reference is valid, for a given statement: if the facts or data it contains can be found entirely or partially within the reference, it is considered 'supported' (data accepts rounding); if all facts and data in the statement cannot be found in the reference, it is considered 'unsupported'.
+
+You should return the result in a JSON list format, where each item in the list contains the statement's index and the judgment result, for example:
+[
+    {{
+        "idx": 1,
+        "result": "supported"
+    }},
+    {{
+        "idx": 2,
+        "result": "unsupported"
+    }}
+]
+
+Below are the reference and statements:
+<reference>
+{reference}
+</reference>
+
+<statements>
+{statements}
+</statements>
+
+Begin the assessment now. Output only the JSON list, without any conversational text or explanations."""
+
+
+def format_criteria_list(criteria_data: Mapping[str, Any]) -> str:
+    """Format criteria for the judge without revealing official weights."""
+    criteria_for_prompt: dict[str, list[dict[str, Any]]] = {}
+    criterions_dict = criteria_data.get("criterions", {})
+    if not isinstance(criterions_dict, Mapping):
+        criterions_dict = {}
+
+    for dimension, criterions_list in criterions_dict.items():
+        if not isinstance(dimension, str) or not isinstance(criterions_list, list):
+            logger.warning("Invalid criteria list for dimension %r; skipping", dimension)
+            continue
+        criteria_for_prompt[dimension] = []
+        for criterion_item in criterions_list:
+            if (
+                isinstance(criterion_item, Mapping)
+                and "criterion" in criterion_item
+                and "explanation" in criterion_item
+            ):
+                criteria_for_prompt[dimension].append(
+                    {
+                        "criterion": criterion_item["criterion"],
+                        "explanation": criterion_item["explanation"],
+                    }
+                )
+            else:
+                logger.warning("Invalid criterion in dimension %r; skipping", dimension)
+
+    try:
+        return json.dumps(criteria_for_prompt, ensure_ascii=False, indent=2)
+    except TypeError as exc:
+        raise ValueError(f"Failed to serialize criteria to JSON: {exc}") from exc
+
+
+def extract_json_from_markdown(text: Any) -> str | None:
+    """Port the official layered JSON extraction and score-specific fallback."""
+    if not isinstance(text, str):
+        return None
+
+    stripped = text.strip()
+    if stripped.startswith("{") and stripped.endswith("}"):
+        try:
+            json.loads(stripped)
+            return stripped
+        except json.JSONDecodeError:
+            pass
+
+    marker_start = text.find("```json")
+    if marker_start >= 0:
+        start = marker_start + len("```json")
+        end = text.find("```", start)
+        if end > start:
+            candidate = text[start:end].strip()
+            try:
+                json.loads(candidate)
+                return candidate
+            except json.JSONDecodeError:
+                pass
+
+    match = re.search(r"```json\s*([\s\S]*?)\s*```", text)
+    if match:
+        candidate = match.group(1).strip()
+        try:
+            json.loads(candidate)
+            return candidate
+        except json.JSONDecodeError:
+            pass
+
+    try:
+        json.loads(stripped)
+        return stripped
+    except json.JSONDecodeError:
+        pass
+
+    start = text.find("{")
+    if start != -1:
+        level = 0
+        for offset, character in enumerate(text[start:]):
+            if character == "{":
+                level += 1
+            elif character == "}":
+                level -= 1
+                if level == 0:
+                    candidate = text[start : start + offset + 1]
+                    try:
+                        json.loads(candidate)
+                        return candidate
+                    except json.JSONDecodeError:
+                        pass
+                    break
+
+    start = text.find("{")
+    end = text.rfind("}")
+    if start != -1 and end > start:
+        candidate = text[start : end + 1]
+        try:
+            json.loads(candidate)
+            return candidate
+        except json.JSONDecodeError:
+            pass
+
+    if "comprehensiveness" in text and "article_1_score" in text and "article_2_score" in text:
+        dimensions = list(DEEPRESEARCH_DIMENSIONS)
+        result: dict[str, list[dict[str, Any]]] = {}
+        for dimension in dimensions:
+            if dimension not in text:
+                continue
+            result[dimension] = []
+            dimension_start = text.find(f'"{dimension}"')
+            if dimension_start == -1:
+                dimension_start = text.find(f"'{dimension}'")
+            if dimension_start == -1:
+                dimension_start = text.find(dimension)
+            if dimension_start == -1:
+                continue
+
+            next_dimension_start = len(text)
+            for next_dimension in dimensions:
+                if next_dimension == dimension:
+                    continue
+                position = text.find(f'"{next_dimension}"', dimension_start)
+                if position == -1:
+                    position = text.find(f"'{next_dimension}'", dimension_start)
+                if position == -1:
+                    position = text.find(next_dimension, dimension_start + len(dimension))
+                if position != -1:
+                    next_dimension_start = min(next_dimension_start, position)
+
+            dimension_content = text[dimension_start:next_dimension_start]
+            criteria = re.findall(r'"criterion"\s*:\s*"([^"]+)"', dimension_content)
+            scores_1 = re.findall(r'"article_1_score"\s*:\s*(\d+\.?\d*)', dimension_content)
+            scores_2 = re.findall(r'"article_2_score"\s*:\s*(\d+\.?\d*)', dimension_content)
+            for index in range(min(len(criteria), len(scores_1), len(scores_2))):
+                result[dimension].append(
+                    {
+                        "criterion": criteria[index],
+                        "article_1_score": float(scores_1[index]),
+                        "article_2_score": float(scores_2[index]),
+                    }
+                )
+        if any(result.values()):
+            return json.dumps(result)
+    return None
+
+
+def calculate_weighted_scores(
+    llm_output_json: Mapping[str, Any],
+    criteria_data: Mapping[str, Any],
+    language: str = "en",
+) -> dict[str, dict[str, Any]]:
+    """Faithfully port the official criteria and dimension weighting math."""
+    del language  # Kept for API parity with the official implementation.
+    results: dict[str, dict[str, Any]] = {
+        "target": {"dims": {}, "total": 0.0},
+        "reference": {"dims": {}, "total": 0.0},
+    }
+    total_target_score = 0.0
+    total_reference_score = 0.0
+    dimension_weights = criteria_data.get("dimension_weight", {})
+    task_id = criteria_data.get("id", "Unknown")
+    if not isinstance(dimension_weights, Mapping):
+        dimension_weights = {}
+
+    criterions_data = criteria_data.get("criterions")
+    if not isinstance(criterions_data, Mapping) or not criterions_data:
+        raise ValueError(
+            f"ID: {task_id} - Missing required criterions data, cannot calculate weighted scores"
+        )
+
+    criterion_weights: dict[str, dict[str, Any]] = {}
+    for dimension, criterions in criterions_data.items():
+        if not isinstance(dimension, str) or not isinstance(criterions, list):
+            continue
+        criterion_weights[dimension] = {
+            criterion["criterion"]: criterion["weight"]
+            for criterion in criterions
+            if isinstance(criterion, Mapping)
+            and isinstance(criterion.get("criterion"), str)
+            and "weight" in criterion
+        }
+
+    unmatched_criteria: set[str] = set()
+    for dimension, scores_list in llm_output_json.items():
+        if not isinstance(dimension, str) or not isinstance(scores_list, list):
+            logger.warning(
+                "ID: %s - Dimension %r in LLM output is not a list; skipping",
+                task_id,
+                dimension,
+            )
+            continue
+        if dimension not in dimension_weights or dimension not in criterion_weights:
+            logger.warning(
+                "ID: %s - Dimension %r is absent from criteria weights/details; skipping",
+                task_id,
+                dimension,
+            )
+            continue
+
+        dimension_map = criterion_weights[dimension]
+        if not dimension_map:
+            logger.warning("ID: %s - No criteria mapping for %r; skipping", task_id, dimension)
+            continue
+
+        target_weighted_sum = 0.0
+        reference_weighted_sum = 0.0
+        total_weight = 0.0
+        article_2_score: float | None = None
+
+        for score_item in scores_list:
+            if not isinstance(score_item, Mapping):
+                logger.warning(
+                    "ID: %s - Non-mapping score item in %r; skipping", task_id, dimension
+                )
+                continue
+            raw_criterion = score_item.get("criterion")
+            criterion_text = raw_criterion.strip() if isinstance(raw_criterion, str) else None
+            article_1_raw = score_item.get("article_1_score")
+            article_2_raw = score_item.get("article_2_score")
+            target_raw = score_item.get("target_score")
+            if target_raw is not None and article_1_raw is None:
+                article_1_raw = target_raw
+
+            try:
+                article_1_score = float(article_1_raw) if article_1_raw is not None else None
+                article_2_score = float(article_2_raw) if article_2_raw is not None else None
+            except (TypeError, ValueError):
+                logger.warning(
+                    "ID: %s - Invalid scores for criterion %r in %r; skipping",
+                    task_id,
+                    criterion_text,
+                    dimension,
+                )
+                continue
+
+            if not criterion_text or article_1_score is None:
+                logger.warning(
+                    "ID: %s - Missing criterion text or target score in %r; skipping",
+                    task_id,
+                    dimension,
+                )
+                continue
+
+            weight = dimension_map.get(criterion_text)
+            criterion_lower = criterion_text.lower()
+            if weight is None:
+                for key, value in dimension_map.items():
+                    if key.lower() == criterion_lower:
+                        weight = value
+                        break
+            if weight is None:
+                for key, value in dimension_map.items():
+                    if criterion_lower in key.lower() or key.lower() in criterion_lower:
+                        weight = value
+                        break
+            if weight is None:
+                unmatched_criteria.add(f"{dimension}:{criterion_text}")
+                weight = sum(dimension_map.values()) / len(dimension_map)
+
+            target_weighted_sum += article_1_score * weight
+            total_weight += weight
+            if article_2_score is not None:
+                reference_weighted_sum += article_2_score * weight
+
+        if total_weight > 0:
+            target_average = target_weighted_sum / total_weight
+            # Official code keys this on the last parsed item. Preserve it: mixed
+            # single/comparative output can therefore change the reference result.
+            reference_average = (
+                reference_weighted_sum / total_weight if article_2_score is not None else 0.0
+            )
+        else:
+            target_average = 0.0
+            reference_average = 0.0
+
+        dimension_key = f"{dimension}_weighted_avg"
+        results["target"]["dims"][dimension_key] = target_average
+        results["reference"]["dims"][dimension_key] = reference_average
+        dimension_weight = dimension_weights.get(dimension, 0)
+        total_target_score += target_average * dimension_weight
+        total_reference_score += reference_average * dimension_weight
+
+    if unmatched_criteria:
+        logger.warning(
+            "ID: %s - %d criteria used average-weight fallback: %s",
+            task_id,
+            len(unmatched_criteria),
+            unmatched_criteria,
+        )
+    results["target"]["total"] = total_target_score
+    results["reference"]["total"] = total_reference_score
+    return results
+
+
+def normalize_comparative_score(target: float, reference: float) -> float:
+    """Normalize one target/reference score pair with the official zero guard."""
+    denominator = target + reference
+    return target / denominator if denominator > 0 else 0.0
+
+
+def normalize_weighted_scores(scores: Mapping[str, Any]) -> dict[str, float]:
+    """Return official overall and per-dimension target shares."""
+    target = scores["target"]
+    reference = scores["reference"]
+    normalized = {
+        "race_overall": normalize_comparative_score(
+            float(target["total"]), float(reference["total"])
+        )
+    }
+    for dimension in DEEPRESEARCH_DIMENSIONS:
+        key = f"{dimension}_weighted_avg"
+        target_score = float(target["dims"].get(key, 0.0))
+        reference_score = float(reference["dims"].get(key, 0.0))
+        normalized[f"race_{dimension}"] = normalize_comparative_score(target_score, reference_score)
+    return normalized
+
+
+def clean_urls(input_text: str) -> str:
+    """Strip text-fragment suffixes from inline Markdown citation URLs."""
+    pattern = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
+
+    def replace(match: re.Match[str]) -> str:
+        title, url = match.groups()
+        return f"[{title}]({clean_citation_url(url)})"
+
+    return pattern.sub(replace, input_text)
+
+
+def clean_citation_url(url: str) -> str:
+    """Apply the official ``#:~:text=`` URL cleanup to a raw URL."""
+    return url.split("#:~:text=", maxsplit=1)[0]
+
+
+def remove_urls(input_text: str) -> str:
+    """Remove URL targets from Markdown citations while retaining their titles."""
+    return re.sub(r"\[([^\]]+)\]\(([^)]+)\)", r"[\1]", input_text)
+
+
+def clean_escape(input_text: str) -> str:
+    """Remove the four illegal JSON escapes handled by the official extractor."""
+    for escaped, replacement in ((r"\>", ">"), (r"\<", "<"), (r"\+", "+"), (r"\~", "~")):
+        input_text = input_text.replace(escaped, replacement)
+    return input_text
+
+
+def group_citations_by_url(
+    citations: Sequence[Mapping[str, Any]],
+) -> dict[str, list[dict[str, Any]]]:
+    """Group extracted citation triplets by their cleaned URL."""
+    groups: dict[str, list[dict[str, Any]]] = {}
+    for citation in citations:
+        url = citation.get("url")
+        fact = citation.get("fact")
+        if not isinstance(url, str) or not url or not isinstance(fact, str) or not fact:
+            continue
+        cleaned_url = clean_citation_url(url)
+        if not cleaned_url:
+            continue
+        groups.setdefault(cleaned_url, []).append(dict(citation, url=cleaned_url))
+    return groups
+
+
+def _json_without_fences(raw: str) -> Any:
+    return json.loads(raw.replace("```json", "").replace("```", ""))
+
+
+def _try_parse_dedup_indices(raw: str, group_size: int) -> list[int] | None:
+    try:
+        parsed = cast(list[int], _json_without_fences(raw))
+    except json.JSONDecodeError:
+        return None
+    if not parsed or 0 in parsed or len(parsed) > group_size:
+        return list(range(1, group_size + 1))
+    if any(index > group_size or index <= -group_size for index in parsed):
+        # The official list access raises IndexError here; retain every fact instead.
+        return list(range(1, group_size + 1))
+    return parsed
+
+
+def parse_dedup_indices(raw: str, group_size: int) -> list[int]:
+    """Parse official one-based dedup indices, falling back to every statement."""
+    parsed = _try_parse_dedup_indices(raw, group_size)
+    return parsed if parsed is not None else list(range(1, group_size + 1))
+
+
+def calculate_fact_statistics(results: Sequence[str], n_tasks: int) -> dict[str, float]:
+    """Calculate official FACT statistics for citation-bearing tasks."""
+    supported = sum(result == "supported" for result in results)
+    evaluated = sum(result != "unknown" for result in results)
+    return {
+        "fact_citation_accuracy": supported / evaluated if evaluated else 0.0,
+        "fact_avg_effective_citations": supported / n_tasks if n_tasks else 0.0,
+        "fact_avg_citations": evaluated / n_tasks if n_tasks else 0.0,
+    }
+
+
+def _unknown_results(fact_count: int) -> list[dict[str, Any]]:
+    return [{"idx": index, "result": "unknown"} for index in range(fact_count)]
+
+
+def is_obvious_scrape_failure(page_text: str) -> bool:
+    """Identify fetch-layer failures that cannot support any statement."""
+    normalized = page_text.strip().lower()
+    return not normalized or normalized.startswith(
+        (
+            "error:",
+            "error fetching webpage:",
+            "scrape failed:",
+            "no content extracted from webpage.",
+        )
+    )
+
+
+def scrape_failure_unknown_results(page_text: str, fact_count: int) -> list[dict[str, Any]] | None:
+    """Short-circuit obvious fetch errors; valid pages still go to the judge."""
+    return _unknown_results(fact_count) if is_obvious_scrape_failure(page_text) else None
+
+
+async def fetch_crawl4ai_page(url: str) -> str:
+    """Call crawl4ai's underlying fetch logic without the registered-tool truncation."""
+    sanitized_url = url.strip()
+    if not sanitized_url:
+        return "Error: Empty URL."
+    if urlsplit(sanitized_url).scheme.lower() not in {"http", "https"}:
+        return "Error: Only http(s) URLs are supported."
+
+    try:
+        from crawl4ai import AsyncWebCrawler
+    except ImportError:
+        raise RuntimeError(
+            "DeepResearch Bench FACT scoring requires crawl4ai. "
+            "Install it with `pip install 'olmo-eval[crawl4ai]'`."
+        ) from None
+
+    try:
+        async with AsyncWebCrawler() as crawler:
+            result = await crawler.arun(sanitized_url)
+    except Exception as exc:
+        logger.exception("crawl4ai FACT fetch failed for %r", sanitized_url)
+        return f"Error fetching webpage: {exc}"
+
+    if not getattr(result, "success", False):
+        error_message = getattr(result, "error_message", None)
+        if error_message:
+            return f"Error fetching webpage: {error_message}"
+        status_code = getattr(result, "status_code", None)
+        if status_code is not None:
+            return f"Error fetching webpage: HTTP {status_code}"
+        return "Error fetching webpage: unknown error"
+
+    markdown = getattr(result, "markdown", None)
+    text = getattr(markdown, "raw_markdown", None) or str(markdown or "")
+    if not text.strip():
+        return "No content extracted from webpage."
+    if len(text) > DEEPRESEARCH_PAGE_CONTENT_LIMIT:
+        text = text[:DEEPRESEARCH_PAGE_CONTENT_LIMIT]
+    return text
+
+
+def _build_judge_fn(default_spec: str, scorer_name: str) -> JudgeFn:
+    spec = os.getenv("OLMO_EVAL_JUDGE", default_spec)
+    model, separator, effort = spec.partition(":")
+    return build_openai_judge_fn(
+        model=model,
+        temperature=0.0,
+        max_tokens=DEEPRESEARCH_JUDGE_MAX_TOKENS,
+        scorer_name=scorer_name,
+        reasoning_effort=(effort if separator else None),
+    )
+
+
+def build_deepresearch_race_judge_fn() -> JudgeFn:
+    """Build the RACE judge from its default or ``$OLMO_EVAL_JUDGE``."""
+    return _build_judge_fn(DEEPRESEARCH_RACE_DEFAULT_JUDGE_SPEC, "DeepResearchBenchRACE")
+
+
+def build_deepresearch_fact_judge_fn() -> JudgeFn:
+    """Build the shared FACT-stage judge from its default or ``$OLMO_EVAL_JUDGE``."""
+    return _build_judge_fn(DEEPRESEARCH_FACT_DEFAULT_JUDGE_SPEC, "DeepResearchBenchFACT")
+
+
+@dataclass(frozen=True)
+class DeepResearchBenchScorer(Scorer):
+    """Placeholder scorer; the task precomputes all RACE and FACT channels."""
+
+    name: str = "deepresearch_bench"
+    score_key: str = "race_overall"
+
+    def score(self, instance: Instance, output: LMOutput) -> float:
+        return float((output.metadata or {}).get(self.score_key, 0.0))
+
+
+class DeepResearchMetricBase(Metric, ABC):
+    scorer: type[Scorer] = DeepResearchBenchScorer
+
+    def supports_pairwise_scorer_fallback(self) -> bool:
+        return False
+
+
+@dataclass(frozen=True)
+class DeepResearchMeanMetric(DeepResearchMetricBase):
+    """Arithmetic mean of a precomputed per-task score."""
+
+    name: str = "race_overall"
+    scorer: type[Scorer] = DeepResearchBenchScorer
+
+    def compute(self, responses: Sequence[Response]) -> float:
+        if not responses:
+            return 0.0
+        return sum(response.scores.get(self.name, 0.0) for response in responses) / len(responses)
+
+    def pairwise_display_format(self) -> str:
+        return "percentage" if self.name.startswith("race_") else "raw"
+
+    def pairwise_unit(self) -> str:
+        return "proportion" if self.name.startswith("race_") else self.name
+
+
+@dataclass(frozen=True)
+class FactCitationAccuracyMetric(DeepResearchMetricBase):
+    """Corpus-level supported / non-unknown FACT accuracy."""
+
+    name: str = "fact_citation_accuracy"
+    scorer: type[Scorer] = DeepResearchBenchScorer
+
+    def compute(self, responses: Sequence[Response]) -> float:
+        supported = sum(
+            response.scores.get("fact_avg_effective_citations", 0.0) for response in responses
+        )
+        evaluated = sum(response.scores.get("fact_avg_citations", 0.0) for response in responses)
+        return supported / evaluated if evaluated else 0.0
+
+    def pairwise_display_format(self) -> str:
+        return "percentage"
+
+    def pairwise_unit(self) -> str:
+        return "proportion"
+
+
+@dataclass(frozen=True)
+class FactAverageCitationMetric(DeepResearchMetricBase):
+    """Average a FACT count over responses with at least one extracted citation."""
+
+    name: str = "fact_avg_citations"
+    scorer: type[Scorer] = DeepResearchBenchScorer
+
+    def compute(self, responses: Sequence[Response]) -> float:
+        numerator = sum(response.scores.get(self.name, 0.0) for response in responses)
+        citation_bearing = sum(
+            response.scores.get("fact_has_citations", 0.0) for response in responses
+        )
+        return numerator / citation_bearing if citation_bearing else 0.0
+
+    def pairwise_display_format(self) -> str:
+        return "raw"
+
+    def pairwise_unit(self) -> str:
+        return self.name
+
+
+RACE_OVERALL_METRIC = DeepResearchMeanMetric(name="race_overall")
+DEEPRESEARCH_METRICS = (
+    RACE_OVERALL_METRIC,
+    *(DeepResearchMeanMetric(name=f"race_{dimension}") for dimension in DEEPRESEARCH_DIMENSIONS),
+    FactCitationAccuracyMetric(),
+    FactAverageCitationMetric(name="fact_avg_effective_citations"),
+    FactAverageCitationMetric(name="fact_avg_citations"),
+)
+
+
+def strip_think_block(text: str) -> str:
+    """Strip a leading reasoning block using the ResearchQA helper pattern."""
+    think_end = text.find("</think>")
+    if think_end >= 0:
+        text = text[think_end + len("</think>") :]
+    return text.strip()
+
+
+def _validated_criteria(doc: Mapping[str, Any]) -> dict[str, Any] | None:
+    criteria = doc.get("criteria")
+    if not isinstance(criteria, Mapping):
+        return None
+    dimension_weight = criteria.get("dimension_weight")
+    criterions = criteria.get("criterions")
+    if not isinstance(dimension_weight, Mapping) or not isinstance(criterions, Mapping):
+        return None
+    return {
+        "dimension_weight": dict(dimension_weight),
+        "criterions": {key: value for key, value in criterions.items()},
+    }
+
+
+@register("deepresearch_bench")
+class DeepResearchBench(Task):
+    """DeepResearch Bench RACE + FACT evaluation."""
+
+    split = Split.TEST
+    data_source = DataSource(path=DEEPRESEARCH_BENCH_REPO, subset="default", split="test")
+    metrics = DEEPRESEARCH_METRICS
+    primary_metric = RACE_OVERALL_METRIC
+    sampling_params = SamplingParams(temperature=0.0, max_tokens=16_384)
+    required_secrets = ("OPENAI_API_KEY",)
+
+    def __init__(self, config: TaskConfig) -> None:
+        super().__init__(config)
+        self._scrape_cache: dict[str, str] = {}
+
+    @property
+    def instances(self) -> Iterator[Instance]:
+        split = (
+            self.config.data_source.split
+            if isinstance(self.config.data_source, DataSource)
+            else None
+        )
+        yield from self._load_instances_cached(split=split)
+
+    def process_doc(self, doc: dict[str, Any], index: int = 0) -> Instance | None:
+        language = doc.get("language")
+        if language not in {"en", "zh"}:
+            return None
+        prompt = doc.get("prompt")
+        reference_article = doc.get("reference_article")
+        criteria = _validated_criteria(doc)
+        if (
+            not isinstance(prompt, str)
+            or not prompt
+            or not isinstance(reference_article, str)
+            or not reference_article
+            or criteria is None
+        ):
+            return None
+
+        identifier = doc.get("id", index + 1)
+        generation_instruction = DEEPRESEARCH_GENERATION_INSTRUCTIONS[language]
+        return Instance(
+            question=f"{prompt}\n\n{generation_instruction}",
+            metadata={
+                "id": identifier,
+                "case_id": identifier,
+                "language": language,
+                "topic": doc.get("topic", ""),
+                "prompt": prompt,
+                "criteria": criteria,
+                "reference_article": reference_article,
+                "index": index,
+            },
+        )
+
+    def format_request(self, instance: Instance) -> LMRequest:
+        return LMRequest(
+            request_type=RequestType.CHAT,
+            messages=({"role": "user", "content": instance.question},),
+        )
+
+    def extract_answer(self, output: LMOutput) -> str:
+        return strip_think_block(output.text)
+
+    async def score_responses(
+        self,
+        responses: Sequence[Response],
+        context: Any = None,
+    ) -> Sequence[Response]:
+        """Run RACE and FACT, retaining every instance in aggregate denominators."""
+        del context
+        self._extract_answers(responses)
+        race_judge = build_deepresearch_race_judge_fn()
+        fact_judge = build_deepresearch_fact_judge_fn()
+
+        race_failures = 0
+        for response in responses:
+            output = response.outputs[0] if response.outputs else None
+            answer = ""
+            if output is not None:
+                answer = (
+                    output.extracted_answer
+                    if isinstance(output.extracted_answer, str)
+                    else output.text
+                )
+
+            if answer:
+                race_scores, race_details, race_failed = await self._score_race(
+                    response.instance, answer, race_judge
+                )
+                fact_scores, fact_details = await self._score_fact(
+                    response.instance, answer, fact_judge
+                )
+            else:
+                race_scores = self._zero_race_scores()
+                race_details = None
+                race_failed = False
+                fact_scores = self._zero_fact_scores()
+                fact_details = []
+
+            race_failures += int(race_failed)
+            response.scores.update(race_scores)
+            response.scores.update(fact_scores)
+            if output is not None:
+                if output.metadata is None:
+                    output.metadata = {}
+                output.metadata["deepresearch_race"] = race_details
+                output.metadata["deepresearch_fact"] = fact_details
+                for metric_name, score in response.scores.items():
+                    output.metadata[f"score:{metric_name}"] = score
+
+        if race_failures:
+            logger.warning(
+                "DeepResearch Bench RACE judge failed for %d instance(s) after %d "
+                "attempts; assigned zero and retained them in the denominator.",
+                race_failures,
+                DEEPRESEARCH_JUDGE_ATTEMPTS,
+            )
+        return responses
+
+    async def _score_race(
+        self,
+        instance: Instance,
+        answer: str,
+        judge_fn: JudgeFn,
+    ) -> tuple[dict[str, float], dict[str, Any] | None, bool]:
+        metadata = instance.metadata
+        criteria = metadata["criteria"]
+        language = metadata["language"]
+        prompt_template = RACE_SCORE_PROMPT_ZH if language == "zh" else RACE_SCORE_PROMPT_EN
+        judge_prompt = prompt_template.format(
+            task_prompt=metadata["prompt"],
+            article_1=answer,
+            article_2=metadata["reference_article"],
+            criteria_list=format_criteria_list(criteria),
+        )
+
+        for attempt in range(DEEPRESEARCH_JUDGE_ATTEMPTS):
+            try:
+                raw = await judge_fn(judge_prompt)
+                extracted_json = extract_json_from_markdown(raw)
+                if extracted_json is None:
+                    raise ValueError("Failed to extract JSON from RACE judge response")
+                parsed = json.loads(extracted_json)
+                if not isinstance(parsed, dict):
+                    raise TypeError("RACE judge response must be a JSON object")
+                missing = [
+                    dimension for dimension in DEEPRESEARCH_DIMENSIONS if dimension not in parsed
+                ]
+                if missing:
+                    raise ValueError(f"RACE judge response is missing dimensions: {missing}")
+                weighted = calculate_weighted_scores(parsed, criteria, language)
+                normalized = normalize_weighted_scores(weighted)
+                return normalized, {"judge_scores": parsed, "weighted_scores": weighted}, False
+            except (json.JSONDecodeError, TypeError, ValueError, KeyError) as exc:
+                logger.warning(
+                    "DeepResearch Bench RACE attempt %d/%d failed for id %r: %s",
+                    attempt + 1,
+                    DEEPRESEARCH_JUDGE_ATTEMPTS,
+                    metadata.get("id"),
+                    exc,
+                )
+            except Exception as exc:
+                logger.warning(
+                    "DeepResearch Bench RACE judge call %d/%d failed for id %r: %s",
+                    attempt + 1,
+                    DEEPRESEARCH_JUDGE_ATTEMPTS,
+                    metadata.get("id"),
+                    exc,
+                )
+            if attempt < DEEPRESEARCH_JUDGE_ATTEMPTS - 1:
+                await asyncio.sleep(2**attempt)
+        return self._zero_race_scores(), None, True
+
+    async def _score_fact(
+        self,
+        instance: Instance,
+        answer: str,
+        judge_fn: JudgeFn,
+    ) -> tuple[dict[str, float], list[dict[str, Any]]]:
+        language = instance.metadata["language"]
+        citations = await self._extract_citations(answer, language, judge_fn)
+        fact_has_citations = float(bool(citations))
+        groups = group_citations_by_url(citations)
+        validation_details: list[dict[str, Any]] = []
+
+        for url, group in groups.items():
+            facts = [str(citation["fact"]) for citation in group]
+            if len(facts) > 1:
+                facts = await self._deduplicate_facts(facts, language, judge_fn)
+
+            page_text = await self._fetch_page(url)
+            validation_results = scrape_failure_unknown_results(page_text, len(facts))
+            if validation_results is None:
+                validation_results = await self._validate_facts(
+                    facts, page_text, language, judge_fn
+                )
+            for position, validation in enumerate(validation_results):
+                returned_index = validation["idx"]
+                fact_index = (
+                    returned_index
+                    if isinstance(returned_index, int) and 0 <= returned_index < len(facts)
+                    else position
+                )
+                validation_details.append(
+                    {
+                        "url": url,
+                        "fact": facts[fact_index],
+                        "result": validation["result"],
+                    }
+                )
+
+        statuses = [detail["result"] for detail in validation_details]
+        statistics = calculate_fact_statistics(statuses, n_tasks=1)
+        statistics["fact_has_citations"] = fact_has_citations
+        return statistics, validation_details
+
+    async def _extract_citations(
+        self, answer: str, language: str, judge_fn: JudgeFn
+    ) -> list[dict[str, Any]]:
+        template = FACT_EXTRACTION_PROMPT_ZH if language == "zh" else FACT_EXTRACTION_PROMPT_EN
+        prompt = template.format(report_text=clean_urls(answer))
+        for attempt in range(DEEPRESEARCH_JUDGE_ATTEMPTS):
+            try:
+                raw = clean_escape(await judge_fn(prompt))
+                parsed = _json_without_fences(raw)
+                if not isinstance(parsed, list):
+                    raise TypeError("FACT extraction result must be a list")
+                citations: list[dict[str, Any]] = []
+                for item in parsed:
+                    if not isinstance(item, Mapping):
+                        raise TypeError("FACT extraction item must be an object")
+                    fact = item.get("fact")
+                    url = item.get("url")
+                    if not isinstance(fact, str) or not isinstance(url, str):
+                        raise TypeError("FACT extraction fact and url must be strings")
+                    citations.append(
+                        {
+                            "fact": remove_urls(fact),
+                            "ref_idx": item.get("ref_idx"),
+                            "url": clean_citation_url(url),
+                        }
+                    )
+                return citations
+            except (json.JSONDecodeError, TypeError) as exc:
+                logger.warning(
+                    "FACT extraction attempt %d/%d failed: %s",
+                    attempt + 1,
+                    DEEPRESEARCH_JUDGE_ATTEMPTS,
+                    exc,
+                )
+            except Exception as exc:
+                logger.warning(
+                    "FACT extraction judge call %d/%d failed: %s",
+                    attempt + 1,
+                    DEEPRESEARCH_JUDGE_ATTEMPTS,
+                    exc,
+                )
+            if attempt < DEEPRESEARCH_JUDGE_ATTEMPTS - 1:
+                await asyncio.sleep(2**attempt)
+        return []
+
+    async def _deduplicate_facts(
+        self, facts: list[str], language: str, judge_fn: JudgeFn
+    ) -> list[str]:
+        statements = "\n".join(f"{index + 1}. {fact}" for index, fact in enumerate(facts))
+        template = (
+            FACT_DEDUPLICATION_PROMPT_ZH if language == "zh" else FACT_DEDUPLICATION_PROMPT_EN
+        )
+        prompt = template.format(statements=statements)
+        indices: list[int] | None = None
+        for attempt in range(DEEPRESEARCH_JUDGE_ATTEMPTS):
+            try:
+                indices = _try_parse_dedup_indices(await judge_fn(prompt), len(facts))
+                if indices is not None:
+                    break
+                raise ValueError("FACT deduplication result must be valid JSON")
+            except Exception as exc:
+                logger.warning(
+                    "FACT deduplication attempt %d/%d failed: %s",
+                    attempt + 1,
+                    DEEPRESEARCH_JUDGE_ATTEMPTS,
+                    exc,
+                )
+            if attempt < DEEPRESEARCH_JUDGE_ATTEMPTS - 1:
+                await asyncio.sleep(2**attempt)
+        indices = indices or list(range(1, len(facts) + 1))
+        return [facts[index - 1] for index in indices]
+
+    async def _fetch_page(self, url: str) -> str:
+        if url not in self._scrape_cache:
+            page_text = ""
+            for attempt in range(DEEPRESEARCH_SCRAPE_ATTEMPTS):
+                page_text = await fetch_crawl4ai_page(url)
+                if not is_obvious_scrape_failure(page_text):
+                    break
+                if attempt < DEEPRESEARCH_SCRAPE_ATTEMPTS - 1:
+                    await asyncio.sleep(1)
+            self._scrape_cache[url] = page_text
+        return self._scrape_cache[url]
+
+    async def _validate_facts(
+        self,
+        facts: list[str],
+        page_text: str,
+        language: str,
+        judge_fn: JudgeFn,
+    ) -> list[dict[str, Any]]:
+        statements = "\n".join(f"{index + 1}. {fact}" for index, fact in enumerate(facts))
+        template = FACT_VALIDATION_PROMPT_ZH if language == "zh" else FACT_VALIDATION_PROMPT_EN
+        prompt = template.format(reference=page_text, statements=statements)
+        for attempt in range(DEEPRESEARCH_JUDGE_ATTEMPTS):
+            try:
+                raw = await judge_fn(prompt)
+                parsed = cast(list[dict[str, Any]], _json_without_fences(raw))
+                for item in parsed:
+                    item["idx"] -= 1
+                assert len(parsed) == len(facts), "FACT validation result length mismatch"
+                return parsed
+            except (AssertionError, json.JSONDecodeError, KeyError, TypeError) as exc:
+                logger.warning(
+                    "FACT validation attempt %d/%d failed: %s",
+                    attempt + 1,
+                    DEEPRESEARCH_JUDGE_ATTEMPTS,
+                    exc,
+                )
+            except Exception as exc:
+                logger.warning("FACT validation judge call failed: %s", exc)
+            if attempt < DEEPRESEARCH_JUDGE_ATTEMPTS - 1:
+                await asyncio.sleep(2**attempt)
+        return _unknown_results(len(facts))
+
+    @staticmethod
+    def _zero_race_scores() -> dict[str, float]:
+        return {
+            "race_overall": 0.0,
+            **{f"race_{dimension}": 0.0 for dimension in DEEPRESEARCH_DIMENSIONS},
+        }
+
+    @staticmethod
+    def _zero_fact_scores() -> dict[str, float]:
+        return {
+            "fact_citation_accuracy": 0.0,
+            "fact_avg_effective_citations": 0.0,
+            "fact_avg_citations": 0.0,
+            "fact_has_citations": 0.0,
+        }
+
+
+register_variant(
+    "deepresearch_bench",
+    "en",
+    data_source=DataSource(path=DEEPRESEARCH_BENCH_REPO, subset="en", split="test"),
+)

--- a/tests/evals/tasks/test_deepresearch_bench.py
+++ b/tests/evals/tasks/test_deepresearch_bench.py
@@ -828,8 +828,8 @@ class TestPromptsAndJudges:
     @pytest.mark.parametrize(
         ("env_spec", "expected_models", "expected_efforts"),
         [
-            (None, ["gpt-5.5", "gpt-5.4-mini"], [None, None]),
-            ("judge-override", ["judge-override", "judge-override"], [None, None]),
+            (None, ["gpt-5.5", "gpt-5.4-mini"], ["medium", "low"]),
+            ("judge-override", ["judge-override", "judge-override"], ["medium", "low"]),
             ("gpt-5.5:high", ["gpt-5.5", "gpt-5.5"], ["high", "high"]),
         ],
     )

--- a/tests/evals/tasks/test_deepresearch_bench.py
+++ b/tests/evals/tasks/test_deepresearch_bench.py
@@ -689,6 +689,37 @@ class TestFactHelpersAndMetrics:
             {"idx": 1, "result": "unknown"},
         ]
 
+    @pytest.mark.parametrize("missing_key", ["result", "idx"])
+    @pytest.mark.anyio
+    async def test_validation_missing_required_key_retries_then_returns_all_unknown(
+        self, task, monkeypatch, missing_key
+    ):
+        calls = 0
+        delays = []
+
+        async def judge(_prompt):
+            nonlocal calls
+            calls += 1
+            items = [
+                {"idx": 1, "result": "supported"},
+                {"idx": 2, "result": "unsupported"},
+            ]
+            del items[1][missing_key]
+            return json.dumps(items)
+
+        async def sleep(delay):
+            delays.append(delay)
+
+        monkeypatch.setattr(deepresearch_bench.asyncio, "sleep", sleep)
+        results = await task._validate_facts(["first", "second"], "valid page", "en", judge)
+
+        assert calls == 3
+        assert delays == [1, 2]
+        assert results == [
+            {"idx": 0, "result": "unknown"},
+            {"idx": 1, "result": "unknown"},
+        ]
+
     @pytest.mark.anyio
     async def test_validation_blindly_decrements_idx_and_accepts_arbitrary_label(self, task):
         async def judge(_prompt):
@@ -900,6 +931,57 @@ async def test_score_responses_runs_race_and_fact_without_network(task, monkeypa
             "result": "supported",
         }
     ]
+
+
+@pytest.mark.anyio
+async def test_unexpected_fact_failure_preserves_race_scores(task, monkeypatch, caplog):
+    instance = task.process_doc(_en_doc())
+    assert instance is not None
+    response = _response(instance, "A complete research report.")
+    race_payload = {
+        dimension: [
+            {
+                "criterion": _criteria()["criterions"][dimension][0]["criterion"],
+                "article_1_score": 8,
+                "article_2_score": 2,
+            }
+        ]
+        for dimension in DEEPRESEARCH_DIMENSIONS
+    }
+
+    async def race_judge(_prompt):
+        return json.dumps(race_payload)
+
+    async def unused_fact_judge(_prompt):
+        return "[]"
+
+    async def fail_fact(*_args):
+        raise RuntimeError("unexpected FACT failure")
+
+    monkeypatch.setattr(deepresearch_bench, "build_deepresearch_race_judge_fn", lambda: race_judge)
+    monkeypatch.setattr(
+        deepresearch_bench, "build_deepresearch_fact_judge_fn", lambda: unused_fact_judge
+    )
+    monkeypatch.setattr(task, "_score_fact", fail_fact)
+
+    scored = await task.score_responses([response])
+
+    assert scored == [response]
+    assert response.scores["race_overall"] == pytest.approx(0.8)
+    for dimension in DEEPRESEARCH_DIMENSIONS:
+        assert response.scores[f"race_{dimension}"] == pytest.approx(0.8)
+    assert {
+        metric: response.scores[metric]
+        for metric in (
+            "fact_citation_accuracy",
+            "fact_avg_effective_citations",
+            "fact_avg_citations",
+            "fact_has_citations",
+        )
+    } == task._zero_fact_scores()
+    assert response.outputs[0].metadata["deepresearch_fact"] == []
+    assert "FACT scoring failed for id 51" in caplog.text
+    assert "FACT scoring failed for 1 instance(s)" in caplog.text
 
 
 @pytest.mark.anyio

--- a/tests/evals/tasks/test_deepresearch_bench.py
+++ b/tests/evals/tasks/test_deepresearch_bench.py
@@ -1,0 +1,725 @@
+"""Tests for the DeepResearch Bench RACE + FACT task."""
+
+import builtins
+import hashlib
+import json
+
+import pytest
+
+from olmo_eval.common.types import Instance, LMOutput, LMRequest, RequestType, Response
+from olmo_eval.evals.tasks import deepresearch_bench
+from olmo_eval.evals.tasks.common import get_task, task_exists
+from olmo_eval.evals.tasks.deepresearch_bench import (
+    DEEPRESEARCH_DIMENSIONS,
+    FACT_DEDUPLICATION_PROMPT_EN,
+    FACT_DEDUPLICATION_PROMPT_ZH,
+    FACT_EXTRACTION_PROMPT_EN,
+    FACT_EXTRACTION_PROMPT_ZH,
+    FACT_VALIDATION_PROMPT_EN,
+    FACT_VALIDATION_PROMPT_ZH,
+    RACE_SCORE_PROMPT_EN,
+    RACE_SCORE_PROMPT_ZH,
+    build_deepresearch_fact_judge_fn,
+    build_deepresearch_race_judge_fn,
+    calculate_fact_statistics,
+    calculate_weighted_scores,
+    clean_citation_url,
+    clean_urls,
+    fetch_crawl4ai_page,
+    format_criteria_list,
+    group_citations_by_url,
+    normalize_comparative_score,
+    normalize_weighted_scores,
+    parse_dedup_indices,
+    remove_urls,
+    scrape_failure_unknown_results,
+)
+
+
+def _criterion(text, explanation, weight):
+    return {"criterion": text, "explanation": explanation, "weight": weight}
+
+
+def _criteria():
+    return {
+        "dimension_weight": {
+            "comprehensiveness": 0.4,
+            "insight": 0.3,
+            "instruction_following": 0.2,
+            "readability": 0.1,
+        },
+        "criterions": {
+            "comprehensiveness": [
+                _criterion("Population projections", "Covers 2020 through 2050.", 0.25),
+                _criterion("Market segmentation", "Covers all requested sectors.", 0.75),
+            ],
+            "insight": [_criterion("Deep synthesis", "Explains non-obvious drivers.", 1.0)],
+            "instruction_following": [
+                _criterion("Answers the question", "Directly responds.", 0.2),
+                _criterion("Uses the timeframe", "Uses the requested years.", 0.8),
+            ],
+            "readability": [_criterion("Clear structure", "Uses navigable sections.", 1.0)],
+        },
+    }
+
+
+def _en_doc():
+    # Trimmed from official query id 51, with the audited joined-row shape.
+    return {
+        "id": 51,
+        "language": "en",
+        "topic": "Finance & Business",
+        "prompt": (
+            "From 2020 to 2050, how many elderly people will there be in Japan? "
+            "What is their consumption potential across clothing, food, housing, and "
+            "transportation?"
+        ),
+        "criteria": _criteria(),
+        "reference_article": (
+            "# Japan's Silver Tsunami\n\nOfficial projections show a sustained aging trend."
+        ),
+    }
+
+
+def _zh_doc():
+    # Trimmed from official query id 1.
+    return {
+        "id": 1,
+        "language": "zh",
+        "topic": "Finance & Business",
+        "prompt": "收集整理目前中国9阶层实际收入和财务状况，特别研究中国中产的特点和人数。",
+        "criteria": _criteria(),
+        "reference_article": "# 当代中国社会阶层结构\n\n本报告分析收入、财富与中产阶层。",
+    }
+
+
+def _response(instance: Instance, text: str) -> Response:
+    return Response(
+        instance=instance,
+        request=LMRequest(request_type=RequestType.CHAT, messages=()),
+        outputs=[LMOutput(text=text)],
+        scores={},
+    )
+
+
+@pytest.fixture
+def task():
+    return get_task("deepresearch_bench")
+
+
+class TestRegistrationAndDocs:
+    def test_registration_and_metrics(self):
+        assert task_exists("deepresearch_bench")
+        assert task_exists("deepresearch_bench:en")
+        task = get_task("deepresearch_bench")
+        assert task.config.data_source.path == "allenai/deepresearch-bench"
+        assert task.config.data_source.subset == "default"
+        assert task.config.data_source.split == "test"
+        assert not hasattr(task.config, "language")
+        assert task.config.sampling_params.temperature == 0.0
+        assert task.config.sampling_params.max_tokens == 16_384
+        assert task.config.get_primary_metric().name == "race_overall"
+        assert {metric.name for metric in task.config.metrics} == {
+            "race_overall",
+            "race_comprehensiveness",
+            "race_insight",
+            "race_instruction_following",
+            "race_readability",
+            "fact_citation_accuracy",
+            "fact_avg_effective_citations",
+            "fact_avg_citations",
+        }
+
+    @pytest.mark.parametrize("doc", [_en_doc(), _zh_doc()])
+    def test_process_doc_preserves_official_fields_and_appends_instruction(self, task, doc):
+        instance = task.process_doc(doc, index=7)
+
+        assert instance is not None
+        assert instance.question.startswith(doc["prompt"] + "\n\n")
+        assert "[source title](url)" in instance.question or "[来源标题](url)" in instance.question
+        assert instance.metadata["id"] == doc["id"]
+        assert instance.metadata["language"] == doc["language"]
+        assert instance.metadata["topic"] == doc["topic"]
+        assert instance.metadata["prompt"] == doc["prompt"]
+        assert instance.metadata["criteria"] == doc["criteria"]
+        assert instance.metadata["reference_article"] == doc["reference_article"]
+        assert instance.metadata["index"] == 7
+
+        request = task.format_request(instance)
+        assert request.request_type == RequestType.CHAT
+        assert request.messages == ({"role": "user", "content": instance.question},)
+
+    def test_english_variant_uses_hub_subset(self):
+        task = get_task("deepresearch_bench:en")
+        assert task.config.data_source.path == "allenai/deepresearch-bench"
+        assert task.config.data_source.subset == "en"
+        assert task.config.data_source.split == "test"
+        assert task.process_doc(_en_doc()) is not None
+
+    def test_think_strip_matches_researchqa_pattern(self, task):
+        output = LMOutput(text="<think>private reasoning</think>\n\nFinal report.")
+        assert task.extract_answer(output) == "Final report."
+
+
+class TestRaceScoring:
+    def test_format_criteria_hides_all_weights(self):
+        rendered = format_criteria_list(_criteria())
+        parsed = json.loads(rendered)
+
+        assert "dimension_weight" not in parsed
+        assert parsed["comprehensiveness"][0] == {
+            "criterion": "Population projections",
+            "explanation": "Covers 2020 through 2050.",
+        }
+        assert "weight" not in rendered
+
+    def test_weighted_math_exact_case_substring_fallback_and_single_score(self):
+        judge_output = {
+            "comprehensiveness": [
+                {
+                    "criterion": "Population projections",
+                    "article_1_score": 8,
+                    "article_2_score": 4,
+                },
+                {
+                    "criterion": "MARKET SEGMENTATION",
+                    "article_1_score": 6,
+                    "article_2_score": 2,
+                },
+            ],
+            "insight": [
+                {
+                    "criterion": "Deep synthesis plus",
+                    "article_1_score": 9,
+                    "article_2_score": 3,
+                }
+            ],
+            "instruction_following": [
+                {
+                    "criterion": "Answers the question",
+                    "article_1_score": 3,
+                    "article_2_score": 1,
+                },
+                {
+                    "criterion": "A criterion the generator paraphrased beyond matching",
+                    "article_1_score": 7,
+                    "article_2_score": 5,
+                },
+            ],
+            "readability": [
+                {
+                    "criterion": "Clear structure",
+                    "target_score": 4,
+                }
+            ],
+        }
+
+        weighted = calculate_weighted_scores(judge_output, _criteria())
+
+        assert weighted["target"]["dims"] == pytest.approx(
+            {
+                "comprehensiveness_weighted_avg": 6.5,
+                "insight_weighted_avg": 9.0,
+                "instruction_following_weighted_avg": 41 / 7,
+                "readability_weighted_avg": 4.0,
+            }
+        )
+        assert weighted["reference"]["dims"] == pytest.approx(
+            {
+                "comprehensiveness_weighted_avg": 2.5,
+                "insight_weighted_avg": 3.0,
+                "instruction_following_weighted_avg": 27 / 7,
+                "readability_weighted_avg": 0.0,
+            }
+        )
+        assert weighted["target"]["total"] == pytest.approx(481 / 70)
+        assert weighted["reference"]["total"] == pytest.approx(187 / 70)
+
+        normalized = normalize_weighted_scores(weighted)
+        assert normalized == pytest.approx(
+            {
+                "race_overall": 481 / 668,
+                "race_comprehensiveness": 6.5 / 9,
+                "race_insight": 0.75,
+                "race_instruction_following": 41 / 68,
+                "race_readability": 1.0,
+            }
+        )
+
+    def test_normalization_zero_guard(self):
+        assert normalize_comparative_score(3.0, 1.0) == 0.75
+        assert normalize_comparative_score(0.0, 0.0) == 0.0
+
+
+class TestFactHelpersAndMetrics:
+    def test_url_cleaning_and_fact_url_removal(self):
+        url = "https://example.test/page#:~:text=quoted%20passage"
+        report = f"A claim [Example]({url}) follows."
+
+        assert clean_citation_url(url) == "https://example.test/page"
+        assert clean_urls(report) == "A claim [Example](https://example.test/page) follows."
+        assert remove_urls(report) == "A claim [Example] follows."
+
+    def test_grouping_uses_cleaned_url(self):
+        citations = [
+            {
+                "fact": "First claim",
+                "ref_idx": 0,
+                "url": "https://example.test/page#:~:text=first",
+            },
+            {"fact": "Second claim", "ref_idx": 0, "url": "https://example.test/page"},
+            {"fact": "Other", "ref_idx": 0, "url": "https://other.test"},
+        ]
+
+        groups = group_citations_by_url(citations)
+
+        assert list(groups) == ["https://example.test/page", "https://other.test"]
+        assert [item["fact"] for item in groups["https://example.test/page"]] == [
+            "First claim",
+            "Second claim",
+        ]
+
+    def test_dedup_index_parsing_and_official_fallback(self):
+        assert parse_dedup_indices("```json\n[1, 3]\n```", 3) == [1, 3]
+        assert parse_dedup_indices("[-1]", 3) == [-1]
+        assert parse_dedup_indices("[0, 2]", 3) == [1, 2, 3]
+        assert parse_dedup_indices("[4]", 3) == [1, 2, 3]
+        assert parse_dedup_indices("[-3]", 3) == [1, 2, 3]
+        assert parse_dedup_indices("not json", 2) == [1, 2]
+
+    @pytest.mark.anyio
+    @pytest.mark.parametrize(
+        ("judge_result", "expected"),
+        [
+            ("[-1]", ["second"]),
+            ("[]", ["first", "second", "third"]),
+            ("[0, 2]", ["first", "second", "third"]),
+            ("[4]", ["first", "second", "third"]),
+        ],
+    )
+    async def test_dedup_success_uses_official_guard_without_retry(
+        self, task, judge_result, expected
+    ):
+        calls = 0
+
+        async def judge(_prompt):
+            nonlocal calls
+            calls += 1
+            return judge_result
+
+        facts = ["first", "second", "third"]
+        assert await task._deduplicate_facts(facts, "en", judge) == expected
+        assert calls == 1
+
+    @pytest.mark.anyio
+    async def test_dedup_retries_only_json_parse_failure(self, task, monkeypatch):
+        judge_results = iter(["not json", "still not json", "[-1]"])
+        delays = []
+
+        async def judge(_prompt):
+            return next(judge_results)
+
+        async def sleep(delay):
+            delays.append(delay)
+
+        monkeypatch.setattr(deepresearch_bench.asyncio, "sleep", sleep)
+        facts = ["first", "second", "third"]
+        assert await task._deduplicate_facts(facts, "en", judge) == ["second"]
+        assert delays == [1, 2]
+
+    @pytest.mark.anyio
+    async def test_dedup_judge_failure_returns_all_facts(self, task, monkeypatch):
+        calls = 0
+        delays = []
+
+        async def judge(_prompt):
+            nonlocal calls
+            calls += 1
+            raise RuntimeError("transient judge failure")
+
+        async def sleep(delay):
+            delays.append(delay)
+
+        monkeypatch.setattr(deepresearch_bench.asyncio, "sleep", sleep)
+        facts = ["first", "second", "third"]
+
+        assert await task._deduplicate_facts(facts, "en", judge) == facts
+        assert calls == 3
+        assert delays == [1, 2]
+
+    def test_stat_semantics_exclude_unknown_and_skip_no_citation_tasks(self):
+        statistics = calculate_fact_statistics(
+            [
+                "supported",
+                "unknown",
+                "unsupported",
+                "supported",
+                "unknown",
+                "supported",
+                "arbitrary-label",
+            ],
+            n_tasks=2,
+        )
+        assert statistics == {
+            "fact_citation_accuracy": 0.6,
+            "fact_avg_effective_citations": 1.5,
+            "fact_avg_citations": 2.5,
+        }
+
+    def test_metric_averages_use_only_citation_bearing_responses(self, task):
+        responses = [
+            _response(Instance(question="one"), ""),
+            _response(Instance(question="two"), ""),
+        ]
+        responses[0].scores.update(
+            {
+                "fact_avg_effective_citations": 2.0,
+                "fact_avg_citations": 3.0,
+                "fact_citation_accuracy": 2 / 3,
+                "fact_has_citations": 1.0,
+            }
+        )
+        responses[1].scores.update(
+            {
+                "fact_avg_effective_citations": 0.0,
+                "fact_avg_citations": 0.0,
+                "fact_citation_accuracy": 0.0,
+                "fact_has_citations": 0.0,
+            }
+        )
+        metrics = {metric.name: metric.compute(responses) for metric in task.config.metrics}
+        assert metrics["fact_citation_accuracy"] == 2 / 3
+        assert metrics["fact_avg_effective_citations"] == 2.0
+        assert metrics["fact_avg_citations"] == 3.0
+
+        responses[0].scores["fact_has_citations"] = 0.0
+        fact_metrics = {metric.name: metric for metric in task.config.metrics}
+        assert fact_metrics["fact_avg_effective_citations"].compute(responses) == 0.0
+        assert fact_metrics["fact_avg_citations"].compute(responses) == 0.0
+
+    def test_scrape_failure_short_circuits_to_unknown(self):
+        assert scrape_failure_unknown_results("Error fetching webpage: timeout", 2) == [
+            {"idx": 0, "result": "unknown"},
+            {"idx": 1, "result": "unknown"},
+        ]
+        assert scrape_failure_unknown_results("A valid source page", 2) is None
+
+    @pytest.mark.anyio
+    async def test_scrape_cache_fetches_each_url_once(self, task, monkeypatch):
+        calls = []
+
+        async def fetch_page(url):
+            calls.append(url)
+            return "A valid source page"
+
+        monkeypatch.setattr(deepresearch_bench, "fetch_crawl4ai_page", fetch_page)
+        assert await task._fetch_page("https://example.test/page") == "A valid source page"
+        assert await task._fetch_page("https://example.test/page") == "A valid source page"
+        assert calls == ["https://example.test/page"]
+
+    @pytest.mark.anyio
+    async def test_crawl4ai_import_error_names_install_extra(self, monkeypatch):
+        real_import = builtins.__import__
+
+        def import_without_crawl4ai(name, *args, **kwargs):
+            if name == "crawl4ai":
+                raise ImportError
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", import_without_crawl4ai)
+        with pytest.raises(
+            RuntimeError,
+            match=r"pip install 'olmo-eval\[crawl4ai\]'",
+        ):
+            await fetch_crawl4ai_page("https://example.test/page")
+
+    @pytest.mark.anyio
+    async def test_validation_failure_returns_all_unknown(self, task, monkeypatch):
+        calls = 0
+        delays = []
+
+        async def judge(_prompt):
+            nonlocal calls
+            calls += 1
+            return "not json"
+
+        async def sleep(delay):
+            delays.append(delay)
+
+        monkeypatch.setattr(deepresearch_bench.asyncio, "sleep", sleep)
+        results = await task._validate_facts(["first", "second"], "valid page", "en", judge)
+
+        assert calls == 3
+        assert delays == [1, 2]
+        assert results == [
+            {"idx": 0, "result": "unknown"},
+            {"idx": 1, "result": "unknown"},
+        ]
+
+    @pytest.mark.anyio
+    async def test_validation_blindly_decrements_idx_and_accepts_arbitrary_label(self, task):
+        async def judge(_prompt):
+            return json.dumps([{"idx": -7, "result": "arbitrary-label"}])
+
+        assert await task._validate_facts(["fact"], "valid page", "en", judge) == [
+            {"idx": -8, "result": "arbitrary-label"}
+        ]
+
+    @pytest.mark.anyio
+    async def test_fact_metadata_pairs_by_returned_idx_then_position(self, task, monkeypatch):
+        citations = [
+            {"fact": "first", "url": "https://example.test"},
+            {"fact": "second", "url": "https://example.test"},
+            {"fact": "third", "url": "https://example.test"},
+        ]
+
+        async def extract(*_args):
+            return citations
+
+        async def deduplicate(facts, *_args):
+            return facts
+
+        async def fetch(_url):
+            return "valid page"
+
+        async def validate(*_args):
+            return [
+                {"idx": 2, "result": "supported"},
+                {"idx": 99, "result": "arbitrary-label"},
+                {"idx": 0, "result": "unknown"},
+            ]
+
+        async def unused_judge(_prompt):
+            return ""
+
+        monkeypatch.setattr(task, "_extract_citations", extract)
+        monkeypatch.setattr(task, "_deduplicate_facts", deduplicate)
+        monkeypatch.setattr(task, "_fetch_page", fetch)
+        monkeypatch.setattr(task, "_validate_facts", validate)
+        instance = task.process_doc(_en_doc())
+        assert instance is not None
+
+        scores, details = await task._score_fact(instance, "report", unused_judge)
+
+        assert [detail["fact"] for detail in details] == ["third", "second", "first"]
+        assert scores == {
+            "fact_citation_accuracy": 0.5,
+            "fact_avg_effective_citations": 1.0,
+            "fact_avg_citations": 2.0,
+            "fact_has_citations": 1.0,
+        }
+
+
+class TestPromptsAndJudges:
+    @pytest.mark.parametrize(
+        ("prompt", "digest"),
+        [
+            (
+                RACE_SCORE_PROMPT_EN,
+                "29c0dc8365d047b293c6e6dce80c840402003aa5171c47e2a6f19a064ca77a1f",
+            ),
+            (
+                RACE_SCORE_PROMPT_ZH,
+                "d324077bbe7218ad1df5c49cf3d0207f66416526c73063be883203d7e80610c4",
+            ),
+            (
+                FACT_EXTRACTION_PROMPT_EN,
+                "3f78bbd60b6a78147bed7c51b5f056e2ba990d299c1064318ef63349009e6e8e",
+            ),
+            (
+                FACT_EXTRACTION_PROMPT_ZH,
+                "2b3ce39d315d8f0637601bbe0262887a0f0e2909bd39b7b5e8fb4b3222f56bcd",
+            ),
+            (
+                FACT_DEDUPLICATION_PROMPT_EN,
+                "7c7965e51c48189f49267b6681efce5dcd6f4638cb331a2e63b937d317c2e93b",
+            ),
+            (
+                FACT_DEDUPLICATION_PROMPT_ZH,
+                "e12080068b5fe54893ee896cdf3d9efe8a0fb221a725d3551f8c8c6b3ed4509c",
+            ),
+            (
+                FACT_VALIDATION_PROMPT_EN,
+                "3d8f531bbad26b004faf2284ccd58ce561bf827d117cae3d2475c9a61e5cb71c",
+            ),
+            (
+                FACT_VALIDATION_PROMPT_ZH,
+                "81358173e19cdee1f560e1445048d800d6d455616782f14574eb4dc0920307d4",
+            ),
+        ],
+    )
+    def test_official_prompt_sha256(self, prompt, digest):
+        assert hashlib.sha256(prompt.encode()).hexdigest() == digest
+
+    def test_official_prompt_distinctive_substrings(self):
+        assert 'Start with "Standard 1"' in RACE_SCORE_PROMPT_EN
+        assert '从"标准1"开始' in RACE_SCORE_PROMPT_ZH
+        assert "A segment of text + [number†" in FACT_EXTRACTION_PROMPT_EN
+        assert "一段文字+[（一个或多个)数字†" in FACT_EXTRACTION_PROMPT_ZH
+        assert "*exactly the same thing*" in FACT_DEDUPLICATION_PROMPT_EN
+        assert "只有表达完全一致的事情时" in FACT_DEDUPLICATION_PROMPT_ZH
+        assert "such as a 'page not found' message" in FACT_VALIDATION_PROMPT_EN
+        assert '如"page not found"页面' in FACT_VALIDATION_PROMPT_ZH
+
+    @pytest.mark.parametrize(
+        ("env_spec", "expected_models", "expected_efforts"),
+        [
+            (None, ["gpt-5.5", "gpt-5.4-mini"], [None, None]),
+            ("judge-override", ["judge-override", "judge-override"], [None, None]),
+            ("gpt-5.5:high", ["gpt-5.5", "gpt-5.5"], ["high", "high"]),
+        ],
+    )
+    def test_single_override_applies_to_both_judges(
+        self, monkeypatch, env_spec, expected_models, expected_efforts
+    ):
+        captured = []
+
+        async def sentinel(_prompt):
+            return ""
+
+        def fake_builder(**kwargs):
+            captured.append(kwargs)
+            return sentinel
+
+        if env_spec is None:
+            monkeypatch.delenv("OLMO_EVAL_JUDGE", raising=False)
+        else:
+            monkeypatch.setenv("OLMO_EVAL_JUDGE", env_spec)
+        monkeypatch.setattr(deepresearch_bench, "build_openai_judge_fn", fake_builder)
+
+        assert build_deepresearch_race_judge_fn() is sentinel
+        assert build_deepresearch_fact_judge_fn() is sentinel
+        assert [call["model"] for call in captured] == expected_models
+        assert [call["reasoning_effort"] for call in captured] == expected_efforts
+        assert [call["scorer_name"] for call in captured] == [
+            "DeepResearchBenchRACE",
+            "DeepResearchBenchFACT",
+        ]
+        assert all(call["temperature"] == 0.0 for call in captured)
+        assert all(call["max_tokens"] == 64_000 for call in captured)
+
+
+@pytest.mark.anyio
+async def test_score_responses_runs_race_and_fact_without_network(task, monkeypatch):
+    instance = task.process_doc(_en_doc())
+    assert instance is not None
+    response = _response(
+        instance,
+        "<think>research plan</think>A supported fact [Source](https://example.test/page).",
+    )
+    race_calls = []
+    fact_calls = []
+
+    race_payload = {
+        dimension: [
+            {
+                "criterion": _criteria()["criterions"][dimension][0]["criterion"],
+                "article_1_score": 8,
+                "article_2_score": 2,
+            }
+        ]
+        for dimension in DEEPRESEARCH_DIMENSIONS
+    }
+
+    async def race_judge(prompt):
+        race_calls.append(prompt)
+        return f"```json\n{json.dumps(race_payload)}\n```"
+
+    async def fact_judge(prompt):
+        fact_calls.append(prompt)
+        if "Here is the main text" in prompt:
+            return json.dumps(
+                [
+                    {
+                        "fact": "A supported fact [Source](https://example.test/page).",
+                        "ref_idx": 0,
+                        "url": "https://example.test/page",
+                    }
+                ]
+            )
+        assert "A valid source page" in prompt
+        return json.dumps([{"idx": 1, "result": "supported"}])
+
+    async def fetch_page(url):
+        assert url == "https://example.test/page"
+        return "A valid source page containing the supported fact."
+
+    monkeypatch.setattr(deepresearch_bench, "build_deepresearch_race_judge_fn", lambda: race_judge)
+    monkeypatch.setattr(deepresearch_bench, "build_deepresearch_fact_judge_fn", lambda: fact_judge)
+    monkeypatch.setattr(deepresearch_bench, "fetch_crawl4ai_page", fetch_page)
+
+    await task.score_responses([response])
+
+    assert len(race_calls) == 1
+    assert len(fact_calls) == 2
+    assert response.scores["race_overall"] == pytest.approx(0.8)
+    for dimension in DEEPRESEARCH_DIMENSIONS:
+        assert response.scores[f"race_{dimension}"] == pytest.approx(0.8)
+    assert response.scores["fact_citation_accuracy"] == 1.0
+    assert response.scores["fact_avg_effective_citations"] == 1.0
+    assert response.scores["fact_avg_citations"] == 1.0
+    assert response.scores["fact_has_citations"] == 1.0
+    assert response.outputs[0].extracted_answer.startswith("A supported fact")
+    assert response.outputs[0].metadata["deepresearch_fact"] == [
+        {
+            "url": "https://example.test/page",
+            "fact": "A supported fact [Source].",
+            "result": "supported",
+        }
+    ]
+
+
+@pytest.mark.anyio
+async def test_empty_answer_sets_fact_has_citations_to_zero(task, monkeypatch):
+    instance = task.process_doc(_en_doc())
+    assert instance is not None
+    response = _response(instance, "<think>research plan only</think>")
+    judge_calls = 0
+
+    async def judge(_prompt):
+        nonlocal judge_calls
+        judge_calls += 1
+        return ""
+
+    monkeypatch.setattr(deepresearch_bench, "build_deepresearch_race_judge_fn", lambda: judge)
+    monkeypatch.setattr(deepresearch_bench, "build_deepresearch_fact_judge_fn", lambda: judge)
+
+    await task.score_responses([response])
+
+    assert judge_calls == 0
+    assert response.scores["fact_has_citations"] == 0.0
+    assert response.scores["fact_avg_effective_citations"] == 0.0
+    assert response.scores["fact_avg_citations"] == 0.0
+
+
+@pytest.mark.anyio
+async def test_race_parse_failure_retries_and_keeps_zero_instance(task, monkeypatch):
+    instance = task.process_doc(_en_doc())
+    assert instance is not None
+    response = _response(instance, "A report without citations.")
+    race_calls = 0
+    delays = []
+
+    async def race_judge(_prompt):
+        nonlocal race_calls
+        race_calls += 1
+        return "malformed"
+
+    async def fact_judge(_prompt):
+        return "[]"
+
+    async def sleep(delay):
+        delays.append(delay)
+
+    monkeypatch.setattr(deepresearch_bench, "build_deepresearch_race_judge_fn", lambda: race_judge)
+    monkeypatch.setattr(deepresearch_bench, "build_deepresearch_fact_judge_fn", lambda: fact_judge)
+    monkeypatch.setattr(deepresearch_bench.asyncio, "sleep", sleep)
+
+    scored = await task.score_responses([response])
+
+    assert scored == [response]
+    assert race_calls == 3
+    assert delays == [1, 2]
+    assert response.scores["race_overall"] == 0.0
+    assert response.scores["fact_has_citations"] == 0.0
+    assert task.config.get_primary_metric().compute(scored) == 0.0

--- a/tests/evals/tasks/test_deepresearch_bench.py
+++ b/tests/evals/tasks/test_deepresearch_bench.py
@@ -3,6 +3,7 @@
 import builtins
 import hashlib
 import json
+import re
 
 import pytest
 
@@ -11,6 +12,7 @@ from olmo_eval.evals.tasks import deepresearch_bench
 from olmo_eval.evals.tasks.common import get_task, task_exists
 from olmo_eval.evals.tasks.deepresearch_bench import (
     DEEPRESEARCH_DIMENSIONS,
+    DEEPRESEARCH_GENERATION_INSTRUCTIONS,
     FACT_DEDUPLICATION_PROMPT_EN,
     FACT_DEDUPLICATION_PROMPT_ZH,
     FACT_EXTRACTION_PROMPT_EN,
@@ -136,7 +138,7 @@ class TestRegistrationAndDocs:
 
         assert instance is not None
         assert instance.question.startswith(doc["prompt"] + "\n\n")
-        assert "[source title](url)" in instance.question or "[来源标题](url)" in instance.question
+        assert instance.question.endswith(DEEPRESEARCH_GENERATION_INSTRUCTIONS[doc["language"]])
         assert instance.metadata["id"] == doc["id"]
         assert instance.metadata["language"] == doc["language"]
         assert instance.metadata["topic"] == doc["topic"]
@@ -159,6 +161,230 @@ class TestRegistrationAndDocs:
     def test_think_strip_matches_researchqa_pattern(self, task):
         output = LMOutput(text="<think>private reasoning</think>\n\nFinal report.")
         assert task.extract_answer(output) == "Final report."
+
+    @pytest.mark.parametrize(
+        (
+            "language",
+            "bare_placeholder",
+            "citation_format",
+            "inline_citation",
+            "replacement_clause",
+        ),
+        [
+            (
+                "en",
+                "[source title]",
+                "[<the source's actual title>](<the source's actual URL>)",
+                "inline Markdown citation",
+                "Replace both placeholders with the real page title and URL",
+            ),
+            (
+                "zh",
+                "[来源标题]",
+                "[<来源的真实标题>](<来源的真实链接>)",
+                "行内 Markdown 引用",
+                "请将两个占位符替换为真实网页标题和链接",
+            ),
+        ],
+    )
+    def test_generation_instruction_uses_noncopyable_citation_placeholders(
+        self,
+        language,
+        bare_placeholder,
+        citation_format,
+        inline_citation,
+        replacement_clause,
+    ):
+        instruction = DEEPRESEARCH_GENERATION_INSTRUCTIONS[language]
+
+        assert instruction
+        assert bare_placeholder not in instruction
+        assert citation_format in instruction
+        assert inline_citation in instruction
+        assert replacement_clause in instruction
+        assert "](<" in instruction
+        assert re.search(r"https?://", instruction, flags=re.IGNORECASE) is None
+
+
+class TestGeneratedReportCleaning:
+    def test_dangling_nid_76_closing_tags_are_removed_and_report_survives(self, task):
+        report = (
+            "# Findings\n\nThe evidence supports the conclusion.\n"
+            "The final sources were MDPI and Healthline."
+        )
+        generated = f"{report}\n</parameter>\n</function>\n</tool_call>"
+
+        cleaned = task.extract_answer(LMOutput(text=generated))
+
+        assert cleaned == report
+        assert cleaned.endswith("The final sources were MDPI and Healthline.")
+        assert "<" not in cleaned
+
+    def test_channel_and_harmony_markers_are_removed_on_production_path(self, task):
+        report = "# Findings\n\nA legitimate report sentence."
+        generated = f"<|channel>thought\n<channel|>{report}<|im_end|>"
+
+        assert task.extract_answer(LMOutput(text=generated)) == report
+
+    def test_pure_gemma_channel_and_tool_call_scaffold_becomes_empty(self, task):
+        generated = "<|channel>thought<tool_call|>"
+
+        assert task.extract_answer(LMOutput(text=generated)) == ""
+
+    def test_complete_tool_call_wrapper_loses_markup_but_keeps_prose(self, task):
+        generated = '<tool_call name="write_report">\nA legitimate report sentence.\n</tool_call>'
+
+        assert task.extract_answer(LMOutput(text=generated)) == "A legitimate report sentence."
+
+    def test_complete_tool_response_wrapper_loses_markup_but_keeps_prose(self, task):
+        generated = "<tool_response>\nA sourced report sentence.\n</tool_response>"
+
+        assert task.extract_answer(LMOutput(text=generated)) == "A sourced report sentence."
+
+    @pytest.mark.parametrize("family", ["tool_call", "tool_response", "function", "parameter"])
+    @pytest.mark.parametrize("quote", ['"', "'"])
+    @pytest.mark.parametrize("value", ["write=report", "write report"])
+    def test_quoted_scaffold_attributes_accept_spaces_and_equals_on_production_path(
+        self, task, family, quote, value
+    ):
+        generated = f"<{family} name={quote}{value}{quote}>Final report.</{family}>"
+
+        assert task.extract_answer(LMOutput(text=generated)) == "Final report."
+
+    @pytest.mark.parametrize("value", ["write=report", "write report"])
+    def test_unquoted_scaffold_attributes_remain_identifier_shaped(self, task, value):
+        generated = f"<tool_call name={value}>Final report."
+
+        assert task.extract_answer(LMOutput(text=generated)) == generated
+
+    @pytest.mark.parametrize(
+        "generated",
+        [
+            '<tool_call name="write report>Visible prose > remains visible.',
+            "<tool_call name='write report>Visible prose > remains visible.",
+            '<tool_call name="write report\nVisible prose > remains visible.',
+            "<tool_call name='write report\nVisible prose > remains visible.",
+        ],
+    )
+    def test_unterminated_quoted_opener_cannot_cross_angle_or_newline(self, task, generated):
+        assert task.extract_answer(LMOutput(text=generated)) == generated
+
+    def test_double_quoted_scaffold_attribute_cannot_consume_quoted_prose(self, task):
+        generated = '<function name="a" and "b" > tail.'
+
+        assert task.extract_answer(LMOutput(text=generated)) == generated
+
+    def test_single_quoted_scaffold_attribute_cannot_consume_apostrophe_prose(self, task):
+        generated = "<function name='x' the model's output '> tail."
+
+        assert task.extract_answer(LMOutput(text=generated)) == generated
+
+    def test_function_opener_with_double_quoted_spaced_value_is_stripped(self, task):
+        generated = '<function name="write report">Final report.'
+
+        assert task.extract_answer(LMOutput(text=generated)) == "Final report."
+
+    def test_tool_call_opener_with_multiple_quoted_attributes_is_stripped(self, task):
+        generated = '<tool_call name="a b" id="c d">Final report.'
+
+        assert task.extract_answer(LMOutput(text=generated)) == "Final report."
+
+    @pytest.mark.parametrize(
+        "generated",
+        [
+            (
+                "<|start|>assistant<|channel|>analysis<|message|>Private reasoning."
+                "<|end|><|start|>assistant<|channel|>final<|message|>Final report."
+                "<|return|>"
+            ),
+            (
+                "<start|>assistant<|channel>thought<message|>Private reasoning."
+                "<end|><start|>assistant<|channel>final<message|>Final report.<return|>"
+            ),
+        ],
+    )
+    def test_reasoning_channel_content_is_dropped_when_final_channel_exists(self, task, generated):
+        assert task.extract_answer(LMOutput(text=generated)) == "Final report."
+
+    def test_report_content_before_first_channel_is_retained_with_final_content(self, task):
+        generated = (
+            "Report body comes first."
+            "<|channel|>analysis<|message|>Private reasoning."
+            "<|channel|>final<|message|>Final report."
+        )
+
+        assert task.extract_answer(LMOutput(text=generated)) == (
+            "Report body comes first. Final report."
+        )
+
+    def test_special_token_removal_separates_adjacent_words(self, task):
+        generated = "First<|im_end|>second"
+
+        assert task.extract_answer(LMOutput(text=generated)) == "First second"
+
+    def test_think_block_is_removed_before_scaffold_tags(self):
+        generated = (
+            "<think>private reasoning with <tool_call></think>\n"
+            "<tool_call><function=write_report><parameter=report>"
+            "Final report sentence.</parameter></function></tool_call>"
+        )
+
+        assert deepresearch_bench._clean_generated_report(generated) == ("Final report sentence.")
+
+    def test_text_without_tags_is_unchanged_modulo_strip(self):
+        report = "A plain report with no scaffold markup."
+
+        assert deepresearch_bench._clean_generated_report(f" \n{report}\n ") == report
+
+    def test_unpaired_bare_function_keyword_in_prose_is_preserved(self):
+        report = "C++ does not use the `<function>` keyword for function declarations."
+
+        assert deepresearch_bench._clean_generated_report(report) == report
+
+    @pytest.mark.parametrize(
+        "code",
+        [
+            "`<function>example</function>`",
+            '```xml\n<tool_call name="example">\n</tool_call>\n```',
+        ],
+    )
+    def test_scaffold_examples_in_markdown_code_are_preserved(self, code):
+        report = f"The documentation shows {code} as an example."
+
+        assert deepresearch_bench._clean_generated_report(report) == report
+
+    def test_paired_bare_function_tags_in_prose_lose_markup_but_keep_content(self):
+        report = "The prose uses <function>call</function> to discuss the wrapper."
+
+        assert deepresearch_bench._clean_generated_report(report) == (
+            "The prose uses call to discuss the wrapper."
+        )
+
+    def test_bare_parameter_pairing_crosses_preserved_inline_code_on_production_path(self, task):
+        generated = "<parameter>A report cites `x = <parameter>` verbatim.</parameter>"
+
+        assert task.extract_answer(LMOutput(text=generated)) == (
+            "A report cites `x = <parameter>` verbatim."
+        )
+
+    def test_malformed_opener_is_preserved_on_production_path(self, task):
+        generated = '<function name="write_report"\n# Findings\n\nThe report starts here.'
+
+        assert task.extract_answer(LMOutput(text=generated)) == generated
+
+    def test_malformed_opener_cannot_consume_prose_at_bare_greater_than(self, task):
+        generated = (
+            '<parameter name="report"\n'
+            "# Findings\n\nGlobal spending > 100 trillion dollars.\n"
+            "The result was not significant (p > 0.05)."
+        )
+
+        assert task.extract_answer(LMOutput(text=generated)) == generated
+
+    def test_large_bare_tag_sequence_is_cleaned_without_pairwise_lookahead(self):
+        generated = "<function>" * 10_000 + "report" + "</function>" * 10_000
+
+        assert deepresearch_bench._clean_generated_report(generated) == "report"
 
 
 class TestRaceScoring:
@@ -259,6 +485,13 @@ class TestFactHelpersAndMetrics:
         assert clean_citation_url(url) == "https://example.test/page"
         assert clean_urls(report) == "A claim [Example](https://example.test/page) follows."
         assert remove_urls(report) == "A claim [Example] follows."
+
+    def test_url_cleaning_removes_commonmark_autolink_brackets(self):
+        url = " <https://example.test/page#:~:text=quoted%20passage> "
+        report = f"A claim [Example]({url}) follows."
+
+        assert clean_citation_url(url) == "https://example.test/page"
+        assert clean_urls(report) == "A claim [Example](https://example.test/page) follows."
 
     def test_grouping_uses_cleaned_url(self):
         citations = [


### PR DESCRIPTION
Adds **DeepResearch Bench** ([arXiv 2506.11763](https://arxiv.org/abs/2506.11763), [official repo](https://github.com/Ayanami0730/deep_research_bench), Apache-2.0): 100 PhD-level deep-research tasks (50 en / 50 zh, 22 topics). The model writes a citation-rich research report with web tools; scoring applies both official frameworks:

- **RACE** (primary, `race_overall` + 4 dimension metrics): judge compares the report against the official reference article under the task's pre-generated weighted criteria (verbatim bilingual prompts; score math ported faithfully incl. fuzzy criterion matching and `target/(target+reference)` normalization). Judge default `gpt-5.5` at the official `score` stage effort (medium).
- **FACT** (`fact_citation_accuracy`, `fact_avg_citations`, `fact_avg_effective_citations`): extract (fact, url) pairs -> group/dedup -> scrape -> support judgment, with the official stat semantics (unknown excluded; averages divide by citation-bearing tasks). Judge default `gpt-5.4-mini` at the official `fact` stage effort (low). Both judges overridable via `OLMO_EVAL_JUDGE` (`model` or `model:effort`).

**Dataset**: `allenai/deepresearch-bench` (configs `default`/`en`/`zh`), built by `scripts/internal/build_deepresearch_bench_dataset.py` from the official repo at pinned commit `469cce5`; `deepresearch_bench:en` selects the English subset.

**Deviations from the official pipeline** (documented in the module docstring): crawl4ai scraping instead of Jina Reader; deterministic report sanitation instead of the optional LLM ArticleCleaner; judge override env; the report-generation instruction is ours (official leaves system prompting unspecified); unconditional `clean_urls` + fragment-normalized grouping; 3 judge attempts (official RACE uses 10) with zero-and-keep-in-denominator on final failure.

## Hardening from a real 200-instance audit

Auditing a full 4-model x 50-task campaign drove three follow-up commits:

- `8bdb828` — deterministic sanitizer for model scaffold in scored reports: gemma-4 channel markers appeared in 50/50 of its reports (three "reports" were nothing but markers yet were judged), and one Qwen report ended in dangling tool-call tags. Also made the citation instruction copy-resistant (models echoed the literal example anchor text) and `clean_citation_url` now accepts CommonMark angle-bracket destinations. Validated in both directions against all 200 generations: exactly the 51 scaffold-affected reports change (pure deletions, zero legitimate prose lost) and a post-clean token census finds no remaining scaffold.
- `9cf070e` — FACT robustness: malformed validation items (missing `idx`/`result`) retry then fall back to all-unknown instead of erroring the instance (the official pipeline crashes outright on that input), and an unexpected FACT failure zeroes only the FACT channels instead of discarding the instance's already-computed RACE scores.
- `786e4c0` — judge reasoning effort mirrors the official stage configuration (`score`→medium, `fact`→low, from the reference `utils/api.py`) unless an explicit `:effort` suffix overrides it; the FACT stage is ~90% of judging volume, so this also cuts scoring cost substantially.

**Tests**: 91 unit tests, incl. SHA-256 pins of all 8 official prompt constants, differential fixtures for the RACE math, official-semantics tests for dedup/validation fallback paths, FACT denominator tests, and production-path sanitizer regressions.

## Campaign results

`deepresearch_bench:en`, all 50 tasks, `web_search_agent_crawl4ai`, `OLMO_EVAL_JUDGE=gpt-5.6-luna`:

| model | n | RACE overall | FACT citation acc | citations / effective | tools per task |
|---|---|---|---|---|---|
| Qwen3.5-35B-A3B | 23/50* | 0.448 | 0.849 | 20.4 / 17.3 | 14 search + 18 fetch |
| Qwen3.5-9B | 50/50 | 0.422 | 0.778 | 25.9 / 20.1 | 17 search + 16 fetch |
| gemma-4-26B-A4B | 46/50* | 0.393 | 0.824 | 6.4 / 5.3 | 2 search + 1 fetch |
| Olmo-3-7B | 50/50 | 0.387 | 0.139 | 4.2 / 0.6 | 0 (memory-only) |

\*35B and gemma tails were cut short by a judge-API quota outage; affected instances are excluded (not zero-filled). All 200 generations are archived and re-scorable offline without GPUs or search credits.

The FACT axis is doing exactly what the benchmark intends: Olmo writes fluent reports (RACE within 0.05 of the Qwens) but invents citations — 0.6 verifiable citations per task vs 17-20 for the Qwens.

## Repro

```
pip install 'olmo-eval[crawl4ai]' && crawl4ai-setup
olmo-eval run -m Qwen/Qwen3.5-9B -H web_search_agent_crawl4ai \
  -o provider.max_model_len=65536 -t deepresearch_bench:en -o limit=10
```