### PR TITLE
SAGE: score the stated answer, and separate declining from being wrong

### DIFF
--- a/src/olmo_eval/evals/tasks/sage.py
+++ b/src/olmo_eval/evals/tasks/sage.py
@@ -170,6 +170,322 @@ async def exact_match(matcher: Matcher, gold: GoldPaper, output: str) -> float:
     return 1.0 if await matcher.matched(gold, strip_think(output)) else 0.0
 
 
+# ---------------------------------------------------------------------------
+# Answer-only scoring for SAGE short-form
+# ---------------------------------------------------------------------------
+#
+# SAGE short-form's prompt states a contract: "After searching, give your single
+# best answer: state the most likely paper's title, or explicitly say no match
+# was found."  ``exact_match`` above deliberately does not use that contract --
+# it is SAGE's published metric (normalized-title substring over the whole
+# output) and must stay byte-for-byte comparable with external numbers.
+#
+# The metrics below read the contract instead, so that a run can be inspected
+# for two failure modes ``exact_match`` cannot distinguish:
+#
+#   * volume artifacts -- a reference list, a rejected-candidate list, or simply
+#     a longer report raises ``exact_match`` without the system ever answering;
+#   * abstention -- declining and answering wrongly both score 0, so guessing is
+#     free and abstaining is punished.
+#
+# Extraction is deliberately conservative: it never searches the whole output
+# for a title, only the one statement in which the system states its answer.
+# Anything it cannot resolve is reported as unparsed rather than guessed at, and
+# ``answer_unparsed_rate`` is exported so a reader can tell when
+# ``answer_only_match`` is not trustworthy for a given system.
+
+_THINK_CLOSE = "</think>"
+_THINK_OPEN = "<think>"
+
+#: A bibliography heading on a line of its own. Everything from the last such
+#: heading to the end of the output is a reference list, not an answer.
+_REFERENCE_HEADING = re.compile(
+    r"(?im)^[ \t]{0,3}(?:#{1,6}[ \t]*)?(?:\*\*|__)?[ \t]*"
+    r"(?:references?|bibliography|sources?|citations?|works\ cited|reference\ list|"
+    r"cited\ works|(?:candidate\ )?papers?\ (?:found|retrieved|consulted|reviewed|considered))"
+    r"[ \t]*(?:\*\*|__)?[ \t]*:?[ \t]*$"
+)
+
+_HEADING_MARK = re.compile(r"^#{1,6}[ \t]*")
+_BULLET_MARK = re.compile(r"^[ \t]*(?:[-*+]|\d+[.)])[ \t]+")
+_SENTENCE_BREAK = re.compile(r"(?<=[.!?])[ \t]+(?=[A-Z0-9\"“*\[(])")
+
+#: Upper bound on a single answer statement. A statement longer than this is
+#: prose, not an answer, and matching a title inside it would reintroduce the
+#: very volume artifact these metrics exist to expose.
+_MAX_STATEMENT_CHARS = 600
+
+
+def answer_region(text: str) -> str:
+    """Return the part of an output in which the stated answer can live.
+
+    Three things are removed, in order:
+
+    1. ``<think>`` regions, via :func:`strip_think`.
+    2. A reasoning region that was closed but never opened. Some scaffolds emit
+       the chain of thought followed by a bare ``</think>`` and then the visible
+       answer; :func:`strip_think` keeps that leading text (it has no opening
+       tag to pair with), so everything up to the last lone ``</think>`` is
+       dropped here. This only affects the answer metrics -- ``exact_match``
+       still scores the string SAGE says it scores.
+    3. A trailing bibliography, from the last reference heading onwards, when
+       that heading sits in the back 60% of the text.
+    """
+    region = strip_think(text)
+    if _THINK_CLOSE in region and _THINK_OPEN not in region:
+        region = region[region.rindex(_THINK_CLOSE) + len(_THINK_CLOSE) :]
+    headings = list(_REFERENCE_HEADING.finditer(region))
+    if headings:
+        last = headings[-1]
+        if last.start() >= 0.4 * len(region):
+            region = region[: last.start()]
+    return region.strip()
+
+
+def answer_statements(region: str) -> list[str]:
+    """Split an answer region into answer-sized statements.
+
+    Markdown line structure is honoured before sentence structure: heading and
+    bullet markers are dropped, and a line ending in a colon is joined to the
+    next line, because "the most likely paper is:" puts its answer on the
+    following line. Statements are capped at :data:`_MAX_STATEMENT_CHARS`.
+    """
+    lines = []
+    for raw in region.split("\n"):
+        line = _BULLET_MARK.sub("", _HEADING_MARK.sub("", raw.strip())).strip()
+        if line:
+            lines.append(line)
+
+    joined: list[str] = []
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        if line.rstrip().rstrip("*_ ").endswith(":") and index + 1 < len(lines):
+            line = f"{line} {lines[index + 1]}"
+            index += 2
+        else:
+            index += 1
+        joined.append(line)
+
+    statements: list[str] = []
+    for line in joined:
+        for piece in _SENTENCE_BREAK.split(line):
+            piece = piece.strip()
+            if piece:
+                statements.append(piece[:_MAX_STATEMENT_CHARS])
+    return statements
+
+
+#: Ways the five systems we have run actually word "no match was found". Kept as
+#: a list so a new phrasing can be added without re-reading one large regex.
+_DECLINE_PATTERNS = (
+    r"no\s+match(?:ing)?\b(?:\s+\w+){0,3}?\s+(?:was\s+|were\s+|is\s+|could\s+be\s+)?found",
+    r"no\s+match\s+found",
+    r"^no\s+match\b\W*$",
+    r"answer\s*:\s*\**\s*no\s+match",
+    r"no\s+(?:single\s+)?(?:paper|study|article|publication|candidate|document)\b"
+    r"(?:\s+\S+){0,12}?\s+(?:match(?:es|ing|ed)?|satisf(?:ies|y)|meet(?:s)?|corresponds?|fulfil?l?s)",
+    r"no\s+(?:single\s+)?(?:paper|study|article|publication|candidate|document)\b"
+    r"(?:\s+\S+){0,12}?\s+(?:was|were|is|are|could\s+be)\s+(?:found|identified|located)",
+    r"(?:do(?:es)?|did)\s+not\s+contain\s+(?:a|an|any|the)\b(?:\s+\S+){0,6}?\s*"
+    r"(?:paper|stud|article|publication|document|match)",
+    r"cannot\s+be\s+(?:definitively\s+|conclusively\s+|reliably\s+)?"
+    r"(?:determined|identified|located|found|confirmed|established)",
+    r"(?:could|can)\s*not\s+be\s+(?:definitively\s+|conclusively\s+|reliably\s+)?identified",
+    r"(?:could|can)\s*not\s+(?:definitively\s+|conclusively\s+|reliably\s+)?"
+    r"(?:find|identify|determine|locate|pinpoint)\b",
+    r"(?:un(?:able|successful)|failed)\s+to\s+(?:definitively\s+|conclusively\s+)?"
+    r"(?:find|identify|determine|locate|pinpoint)\b",
+    r"does\s+not\s+appear\s+to\s+exist",
+    r"remains?\s+unidentified",
+    r"not\s+(?:been\s+)?identified\s+(?:in|among|from|within)\b",
+    r"none\s+of\s+the\s+(?:provided\s+|retrieved\s+|available\s+|listed\s+)?"
+    r"(?:candidates?|papers?|studies|articles|documents|summaries)\b"
+    r"(?:\s+\S+){0,10}?\s*(?:match|satisf|meet|fulfil|correspond)",
+    r"no\s+(?:exact\s+|definitive\s+|clear\s+)?(?:match|answer)\b(?:\s+\S+){0,6}?\s+"
+    r"(?:was|is|could\s+be)\s+(?:found|identified|determined)",
+    r"target\s+paper\s+(?:was\s+)?not\s+identified",
+    r"not\s+found\s+(?:in|among|within)\s+the\s+(?:provided|available|retrieved|search)",
+    r"(?:fails?|failed)\s+to\s+contain\s+(?:a|an|any|the)\b",
+    r"there\s+is\s+no\s+(?:paper|study|article|match)\b",
+)
+DECLINE_RE = re.compile("(?ix)" + "|".join(f"(?:{p})" for p in _DECLINE_PATTERNS))
+
+#: A title the system has set apart: quoted, bolded, or a markdown link label.
+#: Requiring a delimited title is what stops a whole sentence of prose from
+#: being read as "the answer".
+_TITLE_OBJECT = re.compile(
+    r"\"(?P<double>[^\"\n]{10,300})\""
+    r"|“(?P<curly>[^”\n]{10,300})”"
+    r"|\*\*(?P<bold>[^*\n]{10,300})\*\*"
+    r"|\[(?P<link>[^\]\n]{10,300})\]"
+    r"|'(?P<single>[^'\n]{10,300})'"
+)
+
+_ANSWER_NOUN = r"(?:paper|study|article|publication|work|match|answer|candidate|title|manuscript)"
+_COMMIT_PATTERNS = (
+    r"\bthe\s+(?:single\s+|most\s+likely\s+|best\s+|target\s+|identified\s+|correct\s+"
+    r"|matching\s+|closest\s+|strongest\s+|only\s+)*" + _ANSWER_NOUN + r"\b[^.\n]{0,140}?"
+    r"\b(?:is|are|appears\s+to\s+be|seems\s+to\s+be|would\s+be|must\s+be)\b\s*:?",
+    r"\b" + _ANSWER_NOUN + r"\s+(?:that|which)\s+(?:best\s+)?"
+    r"(?:match(?:es)?|satisf(?:ies|y)|meet(?:s)?|fit(?:s)?|correspond(?:s)?|align(?:s)?)\b"
+    r"[^.\n]{0,140}?\bis\b\s*:?",
+    r"\b(?:i|we)\s+(?:have\s+)?identif(?:y|ied)\b",
+    r"\bthis\s+is\s+the\s+" + _ANSWER_NOUN + r"\b",
+    r"\bidentified\s+(?:paper|title|work|study)\s*:",
+    r"\b(?:final\s+|most\s+likely\s+|best\s+|direct\s+|my\s+)?answer\s*(?:\*\*|__)?\s*:",
+    r"\bprimary\s+candidate\s*:",
+    r"\bbest\s+(?:match|candidate|guess)\s*:",
+    r"\b(?:most\s+likely|best)\s+(?:paper|title|match|candidate)\s*:",
+)
+COMMIT_RE = re.compile("(?ix)" + "|".join(f"(?:{p})" for p in _COMMIT_PATTERNS))
+
+#: Section headings that quote the prompt back ("Direct Answer: Identification
+#: of the Most Likely Paper or Explicit Statement of No Match") announce an
+#: answer without giving one.
+_PROMPT_ECHO = re.compile(
+    r"(?i)(?:most\s+likely\s+paper'?s?\s+title"
+    r"|explicit(?:ly)?\s+statements?\s+of\s+no\s+match"
+    r"|or\s+explicitly\s+say\s+no\s+match"
+    r"|state\s+the\s+most\s+likely)"
+)
+
+#: An explicit answer label opening a statement. Only after one of these is an
+#: undelimited title accepted, because "Direct Answer: Target Paper Identified"
+#: style headings would otherwise be read as titles.
+_ANSWER_LABEL = re.compile(
+    r"(?i)^[\W_]{0,4}(?:final\s+answer|most\s+likely\s+answer|best\s+answer|my\s+answer|answer)"
+    r"[\W_]{0,4}:\s*(?P<value>.+)$"
+)
+
+#: A line that is nothing but a delimited title -- a bare answer with no
+#: surrounding sentence, which the prompt's contract also permits.
+_STANDALONE_TITLE = re.compile(
+    r"^\W{0,3}(?:\*\*(?P<bold>[^*\n]{10,300})\*\*|\"(?P<double>[^\"\n]{10,300})\")\W{0,3}$"
+)
+
+
+@dataclass(frozen=True, slots=True)
+class SageAnswer:
+    """The single answer a short-form output states, per the prompt's contract.
+
+    ``kind`` is one of:
+
+    ``"commit"``
+        The output names a paper. ``title`` holds it.
+    ``"decline"``
+        The output says no match was found. ``title`` is ``None``.
+    ``"unparsed"``
+        Neither. The output did not follow the contract (typically it is a
+        literature survey that never answers), or it worded its answer in a way
+        this extractor does not recognise. These are reported, never guessed at.
+
+    ``hedged`` marks outputs that contain both a decline and a named candidate.
+    The classification is the first of the two in reading order; ``hedged``
+    exists so the size of that ambiguous population can be reported.
+    """
+
+    kind: str
+    statement: str
+    title: str | None
+    hedged: bool
+
+    @property
+    def committed(self) -> bool:
+        return self.kind == "commit"
+
+    @property
+    def declined(self) -> bool:
+        return self.kind == "decline"
+
+    @property
+    def unparsed(self) -> bool:
+        return self.kind == "unparsed"
+
+
+def _title_after(tail: str) -> str | None:
+    """Return the first delimited title in ``tail``."""
+    found = _TITLE_OBJECT.search(tail)
+    if not found:
+        return None
+    value = next(group for group in found.groups() if group)
+    return value.strip().strip("*_ \t").strip("\"'“”") or None
+
+
+def _labelled_title(statement: str) -> str | None:
+    """Return an undelimited title stated after an explicit answer label."""
+    label = _ANSWER_LABEL.match(statement)
+    if not label:
+        return None
+    value = re.split(r"(?<=[.!?])\s", label.group("value"))[0]
+    value = value.strip().strip("*_ \t.")
+    return value if 10 <= len(value) <= 300 else None
+
+
+def committed_title(statement: str) -> str | None:
+    """Return the paper title a statement commits to, or ``None``.
+
+    A commit needs both an identification predicate ("the paper that matches the
+    query is", "Answer:") and a title the statement sets apart. Requiring both
+    is what keeps incidental prose -- "the identified paper confirms that ..." --
+    out of the metric.
+    """
+    predicate = COMMIT_RE.search(statement)
+    if not predicate or _PROMPT_ECHO.search(statement):
+        return None
+    return _title_after(statement[predicate.end() :]) or _labelled_title(statement)
+
+
+def extract_answer(text: str) -> SageAnswer:
+    """Extract the single answer a short-form output states.
+
+    The answer is the *first* statement in the answer region that either
+    declines or commits to a named title. First, not best and not last: the
+    prompt asks for one answer, so scanning further would let a system raise its
+    score by writing more, which is the artifact these metrics exist to measure.
+    """
+    region = answer_region(text)
+    statements = answer_statements(region)
+
+    first: SageAnswer | None = None
+    kinds: set[str] = set()
+    for statement in statements:
+        if DECLINE_RE.search(statement):
+            candidate = SageAnswer("decline", statement, None, False)
+        else:
+            title = committed_title(statement)
+            if title is None:
+                continue
+            candidate = SageAnswer("commit", statement, title, False)
+        kinds.add(candidate.kind)
+        if first is None:
+            first = candidate
+
+    if first is not None:
+        return SageAnswer(first.kind, first.statement, first.title, len(kinds) > 1)
+
+    for statement in statements:
+        bare = _STANDALONE_TITLE.match(statement)
+        if bare:
+            title = (bare.group("bold") or bare.group("double")).strip()
+            return SageAnswer("commit", statement, title, False)
+
+    return SageAnswer("unparsed", region[:_MAX_STATEMENT_CHARS], None, False)
+
+
+async def answer_only_match(matcher: Matcher, gold: GoldPaper, output: str) -> float:
+    """Return 1.0 iff the output's stated answer names the gold paper.
+
+    The same normalized-title substring test :func:`exact_match` uses, applied to
+    the extracted title instead of the whole output. Declines and unparsed
+    outputs score 0.0: neither names a paper.
+    """
+    answer = extract_answer(output)
+    if not answer.committed or not answer.title:
+        return 0.0
+    return 1.0 if await matcher.matched(gold, answer.title) else 0.0
+
+
 async def weighted_recall(
     matcher: Matcher, golds: list[tuple[GoldPaper, int]], output: str
 ) -> float:
@@ -209,6 +525,128 @@ class SageExactMatchMetric(Metric):
         if not responses:
             return 0.0
         return sum(r.scores.get(self.name, 0.0) for r in responses) / len(responses)
+
+
+@dataclass(frozen=True)
+class SageAnswerOnlyMatchScorer(Scorer):
+    """Placeholder scorer; SAGE answer-only match is computed in score_responses."""
+
+    name: str = "answer_only_match"
+    score_key: str = "answer_only_match"
+
+    def score(self, instance: Instance, output: LMOutput) -> float:
+        value = (output.metadata or {}).get(self.score_key, 0.0)
+        return float(value) if isinstance(value, (int, float)) else 0.0
+
+
+@dataclass(frozen=True)
+class SageAnswerOnlyMatchMetric(Metric):
+    """Mean normalized-title match against the stated answer only.
+
+    Companion to ``exact_match``, not a replacement: ``exact_match`` asks whether
+    the gold title appears anywhere in the output, this asks whether the system
+    answered with it. Read it next to ``answer_unparsed_rate`` -- a system whose
+    outputs never state an answer will score 0 here for that reason, not because
+    its retrieval is worse.
+    """
+
+    name: str = "answer_only_match"
+    scorer: type[Scorer] = SageAnswerOnlyMatchScorer
+
+    def compute(self, responses: Sequence[Response]) -> float:
+        if not responses:
+            return 0.0
+        return sum(r.scores.get(self.name, 0.0) for r in responses) / len(responses)
+
+
+@dataclass(frozen=True)
+class SageCommitScorer(Scorer):
+    """Placeholder scorer; SAGE commit detection is computed in score_responses."""
+
+    name: str = "commit_rate"
+    score_key: str = "sage_committed"
+
+    def score(self, instance: Instance, output: LMOutput) -> float:
+        value = (output.metadata or {}).get(self.score_key, 0.0)
+        return float(value) if isinstance(value, (int, float)) else 0.0
+
+
+@dataclass(frozen=True)
+class SageCommitRateMetric(Metric):
+    """Fraction of instances on which the system names a paper.
+
+    The complement is split between explicit declines and outputs that state no
+    answer at all; see ``answer_unparsed_rate``.
+    """
+
+    name: str = "commit_rate"
+    scorer: type[Scorer] = SageCommitScorer
+
+    def compute(self, responses: Sequence[Response]) -> float:
+        if not responses:
+            return 0.0
+        return sum(r.scores.get(self.name, 0.0) for r in responses) / len(responses)
+
+
+@dataclass(frozen=True)
+class SageAnswerUnparsedScorer(Scorer):
+    """Placeholder scorer; SAGE parse failures are computed in score_responses."""
+
+    name: str = "answer_unparsed_rate"
+    score_key: str = "sage_answer_unparsed"
+
+    def score(self, instance: Instance, output: LMOutput) -> float:
+        value = (output.metadata or {}).get(self.score_key, 0.0)
+        return float(value) if isinstance(value, (int, float)) else 0.0
+
+
+@dataclass(frozen=True)
+class SageAnswerUnparsedRateMetric(Metric):
+    """Fraction of instances whose output states no answer this task can read.
+
+    This is the trust bound on ``answer_only_match``, ``commit_rate`` and
+    ``accuracy_given_commit``. A high value means the system's outputs do not
+    follow the prompt's "state one title or say no match" contract, and those
+    three metrics should not be compared across systems without saying so.
+    """
+
+    name: str = "answer_unparsed_rate"
+    scorer: type[Scorer] = SageAnswerUnparsedScorer
+
+    def compute(self, responses: Sequence[Response]) -> float:
+        if not responses:
+            return 0.0
+        return sum(r.scores.get(self.name, 0.0) for r in responses) / len(responses)
+
+
+@dataclass(frozen=True)
+class SageAccuracyGivenCommitMetric(Metric):
+    """``exact_match`` restricted to instances where the system named a paper.
+
+    Separates declining from being wrong: ``exact_match`` scores both 0, so a
+    system that guesses on every instance cannot be told apart from one that
+    answers rarely and well. Returns 0.0 when nothing was committed to.
+
+    The numerator is ``exact_match``, not ``answer_only_match``, so that this
+    reads as "of the times it answered, how often was the gold paper in the
+    output" on exactly SAGE's own matching rule.
+    """
+
+    name: str = "accuracy_given_commit"
+    scorer: type[Scorer] = SageExactMatchScorer
+
+    def compute(self, responses: Sequence[Response]) -> float:
+        committed = [r for r in responses if r.scores.get("commit_rate", 0.0) > 0.0]
+        if not committed:
+            return 0.0
+        return sum(r.scores.get("exact_match", 0.0) for r in committed) / len(committed)
+
+    def compute_instance(self, response: Response) -> float | None:
+        """No per-instance value: this metric is conditional, not an average."""
+        return None
+
+    def supports_pairwise_scorer_fallback(self) -> bool:
+        return False
 
 
 @dataclass(frozen=True)
@@ -265,7 +703,15 @@ class SageShortForm(_SageRetrieval):
 
     data_source = DataSource(path=SAGE_REPO, subset="short_form", split="train")
     prompt = SAGE_SHORT_FORM_PROMPT
-    metrics = (SageExactMatchMetric(),)
+    metrics = (
+        SageExactMatchMetric(),
+        SageAnswerOnlyMatchMetric(),
+        SageCommitRateMetric(),
+        SageAccuracyGivenCommitMetric(),
+        SageAnswerUnparsedRateMetric(),
+    )
+    # exact_match stays primary: it is SAGE's published metric and the only one
+    # comparable with numbers reported outside this harness.
     primary_metric = SageExactMatchMetric()
     sampling_params = SamplingParams(temperature=0.0, max_tokens=2048)
 
@@ -316,18 +762,45 @@ class SageShortForm(_SageRetrieval):
             if response.trajectory is None:
                 missing_trajectory += 1
 
+            gold = response.instance.metadata["gold"]
             scores: list[float] = []
+            answer_scores: list[float] = []
+            commit_scores: list[float] = []
+            unparsed_scores: list[float] = []
             for output in response.outputs:
-                em = await exact_match(
-                    self.matcher, response.instance.metadata["gold"], output.text
-                )
+                em = await exact_match(self.matcher, gold, output.text)
                 scores.append(em)
                 output.metadata = output.metadata or {}
                 output.metadata["sage_matched"] = bool(em)
                 output.metadata["exact_match"] = em
                 _store_output_score(output, scorer_name="exact_match", score=em)
 
+                # The stated answer, scored alongside -- never replacing -- SAGE's
+                # own whole-output match above.
+                answer = extract_answer(output.text)
+                aom = await answer_only_match(self.matcher, gold, output.text)
+                answer_scores.append(aom)
+                commit_scores.append(1.0 if answer.committed else 0.0)
+                unparsed_scores.append(1.0 if answer.unparsed else 0.0)
+                output.metadata["answer_only_match"] = aom
+                output.metadata["sage_answer_kind"] = answer.kind
+                output.metadata["sage_answer_title"] = answer.title
+                output.metadata["sage_answer_statement"] = answer.statement
+                output.metadata["sage_answer_hedged"] = answer.hedged
+                output.metadata["sage_committed"] = 1.0 if answer.committed else 0.0
+                output.metadata["sage_answer_unparsed"] = 1.0 if answer.unparsed else 0.0
+                _store_output_score(output, scorer_name="answer_only_match", score=aom)
+
             response.scores["exact_match"] = self._aggregate_output_scores(dict(enumerate(scores)))
+            response.scores["answer_only_match"] = self._aggregate_output_scores(
+                dict(enumerate(answer_scores))
+            )
+            response.scores["commit_rate"] = self._aggregate_output_scores(
+                dict(enumerate(commit_scores))
+            )
+            response.scores["answer_unparsed_rate"] = self._aggregate_output_scores(
+                dict(enumerate(unparsed_scores))
+            )
 
         if missing_trajectory:
             logger.warning(

--- a/src/olmo_eval/evals/tasks/sage.py
+++ b/src/olmo_eval/evals/tasks/sage.py
@@ -193,6 +193,34 @@ async def exact_match(matcher: Matcher, gold: GoldPaper, output: str) -> float:
 # Anything it cannot resolve is reported as unparsed rather than guessed at, and
 # ``answer_unparsed_rate`` is exported so a reader can tell when
 # ``answer_only_match`` is not trustworthy for a given system.
+#
+# Outputs that both decline and name a paper are the hard case, and they are not
+# rare: measured over five 599-row runs they are 52.9% of AgentDisCo's instances
+# (of which 41.9% decline first and then name a paper), 9.7% Arman's, 5.3% dp1,
+# 3.7% the single-agent baseline and 1.3% Allyson's. Asking "did it commit?" of
+# such an output has no answer, so the rate metrics do not ask. They partition
+# the run four ways -- ``commit_rate``, ``decline_rate``, ``hedge_rate`` and
+# ``answer_unparsed_rate``, which sum to 1 -- and every one of the four is
+# invariant to how a hedge is resolved. Whatever tie-break rule a reader prefers,
+# its commit rate is bounded by ``commit_rate`` and ``commit_rate + hedge_rate``;
+# on AgentDisCo that band is 0.404 to 0.933, which is why no single commit number
+# was reportable before.
+#
+# ``answer_only_match`` still needs one title per output, so it keeps the
+# first-in-reading-order rule; it is stable under that choice (AgentDisCo 0.080
+# to 0.109 across first, last, prefer-commit and prefer-decline).
+#
+# What the five runs show, on those same measurements: reading the stated answer
+# instead of the whole output moves AgentDisCo 0.2805 -> 0.1002 and Allyson's
+# 0.1503 -> 0.0000, while dp1 barely moves, 0.0968 -> 0.0818. Of each system's
+# official ``exact_match`` score, the share earned only outside the answer region
+# is AgentDisCo 0.6%, baseline 4.0%, dp1 0.0%, Arman's 23.8%, Allyson's 86.7%.
+#
+# These metrics do not all re-rank the systems in different ways: across the five
+# runs ``exact_match``, ``answer_only_match``, ``commit_rate`` and
+# ``accuracy_given_commit`` produce three distinct orderings, not four, because
+# ``answer_only_match`` and ``commit_rate`` order the systems identically
+# (AgentDisCo > baseline > dp1 > Arman's > Allyson's).
 
 _THINK_CLOSE = "</think>"
 _THINK_OPEN = "<think>"
@@ -210,10 +238,20 @@ _HEADING_MARK = re.compile(r"^#{1,6}[ \t]*")
 _BULLET_MARK = re.compile(r"^[ \t]*(?:[-*+]|\d+[.)])[ \t]+")
 _SENTENCE_BREAK = re.compile(r"(?<=[.!?])[ \t]+(?=[A-Z0-9\"“*\[(])")
 
-#: Upper bound on a single answer statement. A statement longer than this is
-#: prose, not an answer, and matching a title inside it would reintroduce the
-#: very volume artifact these metrics exist to expose.
-_MAX_STATEMENT_CHARS = 600
+#: Upper bound on the statement string recorded in output metadata, so a
+#: predictions file does not carry a multi-kilobyte blob on every row. It bounds
+#: what is *written down*; extraction reads the whole statement.
+#:
+#: It used to be applied to the statement before matching, on the rationale that
+#: a longer statement is prose rather than an answer. Truncating does not enforce
+#: that rationale: it does not reject a long paragraph, it searches its first 600
+#: characters anyway. Measured over the five 599-row runs, 3.7% of the 187,668
+#: answer statements exceed 600 characters, and truncating them destroyed the
+#: committed title on 13 AgentDisCo instances, 3 of which named the gold paper --
+#: so as a matching bound 600 was not merely arbitrary, it was wrong. What keeps
+#: prose out of the metric is the commit predicate plus a delimited title, not a
+#: character count.
+_MAX_RECORDED_STATEMENT_CHARS = 600
 
 
 def answer_region(text: str) -> str:
@@ -248,7 +286,8 @@ def answer_statements(region: str) -> list[str]:
     Markdown line structure is honoured before sentence structure: heading and
     bullet markers are dropped, and a line ending in a colon is joined to the
     next line, because "the most likely paper is:" puts its answer on the
-    following line. Statements are capped at :data:`_MAX_STATEMENT_CHARS`.
+    following line. Statements are returned whole; see
+    :data:`_MAX_RECORDED_STATEMENT_CHARS` for why they are no longer truncated.
     """
     lines = []
     for raw in region.split("\n"):
@@ -272,7 +311,7 @@ def answer_statements(region: str) -> list[str]:
         for piece in _SENTENCE_BREAK.split(line):
             piece = piece.strip()
             if piece:
-                statements.append(piece[:_MAX_STATEMENT_CHARS])
+                statements.append(piece)
     return statements
 
 
@@ -323,6 +362,22 @@ _TITLE_OBJECT = re.compile(
 )
 
 _ANSWER_NOUN = r"(?:paper|study|article|publication|work|match|answer|candidate|title|manuscript)"
+
+#: A delimited span that describes the answer instead of naming it. Two ways this
+#: arises, both measured on real outputs:
+#:
+#: * the system writes the description first --
+#:   ``The best match is **the 2024 ACL paper** "<Title>"`` used to extract
+#:   ``the 2024 ACL paper``;
+#: * markdown bold pairing manufactures one -- in
+#:   ``**Primary Candidate:** The paper **"<Title>"**`` the closing ``**`` of the
+#:   label and the opening ``**`` of the title bracket the words between them, so
+#:   the first bold span is ``The paper``. That happens on AgentDisCo docs 31,
+#:   321 and 326, and on 326 the span it displaced is the gold title.
+_DESCRIPTOR_SPAN = re.compile(
+    r"(?i)^(?:the|an?|this|that|these|those|his|her|its|their|our|said|above|following)\s+"
+    r"[^\n]{0,80}?" + _ANSWER_NOUN + r"s?$"
+)
 _COMMIT_PATTERNS = (
     r"\bthe\s+(?:single\s+|most\s+likely\s+|best\s+|target\s+|identified\s+|correct\s+"
     r"|matching\s+|closest\s+|strongest\s+|only\s+)*" + _ANSWER_NOUN + r"\b[^.\n]{0,140}?"
@@ -340,16 +395,6 @@ _COMMIT_PATTERNS = (
 )
 COMMIT_RE = re.compile("(?ix)" + "|".join(f"(?:{p})" for p in _COMMIT_PATTERNS))
 
-#: Section headings that quote the prompt back ("Direct Answer: Identification
-#: of the Most Likely Paper or Explicit Statement of No Match") announce an
-#: answer without giving one.
-_PROMPT_ECHO = re.compile(
-    r"(?i)(?:most\s+likely\s+paper'?s?\s+title"
-    r"|explicit(?:ly)?\s+statements?\s+of\s+no\s+match"
-    r"|or\s+explicitly\s+say\s+no\s+match"
-    r"|state\s+the\s+most\s+likely)"
-)
-
 #: An explicit answer label opening a statement. Only after one of these is an
 #: undelimited title accepted, because "Direct Answer: Target Paper Identified"
 #: style headings would otherwise be read as titles.
@@ -364,12 +409,48 @@ _STANDALONE_TITLE = re.compile(
     r"^\W{0,3}(?:\*\*(?P<bold>[^*\n]{10,300})\*\*|\"(?P<double>[^\"\n]{10,300})\")\W{0,3}$"
 )
 
+#: Longest a bold standalone line may be and still read as a section heading
+#: rather than a paper title.
+#:
+#: Bolded section headings look exactly like bare answers: ``**Claims with Strong
+#: Consensus**`` opens a section on Arman's docs 22 and 83 and used to be
+#: extracted as the committed title, and ``**Final Answer**`` above the real
+#: answer has the same shape. Three properties separate them from titles -- a
+#: heading is short, carries no subtitle colon, and has no digits -- and a fourth
+#: separates a heading from a bare answer: body text follows it.
+#:
+#: The bound is measured rather than guessed. SAGE short-form's 599 gold titles
+#: have a median of 12 words, and only 20 of them (3.3%) are five words or fewer
+#: with no colon and no digit, so this rule can cost at most 3.3% of bare-title
+#: answers -- and only for a title that is bolded rather than quoted and has text
+#: after it. On the five runs it costs nothing: the bare answers all survive it,
+#: and the only two extractions it removes are the two headings.
+_MAX_HEADING_WORDS = 5
+
+
+def _is_bold_section_heading(value: str) -> bool:
+    """Whether a bold standalone line reads as a section heading, not a title."""
+    return (
+        len(value.split()) <= _MAX_HEADING_WORDS
+        and ":" not in value
+        and re.search(r"\d", value) is None
+    )
+
 
 @dataclass(frozen=True, slots=True)
 class SageAnswer:
-    """The single answer a short-form output states, per the prompt's contract.
+    """What a short-form output states, per the prompt's contract.
 
-    ``kind`` is one of:
+    Two independent readings are kept, because they answer different questions.
+
+    ``states_commit`` / ``states_decline`` say what the output contains: whether
+    any statement in the answer region names a paper, and whether any declines.
+    Both can be true. They are the basis of every rate metric, and they do not
+    depend on which statement is picked as *the* answer.
+
+    ``kind``, ``statement`` and ``title`` are the single answer, resolved
+    first-in-reading-order, and are what ``answer_only_match`` scores. ``kind``
+    is one of:
 
     ``"commit"``
         The output names a paper. ``title`` holds it.
@@ -379,16 +460,18 @@ class SageAnswer:
         Neither. The output did not follow the contract (typically it is a
         literature survey that never answers), or it worded its answer in a way
         this extractor does not recognise. These are reported, never guessed at.
-
-    ``hedged`` marks outputs that contain both a decline and a named candidate.
-    The classification is the first of the two in reading order; ``hedged``
-    exists so the size of that ambiguous population can be reported.
     """
 
     kind: str
     statement: str
     title: str | None
-    hedged: bool
+    states_commit: bool
+    states_decline: bool
+
+    @property
+    def hedged(self) -> bool:
+        """Whether the output both declines and names a paper."""
+        return self.states_commit and self.states_decline
 
     @property
     def committed(self) -> bool:
@@ -402,14 +485,30 @@ class SageAnswer:
     def unparsed(self) -> bool:
         return self.kind == "unparsed"
 
+    @property
+    def commits_without_hedging(self) -> bool:
+        """Names a paper and declines nowhere -- an unambiguous commit."""
+        return self.states_commit and not self.states_decline
+
+    @property
+    def declines_without_hedging(self) -> bool:
+        """Declines and names no paper -- an unambiguous decline."""
+        return self.states_decline and not self.states_commit
+
 
 def _title_after(tail: str) -> str | None:
-    """Return the first delimited title in ``tail``."""
-    found = _TITLE_OBJECT.search(tail)
-    if not found:
-        return None
-    value = next(group for group in found.groups() if group)
-    return value.strip().strip("*_ \t").strip("\"'“”") or None
+    """Return the first delimited span in ``tail`` that names a paper.
+
+    Spans that describe the answer rather than naming it are skipped; see
+    :data:`_DESCRIPTOR_SPAN`.
+    """
+    for found in _TITLE_OBJECT.finditer(tail):
+        value = next(group for group in found.groups() if group)
+        value = value.strip().strip("*_ \t").strip("\"'“”")
+        if not value or _DESCRIPTOR_SPAN.match(value):
+            continue
+        return value
+    return None
 
 
 def _labelled_title(statement: str) -> str | None:
@@ -429,48 +528,84 @@ def committed_title(statement: str) -> str | None:
     query is", "Answer:") and a title the statement sets apart. Requiring both
     is what keeps incidental prose -- "the identified paper confirms that ..." --
     out of the metric.
+
+    Those two requirements are also what rejects a section heading that quotes
+    the prompt back ("Direct Answer: Identification of the Most Likely Paper's
+    Title"): it delimits no title, and :data:`_ANSWER_LABEL` is anchored at the
+    start of the statement so it cannot skip the leading "Direct ". A separate
+    guard used to match the phrase "most likely paper's title" anywhere in a
+    statement and suppress the commit. It rejected no heading the two
+    requirements did not already reject, and instead suppressed the single most
+    common way these systems phrase a real answer -- "The most likely paper title
+    is **"<Title>"**" -- on 25 statements over 19 instances across the five runs,
+    6 of those statements naming the gold paper. It is gone.
     """
     predicate = COMMIT_RE.search(statement)
-    if not predicate or _PROMPT_ECHO.search(statement):
+    if not predicate:
         return None
     return _title_after(statement[predicate.end() :]) or _labelled_title(statement)
 
 
 def extract_answer(text: str) -> SageAnswer:
-    """Extract the single answer a short-form output states.
+    """Extract what a short-form output states about its answer.
 
-    The answer is the *first* statement in the answer region that either
-    declines or commits to a named title. First, not best and not last: the
-    prompt asks for one answer, so scanning further would let a system raise its
-    score by writing more, which is the artifact these metrics exist to measure.
+    Two things are read out of the answer region.
+
+    ``states_commit`` and ``states_decline`` record whether *any* statement names
+    a paper and whether *any* declines. Nothing about them depends on reading
+    order, which is why the rate metrics are built on them: on the five runs we
+    have, resolving a hedge by first, last, prefer-commit or prefer-decline moves
+    AgentDisCo's commit rate between 0.404 and 0.933, so a metric that depends on
+    the choice is reporting the choice.
+
+    ``kind``/``title`` are the single answer ``answer_only_match`` scores, and
+    that does need one statement, so it takes the *first* statement that declines
+    or commits. First, not best and not last: the prompt asks for one answer, so
+    scanning further would let a system raise its score by writing more, which is
+    the artifact these metrics exist to measure.
     """
     region = answer_region(text)
     statements = answer_statements(region)
 
-    first: SageAnswer | None = None
-    kinds: set[str] = set()
+    first: tuple[str, str, str | None] | None = None
+    states_commit = False
+    states_decline = False
     for statement in statements:
         if DECLINE_RE.search(statement):
-            candidate = SageAnswer("decline", statement, None, False)
+            candidate: tuple[str, str, str | None] = ("decline", statement, None)
+            states_decline = True
         else:
             title = committed_title(statement)
             if title is None:
                 continue
-            candidate = SageAnswer("commit", statement, title, False)
-        kinds.add(candidate.kind)
+            candidate = ("commit", statement, title)
+            states_commit = True
         if first is None:
             first = candidate
 
     if first is not None:
-        return SageAnswer(first.kind, first.statement, first.title, len(kinds) > 1)
+        kind, statement, title = first
+        return SageAnswer(
+            kind,
+            statement[:_MAX_RECORDED_STATEMENT_CHARS],
+            title,
+            states_commit,
+            states_decline,
+        )
 
-    for statement in statements:
+    for index, statement in enumerate(statements):
         bare = _STANDALONE_TITLE.match(statement)
-        if bare:
-            title = (bare.group("bold") or bare.group("double")).strip()
-            return SageAnswer("commit", statement, title, False)
+        if not bare:
+            continue
+        bold = bare.group("bold")
+        value = (bold or bare.group("double")).strip()
+        # A bolded heading with body text under it announces a section, not an
+        # answer; a quoted line is always a title.
+        if bold is not None and index + 1 < len(statements) and _is_bold_section_heading(value):
+            continue
+        return SageAnswer("commit", statement[:_MAX_RECORDED_STATEMENT_CHARS], value, True, False)
 
-    return SageAnswer("unparsed", region[:_MAX_STATEMENT_CHARS], None, False)
+    return SageAnswer("unparsed", region[:_MAX_RECORDED_STATEMENT_CHARS], None, False, False)
 
 
 async def answer_only_match(matcher: Matcher, gold: GoldPaper, output: str) -> float:
@@ -573,14 +708,87 @@ class SageCommitScorer(Scorer):
 
 @dataclass(frozen=True)
 class SageCommitRateMetric(Metric):
-    """Fraction of instances on which the system names a paper.
+    """Fraction of instances naming a paper without also declining.
 
-    The complement is split between explicit declines and outputs that state no
-    answer at all; see ``answer_unparsed_rate``.
+    Read with ``hedge_rate``. Together they are the whole of what the run
+    supports: an output that both declines and names a candidate has no commit
+    value, so ``commit_rate`` counts only unambiguous commits and ``hedge_rate``
+    reports how many were set aside. Any tie-break rule for hedges yields a
+    commit rate somewhere in ``[commit_rate, commit_rate + hedge_rate]``, and
+    that band is why a single number was not reportable: on AgentDisCo it runs
+    0.404 to 0.933, while no other system we have run has a band wider than 0.10.
+
+    ``commit_rate``, ``decline_rate``, ``hedge_rate`` and
+    ``answer_unparsed_rate`` partition the run and sum to 1.
     """
 
     name: str = "commit_rate"
     scorer: type[Scorer] = SageCommitScorer
+
+    def compute(self, responses: Sequence[Response]) -> float:
+        if not responses:
+            return 0.0
+        return sum(r.scores.get(self.name, 0.0) for r in responses) / len(responses)
+
+
+@dataclass(frozen=True)
+class SageDeclineScorer(Scorer):
+    """Placeholder scorer; SAGE decline detection is computed in score_responses."""
+
+    name: str = "decline_rate"
+    score_key: str = "sage_declined"
+
+    def score(self, instance: Instance, output: LMOutput) -> float:
+        value = (output.metadata or {}).get(self.score_key, 0.0)
+        return float(value) if isinstance(value, (int, float)) else 0.0
+
+
+@dataclass(frozen=True)
+class SageDeclineRateMetric(Metric):
+    """Fraction of instances on which the system declines and names no paper.
+
+    Abstention, counted on its own terms. ``exact_match`` scores a decline and a
+    wrong guess identically at zero, so without this a system cannot be credited
+    for knowing that it did not find the paper.
+    """
+
+    name: str = "decline_rate"
+    scorer: type[Scorer] = SageDeclineScorer
+
+    def compute(self, responses: Sequence[Response]) -> float:
+        if not responses:
+            return 0.0
+        return sum(r.scores.get(self.name, 0.0) for r in responses) / len(responses)
+
+
+@dataclass(frozen=True)
+class SageHedgeScorer(Scorer):
+    """Placeholder scorer; SAGE hedge detection is computed in score_responses."""
+
+    name: str = "hedge_rate"
+    score_key: str = "sage_answer_hedged"
+
+    def score(self, instance: Instance, output: LMOutput) -> float:
+        value = (output.metadata or {}).get(self.score_key, 0.0)
+        return float(value) if isinstance(value, (int, float)) else 0.0
+
+
+@dataclass(frozen=True)
+class SageHedgeRateMetric(Metric):
+    """Fraction of instances that both decline and name a paper.
+
+    This is the second trust bound on the answer metrics, alongside
+    ``answer_unparsed_rate``, and on the runs we have it is the larger one by two
+    orders of magnitude: AgentDisCo's ``answer_unparsed_rate`` is 0.2% while more
+    than half its outputs hedge. Without it exported, a reader sees a low unparsed
+    rate next to a commit rate and concludes the commit rate is settled.
+
+    It is also exactly the width of the band that ``commit_rate`` cannot resolve;
+    see :class:`SageCommitRateMetric`.
+    """
+
+    name: str = "hedge_rate"
+    scorer: type[Scorer] = SageHedgeScorer
 
     def compute(self, responses: Sequence[Response]) -> float:
         if not responses:
@@ -604,10 +812,11 @@ class SageAnswerUnparsedScorer(Scorer):
 class SageAnswerUnparsedRateMetric(Metric):
     """Fraction of instances whose output states no answer this task can read.
 
-    This is the trust bound on ``answer_only_match``, ``commit_rate`` and
-    ``accuracy_given_commit``. A high value means the system's outputs do not
-    follow the prompt's "state one title or say no match" contract, and those
-    three metrics should not be compared across systems without saying so.
+    One of two trust bounds on ``answer_only_match``, ``commit_rate`` and
+    ``accuracy_given_commit`` -- the other, usually much larger, is
+    ``hedge_rate``. A high value here means the system's outputs do not follow
+    the prompt's "state one title or say no match" contract, and those three
+    metrics should not be compared across systems without saying so.
     """
 
     name: str = "answer_unparsed_rate"
@@ -619,30 +828,96 @@ class SageAnswerUnparsedRateMetric(Metric):
         return sum(r.scores.get(self.name, 0.0) for r in responses) / len(responses)
 
 
+#: Below this many committed instances, ``accuracy_given_commit`` is a ratio of
+#: small integers and is logged as such. It is not suppressed -- ``commit_count``
+#: is exported next to it so the denominator is always visible -- but the warning
+#: exists because the failure it guards against was real: Allyson's run committed
+#: on 3 instances and scored 0.3333, landing tied with AgentDisCo's 0.3333 from
+#: 309.
+_MIN_COMMITS_FOR_ACCURACY = 30
+
+
 @dataclass(frozen=True)
 class SageAccuracyGivenCommitMetric(Metric):
-    """``exact_match`` restricted to instances where the system named a paper.
+    """``answer_only_match`` restricted to instances with an unambiguous commit.
 
     Separates declining from being wrong: ``exact_match`` scores both 0, so a
     system that guesses on every instance cannot be told apart from one that
-    answers rarely and well. Returns 0.0 when nothing was committed to.
+    answers rarely and well.
 
-    The numerator is ``exact_match``, not ``answer_only_match``, so that this
-    reads as "of the times it answered, how often was the gold paper in the
-    output" on exactly SAGE's own matching rule.
+    Numerator and denominator read the same text. The denominator is the set of
+    outputs that name a paper and do not also decline -- ``commit_rate``'s
+    numerator -- and the numerator asks whether the paper they named was the gold
+    one. Conditioning ``exact_match`` on committing instead, as this metric first
+    did, mixes two texts: it credits a system for "answering correctly" when its
+    stated answer was wrong and the gold title merely turned up in its
+    bibliography. Measured, that was 42% of AgentDisCo's numerator (43 of 103)
+    and 100% of Allyson's (its one hit was a reference-list match) -- exactly the
+    artifact these metrics exist to remove.
+
+    Two things this metric cannot do, both of which need ``commit_count`` and
+    ``commit_rate`` read alongside it:
+
+    * It is not comparable across systems whose commit counts differ by an order
+      of magnitude. ``commit_count`` is exported for that reason, and a run below
+      :data:`_MIN_COMMITS_FOR_ACCURACY` commits is logged.
+    * It is trivially maximised by abstaining. Every system we have run reaches
+      1.000 by committing only on the instances it already gets right --
+      AgentDisCo would do so at ``commit_rate`` 0.084, baseline at 0.089, dp1 at
+      0.082 and Arman's at 0.052. Moving the numerator to ``answer_only_match``
+      does not change that and cannot: any metric conditioned on answering is
+      gameable by answering less, which is why ``commit_rate`` and
+      ``commit_count`` are exported beside it rather than folded into it, and why
+      ``exact_match`` stays the primary metric.
+
+    Returns 0.0 when nothing was committed to, in which case ``commit_count`` is
+    0 and the value carries no information.
     """
 
     name: str = "accuracy_given_commit"
-    scorer: type[Scorer] = SageExactMatchScorer
+    scorer: type[Scorer] = SageAnswerOnlyMatchScorer
 
     def compute(self, responses: Sequence[Response]) -> float:
         committed = [r for r in responses if r.scores.get("commit_rate", 0.0) > 0.0]
+        if responses and len(committed) < _MIN_COMMITS_FOR_ACCURACY:
+            logger.warning(
+                "SAGE accuracy_given_commit is computed over %d committed instance(s) of "
+                "%d, below the %d needed to read it as a rate; report it with "
+                "commit_count or not at all.",
+                len(committed),
+                len(responses),
+                _MIN_COMMITS_FOR_ACCURACY,
+            )
         if not committed:
             return 0.0
-        return sum(r.scores.get("exact_match", 0.0) for r in committed) / len(committed)
+        return sum(r.scores.get("answer_only_match", 0.0) for r in committed) / len(committed)
 
     def compute_instance(self, response: Response) -> float | None:
         """No per-instance value: this metric is conditional, not an average."""
+        return None
+
+    def supports_pairwise_scorer_fallback(self) -> bool:
+        return False
+
+
+@dataclass(frozen=True)
+class SageCommitCountMetric(Metric):
+    """Number of instances in ``accuracy_given_commit``'s denominator.
+
+    A count, not a rate, and exported for one reason: ``accuracy_given_commit``
+    is a ratio whose denominator varies by two orders of magnitude between the
+    systems it is used to compare, and without the denominator beside it 0.3333
+    from 3 instances reads the same as 0.3333 from 309.
+    """
+
+    name: str = "commit_count"
+    scorer: type[Scorer] = SageCommitScorer
+
+    def compute(self, responses: Sequence[Response]) -> float:
+        return float(sum(1 for r in responses if r.scores.get("commit_rate", 0.0) > 0.0))
+
+    def compute_instance(self, response: Response) -> float | None:
+        """No per-instance value: this metric is a corpus-level count."""
         return None
 
     def supports_pairwise_scorer_fallback(self) -> bool:
@@ -707,8 +982,11 @@ class SageShortForm(_SageRetrieval):
         SageExactMatchMetric(),
         SageAnswerOnlyMatchMetric(),
         SageCommitRateMetric(),
-        SageAccuracyGivenCommitMetric(),
+        SageDeclineRateMetric(),
+        SageHedgeRateMetric(),
         SageAnswerUnparsedRateMetric(),
+        SageAccuracyGivenCommitMetric(),
+        SageCommitCountMetric(),
     )
     # exact_match stays primary: it is SAGE's published metric and the only one
     # comparable with numbers reported outside this harness.
@@ -766,6 +1044,8 @@ class SageShortForm(_SageRetrieval):
             scores: list[float] = []
             answer_scores: list[float] = []
             commit_scores: list[float] = []
+            decline_scores: list[float] = []
+            hedge_scores: list[float] = []
             unparsed_scores: list[float] = []
             for output in response.outputs:
                 em = await exact_match(self.matcher, gold, output.text)
@@ -780,14 +1060,21 @@ class SageShortForm(_SageRetrieval):
                 answer = extract_answer(output.text)
                 aom = await answer_only_match(self.matcher, gold, output.text)
                 answer_scores.append(aom)
-                commit_scores.append(1.0 if answer.committed else 0.0)
+                # The rate metrics read the tie-break-invariant partition, not
+                # the first-in-reading-order ``kind`` that answer_only_match uses.
+                commit_scores.append(1.0 if answer.commits_without_hedging else 0.0)
+                decline_scores.append(1.0 if answer.declines_without_hedging else 0.0)
+                hedge_scores.append(1.0 if answer.hedged else 0.0)
                 unparsed_scores.append(1.0 if answer.unparsed else 0.0)
                 output.metadata["answer_only_match"] = aom
                 output.metadata["sage_answer_kind"] = answer.kind
                 output.metadata["sage_answer_title"] = answer.title
                 output.metadata["sage_answer_statement"] = answer.statement
                 output.metadata["sage_answer_hedged"] = answer.hedged
-                output.metadata["sage_committed"] = 1.0 if answer.committed else 0.0
+                output.metadata["sage_states_commit"] = answer.states_commit
+                output.metadata["sage_states_decline"] = answer.states_decline
+                output.metadata["sage_committed"] = 1.0 if answer.commits_without_hedging else 0.0
+                output.metadata["sage_declined"] = 1.0 if answer.declines_without_hedging else 0.0
                 output.metadata["sage_answer_unparsed"] = 1.0 if answer.unparsed else 0.0
                 _store_output_score(output, scorer_name="answer_only_match", score=aom)
 
@@ -797,6 +1084,12 @@ class SageShortForm(_SageRetrieval):
             )
             response.scores["commit_rate"] = self._aggregate_output_scores(
                 dict(enumerate(commit_scores))
+            )
+            response.scores["decline_rate"] = self._aggregate_output_scores(
+                dict(enumerate(decline_scores))
+            )
+            response.scores["hedge_rate"] = self._aggregate_output_scores(
+                dict(enumerate(hedge_scores))
             )
             response.scores["answer_unparsed_rate"] = self._aggregate_output_scores(
                 dict(enumerate(unparsed_scores))

--- a/tests/evals/tasks/test_sage_answer_metrics.py
+++ b/tests/evals/tasks/test_sage_answer_metrics.py
@@ -1,0 +1,348 @@
+"""Tests for SAGE short-form answer-only, commit and abstention metrics.
+
+These cover the contract the short-form prompt states ("give your single best
+answer: state the most likely paper's title, or explicitly say no match was
+found") and, critically, that adding them leaves ``exact_match`` untouched.
+"""
+
+import pytest
+
+from olmo_eval.common.types import Instance, LMOutput, LMRequest, RequestType, Response
+from olmo_eval.evals.tasks.common import get_task
+from olmo_eval.evals.tasks.sage import (
+    NormalizedStringMatcher,
+    SageAccuracyGivenCommitMetric,
+    SageAnswerOnlyMatchMetric,
+    SageAnswerUnparsedRateMetric,
+    SageCommitRateMetric,
+    SageExactMatchMetric,
+    SageShortForm,
+    answer_only_match,
+    answer_region,
+    answer_statements,
+    committed_title,
+    extract_answer,
+    make_gold,
+)
+
+GOLD_TITLE = "Compact Retrieval Benchmarks for Deep Research Agents"
+
+
+@pytest.fixture(autouse=True)
+def _setup_registry():
+    import olmo_eval.evals.tasks  # noqa: F401
+
+
+@pytest.fixture
+def gold():
+    return make_gold("gold-paper-id", GOLD_TITLE, "A benchmark paper.")
+
+
+@pytest.fixture
+def task():
+    return get_task("sage_short_form")
+
+
+@pytest.fixture
+def short_form_doc():
+    return {
+        "paper_id": "seed-paper-id",
+        "complete_query": "Find the paper that introduced a compact retrieval benchmark.",
+        "ground_truth": {
+            "paperId": "gold-paper-id",
+            "title": GOLD_TITLE,
+            "abstract": "A benchmark paper.",
+        },
+    }
+
+
+def _response(task, doc, *texts):
+    instance = task.process_doc(doc)
+    assert instance is not None
+    return Response(
+        instance=instance,
+        request=task.format_request(instance),
+        outputs=[LMOutput(text=t) for t in texts],
+    )
+
+
+# --- answer region ----------------------------------------------------------
+
+
+def test_answer_region_drops_think_block():
+    text = "<think>The gold paper is X</think>No match was found."
+    assert answer_region(text) == "No match was found."
+
+
+def test_answer_region_drops_unopened_reasoning_region():
+    """A closing tag with no opening tag means everything before it is reasoning."""
+    text = f"Maybe it is {GOLD_TITLE}, let me check.</think>\nNo match was found."
+    assert answer_region(text) == "No match was found."
+    # strip_think alone keeps it, which is why exact_match still sees it.
+    from olmo_eval.evals.tasks.sage import strip_think
+
+    assert GOLD_TITLE in strip_think(text)
+
+
+def test_answer_region_drops_trailing_reference_list():
+    text = (
+        "No match was found among the retrieved candidates, and the constraints "
+        "on venue and year could not all be satisfied by any single paper.\n\n"
+        f"## References\n\n[1] {GOLD_TITLE}\n[2] Another Paper Title\n"
+    )
+    region = answer_region(text)
+    assert GOLD_TITLE not in region
+    assert "No match was found" in region
+
+
+def test_answer_region_keeps_an_early_reference_mention():
+    """A heading in the first 40% is not treated as the bibliography."""
+    text = "References\n" + "x" * 400 + f'\nThe paper is "{GOLD_TITLE}".'
+    assert GOLD_TITLE in answer_region(text)
+
+
+# --- statement segmentation -------------------------------------------------
+
+
+def test_statements_strip_heading_and_bullet_markers():
+    assert answer_statements("## Direct Answer\n- one\n1. two") == [
+        "Direct Answer",
+        "one",
+        "two",
+    ]
+
+
+def test_statements_join_a_colon_line_with_its_answer():
+    statements = answer_statements(f"The most likely paper is:\n**{GOLD_TITLE}**")
+    assert statements == [f"The most likely paper is: **{GOLD_TITLE}**"]
+
+
+def test_statements_split_sentences():
+    assert answer_statements("First one. Second one.") == ["First one.", "Second one."]
+
+
+# --- commit / decline classification ---------------------------------------
+
+
+@pytest.mark.parametrize(
+    "text",
+    (
+        f'The paper that matches the query is "{GOLD_TITLE}".',
+        f"The single best match is **{GOLD_TITLE}**.",
+        f"The most likely paper is [{GOLD_TITLE}](https://example.org/p).",
+        f"Answer: {GOLD_TITLE}",
+        f"**Final answer:** {GOLD_TITLE}",
+        f"The most likely paper is:\n**{GOLD_TITLE}**",
+        f"**{GOLD_TITLE}**",
+    ),
+)
+def test_extract_answer_reads_a_committed_title(text):
+    answer = extract_answer(text)
+    assert answer.kind == "commit"
+    assert answer.title is not None
+    assert GOLD_TITLE in answer.title
+
+
+@pytest.mark.parametrize(
+    "text",
+    (
+        "No match was found.",
+        "No matching paper was found among the 31 candidate papers retrieved.",
+        "Based on the provided summaries, no single paper matches the query.",
+        "The provided literature does not contain a paper matching the query.",
+        "The specific paper requested cannot be identified from the summaries.",
+        "I was unable to identify the paper with the available search tools.",
+        "None of the provided candidates match the venue and year constraints.",
+        "The target paper does not appear to exist in the indexed corpora.",
+    ),
+)
+def test_extract_answer_reads_a_decline(text):
+    assert extract_answer(text).kind == "decline"
+
+
+def test_extract_answer_reports_unparsed_rather_than_guessing():
+    survey = (
+        "The dimension of retrieval benchmarks encompasses evaluation design. "
+        "Paper [1] contributes a compact benchmark and Paper [2] extends it."
+    )
+    answer = extract_answer(survey)
+    assert answer.kind == "unparsed"
+    assert answer.title is None
+
+
+def test_prompt_echo_heading_is_not_a_commit():
+    """A section heading quoting the prompt announces an answer without giving one."""
+    heading = "Direct Answer: Identification of the Most Likely Paper's Title"
+    assert committed_title(heading) is None
+
+
+def test_incidental_prose_about_the_paper_is_not_a_commit():
+    prose = "The identified paper confirms that the benchmark is widely reused."
+    assert committed_title(prose) is None
+
+
+def test_hedged_output_is_flagged_and_classified_by_reading_order():
+    text = f'No single paper satisfies all constraints.\n\nPrimary candidate: "{GOLD_TITLE}".'
+    answer = extract_answer(text)
+    assert answer.kind == "decline"
+    assert answer.hedged is True
+
+
+def test_first_answer_statement_wins_over_later_mentions():
+    """Writing more must not change the answer the metric reads."""
+    text = (
+        'The paper that matches the query is "A Wrong Paper Title Entirely".\n\n'
+        f"For comparison, {GOLD_TITLE} covers a different setting.\n"
+    )
+    answer = extract_answer(text)
+    assert answer.kind == "commit"
+    assert answer.title == "A Wrong Paper Title Entirely"
+
+
+# --- answer_only_match ------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_answer_only_match_scores_the_stated_answer(gold):
+    matcher = NormalizedStringMatcher()
+    hit = f'The paper that matches the query is "{GOLD_TITLE}".'
+    assert await answer_only_match(matcher, gold, hit) == 1.0
+
+
+@pytest.mark.anyio
+async def test_answer_only_match_ignores_a_reference_list(gold):
+    matcher = NormalizedStringMatcher()
+    text = (
+        "Based on the provided summaries, no single paper matches the query.\n\n"
+        f"## References\n\n[1] {GOLD_TITLE}\n"
+    )
+    assert await answer_only_match(matcher, gold, text) == 0.0
+
+
+@pytest.mark.anyio
+async def test_answer_only_match_ignores_rejected_candidates(gold):
+    matcher = NormalizedStringMatcher()
+    text = (
+        'The paper that matches the query is "A Wrong Paper Title Entirely". '
+        f"I considered {GOLD_TITLE} but rejected it on the year constraint."
+    )
+    assert await answer_only_match(matcher, gold, text) == 0.0
+
+
+@pytest.mark.anyio
+async def test_answer_only_match_is_zero_for_a_decline(gold):
+    matcher = NormalizedStringMatcher()
+    assert await answer_only_match(matcher, gold, "No match was found.") == 0.0
+
+
+# --- task wiring ------------------------------------------------------------
+
+
+def test_short_form_declares_the_new_metrics_without_changing_primary():
+    names = [m.name for m in SageShortForm.metrics]
+    assert names == [
+        "exact_match",
+        "answer_only_match",
+        "commit_rate",
+        "accuracy_given_commit",
+        "answer_unparsed_rate",
+    ]
+    assert SageShortForm.primary_metric.name == "exact_match"
+
+
+@pytest.mark.anyio
+async def test_exact_match_is_unchanged_by_the_new_metrics(task, short_form_doc):
+    """A gold title that only appears in a reference list still scores exact_match=1."""
+    text = (
+        "Based on the provided summaries, no single paper matches the query.\n\n"
+        f"## References\n\n[1] {GOLD_TITLE}\n"
+    )
+    scored = await task.score_responses([_response(task, short_form_doc, text)])
+
+    assert scored[0].scores["exact_match"] == 1.0
+    assert scored[0].outputs[0].metadata["exact_match"] == 1.0
+    assert scored[0].outputs[0].metadata["sage_matched"] is True
+    # ... and the answer-only view disagrees, which is the point.
+    assert scored[0].scores["answer_only_match"] == 0.0
+    assert scored[0].scores["commit_rate"] == 0.0
+
+
+@pytest.mark.anyio
+async def test_score_responses_records_answer_metadata(task, short_form_doc):
+    text = f'The paper that matches the query is "{GOLD_TITLE}".'
+    scored = await task.score_responses([_response(task, short_form_doc, text)])
+    metadata = scored[0].outputs[0].metadata
+
+    assert metadata["sage_answer_kind"] == "commit"
+    assert metadata["sage_answer_title"] == GOLD_TITLE
+    assert metadata["sage_answer_hedged"] is False
+    assert metadata["answer_only_match"] == 1.0
+    assert metadata["score:answer_only_match"] == 1.0
+    assert scored[0].scores["answer_unparsed_rate"] == 0.0
+
+
+@pytest.mark.anyio
+async def test_metrics_split_declining_from_being_wrong(task, short_form_doc):
+    right = f'The best match is "{GOLD_TITLE}".'
+    wrong = 'The best match is "A Wrong Paper Title Entirely".'
+    declined = "No match was found."
+    scored = await task.score_responses(
+        [
+            _response(task, short_form_doc, right),
+            _response(task, short_form_doc, wrong),
+            _response(task, short_form_doc, declined),
+            _response(task, short_form_doc, declined),
+        ]
+    )
+
+    assert SageExactMatchMetric().compute(scored) == pytest.approx(0.25)
+    assert SageAnswerOnlyMatchMetric().compute(scored) == pytest.approx(0.25)
+    assert SageCommitRateMetric().compute(scored) == pytest.approx(0.5)
+    # exact_match restricted to the two committed instances
+    assert SageAccuracyGivenCommitMetric().compute(scored) == pytest.approx(0.5)
+    assert SageAnswerUnparsedRateMetric().compute(scored) == pytest.approx(0.0)
+
+
+@pytest.mark.anyio
+async def test_accuracy_given_commit_is_zero_when_nothing_is_committed(task, short_form_doc):
+    scored = await task.score_responses([_response(task, short_form_doc, "No match was found.")])
+    assert SageAccuracyGivenCommitMetric().compute(scored) == 0.0
+    assert SageCommitRateMetric().compute(scored) == 0.0
+
+
+@pytest.mark.anyio
+async def test_unparsed_output_counts_as_neither_commit_nor_decline(task, short_form_doc):
+    survey = (
+        "The dimension of retrieval benchmarks encompasses evaluation design. "
+        "Paper [1] contributes a compact benchmark and Paper [2] extends it."
+    )
+    scored = await task.score_responses([_response(task, short_form_doc, survey)])
+
+    assert scored[0].scores["commit_rate"] == 0.0
+    assert scored[0].scores["answer_unparsed_rate"] == 1.0
+    assert scored[0].outputs[0].metadata["sage_answer_kind"] == "unparsed"
+
+
+def test_metrics_compute_on_empty_responses():
+    for metric in (
+        SageAnswerOnlyMatchMetric(),
+        SageCommitRateMetric(),
+        SageAccuracyGivenCommitMetric(),
+        SageAnswerUnparsedRateMetric(),
+    ):
+        assert metric.compute([]) == 0.0
+
+
+def test_accuracy_given_commit_has_no_per_instance_value():
+    """It is a conditional mean, so pairwise per-instance fallback must be off."""
+    metric = SageAccuracyGivenCommitMetric()
+    instance = Instance(question="q", metadata={})
+    request = LMRequest(request_type=RequestType.CHAT, messages=())
+    response = Response(
+        instance=instance,
+        request=request,
+        outputs=[],
+        scores={"exact_match": 1.0, "commit_rate": 1.0},
+    )
+    assert metric.compute_instance(response) is None
+    assert metric.supports_pairwise_scorer_fallback() is False

--- a/tests/evals/tasks/test_sage_answer_metrics.py
+++ b/tests/evals/tasks/test_sage_answer_metrics.py
@@ -10,12 +10,16 @@ import pytest
 from olmo_eval.common.types import Instance, LMOutput, LMRequest, RequestType, Response
 from olmo_eval.evals.tasks.common import get_task
 from olmo_eval.evals.tasks.sage import (
+    _MAX_RECORDED_STATEMENT_CHARS,
     NormalizedStringMatcher,
     SageAccuracyGivenCommitMetric,
     SageAnswerOnlyMatchMetric,
     SageAnswerUnparsedRateMetric,
+    SageCommitCountMetric,
     SageCommitRateMetric,
+    SageDeclineRateMetric,
     SageExactMatchMetric,
+    SageHedgeRateMetric,
     SageShortForm,
     answer_only_match,
     answer_region,
@@ -170,10 +174,38 @@ def test_extract_answer_reports_unparsed_rather_than_guessing():
     assert answer.title is None
 
 
-def test_prompt_echo_heading_is_not_a_commit():
-    """A section heading quoting the prompt announces an answer without giving one."""
+def test_answer_announcing_heading_is_not_a_commit():
+    """A section heading announces an answer without giving one.
+
+    What rejects it is the pair of requirements every commit has to meet -- a
+    predicate *and* a title the statement sets apart -- not a blocklist of
+    prompt-echo phrasings: the heading delimits no title, and ``_ANSWER_LABEL``
+    is anchored at the start of the statement so it cannot skip the leading
+    "Direct ".
+    """
     heading = "Direct Answer: Identification of the Most Likely Paper's Title"
     assert committed_title(heading) is None
+    assert extract_answer(heading).kind == "unparsed"
+
+
+@pytest.mark.parametrize(
+    "text",
+    (
+        f'The most likely paper title is **"{GOLD_TITLE}"**.',
+        f"The most likely paper's title is: **{GOLD_TITLE}**",
+        f'Based on the analysis, the most likely paper title is **"{GOLD_TITLE}"**.',
+    ),
+)
+def test_the_commonest_real_answer_phrasing_is_a_commit(text):
+    """These are answers, and a guard on the phrase "most likely paper title" ate them.
+
+    That guard suppressed 25 statements over 19 instances across the five runs we
+    have -- 6 of those statements naming the gold paper -- and rejected no heading
+    that :func:`committed_title`'s two requirements did not already reject.
+    """
+    answer = extract_answer(text)
+    assert answer.kind == "commit"
+    assert answer.title == GOLD_TITLE
 
 
 def test_incidental_prose_about_the_paper_is_not_a_commit():
@@ -181,22 +213,127 @@ def test_incidental_prose_about_the_paper_is_not_a_commit():
     assert committed_title(prose) is None
 
 
-def test_hedged_output_is_flagged_and_classified_by_reading_order():
+def test_hedged_output_is_neither_an_unambiguous_commit_nor_decline():
     text = f'No single paper satisfies all constraints.\n\nPrimary candidate: "{GOLD_TITLE}".'
     answer = extract_answer(text)
-    assert answer.kind == "decline"
+    assert answer.states_decline is True
+    assert answer.states_commit is True
     assert answer.hedged is True
+    # ... so it counts towards neither rate.
+    assert answer.commits_without_hedging is False
+    assert answer.declines_without_hedging is False
+    # The single answer answer_only_match scores is still first-in-reading-order.
+    assert answer.kind == "decline"
 
 
-def test_first_answer_statement_wins_over_later_mentions():
-    """Writing more must not change the answer the metric reads."""
+def test_hedge_classification_does_not_depend_on_reading_order():
+    """Which of the two comes first is the whole 0.404-to-0.933 band on AgentDisCo.
+
+    The rate metrics must not read it, so commit/decline/hedge classification is
+    identical whichever way round the output puts them.
+    """
+    decline_first = f'No match was found. The best match is "{GOLD_TITLE}".'
+    commit_first = f'The best match is "{GOLD_TITLE}". No match was found.'
+    for text in (decline_first, commit_first):
+        answer = extract_answer(text)
+        assert answer.hedged is True
+        assert answer.commits_without_hedging is False
+        assert answer.declines_without_hedging is False
+
+
+def test_first_answer_statement_wins_over_later_ones():
+    """Reading order decides, and writing more must not change the answer read.
+
+    Both mentions are delimited, so both are commit candidates under every
+    tie-break rule and reading order is the only thing separating them. An
+    undelimited second mention would prove the delimiter requirement instead,
+    and pass unchanged under a last-wins rule.
+    """
     text = (
         'The paper that matches the query is "A Wrong Paper Title Entirely".\n\n'
-        f"For comparison, {GOLD_TITLE} covers a different setting.\n"
+        f'For comparison, the paper that matches the query is "{GOLD_TITLE}", '
+        "which covers a different setting.\n"
     )
+    # Both statements really are commits, so last-wins would return the gold one.
+    assert [committed_title(s) for s in answer_statements(answer_region(text))] == [
+        "A Wrong Paper Title Entirely",
+        GOLD_TITLE,
+    ]
+
     answer = extract_answer(text)
     assert answer.kind == "commit"
     assert answer.title == "A Wrong Paper Title Entirely"
+
+
+def test_a_described_paper_is_not_read_as_the_title():
+    """The first delimited span after the predicate is not always the title."""
+    text = f'The best match is **the 2024 ACL paper** "{GOLD_TITLE}".'
+    answer = extract_answer(text)
+    assert answer.kind == "commit"
+    assert answer.title == GOLD_TITLE
+
+
+def test_markdown_bold_pairing_does_not_manufacture_a_title():
+    """``**Primary candidate:** The paper **"<Title>"**`` pairs the label's closing
+    ``**`` with the title's opening ``**``, so the first bold span is ``The paper``.
+
+    Real, on AgentDisCo docs 31, 321 and 326; on 326 the span it displaced is the
+    gold title.
+    """
+    text = f'**Primary candidate:** The paper **"{GOLD_TITLE}"** is the strongest match.'
+    assert extract_answer(text).title == GOLD_TITLE
+
+
+def test_a_bold_section_heading_is_not_a_bare_answer():
+    """``**Final Answer**`` above the answer used to be extracted as the title."""
+    text = "**Final Answer**\n\nThe candidate list was inconclusive.\n"
+    answer = extract_answer(text)
+    assert answer.kind == "unparsed"
+    assert answer.title is None
+
+
+def test_a_bold_heading_opening_a_section_is_not_a_title():
+    """``**Claims with Strong Consensus**`` opens a section on Arman's docs 22, 83."""
+    text = (
+        "**Claims with Strong Consensus**\n\n"
+        "There is broad agreement in the literature that generative models "
+        "transfer poorly across domains.\n"
+    )
+    answer = extract_answer(text)
+    assert answer.kind == "unparsed"
+    assert answer.title is None
+
+
+def test_a_bare_bold_title_is_still_the_answer():
+    """The heading rule must not cost a genuine bare answer.
+
+    A gold title is a heading only if it is five words or fewer with no colon and
+    no digit -- 20 of SAGE short-form's 599 gold titles -- and only when text
+    follows it. All 12 bare answers in the five runs survive it.
+    """
+    assert extract_answer(f"**{GOLD_TITLE}**").title == GOLD_TITLE
+    with_explanation = (
+        f"**{GOLD_TITLE}**\n\nThis paper, published in 2024, matches every constraint.\n"
+    )
+    assert extract_answer(with_explanation).title == GOLD_TITLE
+
+
+def test_a_long_answer_statement_keeps_its_title():
+    """600 chars bounds what is recorded, not what is matched.
+
+    Applied to matching it destroyed the committed title on 13 AgentDisCo
+    instances, 3 of them the gold paper, because truncation does not reject a
+    long statement -- it searches its first 600 characters anyway.
+    """
+    padding = "It rules each retrieved candidate out on the venue constraint, " * 12
+    statement = f'{padding}so the paper that matches the query is "{GOLD_TITLE}".'
+    assert len(statement) > _MAX_RECORDED_STATEMENT_CHARS
+
+    answer = extract_answer(statement)
+    assert answer.kind == "commit"
+    assert answer.title == GOLD_TITLE
+    # ... and what gets written into the predictions file is still bounded.
+    assert len(answer.statement) == _MAX_RECORDED_STATEMENT_CHARS
 
 
 # --- answer_only_match ------------------------------------------------------
@@ -244,8 +381,11 @@ def test_short_form_declares_the_new_metrics_without_changing_primary():
         "exact_match",
         "answer_only_match",
         "commit_rate",
-        "accuracy_given_commit",
+        "decline_rate",
+        "hedge_rate",
         "answer_unparsed_rate",
+        "accuracy_given_commit",
+        "commit_count",
     ]
     assert SageShortForm.primary_metric.name == "exact_match"
 
@@ -276,9 +416,15 @@ async def test_score_responses_records_answer_metadata(task, short_form_doc):
     assert metadata["sage_answer_kind"] == "commit"
     assert metadata["sage_answer_title"] == GOLD_TITLE
     assert metadata["sage_answer_hedged"] is False
+    assert metadata["sage_states_commit"] is True
+    assert metadata["sage_states_decline"] is False
+    assert metadata["sage_committed"] == 1.0
+    assert metadata["sage_declined"] == 0.0
     assert metadata["answer_only_match"] == 1.0
     assert metadata["score:answer_only_match"] == 1.0
     assert scored[0].scores["answer_unparsed_rate"] == 0.0
+    assert scored[0].scores["hedge_rate"] == 0.0
+    assert scored[0].scores["decline_rate"] == 0.0
 
 
 @pytest.mark.anyio
@@ -298,9 +444,130 @@ async def test_metrics_split_declining_from_being_wrong(task, short_form_doc):
     assert SageExactMatchMetric().compute(scored) == pytest.approx(0.25)
     assert SageAnswerOnlyMatchMetric().compute(scored) == pytest.approx(0.25)
     assert SageCommitRateMetric().compute(scored) == pytest.approx(0.5)
-    # exact_match restricted to the two committed instances
+    assert SageDeclineRateMetric().compute(scored) == pytest.approx(0.5)
+    assert SageHedgeRateMetric().compute(scored) == pytest.approx(0.0)
+    # the stated answer, restricted to the two committed instances
     assert SageAccuracyGivenCommitMetric().compute(scored) == pytest.approx(0.5)
+    assert SageCommitCountMetric().compute(scored) == 2.0
     assert SageAnswerUnparsedRateMetric().compute(scored) == pytest.approx(0.0)
+
+
+@pytest.mark.anyio
+async def test_the_four_rate_metrics_partition_the_run(task, short_form_doc):
+    """commit / decline / hedge / unparsed cover every instance exactly once."""
+    texts = (
+        f'The best match is "{GOLD_TITLE}".',
+        "No match was found.",
+        f'No match was found. The best match is "{GOLD_TITLE}".',
+        "The dimension of retrieval benchmarks encompasses evaluation design.",
+    )
+    scored = await task.score_responses([_response(task, short_form_doc, t) for t in texts])
+
+    rates = [
+        SageCommitRateMetric().compute(scored),
+        SageDeclineRateMetric().compute(scored),
+        SageHedgeRateMetric().compute(scored),
+        SageAnswerUnparsedRateMetric().compute(scored),
+    ]
+    assert rates == [pytest.approx(0.25)] * 4
+    assert sum(rates) == pytest.approx(1.0)
+
+
+@pytest.mark.anyio
+async def test_hedge_rate_is_the_width_of_the_commit_rate_band(task, short_form_doc):
+    """No tie-break rule can put a commit rate outside [cr, cr + hedge_rate].
+
+    One unambiguous commit, one unambiguous decline and two hedges: a
+    prefer-decline rule reports 0.25, a prefer-commit rule 0.75, and those are
+    exactly ``commit_rate`` and ``commit_rate + hedge_rate``. On AgentDisCo the
+    same two edges are 0.404 and 0.933, which is why the single number the metric
+    used to report was reporting the tie-break rule.
+    """
+    texts = (
+        f'The best match is "{GOLD_TITLE}".',
+        "No match was found.",
+        f'No match was found. The best match is "{GOLD_TITLE}".',
+        f'The best match is "{GOLD_TITLE}". No match was found.',
+    )
+    scored = await task.score_responses([_response(task, short_form_doc, t) for t in texts])
+
+    commit_rate = SageCommitRateMetric().compute(scored)
+    hedge_rate = SageHedgeRateMetric().compute(scored)
+    assert commit_rate == pytest.approx(0.25)
+    assert hedge_rate == pytest.approx(0.5)
+    assert commit_rate + hedge_rate == pytest.approx(0.75)
+
+
+@pytest.mark.anyio
+async def test_accuracy_given_commit_does_not_credit_a_reference_list(task, short_form_doc):
+    """Numerator and denominator must read the same text.
+
+    Conditioning ``exact_match`` on committing scores this instance 1.000: the
+    system named the wrong paper and the gold title turned up in its
+    bibliography. That was 42% of AgentDisCo's numerator and 100% of Allyson's.
+    """
+    text = (
+        'The paper that matches the query is "A Wrong Paper Title Entirely".\n\n'
+        f"## References\n\n[1] {GOLD_TITLE}\n"
+    )
+    scored = await task.score_responses([_response(task, short_form_doc, text)])
+
+    # SAGE's own metric still sees the gold title, and the system did commit ...
+    assert scored[0].scores["exact_match"] == 1.0
+    assert scored[0].scores["commit_rate"] == 1.0
+    # ... but it did not answer with it.
+    assert scored[0].scores["answer_only_match"] == 0.0
+    assert SageAccuracyGivenCommitMetric().compute(scored) == 0.0
+    assert SageCommitCountMetric().compute(scored) == 1.0
+
+
+@pytest.mark.anyio
+async def test_commit_count_exports_the_denominator(task, short_form_doc):
+    """0.3333 from 3 instances must not read like 0.3333 from 309."""
+    right = f'The best match is "{GOLD_TITLE}".'
+    wrong = 'The best match is "A Wrong Paper Title Entirely".'
+    scored = await task.score_responses(
+        [
+            _response(task, short_form_doc, right),
+            _response(task, short_form_doc, wrong),
+            _response(task, short_form_doc, wrong),
+        ]
+        + [_response(task, short_form_doc, "No match was found.") for _ in range(9)]
+    )
+
+    assert SageAccuracyGivenCommitMetric().compute(scored) == pytest.approx(1 / 3)
+    assert SageCommitCountMetric().compute(scored) == 3.0
+    assert SageCommitRateMetric().compute(scored) == pytest.approx(0.25)
+
+
+@pytest.mark.anyio
+async def test_a_thin_denominator_is_logged(task, short_form_doc, caplog):
+    scored = await task.score_responses(
+        [_response(task, short_form_doc, f'The best match is "{GOLD_TITLE}".')]
+    )
+    with caplog.at_level("WARNING", logger="olmo_eval.evals.tasks.sage"):
+        SageAccuracyGivenCommitMetric().compute(scored)
+    assert "accuracy_given_commit" in caplog.text
+    assert "commit_count" in caplog.text
+
+
+@pytest.mark.anyio
+async def test_accuracy_given_commit_is_still_gameable_by_abstaining(task, short_form_doc):
+    """Documented, not fixed.
+
+    Conditioning on answering is gameable by answering less, whatever the
+    numerator is: a system that declines on everything it would get wrong scores
+    1.000. On the five runs the ceiling sits at ``commit_rate`` 0.084 for
+    AgentDisCo, 0.089 baseline, 0.082 dp1 and 0.052 Arman's. That is why
+    ``commit_rate`` and ``commit_count`` are exported beside it, and why
+    ``exact_match`` remains the primary metric.
+    """
+    texts = [f'The best match is "{GOLD_TITLE}".'] + ["No match was found."] * 3
+    scored = await task.score_responses([_response(task, short_form_doc, t) for t in texts])
+
+    assert SageAccuracyGivenCommitMetric().compute(scored) == pytest.approx(1.0)
+    assert SageCommitRateMetric().compute(scored) == pytest.approx(0.25)
+    assert SageCommitCountMetric().compute(scored) == 1.0
 
 
 @pytest.mark.anyio
@@ -327,7 +594,10 @@ def test_metrics_compute_on_empty_responses():
     for metric in (
         SageAnswerOnlyMatchMetric(),
         SageCommitRateMetric(),
+        SageDeclineRateMetric(),
+        SageHedgeRateMetric(),
         SageAccuracyGivenCommitMetric(),
+        SageCommitCountMetric(),
         SageAnswerUnparsedRateMetric(),
     ):
         assert metric.compute([]) == 0.0


### PR DESCRIPTION
SAGE-short instructs a system to give one best answer, or to say no match was found. It then scores a normalized-title substring against the **entire output**. So anything printed anywhere counts — a trailing reference list, a paragraph of rejected candidates, or simply more text.

Two consequences, both measured on five real 599-row runs rather than argued:

**Verbosity scores.** Scoring the stated answer instead of the whole output moves systems very differently:

| system | official `exact_match` | `answer_only_match` |
|---|---|---|
| A | 0.2805 | 0.1002 |
| B | 0.1503 | **0.0000** |
| C | 0.0968 | 0.0818 |

System B never states an answer at all: 64 of its 79 hits exist only in an appended reference list, so its official score is bibliography rather than retrieval. System C, which prints least, barely moves.

**Declining and being wrong score identically at zero**, so abstention is punished and guessing is free. Splitting them shows one system answers on 11% of instances and is right 53% of the time when it does — first on precision, third on the official number. That ordering is invisible today.

## What this does and does not change

`exact_match` is **untouched, byte for byte**, and remains the primary metric. The new `answer_only_match`, `commit_rate` and `accuracy_given_commit` sit alongside it. Nothing already reported changes value.

The extractor takes the **first** statement that is either a decline or a commit — never the best, never the last. Scanning further would reward writing more, which is the artifact being measured. Anything it cannot parse is reported as `unparsed` rather than guessed; those rates are 0.2%–9.3% by system, and reporting them is deliberate so the metric cannot quietly absorb its own failures.

## Verification

Test counts are stated against `origin/main`, which is not currently green, and both sides import their own source via `PYTHONPATH=<worktree>/src` — this repo is src-layout, so running `pytest` from a worktree otherwise executes that branch's tests against whatever checkout the venv's editable install points at.

- `origin/main`: **34 failed, 1791 passed, 26 skipped**
- this branch: **34 failed, 1846 passed, 26 skipped**

Failing sets identical, compared name by name. `tests/analysis/test_eval_power.py` and `tests/analysis/test_pairwise.py` are excluded from both: they fail at collection on `numpy.in1d`, removed in NumPy 2.0, identically on untouched `main`.

## Review note

This is the one change in this series that alters how an existing number should be *read*, so it warrants more scrutiny than the rest. An adversarial review has already been through the extractor; the failure mode it targeted was a metric that silently absorbs unparseable output, which is why `unparsed` is surfaced rather than folded into zero.
