### PR TITLE
Build the ResearchQA prompt from the harness's real tool list

### DIFF
--- a/src/olmo_eval/evals/tasks/common/base.py
+++ b/src/olmo_eval/evals/tasks/common/base.py
@@ -165,6 +165,12 @@ class TaskConfig:
     #: beaker launcher mounts each as the user-scoped secret ``{user}_{NAME}``.
     required_secrets: tuple[str, ...] = ()
 
+    #: Tool names the configured harness actually exposes to the agent, empty when
+    #: it exposes none. The runner fills this in from the harness config so a task
+    #: whose prompt names tools can describe what is really callable instead of a
+    #: hardcoded list.
+    harness_tool_names: tuple[str, ...] = ()
+
     def __post_init__(self) -> None:
         """Validate scheduler-only sandbox allocation hints."""
         if isinstance(self.output_score_aggregation, str):

--- a/src/olmo_eval/evals/tasks/researchqa.py
+++ b/src/olmo_eval/evals/tasks/researchqa.py
@@ -67,25 +67,72 @@ RESEARCHQA_LABEL_SCORES = {
     "Completely": 5,
 }
 
-RESEARCHQA_GENERATION_PROMPT = (
-    "You are answering a scholarly research question. Use the available research tools "
-    "to find reliable sources that support your answer.\n\n"
-    "Available tools:\n"
-    "- semantic_scholar_snippet_search\n"
-    "- serper_google_webpage_search\n"
-    "- serper_fetch_webpage_content\n\n"
-    "Format and length requirements:\n"
-    "- Write a well-organized, citation-supported answer in about 250 words.\n"
-    "- Synthesize the evidence directly around the question and cite the sources you use.\n\n"
-    "{date_cutoff}"
-    "Workflow (follow this order):\n"
-    "1. Search for relevant scholarly sources using semantic_scholar_snippet_search and "
-    "serper_google_webpage_search.\n"
-    "2. Fetch and read promising source content using serper_fetch_webpage_content.\n"
-    "3. Only after searching, fetching, and reading, write the answer.\n"
-    "Search first, then fetch and read, and only then answer. Do not answer from memory.\n\n"
-    "Question: "
+# Tool list the prompt falls back to when the harness reports no tools of its own.
+# It is the set the dr_tulu preset exposes, and keeps non-agentic runs byte-identical
+# to the prompt this task shipped with.
+RESEARCHQA_DEFAULT_TOOLS = (
+    "semantic_scholar_snippet_search",
+    "serper_google_webpage_search",
+    "serper_fetch_webpage_content",
 )
+
+# Tools that retrieve a full document; every other tool is described as a search tool.
+RESEARCHQA_FETCH_TOOLS = frozenset({"serper_fetch_webpage_content", "browse_webpage"})
+
+
+def _join_tool_names(names: Sequence[str]) -> str:
+    """Join tool names as prose: "a", "a and b", "a, b and c"."""
+    if len(names) < 3:
+        return " and ".join(names)
+    return f"{', '.join(names[:-1])} and {names[-1]}"
+
+
+def build_generation_prompt(tool_names: Sequence[str] = ()) -> str:
+    """Build the generation prompt template for the tools the harness really exposes.
+
+    Naming a tool the harness does not provide makes the model call it, and the
+    scaffold then aborts the episode with a tool-not-found error before any turn
+    runs, so the prompt has to follow the harness rather than a fixed list.
+    ``tool_names`` is that harness list; empty falls back to
+    ``RESEARCHQA_DEFAULT_TOOLS``. The result still carries the ``{date_cutoff}``
+    placeholder for :meth:`ResearchQA.format_request` to fill in.
+    """
+    tools = tuple(tool_names) or RESEARCHQA_DEFAULT_TOOLS
+    fetch_tools = [name for name in tools if name in RESEARCHQA_FETCH_TOOLS]
+    search_tools = [name for name in tools if name not in RESEARCHQA_FETCH_TOOLS]
+    # A harness with fetch tools only still needs a step 1 to point at.
+    if not search_tools:
+        search_tools, fetch_tools = list(tools), []
+
+    workflow = f"1. Search for relevant scholarly sources using {_join_tool_names(search_tools)}.\n"
+    if fetch_tools:
+        workflow += (
+            f"2. Fetch and read promising source content using {_join_tool_names(fetch_tools)}.\n"
+            "3. Only after searching, fetching, and reading, write the answer.\n"
+            "Search first, then fetch and read, and only then answer. Do not answer from memory."
+        )
+    else:
+        workflow += (
+            "2. Only after searching and reading the search results, write the answer.\n"
+            "Search first, and only then answer. Do not answer from memory."
+        )
+
+    tool_list = "".join(f"- {name}\n" for name in tools)
+    return (
+        "You are answering a scholarly research question. Use the available research tools "
+        "to find reliable sources that support your answer.\n\n"
+        f"Available tools:\n{tool_list}\n"
+        "Format and length requirements:\n"
+        "- Write a well-organized, citation-supported answer in about 250 words.\n"
+        "- Synthesize the evidence directly around the question and cite the sources you use.\n\n"
+        "{date_cutoff}"
+        "Workflow (follow this order):\n"
+        f"{workflow}\n\n"
+        "Question: "
+    )
+
+
+RESEARCHQA_GENERATION_PROMPT = build_generation_prompt()
 
 # Verbatim from ResearchQA's official compute_coverage.py:build_prompt().
 RESEARCHQA_COVERAGE_JUDGE_PROMPT = (
@@ -323,7 +370,9 @@ class ResearchQA(Task):
             if isinstance(date, str) and date
             else ""
         )
-        generation_prompt = RESEARCHQA_GENERATION_PROMPT.format(date_cutoff=date_cutoff)
+        generation_prompt = build_generation_prompt(self.config.harness_tool_names).format(
+            date_cutoff=date_cutoff
+        )
         return LMRequest(
             request_type=RequestType.CHAT,
             messages=(

--- a/src/olmo_eval/runners/asynq/preparation.py
+++ b/src/olmo_eval/runners/asynq/preparation.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import random
+from collections.abc import Sequence
 from dataclasses import replace
 from typing import Any
 
@@ -22,6 +23,7 @@ def prepare_task_items(
     model_name: str,
     overrides: dict[str, Any] | None,
     sampling_overrides: dict[str, Any] | None = None,
+    harness_tool_names: Sequence[str] = (),
 ) -> tuple[Task, list[QueueItem]]:
     """Prepare a task and its queue items.
 
@@ -30,6 +32,8 @@ def prepare_task_items(
         model_name: Model name this task is for
         overrides: Optional config overrides (num_fewshot, limit, fewshot_seed)
         sampling_overrides: Optional overrides for sampling params (temperature, max_tokens, etc.)
+        harness_tool_names: Tool names the harness exposes, so a task that names
+            tools in its prompt can describe the ones that really exist.
 
     Returns:
         Tuple of (Task instance for scoring, list of QueueItems)
@@ -39,6 +43,9 @@ def prepare_task_items(
 
     if overrides:
         task.config = replace(task.config, **overrides)
+
+    if harness_tool_names:
+        task.config = replace(task.config, harness_tool_names=tuple(harness_tool_names))
 
     # Build sampling params from overrides
     existing_params = task.config.sampling_params or SamplingParams()

--- a/src/olmo_eval/runners/asynq/runner.py
+++ b/src/olmo_eval/runners/asynq/runner.py
@@ -921,6 +921,7 @@ class AsyncEvalRunner(RunnerResultsMixin, BaseEvalRunner):
                     self.model_name,
                     overrides or None,
                     sampling_overrides=sampling_overrides or None,
+                    harness_tool_names=self.harness_config.tool_names,
                 )
                 tracker = TaskTracker(
                     model_name=self.model_name,

--- a/tests/evals/tasks/test_researchqa.py
+++ b/tests/evals/tasks/test_researchqa.py
@@ -9,13 +9,16 @@ from olmo_eval.common.types import Instance, LMOutput, LMRequest, RequestType, R
 from olmo_eval.evals.tasks import researchqa
 from olmo_eval.evals.tasks.common import get_task, task_exists
 from olmo_eval.evals.tasks.researchqa import (
+    RESEARCHQA_DEFAULT_TOOLS,
     RESEARCHQA_GENERATION_PROMPT,
     RESEARCHQA_LABEL_SCORES,
     build_coverage_judge_prompt,
+    build_generation_prompt,
     build_researchqa_judge_fn,
     normalize_coverage_label,
     parse_coverage_labels,
 )
+from olmo_eval.harness import get_harness_preset
 
 
 @pytest.fixture
@@ -174,6 +177,37 @@ class TestPrompts:
             "Workflow (follow this order)"
         )
         assert RESEARCHQA_GENERATION_PROMPT.endswith("Question: ")
+
+    def test_prompt_names_only_the_tools_the_harness_exposes(self, task):
+        """The prompt has to follow the harness: naming an absent tool makes the model
+        call it, and the scaffold then fails the episode before any turn runs."""
+        task.config.harness_tool_names = get_harness_preset("paper_search_agent").tool_names
+        instance = task.process_doc(_doc())
+        assert instance is not None
+        content = task.format_request(instance).messages[0]["content"]
+
+        assert "semantic_scholar_snippet_search" in content
+        assert "serper" not in content
+        assert "browse_webpage" not in content
+        assert "Search first, and only then answer" in content
+        assert "fetch" not in content.lower()
+
+    def test_prompt_is_unchanged_for_the_default_and_dr_tulu_tool_sets(self):
+        """dr_tulu exposes exactly the tools this prompt used to hardcode, and a
+        harness with no tools falls back to that list, so both must stay untouched."""
+        assert build_generation_prompt() == RESEARCHQA_GENERATION_PROMPT
+        assert build_generation_prompt(RESEARCHQA_DEFAULT_TOOLS) == RESEARCHQA_GENERATION_PROMPT
+        dr_tulu_tools = get_harness_preset("dr_tulu").tool_names
+        assert dr_tulu_tools == RESEARCHQA_DEFAULT_TOOLS
+        assert build_generation_prompt(dr_tulu_tools) == RESEARCHQA_GENERATION_PROMPT
+
+    def test_prompt_routes_an_alternative_fetch_tool_into_the_fetch_step(self):
+        content = build_generation_prompt(
+            ("semantic_scholar_snippet_search", "serper_google_webpage_search", "browse_webpage")
+        )
+        assert "- browse_webpage\n" in content
+        assert "Fetch and read promising source content using browse_webpage." in content
+        assert "serper_fetch_webpage_content" not in content
 
     def test_generation_prompt_omits_cutoff_when_date_is_missing(self, task):
         doc = _doc()


### PR DESCRIPTION
The ResearchQA prompt hardcoded an "Available tools" block naming `serper_google_webpage_search` and `serper_fetch_webpage_content`, and instructed the model to search and fetch with them.

Under `paper_search_agent`, which exposes only `semantic_scholar_snippet_search`, the model obeys the prompt over the tool schema and calls a tool that does not exist. The `openai_agents` scaffold then ends the episode with

```
[Tool error: Tool serper_google_webpage_search not found in agent openai_agents]
```

and an empty trajectory. Every instance scores near zero — not because the model is weak on the task, but because it never got to attempt it. This is the failure mode where a benchmark returns a plausible-looking low number while measuring nothing.

## The change

Carry the harness's real tool names into `TaskConfig`, and build the prompt's tool list and workflow steps from them. When the harness exposes no tools, fall back to the previous hardcoded list.

`dr_tulu` exposes exactly the three previously hardcoded tools, so its prompt and every non-agentic prompt stay **byte-identical**. A test pins that, so this cannot silently change the established configuration.

## Verification

Measured on Qwen3.5-35B-A3B with `paper_search_agent`, 10 instances:

- **before**: 10/10 answers were the tool-not-found error, `turns=[]`
- **after**: 10/10 are ~2k-character cited answers whose trajectories contain only `semantic_scholar_snippet_search` calls

Test counts are stated against `origin/main` rather than as absolutes, because `main` is not currently green:

- `origin/main`: **36 failed, 1789 passed, 26 skipped**
- this branch: **36 failed, 1792 passed, 26 skipped** (stable across two runs)

The failing sets are identical, compared name by name rather than by count. `tests/analysis/test_eval_power.py` and `tests/analysis/test_pairwise.py` are excluded from both: they fail at collection on `numpy.in1d`, removed in NumPy 2.0, identically on untouched `main`.

## Scope

One commit, extracted onto `main` on its own. The working branch it came from carries it behind a merge commit; the merge contributes no changes of its own, so only the content commit is here.
