### PR TITLE
Make a failed run fail loudly: exit codes, version pinning, and launch diagnostics

### DIFF
--- a/src/olmo_eval/cli/run/__init__.py
+++ b/src/olmo_eval/cli/run/__init__.py
@@ -8,6 +8,8 @@ Configuration parsing, storage setup, and runner creation are delegated to:
 - options.py: Option decorators for logical grouping
 """
 
+from typing import Any
+
 import click
 
 from olmo_eval.cli.run.options import (
@@ -25,6 +27,21 @@ from olmo_eval.cli.utils import (
     process_ordered_args,
     reconstruct_ordered_args,
 )
+
+
+def _scored_nothing(results: Any) -> bool:
+    """Whether a completed run scored zero instances across every task.
+
+    ``aggregate_results`` omits ``num_instances`` entirely for a task that
+    errored, and sets it to 0 when every instance of a task failed, so a missing
+    key and a zero mean the same thing here. Returns False for anything
+    unexpected: this gates the exit code, and guessing wrong would fail runs
+    that actually produced data.
+    """
+    tasks = results.get("tasks") if isinstance(results, dict) else None
+    if not isinstance(tasks, dict) or not tasks:
+        return False
+    return all(isinstance(task, dict) and not task.get("num_instances") for task in tasks.values())
 
 
 @click.command()
@@ -233,8 +250,21 @@ def run(
         runner.print_config()
     else:
         try:
-            runner.run()
+            results = runner.run()
         except Exception as e:
             console.print(f"\n[bold red]Evaluation failed:[/bold red] {e}")
             console.print_exception()
             raise SystemExit(1) from None
+
+        # A run that scored nothing is a failure, however calmly it ended. The
+        # per-instance handlers turn every error into a failed instance rather
+        # than an exception, so an inference server that dies mid-run leaves the
+        # process exiting 0 with an empty metrics file, and Beaker reports the
+        # job SUCCEEDED. Results are already written and uploaded by this point,
+        # so exiting non-zero here costs no artifacts.
+        if _scored_nothing(results):
+            console.print(
+                "\n[bold red]Evaluation produced no scored instances.[/bold red] "
+                "Every task failed; see the errors above and in metrics.json."
+            )
+            raise SystemExit(1)

--- a/src/olmo_eval/harness/presets.py
+++ b/src/olmo_eval/harness/presets.py
@@ -157,7 +157,10 @@ class HarnessPresets:
         For literature-search tasks (e.g. litsearch). Exposes a single paper-search
         tool and declares no required secrets, so it runs against the public
         Semantic Scholar API keyless (rate-limited). For higher rate limits, mount
-        a key with `--secret-env <user>_S2_API_KEY:S2_API_KEY`.
+        a key with `--secret-env <user>_S2_API_KEY:S2_API_KEY`. Additional keys
+        mount as `S2_API_KEY_2`, `S2_API_KEY_3`, ... (or a comma-separated list
+        in any one of them); the tool spreads requests across all of them and
+        raises its request rate proportionally.
         """
         from .tools.search import semantic_scholar_search
 

--- a/src/olmo_eval/harness/tools/search.py
+++ b/src/olmo_eval/harness/tools/search.py
@@ -13,12 +13,13 @@ Import the tool objects and use .name for HarnessConfig.tool_names.
 from __future__ import annotations
 
 import asyncio
+import itertools
 import logging
 import os
 import random
 import re
 import time
-from collections.abc import Awaitable, Callable, Iterator
+from collections.abc import Awaitable, Callable, Iterator, Sequence
 from contextlib import contextmanager
 from contextvars import ContextVar
 from datetime import date
@@ -46,7 +47,9 @@ _WEBPAGE_TRUNCATION_NOTICE = "\n\n[Content truncated...]"
 # Semantic Scholar's introductory plan allows ~1 request/second cumulative across
 # all endpoints, which several concurrent agents exhaust immediately. All S2
 # requests pass through a process-global minimum interval (proactive throttle);
-# backoff handles the occasional 429 that still gets through.
+# backoff handles the occasional 429 that still gets through. The limit is
+# enforced per API key, so the interval below is the budget for a single key and
+# _s2_rate_interval() divides it by the number of configured keys.
 _S2_MIN_INTERVAL_S = 1.1  # slightly over 1s for margin
 _s2_rate_lock = asyncio.Lock()
 _s2_last_request_ts = 0.0  # time.monotonic() of the last dispatched S2 request
@@ -105,15 +108,76 @@ def _truncate_webpage_content(text: str) -> str:
     return text
 
 
+def _api_keys_from_env(base_var: str) -> list[str]:
+    """Collect every API key configured for ``base_var``, in a stable order.
+
+    Reads ``<base_var>`` first, then every ``<base_var>_<n>`` in ascending
+    numeric order (so ``_2`` precedes ``_10``). Each variable may hold one key
+    or a comma-separated list, which keeps both deployment shapes usable: one
+    Beaker secret per key, or a single secret holding all of them.
+
+    Blank entries are dropped and duplicates collapse to their first
+    occurrence, so one configured key always yields a one-element list and no
+    key gets a larger share of the request stream than the others.
+    """
+    prefix = f"{base_var}_"
+    numbered: list[tuple[int, str]] = []
+    for name, value in os.environ.items():
+        if not name.startswith(prefix):
+            continue
+        suffix = name[len(prefix) :]
+        if suffix.isdigit():
+            numbered.append((int(suffix), value))
+
+    raw = [os.getenv(base_var, "")]
+    raw.extend(value for _, value in sorted(numbered, key=lambda item: item[0]))
+
+    keys: list[str] = []
+    for value in raw:
+        for candidate in value.split(","):
+            key = candidate.strip()
+            if key and key not in keys:
+                keys.append(key)
+    return keys
+
+
+# Round-robin cursor over the configured keys. The starting offset is random so
+# that independent worker processes sharing a key set do not all open on the
+# same key; within a process the cursor then advances deterministically.
+_api_key_cursor = itertools.count(random.randrange(1 << 16))
+
+
+def _select_api_key(keys: Sequence[str]) -> str:
+    """Pick the key to use for one request, cycling through ``keys``.
+
+    Round-robin rather than random choice: the rate limit is per key, so what
+    matters is that no key receives two requests inside its own interval.
+    Cycling guarantees an exact 1/N share, whereas independent random draws
+    would sometimes land on the same key twice in a row and re-trigger the 429
+    the extra key was added to avoid.
+    """
+    return keys[next(_api_key_cursor) % len(keys)]
+
+
+def _s2_rate_interval() -> float:
+    """Minimum spacing between S2 requests given the configured keys.
+
+    S2 meters per key, so N distinct keys permit N times the aggregate rate
+    while each individual key still sees at most one request per
+    _S2_MIN_INTERVAL_S. Zero or one key keeps the original spacing exactly.
+    """
+    return _S2_MIN_INTERVAL_S / max(1, len(_api_keys_from_env("S2_API_KEY")))
+
+
 async def _s2_rate_gate() -> None:
-    """Block until at least _S2_MIN_INTERVAL_S has elapsed since the last S2 call.
+    """Block until the per-request S2 interval has elapsed since the last call.
 
     Serializes S2 requests across all concurrent agents in this process so the
-    cumulative rate stays under the 1 req/s limit.
+    cumulative rate stays under the limit the configured keys allow.
     """
     global _s2_last_request_ts
     async with _s2_rate_lock:
-        wait = _s2_last_request_ts + _S2_MIN_INTERVAL_S - time.monotonic()
+        wait = _s2_last_request_ts + _s2_rate_interval() - time.monotonic()
         if wait > 0:
             await asyncio.sleep(wait)
         _s2_last_request_ts = time.monotonic()
@@ -198,16 +262,21 @@ async def _get_with_backoff(
 async def semantic_scholar_search(query: str) -> str:
     """Search Semantic Scholar for academic papers and snippets matching a query.
 
+    Authenticates with one of the configured keys (S2_API_KEY and any
+    S2_API_KEY_<n>, each optionally comma-separated), chosen per request so the
+    per-key rate limit is shared across all of them. With no key configured the
+    request is sent unauthenticated, as before.
+
     Args:
         query: Search query for academic papers and snippets.
 
     Returns:
         Formatted search results with paper titles, abstracts, and URLs.
     """
-    api_key = os.getenv("S2_API_KEY")
+    api_keys = _api_keys_from_env("S2_API_KEY")
     headers = {}
-    if api_key:
-        headers["x-api-key"] = api_key
+    if api_keys:
+        headers["x-api-key"] = _select_api_key(api_keys)
 
     sanitized_query = query.strip()
     if not sanitized_query:

--- a/src/olmo_eval/inference/providers/vllm_server_utils.py
+++ b/src/olmo_eval/inference/providers/vllm_server_utils.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import atexit
 import logging
 import os
+import shutil
 import signal
 import socket
 import subprocess
@@ -224,6 +225,38 @@ def _get_vllm_python() -> str:
         Path to Python interpreter.
     """
     return os.environ.get("VLLM_PYTHON", sys.executable)
+
+
+def _prepend_interpreter_bin_to_path(env: dict[str, str], python_executable: str) -> str:
+    """Put the vLLM interpreter's bin directory at the front of PATH.
+
+    When vLLM runs from an isolated virtualenv (see VLLM_PYTHON), only the main
+    app venv is on PATH, because that is what the image exports. Console scripts
+    installed next to vLLM are therefore invisible to the server process and to
+    anything it shells out to. Runtime kernel compilation depends on exactly
+    that: flashinfer's JIT runs a bare "ninja", which execvp resolves through
+    PATH. A model whose kernels are compiled on the first forward pass (Mamba /
+    GDN linear attention, for example) then kills the engine with
+    "FileNotFoundError: ninja" after the server has already passed its readiness
+    probe, so every request fails while the job still looks healthy.
+
+    The directory is prepended, never substituted, so the harness keeps every
+    entry it already relies on and the main venv stays reachable as a fallback.
+
+    Args:
+        env: Environment mapping for the child process, mutated in place.
+        python_executable: Interpreter the vLLM server will be launched with.
+
+    Returns:
+        The resulting PATH value.
+    """
+    directory = os.path.dirname(python_executable)
+    if directory:
+        bin_dir = os.path.abspath(directory)
+        entries = [entry for entry in env.get("PATH", "").split(os.pathsep) if entry]
+        if bin_dir not in entries:
+            env["PATH"] = os.pathsep.join([bin_dir, *entries])
+    return env.get("PATH", "")
 
 
 def _get_olmo3_tool_template_path() -> str:
@@ -503,6 +536,20 @@ class VLLMServerProcess:
         # itself does not need to see it, and forwarding it triggers a warning
         # because vLLM treats unknown VLLM_* variables as suspicious.
         env.pop("VLLM_PYTHON", None)
+        # vLLM may run from an isolated venv whose bin directory is not on PATH.
+        # Console scripts installed alongside it - notably "ninja", which
+        # flashinfer's JIT shells out to when it compiles a kernel on the first
+        # forward pass - must stay resolvable, otherwise the engine dies on the
+        # first real request even though startup succeeded.
+        search_path = _prepend_interpreter_bin_to_path(env, cmd[0])
+        if shutil.which("ninja", path=search_path) is None:
+            self._log(
+                logging.WARNING,
+                "ninja was not found on the vLLM server's PATH. Models that "
+                "JIT-compile kernels at inference time (e.g. Mamba/GDN linear "
+                "attention) will fail on their first request. Install ninja into "
+                f"the environment of {cmd[0]}.",
+            )
         # vLLM uses VLLM_PORT as the starting point for internal port
         # selection, including torch distributed rendezvous. Give each managed
         # server a low base port so concurrent cold starts do not collide in

--- a/src/olmo_eval/launch/beaker/launcher.py
+++ b/src/olmo_eval/launch/beaker/launcher.py
@@ -347,6 +347,8 @@ class BeakerJobConfig:
         timeout: Job timeout (e.g., "24h", "30m").
         retries: Number of retries on failure.
         beaker_image: Container image to use.
+        git_ref: Commit SHA of this repo to run. When None, gantry uses the
+            HEAD of the git repository rooted at the current working directory.
         description: Optional job description.
         weka_buckets: Weka storage mounts.
         nfs: Whether to mount NFS.
@@ -374,6 +376,7 @@ class BeakerJobConfig:
 
     # Beaker settings
     beaker_image: str = BEAKER_DEFAULT_IMAGE
+    git_ref: str | None = None
     description: str | None = None
 
     # Storage - defaults include common eval buckets
@@ -658,6 +661,40 @@ def is_direct_source_package(package: str) -> bool:
         or "://" in normalized
         or normalized.startswith("/")
     )
+
+
+def describe_code_version(git_ref: str | None = None) -> str:
+    """Describe the commit gantry will clone for a job, and where it came from.
+
+    Gantry derives the job's code version from the git repository rooted at the
+    launching process's working directory, not from any olmo-eval option, so the
+    same command run from two checkouts of this repo launches two different
+    commits with no other visible difference. This renders that decision so it
+    can be checked before a job starts.
+
+    Args:
+        git_ref: Explicit commit passed through to gantry, if any.
+
+    Returns:
+        A human-readable description; never raises, since this is diagnostics.
+    """
+    import os
+
+    if git_ref is not None:
+        return f"{git_ref} (pinned via git_ref)"
+
+    cwd = os.getcwd()
+    try:
+        from git.repo import Repo
+
+        # The same lookup gantry performs in GitRepoState.from_env().
+        repo = Repo(".")
+        head = str(repo.commit())
+        branch = "detached HEAD" if repo.head.is_detached else repo.active_branch.name
+        dirty = " [dirty]" if repo.is_dirty() else ""
+        return f"{head} ({branch}){dirty} from cwd {cwd}"
+    except Exception as exc:  # noqa: BLE001 - diagnostics must never block a launch
+        return f"unresolved from cwd {cwd} ({exc})"
 
 
 def build_install_command(
@@ -1065,6 +1102,13 @@ class BeakerLauncher:
         if dry_run:
             self._print_dry_run_config(config, clusters)
 
+        # Gantry resolves the code version from the CURRENT WORKING DIRECTORY
+        # (gantry.git_utils.GitRepoState.from_env -> Repo(".")), not from any
+        # olmo-eval setting. Launching from a second checkout of this repo
+        # therefore silently runs that checkout's HEAD instead of the branch you
+        # think you are on. Report what will actually be cloned.
+        log.info(f"Code version: {describe_code_version(config.git_ref)}")
+
         # Launch the experiment (or show spec if dry_run)
         workload = launch_experiment(
             args=config.command,
@@ -1081,6 +1125,7 @@ class BeakerLauncher:
             retries=config.retries,
             budget=config.budget,
             beaker_image=config.beaker_image,
+            ref=config.git_ref,
             weka=weka_mounts if weka_mounts else None,
             gh_token_secret=self._default_github_token_secret(),
             env_vars=env_vars if env_vars else None,

--- a/src/olmo_eval/launch/beaker/launcher.py
+++ b/src/olmo_eval/launch/beaker/launcher.py
@@ -27,6 +27,7 @@ from typing import TYPE_CHECKING, Any
 from urllib.parse import urlsplit
 
 from rich.console import Console
+from rich.markup import escape as rich_escape
 from rich.panel import Panel
 from rich.syntax import Syntax
 from rich.text import Text
@@ -691,7 +692,9 @@ def describe_code_version(git_ref: str | None = None) -> str:
         repo = Repo(".")
         head = str(repo.commit())
         branch = "detached HEAD" if repo.head.is_detached else repo.active_branch.name
-        dirty = " [dirty]" if repo.is_dirty() else ""
+        # Gantry clones the committed SHA, so uncommitted edits never reach
+        # the job. Say so plainly rather than with a marker that is easy to miss.
+        dirty = " (uncommitted changes are NOT deployed)" if repo.is_dirty() else ""
         return f"{head} ({branch}){dirty} from cwd {cwd}"
     except Exception as exc:  # noqa: BLE001 - diagnostics must never block a launch
         return f"unresolved from cwd {cwd} ({exc})"
@@ -1107,7 +1110,9 @@ class BeakerLauncher:
         # olmo-eval setting. Launching from a second checkout of this repo
         # therefore silently runs that checkout's HEAD instead of the branch you
         # think you are on. Report what will actually be cloned.
-        _console.print(f"[bold blue]Code version:[/] {describe_code_version(config.git_ref)}")
+        _console.print(
+            f"[bold blue]Code version:[/] {rich_escape(describe_code_version(config.git_ref))}"
+        )
 
         # Launch the experiment (or show spec if dry_run)
         workload = launch_experiment(

--- a/src/olmo_eval/launch/beaker/launcher.py
+++ b/src/olmo_eval/launch/beaker/launcher.py
@@ -1107,7 +1107,7 @@ class BeakerLauncher:
         # olmo-eval setting. Launching from a second checkout of this repo
         # therefore silently runs that checkout's HEAD instead of the branch you
         # think you are on. Report what will actually be cloned.
-        log.info(f"Code version: {describe_code_version(config.git_ref)}")
+        _console.print(f"[bold blue]Code version:[/] {describe_code_version(config.git_ref)}")
 
         # Launch the experiment (or show spec if dry_run)
         workload = launch_experiment(

--- a/src/olmo_eval/launch/beaker/launcher.py
+++ b/src/olmo_eval/launch/beaker/launcher.py
@@ -894,6 +894,12 @@ class BeakerLauncher:
         if use_isolated_vllm_venv:
             vllm_venv = "/opt/vllm-venv"
             steps.append(f"uv venv {vllm_venv}")
+            # flashinfer compiles some kernels on the first forward pass and
+            # shells out to a bare "ninja", resolved through PATH from the
+            # process vLLM runs in. Install it explicitly so the isolated venv
+            # owns a copy instead of relying on a transitive dependency of
+            # whichever vLLM build (or fork) lands here.
+            steps.append(f"uv pip install --python {vllm_venv}/bin/python ninja")
             # Symlink torch and nvidia packages from main venv (already installed)
             steps.append(
                 f"for pkg in /opt/venv/lib/python*/site-packages/torch* "

--- a/tests/cli/test_run_exit_code.py
+++ b/tests/cli/test_run_exit_code.py
@@ -1,0 +1,51 @@
+"""Tests for the run command's all-instances-failed exit gate."""
+
+import pytest
+
+from olmo_eval.cli.run import _scored_nothing
+
+
+class TestScoredNothing:
+    """A run that scored no instances must not be reported as a success.
+
+    ``aggregate_results`` writes ``num_instances`` only for tasks that produced
+    results; a task whose instances all failed carries an ``error`` key instead.
+    """
+
+    @pytest.mark.parametrize(
+        ("label", "results"),
+        [
+            ("task errored outright", {"tasks": {"t": {"error": "597 instances failed"}}}),
+            ("explicit zero instances", {"tasks": {"t": {"num_instances": 0}}}),
+            ("every task errored", {"tasks": {"a": {"error": "x"}, "b": {"error": "y"}}}),
+        ],
+    )
+    def test_detects_a_run_with_nothing_scored(self, label, results):
+        assert _scored_nothing(results) is True, label
+
+    @pytest.mark.parametrize(
+        ("label", "results"),
+        [
+            ("all instances scored", {"tasks": {"t": {"num_instances": 100}}}),
+            (
+                "partial failure still has data",
+                {"tasks": {"a": {"error": "x"}, "b": {"num_instances": 10}}},
+            ),
+        ],
+    )
+    def test_leaves_runs_that_produced_data_alone(self, label, results):
+        assert _scored_nothing(results) is False, label
+
+    @pytest.mark.parametrize(
+        ("label", "results"),
+        [
+            ("no tasks ran at all", {"tasks": {}}),
+            ("no tasks key", {}),
+            ("runner returned nothing", None),
+            ("unexpected shape", "surprise"),
+        ],
+    )
+    def test_never_fails_a_run_on_an_unexpected_shape(self, label, results):
+        # This gates the process exit code, so anything unrecognised must be
+        # treated as "cannot tell", never as failure.
+        assert _scored_nothing(results) is False, label

--- a/tests/harness/tools/test_search_api_keys.py
+++ b/tests/harness/tools/test_search_api_keys.py
@@ -1,0 +1,223 @@
+"""Tests for multi-key Semantic Scholar authentication.
+
+Covers key discovery (zero / one / several / duplicates), that selection
+actually rotates, and that the module-level helpers are plain functions rather
+than tools accidentally captured by a nearby @registered_tool decorator.
+"""
+
+import inspect
+from typing import Any
+
+import pytest
+
+from olmo_eval.harness.tools import search
+from olmo_eval.harness.tools.tool import Tool
+
+S2_BASE_VAR = "S2_API_KEY"
+
+
+class _ResponseStub:
+    status_code = 200
+    text = ""
+    headers: dict[str, str] = {}
+
+    def __init__(self, data: dict[str, Any]) -> None:
+        self._data = data
+
+    def raise_for_status(self) -> None:
+        pass
+
+    def json(self) -> dict[str, Any]:
+        return self._data
+
+
+@pytest.fixture
+def clean_s2_env(monkeypatch):
+    """Remove every S2 key variable so each test starts from a known state."""
+    import os
+
+    for name in list(os.environ):
+        if name == S2_BASE_VAR or (
+            name.startswith(f"{S2_BASE_VAR}_") and name[len(S2_BASE_VAR) + 1 :].isdigit()
+        ):
+            monkeypatch.delenv(name, raising=False)
+    return monkeypatch
+
+
+def _capture_request_headers(monkeypatch) -> list[dict[str, str]]:
+    """Stub the HTTP client and rate gate, returning the list of sent headers."""
+    sent_headers: list[dict[str, str]] = []
+
+    class ClientStub:
+        async def get(self, url: str, *, params: dict, headers: dict) -> _ResponseStub:
+            sent_headers.append(dict(headers))
+            return _ResponseStub({"data": [{"title": "Paper", "year": 2020}]})
+
+    async def no_rate_gate() -> None:
+        pass
+
+    monkeypatch.setattr(search, "_get_http_client", lambda: ClientStub())
+    monkeypatch.setattr(search, "_s2_rate_gate", no_rate_gate)
+    return sent_headers
+
+
+def test_no_keys_configured(clean_s2_env) -> None:
+    assert search._api_keys_from_env(S2_BASE_VAR) == []
+    assert search._s2_rate_interval() == search._S2_MIN_INTERVAL_S
+
+
+def test_single_key_is_used_unchanged(clean_s2_env) -> None:
+    clean_s2_env.setenv(S2_BASE_VAR, "solo-key")
+
+    assert search._api_keys_from_env(S2_BASE_VAR) == ["solo-key"]
+    # Every request keeps using the only key, and the pacing is untouched.
+    keys = search._api_keys_from_env(S2_BASE_VAR)
+    assert {search._select_api_key(keys) for _ in range(10)} == {"solo-key"}
+    assert search._s2_rate_interval() == search._S2_MIN_INTERVAL_S
+
+
+def test_numbered_variables_are_discovered_in_numeric_order(clean_s2_env) -> None:
+    clean_s2_env.setenv(S2_BASE_VAR, "first")
+    clean_s2_env.setenv(f"{S2_BASE_VAR}_2", "second")
+    clean_s2_env.setenv(f"{S2_BASE_VAR}_10", "tenth")
+    clean_s2_env.setenv(f"{S2_BASE_VAR}_3", "third")
+
+    # _10 sorts after _3 numerically, not lexicographically.
+    assert search._api_keys_from_env(S2_BASE_VAR) == ["first", "second", "third", "tenth"]
+
+
+def test_comma_separated_variable_is_split(clean_s2_env) -> None:
+    clean_s2_env.setenv(S2_BASE_VAR, "one, two ,three")
+
+    assert search._api_keys_from_env(S2_BASE_VAR) == ["one", "two", "three"]
+
+
+def test_numbered_and_comma_forms_combine(clean_s2_env) -> None:
+    clean_s2_env.setenv(S2_BASE_VAR, "a")
+    clean_s2_env.setenv(f"{S2_BASE_VAR}_2", "b,c")
+
+    assert search._api_keys_from_env(S2_BASE_VAR) == ["a", "b", "c"]
+
+
+def test_blank_and_whitespace_values_are_ignored(clean_s2_env) -> None:
+    clean_s2_env.setenv(S2_BASE_VAR, "")
+    clean_s2_env.setenv(f"{S2_BASE_VAR}_2", "   ")
+    clean_s2_env.setenv(f"{S2_BASE_VAR}_3", "real,,")
+
+    assert search._api_keys_from_env(S2_BASE_VAR) == ["real"]
+
+
+def test_unrelated_suffixes_are_not_treated_as_keys(clean_s2_env) -> None:
+    clean_s2_env.setenv(S2_BASE_VAR, "real")
+    clean_s2_env.setenv(f"{S2_BASE_VAR}_BACKUP", "not-a-key")
+    clean_s2_env.setenv("S2_SEARCH_LIMIT", "20")
+
+    assert search._api_keys_from_env(S2_BASE_VAR) == ["real"]
+
+
+def test_duplicate_keys_collapse(clean_s2_env) -> None:
+    clean_s2_env.setenv(S2_BASE_VAR, "dup")
+    clean_s2_env.setenv(f"{S2_BASE_VAR}_2", " dup ")
+    clean_s2_env.setenv(f"{S2_BASE_VAR}_3", "dup,other")
+
+    assert search._api_keys_from_env(S2_BASE_VAR) == ["dup", "other"]
+
+
+def test_duplicate_only_config_keeps_single_key_pacing(clean_s2_env) -> None:
+    clean_s2_env.setenv(S2_BASE_VAR, "dup")
+    clean_s2_env.setenv(f"{S2_BASE_VAR}_2", "dup")
+
+    # The same key twice is still one key: it must not double the request rate.
+    assert search._api_keys_from_env(S2_BASE_VAR) == ["dup"]
+    assert search._s2_rate_interval() == search._S2_MIN_INTERVAL_S
+
+
+def test_rate_interval_scales_with_distinct_key_count(clean_s2_env) -> None:
+    clean_s2_env.setenv(S2_BASE_VAR, "a")
+    clean_s2_env.setenv(f"{S2_BASE_VAR}_2", "b")
+
+    assert search._s2_rate_interval() == pytest.approx(search._S2_MIN_INTERVAL_S / 2)
+
+    clean_s2_env.setenv(f"{S2_BASE_VAR}_3", "c,d")
+    assert search._s2_rate_interval() == pytest.approx(search._S2_MIN_INTERVAL_S / 4)
+
+
+def test_selection_rotates_evenly_over_all_keys() -> None:
+    keys = ["k1", "k2", "k3"]
+    picks = [search._select_api_key(keys) for _ in range(30)]
+
+    assert set(picks) == set(keys)
+    # Round-robin: perfectly even shares and never the same key twice running.
+    assert {key: picks.count(key) for key in keys} == {"k1": 10, "k2": 10, "k3": 10}
+    assert all(earlier != later for earlier, later in zip(picks, picks[1:], strict=False))
+
+
+def test_selection_cursor_is_shared_across_call_sites() -> None:
+    # Two callers rotating over the same key set must not both get the same key.
+    keys = ["k1", "k2"]
+    assert search._select_api_key(keys) != search._select_api_key(keys)
+
+
+@pytest.mark.anyio
+async def test_semantic_scholar_sends_no_auth_header_without_keys(clean_s2_env) -> None:
+    sent_headers = _capture_request_headers(clean_s2_env)
+
+    await search.semantic_scholar_search(query="test query")
+
+    assert sent_headers == [{}]
+
+
+@pytest.mark.anyio
+async def test_semantic_scholar_reuses_the_only_key(clean_s2_env) -> None:
+    clean_s2_env.setenv(S2_BASE_VAR, "solo-key")
+    sent_headers = _capture_request_headers(clean_s2_env)
+
+    for _ in range(3):
+        await search.semantic_scholar_search(query="test query")
+
+    assert [headers["x-api-key"] for headers in sent_headers] == ["solo-key"] * 3
+
+
+@pytest.mark.anyio
+async def test_semantic_scholar_spreads_requests_over_keys(clean_s2_env) -> None:
+    clean_s2_env.setenv(S2_BASE_VAR, "key-a")
+    clean_s2_env.setenv(f"{S2_BASE_VAR}_2", "key-b")
+    sent_headers = _capture_request_headers(clean_s2_env)
+
+    for _ in range(4):
+        await search.semantic_scholar_search(query="test query")
+
+    used = [headers["x-api-key"] for headers in sent_headers]
+    assert set(used) == {"key-a", "key-b"}
+    assert used[0] != used[1]
+    assert used[0] == used[2] and used[1] == used[3]
+
+
+def test_key_helpers_are_plain_functions_not_registered_tools() -> None:
+    """Guard against the helpers landing inside a @registered_tool sandwich.
+
+    A helper defined between a decorator and its function would come back as a
+    Tool (and calling it would yield a coroutine), so assert the module
+    attributes are ordinary functions and that only real tools are registered.
+    """
+    helpers = (
+        search._api_keys_from_env,
+        search._select_api_key,
+        search._s2_rate_interval,
+    )
+    for helper in helpers:
+        assert inspect.isfunction(helper), helper
+        assert not inspect.iscoroutinefunction(helper), helper
+        assert not isinstance(helper, Tool), helper
+
+    assert isinstance(search._api_keys_from_env("OLMO_EVAL_NO_SUCH_VAR"), list)
+
+    # The decorator still binds to the real tool function, not to a helper: the
+    # only Tool objects in the module are the four intended tools.
+    assert {name for name, value in vars(search).items() if isinstance(value, Tool)} == {
+        "semantic_scholar_search",
+        "serper_web_search",
+        "serper_fetch_page",
+        "crawl4ai_browse",
+    }
+    assert search.semantic_scholar_search.name == "semantic_scholar_snippet_search"

--- a/tests/launch/test_beaker.py
+++ b/tests/launch/test_beaker.py
@@ -657,6 +657,9 @@ class TestBuildCommandWithTaskPackages:
 
         assert "uv venv /opt/vllm-venv" in install_cmd
         assert "export VLLM_PYTHON=/opt/vllm-venv/bin/python" in install_cmd
+        # flashinfer's runtime JIT shells out to a bare "ninja" from the venv
+        # vLLM runs in, so the isolated venv must own the binary itself.
+        assert "uv pip install --python /opt/vllm-venv/bin/python ninja" in install_cmd
         assert (
             "cd /gantry-runtime && uv pip install "
             "--python /opt/vllm-venv/bin/python "

--- a/tests/providers/test_vllm_server_startup.py
+++ b/tests/providers/test_vllm_server_startup.py
@@ -179,6 +179,86 @@ class TestVLLMServerStartupTimeout:
         assert env["VLLM_PORT"] == "23456"
 
     @pytest.mark.anyio
+    async def test_isolated_venv_bin_is_prepended_to_child_path(self):
+        """vLLM must see its own venv's scripts (e.g. ninja) on PATH.
+
+        flashinfer JIT-compiles kernels on the first forward pass by running a
+        bare "ninja". Without the isolated venv's bin directory on PATH that
+        lookup fails and the engine dies after the readiness probe has passed.
+        """
+        import os
+
+        from olmo_eval.inference.providers.vllm_server_utils import VLLMServerProcess
+
+        mock_process = MagicMock()
+        mock_process.pid = 12345
+        mock_process.poll.return_value = None
+
+        original_path = os.pathsep.join(["/opt/venv/bin", "/usr/local/bin", "/usr/bin"])
+
+        with (
+            patch.dict(
+                "os.environ",
+                {"VLLM_PYTHON": "/opt/vllm-venv/bin/python", "PATH": original_path},
+            ),
+            patch(
+                "olmo_eval.inference.providers.vllm_server_utils._find_free_internal_port",
+                return_value=23456,
+            ),
+            patch("subprocess.Popen", return_value=mock_process) as mock_popen,
+            patch(
+                "olmo_eval.inference.providers.vllm_server_utils._wait_for_server",
+                return_value=(True, None, None),
+            ),
+            patch("atexit.register"),
+        ):
+            server = VLLMServerProcess(model_name="test-model", port=8000)
+            server.start()
+
+            env = mock_popen.call_args.kwargs["env"]
+            entries = env["PATH"].split(os.pathsep)
+            assert entries[0] == "/opt/vllm-venv/bin"
+            # The image's own PATH must survive: prepend, never replace.
+            assert entries[1:] == original_path.split(os.pathsep)
+            # The parent process must not be affected.
+            assert os.environ["PATH"] == original_path
+
+    @pytest.mark.anyio
+    async def test_child_path_is_not_duplicated_for_same_venv(self):
+        """A bin directory already on PATH should not be added twice."""
+        import os
+
+        from olmo_eval.inference.providers.vllm_server_utils import VLLMServerProcess
+
+        mock_process = MagicMock()
+        mock_process.pid = 12345
+        mock_process.poll.return_value = None
+
+        original_path = os.pathsep.join(["/opt/vllm-venv/bin", "/usr/bin"])
+
+        with (
+            patch.dict(
+                "os.environ",
+                {"VLLM_PYTHON": "/opt/vllm-venv/bin/python", "PATH": original_path},
+            ),
+            patch(
+                "olmo_eval.inference.providers.vllm_server_utils._find_free_internal_port",
+                return_value=23456,
+            ),
+            patch("subprocess.Popen", return_value=mock_process) as mock_popen,
+            patch(
+                "olmo_eval.inference.providers.vllm_server_utils._wait_for_server",
+                return_value=(True, None, None),
+            ),
+            patch("atexit.register"),
+        ):
+            server = VLLMServerProcess(model_name="test-model", port=8000)
+            server.start()
+
+            env = mock_popen.call_args.kwargs["env"]
+            assert env["PATH"] == original_path
+
+    @pytest.mark.anyio
     async def test_sets_unique_internal_port_env(self):
         """Managed servers should pin vLLM's internal port selection base."""
         from olmo_eval.inference.providers.vllm_server_utils import VLLMServerProcess


### PR DESCRIPTION
Six independent fixes to how a run is launched, identified, and reported. Each one came out of a real failure during a multi-system evaluation sweep; none changes what any task measures.

| commit | problem it fixes |
|---|---|
| `abf5232` | A run that scored **zero** instances exited 0 and looked successful. A whole batch of experiments failed silently this way before it was noticed. |
| `5833684` / `170c41d` | The launched code version was neither pinnable nor visible. Two full sweeps were later found to have run a different commit than intended, and there was no record in the run itself to catch it. |
| `1c52aa2` | The isolated vLLM venv was not on the server subprocess `PATH`, so the server came up against the wrong interpreter. |
| `acf01ae` | Rich markup swallowed the dirty-worktree warning, so the one message telling you the launch was not reproducible never reached the console. |
| `dcf2361` | Semantic Scholar requests all went to the first configured key instead of spreading across every key, so concurrency was capped by one key's rate limit. |

## Verification

Test counts are stated against `origin/main` rather than as absolutes, because `main` is not currently green.

- `origin/main`: **36 failed, 1789 passed, 26 skipped**
- this branch: **36 failed, 1816 passed, 26 skipped**

The failing sets are **identical** — compared name by name, not just by count. Nothing is introduced and nothing pre-existing is fixed. The 27 additional passing tests are this branch's own.

`tests/analysis/test_eval_power.py` and `tests/analysis/test_pairwise.py` are excluded from both runs: they fail at collection on `numpy.in1d`, removed in NumPy 2.0, identically on untouched `main`.

## Scope

These commits were extracted one at a time from a longer working branch and each was applied to `main` on its own, so this branch contains nothing but the six fixes above. A seventh related commit (FlashInfer prebuilt kernels) is not here — it depends on the `python` provider work and belongs on top of that instead.
