### PR TITLE
Add n-gram copying loss/bpb eval for C4

### DIFF
--- a/src/olmo_eval/common/metrics/__init__.py
+++ b/src/olmo_eval/common/metrics/__init__.py
@@ -27,6 +27,11 @@ from .ifeval import (
     IFEvalPromptLooseAccuracy,
     IFEvalPromptStrictAccuracy,
 )
+from .ngram_copying import (
+    NGRAM_COPYING_K_VALUES,
+    NGramCopyingBPBMetricByteAvg,
+    NGramCopyingBPBMetricInstanceAvg,
+)
 
 __all__ = [
     "AccuracyMetric",
@@ -45,6 +50,9 @@ __all__ = [
     "LogprobUncondMCAccuracyMetric",
     "MeanPerplexityMetric",
     "Metric",
+    "NGRAM_COPYING_K_VALUES",
+    "NGramCopyingBPBMetricByteAvg",
+    "NGramCopyingBPBMetricInstanceAvg",
     "PassAtKMetric",
     "PassPowKMetric",
     "RecallMetric",

--- a/src/olmo_eval/common/metrics/__init__.py
+++ b/src/olmo_eval/common/metrics/__init__.py
@@ -30,7 +30,6 @@ from .ifeval import (
 from .ngram_copying import (
     NGRAM_COPYING_K_VALUES,
     NGramCopyingBPBMetricByteAvg,
-    NGramCopyingBPBMetricInstanceAvg,
 )
 
 __all__ = [
@@ -52,7 +51,6 @@ __all__ = [
     "Metric",
     "NGRAM_COPYING_K_VALUES",
     "NGramCopyingBPBMetricByteAvg",
-    "NGramCopyingBPBMetricInstanceAvg",
     "PassAtKMetric",
     "PassPowKMetric",
     "RecallMetric",

--- a/src/olmo_eval/common/metrics/ngram_copying.py
+++ b/src/olmo_eval/common/metrics/ngram_copying.py
@@ -1,0 +1,105 @@
+"""Metrics for n-gram copying: bits per byte restricted to repeated-span positions."""
+
+import math
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+
+from olmo_eval.common.scorers import NGramCopyingBPBScorer
+from olmo_eval.common.types import Response
+
+from .base import Metric
+
+#: Default set of n-gram-length thresholds. Add new values here to extend coverage.
+NGRAM_COPYING_K_VALUES: tuple[int, ...] = (1, 2, 3, 4, 5)
+
+
+def _ngram_copying_masked_totals(
+    response: Response, scorer: NGramCopyingBPBScorer
+) -> tuple[float, int] | None:
+    """Look up the masked (logprob, bytes) totals for a response's document output."""
+    if not response.outputs:
+        return None
+    return scorer.masked_totals(response.outputs[0])
+
+
+@dataclass(frozen=True, slots=True)
+class NGramCopyingBPBMetricInstanceAvg(Metric):
+    """Arithmetic mean of per-document BPB restricted to length-k+ repeated n-grams.
+
+    Documents with no positions meeting the threshold are excluded from the average.
+    """
+
+    name: str = field(init=False)
+    k: int = 1
+    scorer: NGramCopyingBPBScorer = field(init=False)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "name", f"ngram_copying_bpb_instance_avg_k{self.k}")
+        object.__setattr__(self, "scorer", NGramCopyingBPBScorer(k=self.k))
+
+    def compute(self, responses: Sequence[Response]) -> float:
+        values = [value for r in responses if (value := self.compute_instance(r)) is not None]
+        return sum(values) / len(values) if values else 0.0
+
+    def compute_instance(self, response: Response) -> float | None:
+        totals = _ngram_copying_masked_totals(response, self.scorer)
+        if totals is None:
+            return None
+        total_logprob, total_bytes = totals
+        if total_bytes == 0:
+            return None
+        return -total_logprob / (total_bytes * math.log(2))
+
+    def supports_pairwise_scorer_fallback(self) -> bool:
+        return False
+
+    def pairwise_higher_is_better(self) -> bool:
+        return False
+
+
+@dataclass(frozen=True, slots=True)
+class NGramCopyingBPBMetricByteAvg(Metric):
+    """Byte-weighted (corpus-level) BPB restricted to length-k+ repeated n-grams.
+
+    Documents with no positions meeting the threshold are excluded from the sum.
+    """
+
+    name: str = field(init=False)
+    k: int = 1
+    scorer: NGramCopyingBPBScorer = field(init=False)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "name", f"ngram_copying_bpb_byte_avg_k{self.k}")
+        object.__setattr__(self, "scorer", NGramCopyingBPBScorer(k=self.k))
+
+    def compute(self, responses: Sequence[Response]) -> float:
+        total_logprob = 0.0
+        total_bytes = 0
+        for response in responses:
+            totals = _ngram_copying_masked_totals(response, self.scorer)
+            if totals is None:
+                continue
+            logprob, num_bytes = totals
+            if num_bytes == 0:
+                continue
+            total_logprob += logprob
+            total_bytes += num_bytes
+
+        if total_bytes == 0:
+            return 0.0
+        return -total_logprob / (total_bytes * math.log(2))
+
+    def compute_instance(self, response: Response) -> float | None:
+        totals = _ngram_copying_masked_totals(response, self.scorer)
+        if totals is None:
+            return None
+        total_logprob, total_bytes = totals
+        if total_bytes == 0:
+            return None
+        return -total_logprob / (total_bytes * math.log(2))
+
+    def supports_pairwise_scorer_fallback(self) -> bool:
+        return False
+
+    def pairwise_higher_is_better(self) -> bool:
+        return False

--- a/src/olmo_eval/common/metrics/ngram_copying.py
+++ b/src/olmo_eval/common/metrics/ngram_copying.py
@@ -23,45 +23,13 @@ def _ngram_copying_masked_totals(
 
 
 @dataclass(frozen=True, slots=True)
-class NGramCopyingBPBMetricInstanceAvg(Metric):
-    """Arithmetic mean of per-document BPB restricted to length-k+ repeated n-grams.
-
-    Documents with no positions meeting the threshold are excluded from the average.
-    """
-
-    name: str = field(init=False)
-    k: int = 1
-    scorer: NGramCopyingBPBScorer = field(init=False)
-
-    def __post_init__(self) -> None:
-        object.__setattr__(self, "name", f"ngram_copying_bpb_instance_avg_k{self.k}")
-        object.__setattr__(self, "scorer", NGramCopyingBPBScorer(k=self.k))
-
-    def compute(self, responses: Sequence[Response]) -> float:
-        values = [value for r in responses if (value := self.compute_instance(r)) is not None]
-        return sum(values) / len(values) if values else 0.0
-
-    def compute_instance(self, response: Response) -> float | None:
-        totals = _ngram_copying_masked_totals(response, self.scorer)
-        if totals is None:
-            return None
-        total_logprob, total_bytes = totals
-        if total_bytes == 0:
-            return None
-        return -total_logprob / (total_bytes * math.log(2))
-
-    def supports_pairwise_scorer_fallback(self) -> bool:
-        return False
-
-    def pairwise_higher_is_better(self) -> bool:
-        return False
-
-
-@dataclass(frozen=True, slots=True)
 class NGramCopyingBPBMetricByteAvg(Metric):
-    """Byte-weighted (corpus-level) BPB restricted to length-k+ repeated n-grams.
+    """Corpus-level BPB restricted to length-k+ repeated n-grams.
 
-    Documents with no positions meeting the threshold are excluded from the sum.
+    Sums masked logprobs and masked bytes independently across all documents in
+    the corpus, then divides once. Documents with no positions meeting the
+    threshold contribute nothing to either sum, so they're handled without any
+    special-casing rather than being explicitly excluded.
     """
 
     name: str = field(init=False)

--- a/src/olmo_eval/common/scorers/__init__.py
+++ b/src/olmo_eval/common/scorers/__init__.py
@@ -33,6 +33,7 @@ from .llm_judge import (
     SimpleQAJudgeScorer,
     build_openai_judge_fn,
 )
+from .ngram_copying import NGramCopyingBPBScorer, compute_repeated_ngram_mask
 from .substring import SubstringRecallScorer
 from .tools import (
     ToolArgumentScorer,
@@ -52,6 +53,7 @@ __all__ = [
     "CITATION_GROUP_PROMPT",
     "CodeExecutionScorer",
     "compute_citation_scores_from_groups",
+    "compute_repeated_ngram_mask",
     "ContextScorer",
     "ExactMatchFlexScorer",
     "ExactMatchScorer",
@@ -66,6 +68,7 @@ __all__ = [
     "MinervaMathScorer",
     "MultipleChoiceScorer",
     "MultiplEScorer",
+    "NGramCopyingBPBScorer",
     "PerplexityScorer",
     "ProcessScorer",
     "RubricJudgeScorer",

--- a/src/olmo_eval/common/scorers/ngram_copying.py
+++ b/src/olmo_eval/common/scorers/ngram_copying.py
@@ -1,0 +1,81 @@
+"""Scoring for n-gram copying: bits per byte restricted to repeated-span positions."""
+
+import math
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+
+from olmo_eval.common.types import Instance, LMOutput
+
+from .base import Scorer
+
+
+def compute_repeated_ngram_mask(tokens: Sequence[str], k: int) -> list[bool]:
+    """Flag positions whose preceding k-gram already occurred earlier in the sequence.
+
+    Position i is flagged when tokens[i-k+1:i+1] is equal to some earlier k-gram
+    tokens[j-k+1:j+1] with j < i. Match feasibility is monotonic in k (any earlier
+    match of length k implies a match of every shorter length against the same
+    earlier occurrence), so thresholding a document's longest-repeat score at k is
+    equivalent to checking length-k matches directly.
+    """
+    if k < 1:
+        raise ValueError(f"k must be >= 1, got {k}")
+
+    mask = [False] * len(tokens)
+    seen: set[tuple[str, ...]] = set()
+    for i in range(len(tokens)):
+        if i >= k - 1:
+            ngram = tuple(tokens[i - k + 1 : i + 1])
+            mask[i] = ngram in seen
+            seen.add(ngram)
+    return mask
+
+
+@dataclass(frozen=True, slots=True)
+class NGramCopyingBPBScorer(Scorer):
+    """Bits per byte restricted to positions with a length-k+ repeated n-gram.
+
+    Requires ``output.logprobs`` to reflect teacher-forced scoring of the actual
+    document tokens (e.g. a loglikelihood request over the whole document), since
+    repeat detection depends on the true token sequence rather than sampled output.
+    """
+
+    name: str = field(init=False)
+    k: int = 1
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "name", f"ngram_copying_bpb_k{self.k}")
+
+    def masked_totals(self, output: LMOutput) -> tuple[float, int] | None:
+        """Sum logprobs and byte counts over positions with a length-k+ repeat.
+
+        Returns None if the output has no logprobs or no qualifying positions.
+        """
+        if not output.logprobs:
+            return None
+
+        tokens = [entry["token"] for entry in output.logprobs]
+        mask = compute_repeated_ngram_mask(tokens, self.k)
+        if not any(mask):
+            return None
+
+        total_logprob = 0.0
+        total_bytes = 0
+        for entry, matched in zip(output.logprobs, mask, strict=True):
+            if not matched:
+                continue
+            total_logprob += entry.get("logprob", 0.0)
+            token_bytes = entry.get("bytes")
+            total_bytes += (
+                len(token_bytes) if token_bytes is not None else len(entry["token"].encode("utf-8"))
+            )
+        return total_logprob, total_bytes
+
+    def score(self, instance: Instance, output: LMOutput) -> float:
+        totals = self.masked_totals(output)
+        if totals is None:
+            return 0.0
+        total_logprob, total_bytes = totals
+        if total_bytes == 0:
+            return 0.0
+        return -total_logprob / (total_bytes * math.log(2))

--- a/src/olmo_eval/common/scorers/ngram_copying.py
+++ b/src/olmo_eval/common/scorers/ngram_copying.py
@@ -1,7 +1,7 @@
 """Scoring for n-gram copying: bits per byte restricted to repeated-span positions."""
 
 import math
-from collections.abc import Sequence
+from collections.abc import Hashable, Sequence
 from dataclasses import dataclass, field
 
 from olmo_eval.common.types import Instance, LMOutput
@@ -9,7 +9,7 @@ from olmo_eval.common.types import Instance, LMOutput
 from .base import Scorer
 
 
-def compute_repeated_ngram_mask(tokens: Sequence[str], k: int) -> list[bool]:
+def compute_repeated_ngram_mask(tokens: Sequence[Hashable], k: int) -> list[bool]:
     """Flag positions whose preceding k-gram already occurred earlier in the sequence.
 
     Position i is flagged when tokens[i-k+1:i+1] is equal to some earlier k-gram
@@ -22,7 +22,7 @@ def compute_repeated_ngram_mask(tokens: Sequence[str], k: int) -> list[bool]:
         raise ValueError(f"k must be >= 1, got {k}")
 
     mask = [False] * len(tokens)
-    seen: set[tuple[str, ...]] = set()
+    seen: set[tuple[Hashable, ...]] = set()
     for i in range(len(tokens)):
         if i >= k - 1:
             ngram = tuple(tokens[i - k + 1 : i + 1])
@@ -54,7 +54,12 @@ class NGramCopyingBPBScorer(Scorer):
         if not output.logprobs:
             return None
 
-        tokens = [entry["token"] for entry in output.logprobs]
+        # Prefer token IDs as the repeat identity: distinct tokens whose decoded
+        # strings collide (e.g. multi-byte UTF-8 fragments that all render as the
+        # replacement character) must not count as repeats of each other.
+        tokens: list[Hashable] = [
+            entry.get("token_id", entry["token"]) for entry in output.logprobs
+        ]
         mask = compute_repeated_ngram_mask(tokens, self.k)
         if not any(mask):
             return None
@@ -65,6 +70,11 @@ class NGramCopyingBPBScorer(Scorer):
             if not matched:
                 continue
             total_logprob += entry.get("logprob", 0.0)
+            # Byte counts derive from the decoded token string (providers fill
+            # "bytes" the same way), so a token that decodes to the replacement
+            # character contributes its 3-byte encoding rather than the raw
+            # token's true byte length. Exact counts would need tokenizer-level
+            # raw bytes; the error is limited to repeats containing such tokens.
             token_bytes = entry.get("bytes")
             total_bytes += (
                 len(token_bytes) if token_bytes is not None else len(entry["token"].encode("utf-8"))

--- a/src/olmo_eval/common/types/base.py
+++ b/src/olmo_eval/common/types/base.py
@@ -193,6 +193,7 @@ class LogProbEntry(TypedDict):
 
     token: str
     logprob: float
+    token_id: NotRequired[int]
     bytes: NotRequired[list[int]]
     top_logprobs: NotRequired[list[TopLogProb]]
 

--- a/src/olmo_eval/evals/tasks/c4.py
+++ b/src/olmo_eval/evals/tasks/c4.py
@@ -8,7 +8,6 @@ from olmo_eval.common.metrics import (
     CorpusPerplexityMetric,
     Metric,
     NGramCopyingBPBMetricByteAvg,
-    NGramCopyingBPBMetricInstanceAvg,
 )
 from olmo_eval.common.types import (
     Instance,
@@ -131,12 +130,8 @@ register_variant(
 
 
 def _ngram_copying_metrics() -> tuple[Metric, ...]:
-    """Build instance-avg and byte-avg n-gram-copying BPB metrics for every threshold."""
-    return tuple(
-        metric_cls(k=k)
-        for k in NGRAM_COPYING_K_VALUES
-        for metric_cls in (NGramCopyingBPBMetricInstanceAvg, NGramCopyingBPBMetricByteAvg)
-    )
+    """Build the corpus-level n-gram-copying BPB metric for every threshold."""
+    return tuple(NGramCopyingBPBMetricByteAvg(k=k) for k in NGRAM_COPYING_K_VALUES)
 
 
 register_variant(

--- a/src/olmo_eval/evals/tasks/c4.py
+++ b/src/olmo_eval/evals/tasks/c4.py
@@ -3,7 +3,13 @@
 from collections.abc import Iterator
 from typing import Any
 
-from olmo_eval.common.metrics import CorpusPerplexityMetric
+from olmo_eval.common.metrics import (
+    NGRAM_COPYING_K_VALUES,
+    CorpusPerplexityMetric,
+    Metric,
+    NGramCopyingBPBMetricByteAvg,
+    NGramCopyingBPBMetricInstanceAvg,
+)
 from olmo_eval.common.types import (
     Instance,
     LMRequest,
@@ -121,4 +127,45 @@ register_variant(
     "c4_100k",
     "ppl",
     metrics=(CorpusPerplexityMetric(),),
+)
+
+
+def _ngram_copying_metrics() -> tuple[Metric, ...]:
+    """Build instance-avg and byte-avg n-gram-copying BPB metrics for every threshold."""
+    return tuple(
+        metric_cls(k=k)
+        for k in NGRAM_COPYING_K_VALUES
+        for metric_cls in (NGramCopyingBPBMetricInstanceAvg, NGramCopyingBPBMetricByteAvg)
+    )
+
+
+register_variant(
+    "c4",
+    "ngram_copying_bpb",
+    metrics=_ngram_copying_metrics(),
+    primary_metric=NGramCopyingBPBMetricByteAvg(k=5),
+)
+
+
+register_variant(
+    "c4_1k",
+    "ngram_copying_bpb",
+    metrics=_ngram_copying_metrics(),
+    primary_metric=NGramCopyingBPBMetricByteAvg(k=5),
+)
+
+
+register_variant(
+    "c4_10k",
+    "ngram_copying_bpb",
+    metrics=_ngram_copying_metrics(),
+    primary_metric=NGramCopyingBPBMetricByteAvg(k=5),
+)
+
+
+register_variant(
+    "c4_100k",
+    "ngram_copying_bpb",
+    metrics=_ngram_copying_metrics(),
+    primary_metric=NGramCopyingBPBMetricByteAvg(k=5),
 )

--- a/src/olmo_eval/inference/providers/huggingface.py
+++ b/src/olmo_eval/inference/providers/huggingface.py
@@ -196,6 +196,7 @@ class HuggingFaceProvider(InferenceProvider):
                             {
                                 "token": token_str,
                                 "logprob": lp,
+                                "token_id": int(tok),
                                 "bytes": list(token_str.encode("utf-8")),
                             }
                         )
@@ -283,6 +284,7 @@ class HuggingFaceProvider(InferenceProvider):
                         {
                             "token": token_str,
                             "logprob": lp,
+                            "token_id": int(tok),
                             "bytes": list(token_str.encode("utf-8")),
                         }
                     )

--- a/src/olmo_eval/inference/providers/olmo_core.py
+++ b/src/olmo_eval/inference/providers/olmo_core.py
@@ -499,6 +499,7 @@ class OlmoCoreProvider(InferenceProvider):
                 {
                     "token": token_str,
                     "logprob": float(logprob),
+                    "token_id": int(token_id),
                     "bytes": list(token_str.encode("utf-8")),
                 }
             )

--- a/src/olmo_eval/inference/providers/vllm.py
+++ b/src/olmo_eval/inference/providers/vllm.py
@@ -89,6 +89,7 @@ def _convert_logprobs(
             {
                 "token": token_str,
                 "logprob": logprob_val,
+                "token_id": int(token_id),
                 "bytes": list(token_str.encode("utf-8")),
             }
         )
@@ -471,6 +472,7 @@ class VLLMProvider(InferenceProvider):
                         {
                             "token": token_str,
                             "logprob": logprob_val,
+                            "token_id": int(token_id),
                             "bytes": list(token_str.encode("utf-8")),
                         }
                     )

--- a/src/olmo_eval/inference/providers/vllm_server.py
+++ b/src/olmo_eval/inference/providers/vllm_server.py
@@ -1150,6 +1150,7 @@ class VLLMServerProvider(InferenceProvider):
                     {
                         "token": token_str,
                         "logprob": logprob_val,
+                        "token_id": int(token_id),
                         "bytes": list(token_str.encode("utf-8")),
                     }
                 )

--- a/tests/core/test_metrics.py
+++ b/tests/core/test_metrics.py
@@ -10,6 +10,8 @@ from olmo_eval.common.metrics import (
     BPBMetricInstanceAvg,
     LogprobMCAccuracyMetric,
     LogprobPerCharMCAccuracyMetric,
+    NGramCopyingBPBMetricByteAvg,
+    NGramCopyingBPBMetricInstanceAvg,
     SafetyErrorMetric,
 )
 from olmo_eval.common.scorers import MultipleChoiceScorer
@@ -565,3 +567,66 @@ class TestSafetyErrorMetric:
         errors = metric.compute(responses)
 
         assert errors == 0
+
+
+class TestNGramCopyingBPBMetric:
+    """Tests for NGramCopyingBPBMetricInstanceAvg / NGramCopyingBPBMetricByteAvg."""
+
+    def _make_response(self, tokens: list[str], logprobs: list[float]) -> Response:
+        """Build a single-output, teacher-forced (loglikelihood) Response from tokens."""
+        entries = [
+            {"token": tok, "logprob": lp, "bytes": list(tok.encode("utf-8"))}
+            for tok, lp in zip(tokens, logprobs, strict=True)
+        ]
+        text = "".join(tokens)
+        output = LMOutput(text=text, logprobs=entries)
+        return Response(
+            instance=Instance(question="", gold_answer=text),
+            request=LMRequest(request_type=RequestType.LOGLIKELIHOOD, prompt=""),
+            outputs=[output],
+        )
+
+    def test_instance_avg_masks_repeated_positions_only(self):
+        """`a b c a b` at k=1: only positions 3,4 ('a','b') are masked in."""
+        metric = NGramCopyingBPBMetricInstanceAvg(k=1)
+        response = self._make_response(["a", "b", "c", "a", "b"], [-1.0, -1.0, -1.0, -1.0, -1.0])
+
+        # Masked positions 3,4: total_logprob=-2.0, total_bytes=2.
+        expected = 2.0 / (2 * math.log(2))
+        assert metric.compute_instance(response) == pytest.approx(expected)
+        assert metric.compute([response]) == pytest.approx(expected)
+
+    def test_documents_without_repeats_are_excluded(self):
+        """A document with zero positions meeting the threshold is excluded, not zero."""
+        metric = NGramCopyingBPBMetricInstanceAvg(k=1)
+        no_repeats = self._make_response(["p", "q", "r", "s"], [-1.0, -1.0, -1.0, -1.0])
+        with_repeats = self._make_response(
+            ["a", "b", "c", "a", "b"], [-1.0, -1.0, -1.0, -1.0, -1.0]
+        )
+
+        assert metric.compute_instance(no_repeats) is None
+        # Corpus average over both should equal the single qualifying document's value.
+        expected = 2.0 / (2 * math.log(2))
+        assert metric.compute([no_repeats, with_repeats]) == pytest.approx(expected)
+        assert metric.compute([no_repeats]) == 0.0
+
+    def test_byte_avg_weights_by_masked_byte_count(self):
+        """Byte-avg weights each document's contribution by its masked byte count.
+
+        Doc A = "a b a": mask (k=1) is [F,F,T]; masked logprob=-2.0, bytes=1.
+        Doc B = "p p p p": mask (k=1) is [F,T,T,T]; masked logprob=-3.0, bytes=3.
+        """
+        instance_metric = NGramCopyingBPBMetricInstanceAvg(k=1)
+        byte_metric = NGramCopyingBPBMetricByteAvg(k=1)
+        doc_a = self._make_response(["a", "b", "a"], [-1.0, -1.0, -2.0])
+        doc_b = self._make_response(["p", "p", "p", "p"], [-1.0, -1.0, -1.0, -1.0])
+
+        bpb_a = 2.0 / (1 * math.log(2))
+        bpb_b = 3.0 / (3 * math.log(2))
+        assert instance_metric.compute_instance(doc_a) == pytest.approx(bpb_a)
+        assert instance_metric.compute_instance(doc_b) == pytest.approx(bpb_b)
+
+        # Unweighted mean of the two per-document values.
+        assert instance_metric.compute([doc_a, doc_b]) == pytest.approx((bpb_a + bpb_b) / 2)
+        # Byte-weighted: pools logprobs/bytes across documents before dividing.
+        assert byte_metric.compute([doc_a, doc_b]) == pytest.approx(5.0 / (4 * math.log(2)))

--- a/tests/core/test_metrics.py
+++ b/tests/core/test_metrics.py
@@ -11,7 +11,6 @@ from olmo_eval.common.metrics import (
     LogprobMCAccuracyMetric,
     LogprobPerCharMCAccuracyMetric,
     NGramCopyingBPBMetricByteAvg,
-    NGramCopyingBPBMetricInstanceAvg,
     SafetyErrorMetric,
 )
 from olmo_eval.common.scorers import MultipleChoiceScorer
@@ -570,7 +569,7 @@ class TestSafetyErrorMetric:
 
 
 class TestNGramCopyingBPBMetric:
-    """Tests for NGramCopyingBPBMetricInstanceAvg / NGramCopyingBPBMetricByteAvg."""
+    """Tests for NGramCopyingBPBMetricByteAvg."""
 
     def _make_response(self, tokens: list[str], logprobs: list[float]) -> Response:
         """Build a single-output, teacher-forced (loglikelihood) Response from tokens."""
@@ -586,9 +585,9 @@ class TestNGramCopyingBPBMetric:
             outputs=[output],
         )
 
-    def test_instance_avg_masks_repeated_positions_only(self):
+    def test_masks_repeated_positions_only(self):
         """`a b c a b` at k=1: only positions 3,4 ('a','b') are masked in."""
-        metric = NGramCopyingBPBMetricInstanceAvg(k=1)
+        metric = NGramCopyingBPBMetricByteAvg(k=1)
         response = self._make_response(["a", "b", "c", "a", "b"], [-1.0, -1.0, -1.0, -1.0, -1.0])
 
         # Masked positions 3,4: total_logprob=-2.0, total_bytes=2.
@@ -596,37 +595,36 @@ class TestNGramCopyingBPBMetric:
         assert metric.compute_instance(response) == pytest.approx(expected)
         assert metric.compute([response]) == pytest.approx(expected)
 
-    def test_documents_without_repeats_are_excluded(self):
-        """A document with zero positions meeting the threshold is excluded, not zero."""
-        metric = NGramCopyingBPBMetricInstanceAvg(k=1)
+    def test_documents_without_repeats_contribute_nothing(self):
+        """A document with zero positions meeting the threshold doesn't shift the pooled value."""
+        metric = NGramCopyingBPBMetricByteAvg(k=1)
         no_repeats = self._make_response(["p", "q", "r", "s"], [-1.0, -1.0, -1.0, -1.0])
         with_repeats = self._make_response(
             ["a", "b", "c", "a", "b"], [-1.0, -1.0, -1.0, -1.0, -1.0]
         )
 
         assert metric.compute_instance(no_repeats) is None
-        # Corpus average over both should equal the single qualifying document's value.
+        # Pooling with a zero-copy document should equal pooling without it.
         expected = 2.0 / (2 * math.log(2))
         assert metric.compute([no_repeats, with_repeats]) == pytest.approx(expected)
         assert metric.compute([no_repeats]) == 0.0
 
-    def test_byte_avg_weights_by_masked_byte_count(self):
-        """Byte-avg weights each document's contribution by its masked byte count.
+    def test_weights_by_masked_byte_count(self):
+        """Pooling weights each document's contribution by its masked byte count.
 
         Doc A = "a b a": mask (k=1) is [F,F,T]; masked logprob=-2.0, bytes=1.
         Doc B = "p p p p": mask (k=1) is [F,T,T,T]; masked logprob=-3.0, bytes=3.
         """
-        instance_metric = NGramCopyingBPBMetricInstanceAvg(k=1)
-        byte_metric = NGramCopyingBPBMetricByteAvg(k=1)
+        metric = NGramCopyingBPBMetricByteAvg(k=1)
         doc_a = self._make_response(["a", "b", "a"], [-1.0, -1.0, -2.0])
         doc_b = self._make_response(["p", "p", "p", "p"], [-1.0, -1.0, -1.0, -1.0])
 
         bpb_a = 2.0 / (1 * math.log(2))
         bpb_b = 3.0 / (3 * math.log(2))
-        assert instance_metric.compute_instance(doc_a) == pytest.approx(bpb_a)
-        assert instance_metric.compute_instance(doc_b) == pytest.approx(bpb_b)
+        assert metric.compute_instance(doc_a) == pytest.approx(bpb_a)
+        assert metric.compute_instance(doc_b) == pytest.approx(bpb_b)
 
-        # Unweighted mean of the two per-document values.
-        assert instance_metric.compute([doc_a, doc_b]) == pytest.approx((bpb_a + bpb_b) / 2)
-        # Byte-weighted: pools logprobs/bytes across documents before dividing.
-        assert byte_metric.compute([doc_a, doc_b]) == pytest.approx(5.0 / (4 * math.log(2)))
+        # Pools logprobs/bytes across documents before dividing once, rather than
+        # averaging the two per-document values unweighted -- doc B's larger masked
+        # span (3 bytes vs. 1) pulls the pooled result further toward its own bpb.
+        assert metric.compute([doc_a, doc_b]) == pytest.approx(5.0 / (4 * math.log(2)))

--- a/tests/core/test_scorers.py
+++ b/tests/core/test_scorers.py
@@ -5,6 +5,7 @@ import pytest
 from olmo_eval.common.scorers import (
     ExactMatchScorer,
     MultipleChoiceScorer,
+    NGramCopyingBPBScorer,
     compute_repeated_ngram_mask,
 )
 from olmo_eval.common.types import Instance, LMOutput
@@ -324,3 +325,49 @@ class TestComputeRepeatedNgramMask:
         for k in range(1, len(tokens) + 1):
             expected = [score >= k for score in scores]
             assert compute_repeated_ngram_mask(tokens, k) == expected
+
+
+class TestNGramCopyingBPBScorer:
+    """Tests for NGramCopyingBPBScorer repeat identity."""
+
+    def test_colliding_token_strings_with_distinct_ids_are_not_repeats(self):
+        """Distinct tokens whose decoded strings collide (e.g. multi-byte UTF-8
+        fragments that all render as the replacement character) must not count
+        as repeats of each other when token IDs are available."""
+        scorer = NGramCopyingBPBScorer(k=1)
+        output = LMOutput(
+            text="",
+            logprobs=[
+                {"token": "�", "logprob": -1.0, "token_id": 10},
+                {"token": "�", "logprob": -1.0, "token_id": 11},
+            ],
+        )
+
+        assert scorer.masked_totals(output) is None
+
+    def test_repeated_token_ids_are_repeats(self):
+        """The same token ID appearing again counts as a repeat, regardless of
+        what its decoded string looks like."""
+        scorer = NGramCopyingBPBScorer(k=1)
+        output = LMOutput(
+            text="",
+            logprobs=[
+                {"token": "�", "logprob": -1.0, "token_id": 10},
+                {"token": "�", "logprob": -2.0, "token_id": 10},
+            ],
+        )
+
+        assert scorer.masked_totals(output) == (-2.0, len("�".encode()))
+
+    def test_falls_back_to_token_strings_without_ids(self):
+        """Entries lacking token_id fall back to string identity."""
+        scorer = NGramCopyingBPBScorer(k=1)
+        output = LMOutput(
+            text="",
+            logprobs=[
+                {"token": "a", "logprob": -1.0},
+                {"token": "a", "logprob": -2.0},
+            ],
+        )
+
+        assert scorer.masked_totals(output) == (-2.0, 1)

--- a/tests/core/test_scorers.py
+++ b/tests/core/test_scorers.py
@@ -1,6 +1,12 @@
 """Tests for olmo_eval.core.scorers module."""
 
-from olmo_eval.common.scorers import ExactMatchScorer, MultipleChoiceScorer
+import pytest
+
+from olmo_eval.common.scorers import (
+    ExactMatchScorer,
+    MultipleChoiceScorer,
+    compute_repeated_ngram_mask,
+)
 from olmo_eval.common.types import Instance, LMOutput
 
 
@@ -202,3 +208,119 @@ class TestMultipleChoiceScorer:
 
         custom = MultipleChoiceScorer(name="custom_mc")
         assert custom.name == "custom_mc"
+
+
+def _brute_force_ngram_scores(tokens: list[str]) -> list[int]:
+    """Reference (independent of compute_repeated_ngram_mask): for each position,
+    the length of the longest suffix ending there that also occurs earlier in the
+    sequence. Tries the longest candidate length first so it doesn't rely on the
+    monotonicity assumption that the optimized implementation is built on.
+    """
+    n = len(tokens)
+    scores = [0] * n
+    for i in range(n):
+        for length in range(i, 0, -1):
+            suffix = tuple(tokens[i - length + 1 : i + 1])
+            earlier_windows = (tuple(tokens[j : j + length]) for j in range(i - length + 1))
+            if suffix in earlier_windows:
+                scores[i] = length
+                break
+    return scores
+
+
+class TestComputeRepeatedNgramMask:
+    """Tests for compute_repeated_ngram_mask."""
+
+    def test_worked_example(self):
+        """`a b c a b` has per-position longest-repeat length 0 0 0 1 2."""
+        tokens = ["a", "b", "c", "a", "b"]
+
+        assert _brute_force_ngram_scores(tokens) == [0, 0, 0, 1, 2]
+
+        assert compute_repeated_ngram_mask(tokens, k=1) == [
+            False,
+            False,
+            False,
+            True,
+            True,
+        ]
+        assert compute_repeated_ngram_mask(tokens, k=2) == [
+            False,
+            False,
+            False,
+            False,
+            True,
+        ]
+        assert compute_repeated_ngram_mask(tokens, k=3) == [
+            False,
+            False,
+            False,
+            False,
+            False,
+        ]
+
+    def test_periodic_pattern_thresholds(self):
+        """`x y x y x y` repeats at every period-2 offset, for increasing k."""
+        tokens = ["x", "y", "x", "y", "x", "y"]
+
+        assert _brute_force_ngram_scores(tokens) == [0, 0, 1, 2, 3, 4]
+
+        assert compute_repeated_ngram_mask(tokens, k=1) == [
+            False,
+            False,
+            True,
+            True,
+            True,
+            True,
+        ]
+        assert compute_repeated_ngram_mask(tokens, k=2) == [
+            False,
+            False,
+            False,
+            True,
+            True,
+            True,
+        ]
+        assert compute_repeated_ngram_mask(tokens, k=4) == [
+            False,
+            False,
+            False,
+            False,
+            False,
+            True,
+        ]
+
+    def test_no_repeats(self):
+        """A document with no repeated tokens at all is all-False for any k."""
+        tokens = ["p", "q", "r", "s"]
+
+        assert _brute_force_ngram_scores(tokens) == [0, 0, 0, 0]
+        assert compute_repeated_ngram_mask(tokens, k=1) == [False] * 4
+        assert compute_repeated_ngram_mask(tokens, k=2) == [False] * 4
+
+    def test_invalid_k_raises(self):
+        """k must be >= 1."""
+        with pytest.raises(ValueError):
+            compute_repeated_ngram_mask(["a", "b"], k=0)
+
+    @pytest.mark.parametrize(
+        "tokens",
+        [
+            ["a", "b", "c", "a", "b"],
+            ["x", "y", "x", "y", "x", "y"],
+            ["p", "q", "r", "s"],
+            ["m", "m", "m", "m", "m"],
+        ],
+    )
+    def test_mask_matches_thresholded_scores(self, tokens):
+        """compute_repeated_ngram_mask(tokens, k) must equal (score >= k) for every k.
+
+        This is the property the implementation relies on: checking a length-k
+        match directly is equivalent to thresholding the full longest-repeat score,
+        because any earlier match of length k implies a match of every shorter
+        length against that same earlier occurrence.
+        """
+        scores = _brute_force_ngram_scores(tokens)
+        for k in range(1, len(tokens) + 1):
+            expected = [score >= k for score in scores]
+            assert compute_repeated_ngram_mask(tokens, k) == expected


### PR DESCRIPTION
Adds a bits-per-byte metrics restricted to k-gram sequences which have been repeated earlier in the same document, allowing us to measure how well models can copy previously-seen spans of text.

```
x y x y x y   input sequence
0 0 1 2 3 4   n-gram repetition score
F F T T T T   mask @ k = 1
F F F T T T   mask @ k = 2
F F F F T T   mask @ k = 3
F F F F F T   mask @ k = 4
```

Adds `NGramCopyingBPBMetricInstanceAvg` (average of per-document averages) and `NGramCopyingBPBMetricByteAvg` (average across all tokens in corpus) at `k=1...5` and wires them into `c4/c4_1k/c4_10k/c4_100k` as a new `:ngram_copying_bpb` variant.