### PR TITLE
Add HELMET ICL and LongQA tasks (4k-128k)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     # syllapy (transitive via ifbench) imports pkg_resources, which setuptools>=81 removes.
     "setuptools<81",
     "bm25s>=0.3.9",
+    "rouge-score>=0.1.2",
 ]
 
 [project.urls]

--- a/scripts/internal/calibrate_helmet_icl_shots.py
+++ b/scripts/internal/calibrate_helmet_icl_shots.py
@@ -1,0 +1,122 @@
+"""Measure -- and optionally recalibrate -- HELMET ICL shot counts.
+
+For the ICL tasks, context length is set by how many demonstrations get packed
+into the prompt, so each (dataset, length) pair needs a shot count that lands
+the rendered prompt on its target token length.
+
+This is a diagnostic, NOT the source of the values in
+`olmo_eval/data/helmet_tasks.py`. Those are HELMET's own counts, kept verbatim
+so our ICL numbers stay comparable to published HELMET results. HELMET fit
+them against a Llama-2-era tokenizer, so under Olmo 3 they render at
+~0.78-0.85x nominal; the `ratio` column below quantifies that shortfall for
+whatever tokenizer you point it at, which is worth knowing when interpreting
+an ICL length sweep.
+
+The `_ICL_SHOTS` block it prints at the end is what you would paste into
+helmet_tasks.py *if* you decided to recalibrate -- trading comparability with
+published HELMET for prompts that actually hit their nominal lengths. Don't
+paste it in without making that call deliberately.
+
+Whichever counts are used, they stay hardcoded rather than resolved at eval
+time: every model must see the same prompt for its scores to be comparable, so
+the shot count has to be fixed by one reference tokenizer rather than by
+whichever model is being evaluated.
+
+Prompt length is very close to linear in the shot count, so rather than a full
+binary search this fits a line through two probes, solves for the target, and
+refines a few times -- which keeps the expensive large-shot renders to a
+handful per cell.
+
+Usage:
+    uv run python scripts/internal/calibrate_helmet_icl_shots.py
+    uv run python scripts/internal/calibrate_helmet_icl_shots.py --datasets banking77 --sizes 4096
+"""
+
+import argparse
+import statistics
+
+from transformers import AutoTokenizer
+
+from olmo_eval.data.helmet_icl_loader import ICL_DATASETS, load_icl_dataset
+from olmo_eval.data.helmet_tasks import STANDARD_CONTEXT_SIZES
+
+DEFAULT_TOKENIZER = "allenai/Olmo-3-1025-7B"
+# Number of instances to average over per measurement. Prompt length varies a
+# little between instances (different demos, different question), so a single
+# render is a noisy target to calibrate against.
+SAMPLES_PER_MEASUREMENT = 3
+TOLERANCE = 0.005
+MAX_REFINEMENTS = 6
+
+
+def measure_tokens(tokenizer, dataset: str, shots: int, seed: int) -> tuple[float, float]:
+    """Return (mean, stdev) rendered prompt length in tokens for a shot count."""
+    loaded = load_icl_dataset(dataset, shots=shots, max_samples=SAMPLES_PER_MEASUREMENT, seed=seed)
+    lengths = []
+    for record in loaded["data"]:
+        prompt = loaded["user_template"].format(**record) + "\n" + loaded["system_template"]
+        lengths.append(len(tokenizer(prompt)["input_ids"]))
+    stdev = statistics.stdev(lengths) if len(lengths) > 1 else 0.0
+    return statistics.fmean(lengths), stdev
+
+
+def calibrate(tokenizer, dataset: str, target: int, seed: int) -> tuple[int, float, float]:
+    """Find the shot count whose mean prompt length is closest to `target`."""
+    # two probes to fit tokens ~= intercept + slope * shots
+    lo_shots, hi_shots = 32, 128
+    lo_tokens, _ = measure_tokens(tokenizer, dataset, lo_shots, seed)
+    hi_tokens, _ = measure_tokens(tokenizer, dataset, hi_shots, seed)
+
+    slope = (hi_tokens - lo_tokens) / (hi_shots - lo_shots)
+    intercept = lo_tokens - slope * lo_shots
+
+    shots = max(1, round((target - intercept) / slope))
+    best = (shots, *measure_tokens(tokenizer, dataset, shots, seed))
+
+    for _ in range(MAX_REFINEMENTS):
+        mean, stdev = best[1], best[2]
+        if abs(mean - target) / target <= TOLERANCE:
+            break
+        # re-solve using the observed point, holding the fitted slope
+        shots = max(1, shots + round((target - mean) / slope))
+        mean, stdev = measure_tokens(tokenizer, dataset, shots, seed)
+        if abs(mean - target) < abs(best[1] - target):
+            best = (shots, mean, stdev)
+
+    return best
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tokenizer", default=DEFAULT_TOKENIZER)
+    parser.add_argument("--datasets", nargs="+", default=sorted(ICL_DATASETS))
+    parser.add_argument("--sizes", nargs="+", type=int, default=STANDARD_CONTEXT_SIZES)
+    parser.add_argument("--seed", type=int, default=42)
+    args = parser.parse_args()
+
+    tokenizer = AutoTokenizer.from_pretrained(args.tokenizer)
+
+    results: dict[str, list[int]] = {}
+    print(f"calibrating against {args.tokenizer}\n")
+    print(f"{'dataset':14s} {'target':>8s} {'shots':>7s} {'mean tok':>9s} {'sd':>6s} {'ratio':>6s}")
+
+    for dataset in args.datasets:
+        results[dataset] = []
+        for size in args.sizes:
+            shots, mean, stdev = calibrate(tokenizer, dataset, size, args.seed)
+            results[dataset].append(shots)
+            print(f"{dataset:14s} {size:8d} {shots:7d} {mean:9.0f} {stdev:6.0f} {mean / size:6.2f}")
+
+    print(
+        "\n# Olmo-3-calibrated counts. helmet_tasks.py deliberately keeps HELMET's"
+        "\n# originals instead, for comparability with published HELMET results --"
+        "\n# only paste this in if you are making that trade deliberately."
+    )
+    print("_ICL_SHOTS = {")
+    for dataset, shots in results.items():
+        print(f'    "{dataset}": {shots},')
+    print("}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/olmo_eval/common/metrics/__init__.py
+++ b/src/olmo_eval/common/metrics/__init__.py
@@ -31,6 +31,7 @@ from .ngram_copying import (
     NGRAM_COPYING_K_VALUES,
     NGramCopyingBPBMetricByteAvg,
 )
+from .rouge import RougeLF1Metric, RougeLRecallMetric
 
 __all__ = [
     "AccuracyMetric",
@@ -54,6 +55,8 @@ __all__ = [
     "PassAtKMetric",
     "PassPowKMetric",
     "RecallMetric",
+    "RougeLF1Metric",
+    "RougeLRecallMetric",
     "SQuADF1Metric",
     "ToolAccuracyMetric",
     "SubsetAccuracyMetric",

--- a/src/olmo_eval/common/metrics/rouge.py
+++ b/src/olmo_eval/common/metrics/rouge.py
@@ -1,0 +1,43 @@
+"""ROUGE-based metrics."""
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from olmo_eval.common.metrics.base import Metric
+from olmo_eval.common.scorers.base import Scorer
+from olmo_eval.common.scorers.rouge import RougeLF1Scorer, RougeLRecallScorer
+from olmo_eval.common.types import Response
+
+
+@dataclass(frozen=True, slots=True)
+class RougeLF1Metric(Metric):
+    """Mean ROUGE-L F1 across all responses.
+
+    Used for free-form long-context QA where the answer is a phrase rather
+    than an exact string, e.g. HELMET's infbench_qa_eng.
+    """
+
+    name: str = "rougeL_f1"
+    scorer: type[Scorer] = RougeLF1Scorer
+
+    def compute(self, responses: Sequence[Response]) -> float:
+        if not responses:
+            return 0.0
+        scorer_name = self.scorer().name
+        total = sum(r.scores.get(scorer_name, 0.0) for r in responses)
+        return total / len(responses)
+
+
+@dataclass(frozen=True, slots=True)
+class RougeLRecallMetric(Metric):
+    """Mean ROUGE-L recall across all responses."""
+
+    name: str = "rougeL_recall"
+    scorer: type[Scorer] = RougeLRecallScorer
+
+    def compute(self, responses: Sequence[Response]) -> float:
+        if not responses:
+            return 0.0
+        scorer_name = self.scorer().name
+        total = sum(r.scores.get(scorer_name, 0.0) for r in responses)
+        return total / len(responses)

--- a/src/olmo_eval/common/scorers/__init__.py
+++ b/src/olmo_eval/common/scorers/__init__.py
@@ -34,6 +34,7 @@ from .llm_judge import (
     build_openai_judge_fn,
 )
 from .ngram_copying import NGramCopyingBPBScorer, compute_repeated_ngram_mask
+from .rouge import RougeLF1Scorer, RougeLRecallScorer
 from .substring import SubstringRecallScorer
 from .tools import (
     ToolArgumentScorer,
@@ -71,6 +72,8 @@ __all__ = [
     "NGramCopyingBPBScorer",
     "PerplexityScorer",
     "ProcessScorer",
+    "RougeLF1Scorer",
+    "RougeLRecallScorer",
     "RubricJudgeScorer",
     "SafetyScorer",
     "SandboxRequiredError",

--- a/src/olmo_eval/common/scorers/rouge.py
+++ b/src/olmo_eval/common/scorers/rouge.py
@@ -1,0 +1,98 @@
+"""ROUGE-based scorers.
+
+Backed by Google Research's `rouge_score` package with `use_stemmer=True`,
+matching how HELMET (and the InfiniteBench work it draws from) computes ROUGE,
+so scores stay comparable to published numbers. Hand-rolling ROUGE-L is easy
+to get subtly wrong -- tokenization and stemming both move the number -- which
+is why the reference implementation is used instead.
+"""
+
+from dataclasses import dataclass
+from functools import cache
+from typing import Any
+
+from olmo_eval.common.scorers.base import Scorer
+from olmo_eval.common.types import Instance, LMOutput
+
+
+@cache
+def _get_rouge_scorer(rouge_type: str):
+    """Build (and cache) a RougeScorer.
+
+    Construction loads a stemmer, so it's cached rather than rebuilt per
+    instance -- these scorers are called once per response.
+    """
+    from rouge_score import rouge_scorer
+
+    return rouge_scorer.RougeScorer([rouge_type], use_stemmer=True)
+
+
+def _reference_answers(instance: Instance) -> list[str]:
+    """Collect every acceptable gold answer for an instance.
+
+    Handles both multi-reference metadata conventions in this repo
+    (`all_answers`, used by the SQuAD scorer, and `all_gold_answers`, used by
+    RULER/HELMET tasks), falling back to the single `gold_answer`.
+    """
+    metadata: dict[str, Any] = instance.metadata or {}
+    for key in ("all_answers", "all_gold_answers"):
+        answers = metadata.get(key)
+        if answers:
+            return [str(a) for a in answers]
+
+    gold = instance.gold_answer
+    if gold is None:
+        return []
+    if isinstance(gold, (list, tuple)):
+        return [str(a) for a in gold]
+    return [str(gold)]
+
+
+@dataclass(frozen=True, slots=True)
+class RougeLF1Scorer(Scorer):
+    """Max ROUGE-L F-measure over all reference answers.
+
+    Taking the max over references mirrors HELMET's `calculate_metrics`, which
+    scores against every acceptable answer and keeps the best.
+    """
+
+    name: str = "rougeL_f1"
+
+    def score(self, instance: Instance, output: LMOutput) -> float:
+        if output.extracted_answer is None:
+            return 0.0
+        prediction = str(output.extracted_answer)
+        references = _reference_answers(instance)
+        if not references:
+            return 0.0
+
+        scorer = _get_rouge_scorer("rougeL")
+        return max(
+            scorer.score(target=reference, prediction=prediction)["rougeL"].fmeasure
+            for reference in references
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class RougeLRecallScorer(Scorer):
+    """Max ROUGE-L recall over all reference answers.
+
+    HELMET reports recall alongside F1 for some summarization-style tasks
+    (e.g. qmsum uses rougeL_recall), so both are provided here.
+    """
+
+    name: str = "rougeL_recall"
+
+    def score(self, instance: Instance, output: LMOutput) -> float:
+        if output.extracted_answer is None:
+            return 0.0
+        prediction = str(output.extracted_answer)
+        references = _reference_answers(instance)
+        if not references:
+            return 0.0
+
+        scorer = _get_rouge_scorer("rougeL")
+        return max(
+            scorer.score(target=reference, prediction=prediction)["rougeL"].recall
+            for reference in references
+        )

--- a/src/olmo_eval/data/helmet_icl_loader.py
+++ b/src/olmo_eval/data/helmet_icl_loader.py
@@ -1,0 +1,225 @@
+"""HELMET-plus ICL (in-context learning) data loading.
+
+Ports HELMET's `load_icl` (https://github.com/princeton-nlp/HELMET, data.py):
+each instance presents a long list of labelled examples and asks the model to
+label one more. Context length is controlled by the *number of demonstrations*
+rather than by truncating a document, so unlike the recall tasks there is no
+generated data to download -- the source datasets come straight from the Hub
+and the length tier only sets how many shots get packed into the prompt.
+
+Labels are mapped to shuffled integers rather than their natural names, which
+is HELMET's default: it forces the model to learn the mapping from context
+instead of leaning on label semantics it already knows.
+"""
+
+import hashlib
+import math
+import random
+from typing import Any
+
+from datasets import load_dataset
+
+# Source datasets, one entry per HELMET ICL task.
+#
+# HELMET loads several of these with `trust_remote_code=True`, but `datasets`
+# dropped script-based loading in 4.0, so three of the five resolve to a
+# parquet source here instead: CogComp/trec and nlu_evaluation_data via the
+# Hub's auto-converted `refs/convert/parquet` branch (byte-identical content),
+# and banking77 via `legacy-datasets/banking77`, since PolyAI/banking77 hosts
+# only the loading script and no data. Split sizes and label counts were
+# verified against the values HELMET hardcodes.
+ICL_DATASETS: dict[str, dict[str, Any]] = {
+    "trec_coarse": {
+        "path": "CogComp/trec",
+        "revision": "refs/convert/parquet",
+        "train_split": "train",
+        "test_split": "test",
+        "text_field": "text",
+        "label_field": "coarse_label",
+        "num_labels": 6,
+    },
+    "trec_fine": {
+        "path": "CogComp/trec",
+        "revision": "refs/convert/parquet",
+        "train_split": "train",
+        "test_split": "test",
+        "text_field": "text",
+        "label_field": "fine_label",
+        "num_labels": 50,
+    },
+    "banking77": {
+        "path": "legacy-datasets/banking77",
+        "train_split": "train",
+        "test_split": "test",
+        "text_field": "text",
+        "label_field": "label",
+        "num_labels": 77,
+    },
+    "clinic150": {
+        "path": "clinc/clinc_oos",
+        "name": "plus",
+        "train_split": "train",
+        "test_split": "validation",
+        "text_field": "text",
+        "label_field": "intent",
+        "num_labels": 151,
+    },
+    "nlu": {
+        "path": "xingkunliuxtracta/nlu_evaluation_data",
+        "revision": "refs/convert/parquet",
+        # nlu ships a single split; HELMET carves out a test set with a
+        # seeded 90/10 train_test_split.
+        "split_from_train": 0.1,
+        "train_split": "train",
+        "text_field": "text",
+        "label_field": "label",
+        "num_labels": 68,
+    },
+}
+
+_ITEM_TEMPLATE = "{text}\nlabel: {label}"
+# The doubled braces are intentional and load-bearing: they survive .format()
+# as a literal "label: {label}" in the instruction, matching HELMET verbatim.
+_USER_TEMPLATE = (
+    "Use the provided mapping from the text to label to assign a label to the text. "
+    'Only output "label: {{label}}" and nothing else. \n\n{context}\n\n{question}'
+)
+_SYSTEM_TEMPLATE = "label:"
+
+
+def _balance_labels(
+    records: list[dict[str, Any]], label_field: str, shots: int, seed: int
+) -> list[dict[str, Any]]:
+    """Sample `shots` demonstrations with (near-)uniform coverage of every label.
+
+    Faithful port of HELMET's inner `balance_labels`. Demonstrations are laid
+    out in consecutive rounds, each round holding one example per label in a
+    random order, so labels stay interleaved rather than clustered no matter
+    where the prompt gets cut off.
+    """
+    rand = random.Random(seed)
+
+    label_to_samples: dict[Any, list[dict[str, Any]]] = {}
+    for record in records:
+        label_to_samples.setdefault(record[label_field], []).append(record)
+
+    num_rounds = math.ceil(shots / len(label_to_samples))
+    rounds: list[list[dict[str, Any]]] = [[] for _ in range(num_rounds)]
+
+    for samples in label_to_samples.values():
+        indices = rand.sample(range(len(samples)), num_rounds % len(samples))
+        while len(indices) < num_rounds:
+            # sample with replacement when a label has fewer examples than rounds
+            indices += rand.sample(
+                range(len(samples)), min(num_rounds - len(indices), len(samples))
+            )
+        for i, idx in enumerate(indices):
+            rounds[i].append(samples[idx])
+
+    for round_samples in rounds:
+        rand.shuffle(round_samples)
+
+    return [record for round_samples in rounds for record in round_samples][:shots]
+
+
+def _load_splits(spec: dict[str, Any], seed: int):
+    """Load the train/test splits for one ICL source dataset.
+
+    Returns HuggingFace `Dataset`s rather than lists so callers can use
+    `.shuffle(seed=...)`, whose permutation HELMET's instance selection
+    depends on.
+    """
+    load_kwargs: dict[str, Any] = {}
+    if "name" in spec:
+        load_kwargs["name"] = spec["name"]
+    if "revision" in spec:
+        load_kwargs["revision"] = spec["revision"]
+
+    dataset = load_dataset(spec["path"], **load_kwargs)
+
+    if "split_from_train" in spec:
+        split = dataset[spec["train_split"]].train_test_split(
+            test_size=spec["split_from_train"], seed=seed
+        )
+        return split["train"], split["test"]
+
+    return dataset[spec["train_split"]], dataset[spec["test_split"]]
+
+
+def load_icl_dataset(
+    icl_dataset: str,
+    shots: int,
+    max_samples: int | None = None,
+    seed: int = 42,
+) -> dict[str, Any]:
+    """Load a HELMET ICL dataset at a given number of in-context demonstrations.
+
+    Args:
+        icl_dataset: Key into `ICL_DATASETS` (e.g. "banking77").
+        shots: Number of demonstrations to pack into each prompt. This is what
+            sets the context length -- see `helmet_tasks.py` for the per-length
+            shot counts HELMET calibrated.
+        max_samples: Cap on the number of test instances.
+        seed: Base seed; each instance additionally derives its own seed from
+            its text, so demo selection is stable per instance regardless of
+            how many instances are evaluated.
+
+    Returns:
+        Dictionary with `data` (processed records) and the HELMET prompt templates.
+    """
+    if icl_dataset not in ICL_DATASETS:
+        raise ValueError(
+            f"Unknown HELMET ICL dataset '{icl_dataset}'. Available: {sorted(ICL_DATASETS)}"
+        )
+
+    spec = ICL_DATASETS[icl_dataset]
+    text_field = spec["text_field"]
+    label_field = spec["label_field"]
+    num_labels = spec["num_labels"]
+
+    train_dataset, test_dataset = _load_splits(spec, seed)
+    train_records = train_dataset.to_list()
+
+    if max_samples is not None and len(test_dataset) > max_samples:
+        # shuffle first so the balanced subset isn't drawn from the head of the
+        # split, then balance so every label is represented in the test set too
+        test_records = _balance_labels(
+            test_dataset.shuffle(seed=seed).to_list(), label_field, max_samples, seed
+        )
+    else:
+        test_records = test_dataset.to_list()
+
+    def process_example(sample: dict[str, Any]) -> dict[str, Any]:
+        # deterministic per-instance seed, so an instance gets the same demos
+        # and the same label permutation on every run
+        local_seed = (
+            int(hashlib.sha256(sample[text_field].encode("utf-8")).hexdigest(), 16) + seed
+        ) % 2**31
+
+        demos = _balance_labels(train_records, label_field, shots, local_seed)
+
+        # map each label id to a shuffled integer, so the model has to read the
+        # mapping out of the context rather than recognizing the label names
+        label_mapping = list(range(num_labels))
+        random.Random(local_seed).shuffle(label_mapping)
+
+        context = "\n\n".join(
+            _ITEM_TEMPLATE.format(
+                text=demo[text_field], label=str(label_mapping[int(demo[label_field])])
+            )
+            for demo in demos
+        )
+        return {
+            "context": context,
+            "question": sample[text_field],
+            "answer": str(label_mapping[int(sample[label_field])]),
+        }
+
+    data = [process_example(record) for record in test_records]
+
+    return {
+        "data": data,
+        "prompt_template": _USER_TEMPLATE + "\n" + _SYSTEM_TEMPLATE,
+        "user_template": _USER_TEMPLATE,
+        "system_template": _SYSTEM_TEMPLATE,
+    }

--- a/src/olmo_eval/data/helmet_infbench_loader.py
+++ b/src/olmo_eval/data/helmet_infbench_loader.py
@@ -1,0 +1,160 @@
+"""HELMET InfiniteBench (LongQA) data loading.
+
+Ports HELMET's `load_infbench` (https://github.com/princeton-nlp/HELMET,
+data.py): a book-length story plus a question about it. Unlike the recall
+tasks, length here comes from truncating a real document, so these tasks stop
+at standard HELMET's 128k -- the books themselves set the ceiling.
+
+Contexts are truncated with a *fixed reference tokenizer* (Llama 2, as
+upstream) rather than the tokenizer of whichever model is being evaluated.
+That is deliberate and load-bearing: it is what makes every model see exactly
+the same text, and it keeps our numbers comparable to published HELMET
+results. It does mean the realized length under Olmo 3 differs from nominal,
+the same trade already taken for the ICL tasks -- see `helmet_tasks.py`.
+"""
+
+import logging
+from typing import Any
+
+from datasets import Features, Sequence, Value, load_dataset
+
+logger = logging.getLogger(__name__)
+
+# HELMET truncates against meta-llama/Llama-2-7b-hf; this is an ungated mirror
+# of the same tokenizer, so the repo doesn't require gated-model access.
+REFERENCE_TOKENIZER = "NousResearch/Llama-2-7b-hf"
+
+# Appended to a context after cutting it, so the model can tell the document
+# was truncated rather than simply ending. Verbatim from HELMET.
+TRUNCATION_POSTFIX = " ... [the rest of the text is omitted]"
+
+# HELMET passes explicit features when loading InfiniteBench to work around a
+# dataset hashing bug that otherwise surfaces between online/offline runs.
+_INFBENCH_FEATURES = Features(
+    {
+        "id": Value("int64"),
+        "context": Value("string"),
+        "input": Value("string"),
+        "answer": Sequence(Value("string")),
+        "options": Sequence(Value("string")),
+    }
+)
+
+INFBENCH_SUBSETS: dict[str, dict[str, Any]] = {
+    "qa_eng": {
+        "split": "longbook_qa_eng",
+        "user_template": (
+            "You are given a story and a question. Answer the question as concisely as "
+            "you can, using a single phrase if possible.\n\n{demo}{context}\n\n"
+            "Question: {question}"
+        ),
+        "system_template": "Answer:",
+        "demo_template": "[story text]\nQuestion: {question}\nAnswer: {answer}",
+    },
+}
+
+
+def _load_reference_tokenizer(name: str):
+    from transformers import AutoTokenizer
+
+    return AutoTokenizer.from_pretrained(name)
+
+
+def _truncate_context(context: str, max_tokens: int, tokenizer, separator_length: int) -> str:
+    """Cut `context` to `max_tokens` reference-tokenizer tokens, HELMET-style.
+
+    Mirrors HELMET's `truncate_llama2`: the budget is spent on the document
+    itself, with room reserved for the truncation notice appended afterwards.
+    """
+    encoded = tokenizer(context, return_offsets_mapping=True)
+    if len(encoded["input_ids"]) <= max_tokens:
+        return context
+    cut_at = encoded["offset_mapping"][max_tokens - separator_length][1]
+    return context[:cut_at] + TRUNCATION_POSTFIX
+
+
+def load_infbench_dataset(
+    subset: str,
+    max_context_tokens: int,
+    shots: int = 2,
+    max_samples: int | None = None,
+    seed: int = 42,
+    reference_tokenizer: str = REFERENCE_TOKENIZER,
+) -> dict[str, Any]:
+    """Load a HELMET InfiniteBench subset truncated to a target context length.
+
+    Args:
+        subset: Key into `INFBENCH_SUBSETS` (e.g. "qa_eng").
+        max_context_tokens: Token budget for the story, measured with the
+            reference tokenizer. HELMET reserves room for the prompt and the
+            generation, so this is smaller than the task's nominal length.
+        shots: Number of worked examples to prepend. The demos show only a
+            `[story text]` placeholder rather than a real story, so they cost
+            almost nothing against the budget -- as in HELMET.
+        max_samples: Cap on the number of instances.
+        seed: Seed for instance sampling and demo selection.
+        reference_tokenizer: Tokenizer used for truncation. Changing this
+            changes how much text every model sees, so it should stay fixed.
+
+    Returns:
+        Dictionary with `data` (processed records) and the HELMET prompt templates.
+    """
+    if subset not in INFBENCH_SUBSETS:
+        raise ValueError(
+            f"Unknown InfiniteBench subset '{subset}'. Available: {sorted(INFBENCH_SUBSETS)}"
+        )
+
+    spec = INFBENCH_SUBSETS[subset]
+    data = load_dataset("xinrongzhang2022/infinitebench", features=_INFBENCH_FEATURES)[
+        spec["split"]
+    ]
+
+    data = data.map(lambda example: {"question": example["input"], "demo": ""})
+
+    # HELMET filters to contexts of >=65536 reference tokens before sampling.
+    # Every InfiniteBench story clears that bar (the shortest is ~78k tokens),
+    # which HELMET itself notes is "just a sanity step", so the filter is a
+    # no-op and is skipped here -- letting us sample first and truncate only
+    # the rows we keep, instead of tokenizing all 351 book-length contexts.
+    demo_pool = data
+    if max_samples is not None and len(data) > max_samples:
+        data = data.shuffle(seed=seed).select(range(max_samples))
+
+    if shots > 0:
+        demo_template = spec["demo_template"]
+
+        def add_demos(example: dict[str, Any]) -> dict[str, Any]:
+            # drawn from the full pool, not the sampled subset, so demos don't
+            # depend on how many instances are being evaluated
+            demos = demo_pool.filter(lambda x: x["id"] != example["id"])
+            demos = demos.shuffle(seed=seed).select(range(shots))
+            demo_text = "\n\n".join(
+                demo_template.format(question=d["question"], answer=d["answer"][0]) for d in demos
+            )
+            return {"demo": f"For example:\n\n{demo_text}\n\nNow, read the following story:\n\n"}
+
+        data = data.map(add_demos)
+
+    tokenizer = _load_reference_tokenizer(reference_tokenizer)
+    separator_length = len(tokenizer(TRUNCATION_POSTFIX)["input_ids"])
+
+    # InfiniteBench asks several questions about each book (351 rows over 69
+    # stories), so truncation results are memoized per distinct context.
+    truncation_cache: dict[str, str] = {}
+
+    def truncate(example: dict[str, Any]) -> dict[str, Any]:
+        context = example["context"]
+        if context not in truncation_cache:
+            truncation_cache[context] = _truncate_context(
+                context, max_context_tokens, tokenizer, separator_length
+            )
+        return {"context": truncation_cache[context]}
+
+    data = data.map(truncate)
+
+    return {
+        "data": data.to_list(),
+        "prompt_template": spec["user_template"] + "\n\n" + spec["system_template"],
+        "user_template": spec["user_template"],
+        "system_template": spec["system_template"],
+    }

--- a/src/olmo_eval/data/helmet_infbench_loader.py
+++ b/src/olmo_eval/data/helmet_infbench_loader.py
@@ -49,9 +49,39 @@ INFBENCH_SUBSETS: dict[str, dict[str, Any]] = {
             "Question: {question}"
         ),
         "system_template": "Answer:",
-        "demo_template": "[story text]\nQuestion: {question}\nAnswer: {answer}",
+        "demo_template": "[story text]\nQuestion: {question}\nAnswer: {answer[0]}",
+    },
+    "choice_eng": {
+        "split": "longbook_choice_eng",
+        "user_template": (
+            "You are given a story and a question with multiple choices. Choose the best "
+            "answer from the options provided. Only one of the following options is "
+            "correct, output the answer using one single letter (A, B, C, or D). Don't "
+            "say anything else.\n\n{demo}{context}\n\nQuestion: {question}\n"
+            "Options:\n{options}"
+        ),
+        "system_template": "Answer:",
+        "demo_template": (
+            "[story text]\nQuestion: {question}\nOptions:\n{options}\nAnswer: {answer[0]}"
+        ),
+        "multiple_choice": True,
     },
 }
+
+
+def _process_multiple_choice(example: dict[str, Any]) -> dict[str, Any]:
+    """Render the options block and rewrite the answer as a letter.
+
+    HELMET stores two acceptable forms of the gold answer -- the bare letter
+    and "letter. option text" -- because a model may produce either; both are
+    accepted at scoring time.
+    """
+    options = "A. {}\nB. {}\nC. {}\nD. {}".format(*example["options"])
+    letter = chr(ord("A") + example["options"].index(example["answer"][0]))
+    return {
+        "options": options,
+        "answer": [letter, f"{letter}. {example['answer'][0]}"],
+    }
 
 
 def _load_reference_tokenizer(name: str):
@@ -109,7 +139,13 @@ def load_infbench_dataset(
         spec["split"]
     ]
 
-    data = data.map(lambda example: {"question": example["input"], "demo": ""})
+    def process_example(example: dict[str, Any]) -> dict[str, Any]:
+        update = {"question": example["input"], "demo": ""}
+        if spec.get("multiple_choice"):
+            update.update(_process_multiple_choice(example))
+        return update
+
+    data = data.map(process_example)
 
     # HELMET filters to contexts of >=65536 reference tokens before sampling.
     # Every InfiniteBench story clears that bar (the shortest is ~78k tokens),
@@ -128,9 +164,7 @@ def load_infbench_dataset(
             # depend on how many instances are being evaluated
             demos = demo_pool.filter(lambda x: x["id"] != example["id"])
             demos = demos.shuffle(seed=seed).select(range(shots))
-            demo_text = "\n\n".join(
-                demo_template.format(question=d["question"], answer=d["answer"][0]) for d in demos
-            )
+            demo_text = "\n\n".join(demo_template.format(**d) for d in demos)
             return {"demo": f"For example:\n\n{demo_text}\n\nNow, read the following story:\n\n"}
 
         data = data.map(add_demos)

--- a/src/olmo_eval/data/helmet_tasks.py
+++ b/src/olmo_eval/data/helmet_tasks.py
@@ -8,6 +8,10 @@ ceiling, since real-document tasks (LongQA, Summ, RAG, ...) are capped by
 how long the source documents actually are; currently that's just the
 `json_kv` recall task.
 
+Length coverage is therefore ragged, and each task declares its own
+`context_sizes`: `json_kv` spans the full 4k-2m range, while the ICL tasks
+stop at standard HELMET's 128k.
+
 Tasks are generated programmatically from base configurations, following the
 same pattern as `ruler_tasks.py`.
 """
@@ -27,15 +31,52 @@ LENGTH_NAMES = {
     2097152: "2m",
 }
 
-CONTEXT_SIZES = list(LENGTH_NAMES)
+# Standard HELMET lengths, vs. the tiers added by the long-context extension.
+STANDARD_CONTEXT_SIZES = [4096, 8192, 16384, 32768, 65536, 131072]
+EXTENDED_CONTEXT_SIZES = [262144, 524288, 1048576, 2097152]
+CONTEXT_SIZES = STANDARD_CONTEXT_SIZES + EXTENDED_CONTEXT_SIZES
 
 _DEFAULT_MAX_GEN_TOKS = 100
 _DEFAULT_SHOTS = 2
+_DEFAULT_LIMIT = 100
+
+# Shot counts per ICL dataset, aligned with STANDARD_CONTEXT_SIZES. These are
+# HELMET's own calibrated values (scripts/generate_configs.py): for ICL the
+# number of demonstrations, not truncation, is what sets the context length.
+_ICL_SHOTS = {
+    "trec_coarse": [200, 400, 800, 1600, 3300, 6600],
+    "trec_fine": [200, 400, 800, 1600, 3200, 6400],
+    "banking77": [180, 360, 720, 1450, 2900, 5900],
+    "clinic150": [220, 440, 880, 1750, 3525, 7050],
+    "nlu": [250, 510, 1020, 2040, 4080, 8296],
+}
+
+# HELMET evaluates ICL on 500 samples (configs/icl.yaml) rather than the 100
+# used for the recall tasks.
+_ICL_LIMIT = 500
+_ICL_MAX_GEN_TOKS = 20
 
 # Base task configurations, keyed by HELMET task type.
-_BASE_TASKS = {
+_BASE_TASKS: dict[str, dict] = {
     "json_kv": {
+        "kind": "json_kv",
         "tag": "recall",
+        "context_sizes": CONTEXT_SIZES,
+    },
+    **{
+        f"icl_{name}": {
+            "kind": "icl",
+            "tag": "icl",
+            "icl_dataset": name,
+            "context_sizes": STANDARD_CONTEXT_SIZES,
+            "shots_by_size": dict(zip(STANDARD_CONTEXT_SIZES, shots, strict=True)),
+            "max_gen_toks": _ICL_MAX_GEN_TOKS,
+            "limit": _ICL_LIMIT,
+            # HELMET sets stop_new_line=True for ICL: the answer is a single
+            # "label: N" line, so generation should stop at the newline.
+            "stop_new_line": True,
+        }
+        for name, shots in _ICL_SHOTS.items()
     },
 }
 
@@ -43,7 +84,8 @@ _BASE_TASKS = {
 def _generate_helmet_tasks() -> dict:
     """Generate HELMET_TASKS dictionary from base configurations.
 
-    Creates task definitions for all combinations of base tasks and context sizes.
+    Creates task definitions for each base task at each of the context sizes
+    that task actually supports.
 
     Returns:
         Dictionary mapping task names to their configurations.
@@ -51,14 +93,30 @@ def _generate_helmet_tasks() -> dict:
     tasks = {}
 
     for task_type, base_config in _BASE_TASKS.items():
-        for size in CONTEXT_SIZES:
+        for size in base_config.get("context_sizes", CONTEXT_SIZES):
             task_name = f"{task_type}__{size}"
-            tasks[task_name] = {
+
+            shots_by_size = base_config.get("shots_by_size")
+            shots = (
+                shots_by_size[size]
+                if shots_by_size is not None
+                else base_config.get("shots", _DEFAULT_SHOTS)
+            )
+
+            task: dict = {
+                "kind": base_config["kind"],
                 "length_name": LENGTH_NAMES[size],
-                "shots": base_config.get("shots", _DEFAULT_SHOTS),
+                "shots": shots,
                 "max_gen_toks": base_config.get("max_gen_toks", _DEFAULT_MAX_GEN_TOKS),
+                "limit": base_config.get("limit", _DEFAULT_LIMIT),
                 "tag": base_config["tag"],
             }
+            if "icl_dataset" in base_config:
+                task["icl_dataset"] = base_config["icl_dataset"]
+            if base_config.get("stop_new_line"):
+                task["stop_new_line"] = True
+
+            tasks[task_name] = task
 
     return tasks
 

--- a/src/olmo_eval/data/helmet_tasks.py
+++ b/src/olmo_eval/data/helmet_tasks.py
@@ -69,6 +69,13 @@ _ICL_SHOTS = {
 _ICL_LIMIT = 500
 _ICL_MAX_GEN_TOKS = 20
 
+# LongQA reserves part of each length tier for the prompt and the generation,
+# and gives the rest to the story: HELMET names these tasks with a postfix of
+# `length - 200 - generation_max_length` and truncates the context to exactly
+# that many reference-tokenizer tokens (see generate_configs.py).
+_LONGQA_PROMPT_RESERVE = 200
+_INFBENCH_QA_MAX_GEN_TOKS = 10
+
 # Base task configurations, keyed by HELMET task type.
 _BASE_TASKS: dict[str, dict] = {
     "json_kv": {
@@ -90,6 +97,19 @@ _BASE_TASKS: dict[str, dict] = {
             "stop_new_line": True,
         }
         for name, shots in _ICL_SHOTS.items()
+    },
+    "infbench_qa_eng": {
+        "kind": "infbench",
+        "tag": "longqa",
+        "infbench_subset": "qa_eng",
+        # capped at standard HELMET's lengths: the context is a real book, so
+        # it can't be stretched the way json_kv's synthetic context can
+        "context_sizes": STANDARD_CONTEXT_SIZES,
+        "max_gen_toks": _INFBENCH_QA_MAX_GEN_TOKS,
+        "shots": 2,
+        # HELMET runs LongQA with a chat template, so the "Answer:" prefix is
+        # not appended to the prompt as a partial assistant turn
+        "use_chat_template": True,
     },
 }
 
@@ -116,18 +136,26 @@ def _generate_helmet_tasks() -> dict:
                 else base_config.get("shots", _DEFAULT_SHOTS)
             )
 
+            max_gen_toks = base_config.get("max_gen_toks", _DEFAULT_MAX_GEN_TOKS)
+
             task: dict = {
                 "kind": base_config["kind"],
                 "length_name": LENGTH_NAMES[size],
                 "shots": shots,
-                "max_gen_toks": base_config.get("max_gen_toks", _DEFAULT_MAX_GEN_TOKS),
+                "max_gen_toks": max_gen_toks,
                 "limit": base_config.get("limit", _DEFAULT_LIMIT),
                 "tag": base_config["tag"],
             }
             if "icl_dataset" in base_config:
                 task["icl_dataset"] = base_config["icl_dataset"]
+            if "infbench_subset" in base_config:
+                task["infbench_subset"] = base_config["infbench_subset"]
+                # the story gets whatever the prompt and the generation don't
+                task["max_context_tokens"] = size - _LONGQA_PROMPT_RESERVE - max_gen_toks
             if base_config.get("stop_new_line"):
                 task["stop_new_line"] = True
+            if base_config.get("use_chat_template"):
+                task["use_chat_template"] = True
 
             tasks[task_name] = task
 

--- a/src/olmo_eval/data/helmet_tasks.py
+++ b/src/olmo_eval/data/helmet_tasks.py
@@ -111,6 +111,18 @@ _BASE_TASKS: dict[str, dict] = {
         # not appended to the prompt as a partial assistant turn
         "use_chat_template": True,
     },
+    "infbench_choice_eng": {
+        "kind": "infbench",
+        # same loader and task class as qa_eng, but scored by exact match on
+        # the chosen letter rather than ROUGE
+        "metrics_key": "infbench_choice",
+        "tag": "longqa",
+        "infbench_subset": "choice_eng",
+        "context_sizes": STANDARD_CONTEXT_SIZES,
+        "max_gen_toks": _INFBENCH_QA_MAX_GEN_TOKS,
+        "shots": 2,
+        "use_chat_template": True,
+    },
 }
 
 
@@ -140,6 +152,9 @@ def _generate_helmet_tasks() -> dict:
 
             task: dict = {
                 "kind": base_config["kind"],
+                # which metric set to score with; defaults to the task kind,
+                # but subsets sharing a loader can score differently
+                "metrics_key": base_config.get("metrics_key", base_config["kind"]),
                 "length_name": LENGTH_NAMES[size],
                 "shots": shots,
                 "max_gen_toks": max_gen_toks,

--- a/src/olmo_eval/data/helmet_tasks.py
+++ b/src/olmo_eval/data/helmet_tasks.py
@@ -41,8 +41,21 @@ _DEFAULT_SHOTS = 2
 _DEFAULT_LIMIT = 100
 
 # Shot counts per ICL dataset, aligned with STANDARD_CONTEXT_SIZES. These are
-# HELMET's own calibrated values (scripts/generate_configs.py): for ICL the
-# number of demonstrations, not truncation, is what sets the context length.
+# HELMET's own values (scripts/generate_configs.py): for ICL the number of
+# demonstrations, not truncation, is what sets the context length.
+#
+# Caveat worth knowing when reading results: HELMET fit these against a
+# Llama-2-era tokenizer, so under Olmo 3's larger vocabulary the rendered
+# prompts come out at ~0.78-0.85x their nominal length -- "icl_*__4096" is
+# really ~3.3-3.5k tokens, and "__131072" is closer to 105k. They are kept
+# as-is anyway so our ICL numbers stay directly comparable to published
+# HELMET results; the alternative trades that comparability for internal
+# consistency with json_kv, which is calibrated against Olmo 3 and does hit
+# its nominal lengths. Run scripts/internal/calibrate_helmet_icl_shots.py to
+# measure the current shortfall or to generate Olmo-3-calibrated counts.
+#
+# Note also that trec has only 5452 training examples, so its longest tiers
+# repeat demonstrations (balance_labels samples with replacement).
 _ICL_SHOTS = {
     "trec_coarse": [200, 400, 800, 1600, 3300, 6600],
     "trec_fine": [200, 400, 800, 1600, 3200, 6400],

--- a/src/olmo_eval/evals/suites/helmet.py
+++ b/src/olmo_eval/evals/suites/helmet.py
@@ -1,20 +1,34 @@
 """HELMET-plus task suites organized by category and context size.
 
 Mirrors the suite structure in `suites/ruler.py`:
-- Per-category suites for each size: helmet_recall__262144, etc.
-- Combined suites for each size: helmet_all__262144, etc.
+- Per-category suites for each size: helmet_recall__262144, helmet_icl__4096, etc.
+- Combined suites for each size: helmet_all__4096, etc.
+
+Two deliberate differences from `suites/ruler.py`:
+
+1. `helmet_all__*` aggregates the *category* suites rather than flat-averaging
+   every task, matching how the HELMET paper reports an overall number. A flat
+   average would let a category's task count set its weight -- ICL contributes
+   five tasks and recall one, so recall would be worth a sixth of ICL.
+
+2. `helmet_all__*` is only registered where more than one category exists at
+   that length. Above 128k only `json_kv` extends, so a combined suite there
+   would be a rename of `helmet_recall__*` whose composition silently differs
+   from the same suite at shorter lengths -- exactly the thing that turns a
+   length sweep into a misleading trend line. Use `helmet_recall__*` for the
+   extended tiers.
 """
 
 from olmo_eval.data.helmet_tasks import CONTEXT_SIZES, HELMET_TASKS
 from olmo_eval.evals.suites.registry import AggregationStrategy, Suite, register
 
-# Task categories (tags)
-CATEGORIES = ["recall"]
+# Task categories (tags), in the order HELMET reports them
+CATEGORIES = ["recall", "icl"]
 
 
 # Create suites for each (category, context_size) combination
 for size in CONTEXT_SIZES:
-    all_tasks: list[str] = []
+    category_suites: list[Suite] = []
 
     for category in CATEGORIES:
         tasks = [
@@ -33,13 +47,16 @@ for size in CONTEXT_SIZES:
             description=f"HELMET-plus {category} tasks at {size} context length",
         )
         register(suite)
-        all_tasks.extend(tasks)
+        category_suites.append(suite)
 
-    if len(all_tasks) > 0:
+    if len(category_suites) > 1:
         all_tasks_suite = Suite(
             name=f"helmet_all__{size}",
-            tasks=tuple(all_tasks),
-            aggregation=AggregationStrategy.AVERAGE,
-            description=f"All HELMET-plus tasks at {size} context length (flat average)",
+            tasks=tuple(category_suites),
+            aggregation=AggregationStrategy.AVERAGE_OF_AVERAGES,
+            description=(
+                f"All HELMET-plus tasks at {size} context length "
+                f"(mean over category averages: {', '.join(CATEGORIES)})"
+            ),
         )
         register(all_tasks_suite)

--- a/src/olmo_eval/evals/suites/helmet.py
+++ b/src/olmo_eval/evals/suites/helmet.py
@@ -23,7 +23,7 @@ from olmo_eval.data.helmet_tasks import CONTEXT_SIZES, HELMET_TASKS
 from olmo_eval.evals.suites.registry import AggregationStrategy, Suite, register
 
 # Task categories (tags), in the order HELMET reports them
-CATEGORIES = ["recall", "icl"]
+CATEGORIES = ["recall", "longqa", "icl"]
 
 
 # Create suites for each (category, context_size) combination

--- a/src/olmo_eval/evals/tasks/helmet.py
+++ b/src/olmo_eval/evals/tasks/helmet.py
@@ -16,9 +16,12 @@ here so a HELMET run covers more than recall alone.
 
 import re
 from collections.abc import Iterator
+from dataclasses import dataclass
 from typing import Any, cast
 
 from olmo_eval.common.metrics import AccuracyMetric, RecallMetric, RougeLF1Metric
+from olmo_eval.common.scorers import Scorer
+from olmo_eval.common.scorers.base import _squad_normalize_answer
 from olmo_eval.common.types import Instance, LMOutput, LMRequest, RequestType, SamplingParams
 from olmo_eval.data.helmet_icl_loader import load_icl_dataset
 from olmo_eval.data.helmet_infbench_loader import load_infbench_dataset
@@ -208,6 +211,50 @@ class HelmetInfbenchTask(HelmetTask):
         return parsed if parsed else output.text
 
 
+@dataclass(frozen=True, slots=True)
+class InfbenchChoiceScorer(Scorer):
+    """Exact match for InfiniteBench multiple choice, following HELMET.
+
+    HELMET accepts the answer in any of the forms a model realistically emits,
+    so this counts a response correct when the raw generation, or its
+    "Answer:"-stripped form, normalizes to either the bare letter ("B") or the
+    letter with its option text ("B. Paris") -- or when the latter appears
+    anywhere in the generation, which is what catches a verbose model that
+    answers in a sentence.
+
+    It reads `output.text` rather than only `extracted_answer` because that
+    last substring rule is defined against the untouched generation.
+    """
+
+    name: str = "exact_match"
+
+    def score(self, instance: Instance, output: LMOutput) -> float:
+        metadata = instance.metadata or {}
+        golds = metadata.get("all_gold_answers") or []
+        if not golds:
+            gold = instance.gold_answer
+            if gold is None:
+                return 0.0
+            golds = list(gold) if isinstance(gold, (list, tuple)) else [gold]
+        golds = [str(g) for g in golds]
+
+        raw = output.text or ""
+        candidates = [raw]
+        parsed = _parse_labeled_output(raw, prefix="Answer:")
+        if parsed:
+            candidates.append(parsed)
+
+        normalized_golds = {_squad_normalize_answer(g) for g in golds}
+        if any(_squad_normalize_answer(c) in normalized_golds for c in candidates):
+            return 1.0
+
+        # golds[1] is the "letter. option text" form
+        if len(golds) > 1 and golds[1].lower() in raw.lower():
+            return 1.0
+
+        return 0.0
+
+
 _TASK_CLASSES: dict[str, type[HelmetTask]] = {
     "json_kv": HelmetJsonKvTask,
     "icl": HelmetIclTask,
@@ -221,6 +268,10 @@ _TASK_METRICS: dict[str, tuple] = {
     "json_kv": ((RecallMetric(),), "recall"),
     "icl": ((AccuracyMetric(name="exact_match"),), "exact_match"),
     "infbench": ((RougeLF1Metric(),), "rougeL_f1"),
+    "infbench_choice": (
+        (AccuracyMetric(name="exact_match", scorer=InfbenchChoiceScorer),),
+        "exact_match",
+    ),
 }
 
 
@@ -230,9 +281,8 @@ def _make_helmet_task_class(task_name: str, task_cfg: dict) -> type[HelmetTask]:
     Subclasses carry only class-level attributes (metrics, sampling_params, limit);
     all runtime state is derived from config.name inside HelmetTask.__init__.
     """
-    kind = task_cfg["kind"]
-    base_cls = _TASK_CLASSES[kind]
-    metrics, primary_metric = _TASK_METRICS[kind]
+    base_cls = _TASK_CLASSES[task_cfg["kind"]]
+    metrics, primary_metric = _TASK_METRICS[task_cfg["metrics_key"]]
 
     stop_sequences = ("\n",) if task_cfg.get("stop_new_line") else None
 

--- a/src/olmo_eval/evals/tasks/helmet.py
+++ b/src/olmo_eval/evals/tasks/helmet.py
@@ -6,21 +6,34 @@ currently the `json_kv` recall task (JSON key-value retrieval, based on
 https://github.com/nelson-liu/lost-in-the-middle), calibrated up to 2m
 tokens against the Olmo 3 tokenizer. Data is published as the ai2-internal
 `allenai/helmet-plus` dataset on the Hub.
+
+The ICL tasks are carried over from standard HELMET at its original 4k-128k
+lengths. They aren't length-extendable the way `json_kv` is -- their context
+is built from real labelled examples, so length is capped by how many
+demonstrations the source datasets actually contain -- but they're included
+here so a HELMET run covers more than recall alone.
 """
 
+import re
 from collections.abc import Iterator
 from typing import Any, cast
 
-from olmo_eval.common.metrics import RecallMetric
+from olmo_eval.common.metrics import AccuracyMetric, RecallMetric
 from olmo_eval.common.types import Instance, LMOutput, LMRequest, RequestType, SamplingParams
+from olmo_eval.data.helmet_icl_loader import load_icl_dataset
 from olmo_eval.data.helmet_loader import load_json_kv_dataset
 from olmo_eval.data.helmet_tasks import HELMET_TASKS
 from olmo_eval.evals.tasks.common.base import Task, TaskConfig
 from olmo_eval.evals.tasks.common.registry import register
 
 
-class HelmetJsonKvTask(Task):
-    """HELMET-plus json_kv task: extract a value for a given key from a long JSON blob."""
+class HelmetTask(Task):
+    """Shared plumbing for HELMET-plus tasks.
+
+    Subclasses implement `_load_dataset` to fetch their data; everything from
+    prompt assembly onward is common, since all HELMET tasks share the same
+    `user_template` / `system_template` prompt shape.
+    """
 
     def __init__(self, config: TaskConfig) -> None:
         super().__init__(config)
@@ -35,23 +48,15 @@ class HelmetJsonKvTask(Task):
         self._dataset = None
         self._templates = None
 
-    def _load_data(self) -> None:
-        """Load the helmet-plus dataset if not already loaded.
+    def _load_dataset(self) -> dict[str, Any]:
+        """Return the loader payload: `data` plus the HELMET prompt templates."""
+        raise NotImplementedError
 
-        HELMET-plus data is pre-generated at specific context lengths (e.g.
-        256k, 2m tokens) and published as JSONL files on the Hub, so it's
-        downloaded and cached via huggingface_hub rather than the standard
-        dataset pipeline.
-        """
+    def _load_data(self) -> None:
         if self._dataset is not None:
             return
 
-        loaded = load_json_kv_dataset(
-            length_name=self.helmet_config["length_name"],
-            shots=self.helmet_config["shots"],
-            max_samples=self.config.limit,
-            seed=self.config.seed,
-        )
+        loaded = self._load_dataset()
 
         self._dataset = loaded["data"]
         self._templates = {
@@ -122,25 +127,100 @@ class HelmetJsonKvTask(Task):
         return output.text
 
 
-def _make_helmet_task_class(task_name: str, task_cfg: dict) -> type[HelmetJsonKvTask]:
+class HelmetJsonKvTask(HelmetTask):
+    """HELMET-plus json_kv task: extract a value for a given key from a long JSON blob."""
+
+    def _load_dataset(self) -> dict[str, Any]:
+        """Load the helmet-plus json_kv data for this task's length tier.
+
+        HELMET-plus data is pre-generated at specific context lengths (e.g.
+        256k, 2m tokens) and published as JSONL files on the Hub, so it's
+        downloaded and cached via huggingface_hub rather than the standard
+        dataset pipeline.
+        """
+        return load_json_kv_dataset(
+            length_name=self.helmet_config["length_name"],
+            shots=self.helmet_config["shots"],
+            max_samples=self.config.limit,
+            seed=self.config.seed,
+        )
+
+
+def _parse_labeled_output(text: str, prefix: str) -> str | None:
+    """Pull the answer out of a `label: N`-style completion.
+
+    Mirrors HELMET's `parse_output` (utils.py): prefer the text following the
+    prefix, otherwise fall back to the first line, then strip a repeated
+    prefix that chat-style models often echo back.
+    """
+    patterns = [
+        re.compile(f"(?:{re.escape(prefix)})(.*)(?:\n|$)", flags=re.IGNORECASE),
+        re.compile(r"(?:^)(.*)(?:\n|$)"),
+    ]
+    for pattern in patterns:
+        match = pattern.search(text)
+        if match is not None:
+            return re.sub(
+                f"^{re.escape(prefix)}", "", match[1].strip(), flags=re.IGNORECASE
+            ).strip()
+    return None
+
+
+class HelmetIclTask(HelmetTask):
+    """HELMET ICL task: label a text given many labelled demonstrations in context."""
+
+    def _load_dataset(self) -> dict[str, Any]:
+        return load_icl_dataset(
+            icl_dataset=self.helmet_config["icl_dataset"],
+            shots=self.helmet_config["shots"],
+            max_samples=self.config.limit,
+            seed=self.config.seed,
+        )
+
+    def extract_answer(self, output: LMOutput) -> Any:
+        return _parse_labeled_output(output.text, prefix="label:")
+
+
+_TASK_CLASSES: dict[str, type[HelmetTask]] = {
+    "json_kv": HelmetJsonKvTask,
+    "icl": HelmetIclTask,
+}
+
+# Per-kind metric configuration. HELMET scores json_kv with substring exact
+# match (RecallMetric's substring scorer is equivalent for a single gold
+# answer) and ICL with exact match; see HELMET's scripts/collect_results.py.
+_TASK_METRICS: dict[str, tuple] = {
+    "json_kv": ((RecallMetric(),), "recall"),
+    "icl": ((AccuracyMetric(name="exact_match"),), "exact_match"),
+}
+
+
+def _make_helmet_task_class(task_name: str, task_cfg: dict) -> type[HelmetTask]:
     """Create a task subclass for a HELMET-plus task variant.
 
     Subclasses carry only class-level attributes (metrics, sampling_params, limit);
-    all runtime state is derived from config.name inside HelmetJsonKvTask.__init__.
+    all runtime state is derived from config.name inside HelmetTask.__init__.
     """
+    kind = task_cfg["kind"]
+    base_cls = _TASK_CLASSES[kind]
+    metrics, primary_metric = _TASK_METRICS[kind]
+
+    stop_sequences = ("\n",) if task_cfg.get("stop_new_line") else None
+
     return type(
         f"Helmet_{task_name}",
-        (HelmetJsonKvTask,),
+        (base_cls,),
         {
             "__module__": __name__,
-            "metrics": (RecallMetric(),),
-            "primary_metric": "recall",
+            "metrics": metrics,
+            "primary_metric": primary_metric,
             "sampling_params": SamplingParams(
                 temperature=0.0,
                 top_p=1.0,
                 max_tokens=task_cfg["max_gen_toks"],
+                stop_sequences=stop_sequences,
             ),
-            "limit": 100,
+            "limit": task_cfg["limit"],
         },
     )
 

--- a/src/olmo_eval/evals/tasks/helmet.py
+++ b/src/olmo_eval/evals/tasks/helmet.py
@@ -18,9 +18,10 @@ import re
 from collections.abc import Iterator
 from typing import Any, cast
 
-from olmo_eval.common.metrics import AccuracyMetric, RecallMetric
+from olmo_eval.common.metrics import AccuracyMetric, RecallMetric, RougeLF1Metric
 from olmo_eval.common.types import Instance, LMOutput, LMRequest, RequestType, SamplingParams
 from olmo_eval.data.helmet_icl_loader import load_icl_dataset
+from olmo_eval.data.helmet_infbench_loader import load_infbench_dataset
 from olmo_eval.data.helmet_loader import load_json_kv_dataset
 from olmo_eval.data.helmet_tasks import HELMET_TASKS
 from olmo_eval.evals.tasks.common.base import Task, TaskConfig
@@ -85,7 +86,13 @@ class HelmetTask(Task):
             raise RuntimeError("Templates not loaded. Call _load_data() first.")
 
         question = self._templates["user"].format(**doc)
-        prepend_text = self._templates["system"]
+
+        # With a chat template the answer prefix is left off rather than fed in
+        # as a partial assistant turn, matching how HELMET runs its chat-format
+        # tasks (and how ruler.py handles the same distinction).
+        prepend_text = (
+            "" if self.helmet_config.get("use_chat_template") else self._templates["system"]
+        )
 
         answer = doc.get("answer")
 
@@ -181,9 +188,30 @@ class HelmetIclTask(HelmetTask):
         return _parse_labeled_output(output.text, prefix="label:")
 
 
+class HelmetInfbenchTask(HelmetTask):
+    """HELMET LongQA task: answer a question about a book-length story."""
+
+    def _load_dataset(self) -> dict[str, Any]:
+        return load_infbench_dataset(
+            subset=self.helmet_config["infbench_subset"],
+            max_context_tokens=self.helmet_config["max_context_tokens"],
+            shots=self.helmet_config["shots"],
+            max_samples=self.config.limit,
+            seed=self.config.seed,
+        )
+
+    def extract_answer(self, output: LMOutput) -> Any:
+        # HELMET scores the raw generation and the "Answer:"-stripped version,
+        # keeping whichever is better; stripping here is the closer of the two
+        # for a chat model that echoes the prefix, and a no-op otherwise.
+        parsed = _parse_labeled_output(output.text, prefix="Answer:")
+        return parsed if parsed else output.text
+
+
 _TASK_CLASSES: dict[str, type[HelmetTask]] = {
     "json_kv": HelmetJsonKvTask,
     "icl": HelmetIclTask,
+    "infbench": HelmetInfbenchTask,
 }
 
 # Per-kind metric configuration. HELMET scores json_kv with substring exact
@@ -192,6 +220,7 @@ _TASK_CLASSES: dict[str, type[HelmetTask]] = {
 _TASK_METRICS: dict[str, tuple] = {
     "json_kv": ((RecallMetric(),), "recall"),
     "icl": ((AccuracyMetric(name="exact_match"),), "exact_match"),
+    "infbench": ((RougeLF1Metric(),), "rougeL_f1"),
 }
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -43,8 +43,7 @@ dependencies = [
     { name = "bettermap" },
     { name = "cached-path" },
     { name = "importlib-resources" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-vllm') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra != 'extra-9-olmo-eval-vllm') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
     { name = "omegaconf" },
     { name = "packaging" },
     { name = "requests" },
@@ -224,8 +223,8 @@ dependencies = [
     { name = "click" },
     { name = "click-log" },
     { name = "networkx" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands')" },
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands' or extra != 'extra-9-olmo-eval-vllm'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-agents' or extra == 'extra-9-olmo-eval-clients' or extra == 'extra-9-olmo-eval-olmo-core' or extra != 'extra-9-olmo-eval-openhands' or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands'" },
     { name = "rtree" },
     { name = "scipy" },
     { name = "shapely" },
@@ -611,8 +610,8 @@ dependencies = [
     { name = "petname" },
     { name = "pyyaml" },
     { name = "requests" },
-    { name = "rich", version = "13.9.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-olmo-core' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
-    { name = "rich", version = "14.3.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands' or extra != 'extra-9-olmo-eval-olmo-core'" },
+    { name = "rich", version = "13.9.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-agents' or extra == 'extra-9-olmo-eval-clients' or extra == 'extra-9-olmo-eval-olmo-core' or extra != 'extra-9-olmo-eval-openhands' or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "rich", version = "14.3.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands'" },
     { name = "tomli" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/94/79/b5a94a955fcef4dc614fbc9a40a0d5509268de87cb736bf9b69c0ecca6f0/beaker_gantry-3.7.0.tar.gz", hash = "sha256:4304c406a4d47fcef9b00c623a9b1ced2e00fe67c037f6c8dd75750d9ab6623c", size = 64174, upload-time = "2026-04-08T23:44:25.324Z" }
@@ -782,8 +781,8 @@ name = "bm25s"
 version = "0.3.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands')" },
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands' or extra != 'extra-9-olmo-eval-vllm'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-agents' or extra == 'extra-9-olmo-eval-clients' or extra == 'extra-9-olmo-eval-olmo-core' or extra != 'extra-9-olmo-eval-openhands' or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7c/ab/39d08d4589dad6f5735a6b03ee083088dc37fba57fa45d4a0749393b9295/bm25s-0.3.9.tar.gz", hash = "sha256:895c679d952b7de8355edb5f3e1a620a1e2f294d1d42b919bf0821cce2e2f597", size = 80528, upload-time = "2026-05-13T23:08:20.952Z" }
 wheels = [
@@ -1384,8 +1383,8 @@ name = "contourpy"
 version = "1.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands')" },
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands' or extra != 'extra-9-olmo-eval-vllm'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-agents' or extra == 'extra-9-olmo-eval-clients' or extra == 'extra-9-olmo-eval-olmo-core' or extra != 'extra-9-olmo-eval-openhands' or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
 wheels = [
@@ -1557,12 +1556,12 @@ dependencies = [
     { name = "fake-useragent" },
     { name = "httpx", extra = ["http2"] },
     { name = "humanize" },
-    { name = "lark", version = "1.2.2", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands')" },
-    { name = "lark", version = "1.3.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands' or extra != 'extra-9-olmo-eval-vllm'" },
+    { name = "lark", version = "1.2.2", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-agents' or extra == 'extra-9-olmo-eval-clients' or extra == 'extra-9-olmo-eval-olmo-core' or extra != 'extra-9-olmo-eval-openhands' or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "lark", version = "1.3.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands'" },
     { name = "lxml" },
     { name = "nltk" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands')" },
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands' or extra != 'extra-9-olmo-eval-vllm'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-agents' or extra == 'extra-9-olmo-eval-clients' or extra == 'extra-9-olmo-eval-olmo-core' or extra != 'extra-9-olmo-eval-openhands' or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands'" },
     { name = "patchright" },
     { name = "pillow" },
     { name = "playwright" },
@@ -1574,8 +1573,8 @@ dependencies = [
     { name = "pyyaml" },
     { name = "rank-bm25" },
     { name = "requests" },
-    { name = "rich", version = "13.9.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-olmo-core' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
-    { name = "rich", version = "14.3.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands' or extra != 'extra-9-olmo-eval-olmo-core'" },
+    { name = "rich", version = "13.9.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-agents' or extra == 'extra-9-olmo-eval-clients' or extra == 'extra-9-olmo-eval-olmo-core' or extra != 'extra-9-olmo-eval-openhands' or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "rich", version = "14.3.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands'" },
     { name = "shapely" },
     { name = "snowballstemmer" },
     { name = "unclecode-litellm" },
@@ -1650,7 +1649,7 @@ name = "cuda-bindings"
 version = "12.9.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-9-olmo-eval-olmo-core') or (sys_platform == 'emscripten' and extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (sys_platform == 'emscripten' and extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-vllm') or (sys_platform == 'emscripten' and extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (sys_platform == 'emscripten' and extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-vllm') or (sys_platform == 'emscripten' and extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands') or (sys_platform == 'emscripten' and extra != 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm') or (sys_platform == 'win32' and extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (sys_platform == 'win32' and extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-vllm') or (sys_platform == 'win32' and extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (sys_platform == 'win32' and extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-vllm') or (sys_platform == 'win32' and extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands') or (sys_platform == 'win32' and extra != 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm') or (extra != 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-vllm') or (extra == 'extra-9-olmo-eval-agents' and extra != 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra != 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands')" },
+    { name = "cuda-pathfinder" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/c2/65bfd79292b8ff18be4dd7f7442cea37bcbc1a228c1886f1dea515c45b67/cuda_bindings-12.9.4-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:694ba35023846625ef471257e6b5a4bc8af690f961d197d77d34b1d1db393f56", size = 11760260, upload-time = "2025-10-21T14:51:40.79Z" },
@@ -1767,11 +1766,11 @@ dependencies = [
     { name = "httpx" },
     { name = "huggingface-hub" },
     { name = "multiprocess" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands')" },
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands' or extra != 'extra-9-olmo-eval-vllm'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-agents' or extra == 'extra-9-olmo-eval-clients' or extra == 'extra-9-olmo-eval-olmo-core' or extra != 'extra-9-olmo-eval-openhands' or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands'" },
     { name = "packaging" },
-    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and extra == 'extra-9-olmo-eval-vllm') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm') or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands')" },
-    { name = "pandas", version = "3.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' or extra == 'extra-9-olmo-eval-openhands' or extra != 'extra-9-olmo-eval-vllm'" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and extra == 'extra-9-olmo-eval-agents') or (python_full_version >= '3.14' and extra == 'extra-9-olmo-eval-clients') or (python_full_version >= '3.14' and extra == 'extra-9-olmo-eval-olmo-core') or (python_full_version >= '3.14' and extra != 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "pandas", version = "3.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' or extra == 'extra-9-olmo-eval-openhands'" },
     { name = "pyarrow" },
     { name = "pyyaml" },
     { name = "requests" },
@@ -2095,8 +2094,8 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
     { name = "pydantic" },
-    { name = "starlette", version = "0.52.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands')" },
-    { name = "starlette", version = "1.0.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands' or extra != 'extra-9-olmo-eval-vllm'" },
+    { name = "starlette", version = "0.52.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-agents' or extra == 'extra-9-olmo-eval-clients' or extra == 'extra-9-olmo-eval-olmo-core' or extra != 'extra-9-olmo-eval-openhands' or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "starlette", version = "1.0.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands'" },
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
@@ -2108,14 +2107,14 @@ wheels = [
 [package.optional-dependencies]
 standard = [
     { name = "email-validator" },
-    { name = "fastapi-cli", extra = ["standard"], marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands')" },
+    { name = "fastapi-cli", extra = ["standard"], marker = "extra == 'extra-9-olmo-eval-agents' or extra == 'extra-9-olmo-eval-clients' or extra == 'extra-9-olmo-eval-olmo-core' or extra != 'extra-9-olmo-eval-openhands' or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
     { name = "fastar" },
     { name = "httpx" },
     { name = "jinja2" },
     { name = "pydantic-extra-types" },
     { name = "pydantic-settings" },
     { name = "python-multipart" },
-    { name = "uvicorn", extra = ["standard"], marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands')" },
+    { name = "uvicorn", extra = ["standard"], marker = "extra == 'extra-9-olmo-eval-agents' or extra == 'extra-9-olmo-eval-clients' or extra == 'extra-9-olmo-eval-olmo-core' or extra != 'extra-9-olmo-eval-openhands' or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
 ]
 
 [[package]]
@@ -2125,7 +2124,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "rich-toolkit" },
     { name = "typer" },
-    { name = "uvicorn", extra = ["standard"], marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands')" },
+    { name = "uvicorn", extra = ["standard"], marker = "extra == 'extra-9-olmo-eval-agents' or extra == 'extra-9-olmo-eval-clients' or extra == 'extra-9-olmo-eval-olmo-core' or extra != 'extra-9-olmo-eval-openhands' or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6e/58/74797ae9e4610cfa0c6b34c8309096d3b20bb29be3b8b5fbf1004d10fa5f/fastapi_cli-0.0.24.tar.gz", hash = "sha256:1afc9c9e21d7ebc8a3ca5e31790cd8d837742be7e4f8b9236e99cb3451f0de00", size = 19043, upload-time = "2026-02-24T10:45:10.476Z" }
 wheels = [
@@ -2135,7 +2134,7 @@ wheels = [
 [package.optional-dependencies]
 standard = [
     { name = "fastapi-cloud-cli" },
-    { name = "uvicorn", extra = ["standard"], marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands')" },
+    { name = "uvicorn", extra = ["standard"], marker = "extra == 'extra-9-olmo-eval-agents' or extra == 'extra-9-olmo-eval-clients' or extra == 'extra-9-olmo-eval-olmo-core' or extra != 'extra-9-olmo-eval-openhands' or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
 ]
 
 [[package]]
@@ -2145,12 +2144,12 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fastar" },
     { name = "httpx" },
-    { name = "pydantic", extra = ["email"], marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands')" },
+    { name = "pydantic", extra = ["email"], marker = "extra == 'extra-9-olmo-eval-agents' or extra == 'extra-9-olmo-eval-clients' or extra == 'extra-9-olmo-eval-olmo-core' or extra != 'extra-9-olmo-eval-openhands' or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
     { name = "rich-toolkit" },
     { name = "rignore" },
     { name = "sentry-sdk" },
     { name = "typer" },
-    { name = "uvicorn", extra = ["standard"], marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands')" },
+    { name = "uvicorn", extra = ["standard"], marker = "extra == 'extra-9-olmo-eval-agents' or extra == 'extra-9-olmo-eval-clients' or extra == 'extra-9-olmo-eval-olmo-core' or extra != 'extra-9-olmo-eval-openhands' or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/67/79/66567c39c5fab6dbebf9e40b3a3fcb0e2ec359517c87a67434c76b06e60b/fastapi_cloud_cli-0.17.0.tar.gz", hash = "sha256:2b6c241b63427023bd1e23b3251f23234aba4b05428b245a050e92db1389823c", size = 47276, upload-time = "2026-04-15T13:17:56.402Z" }
 wheels = [
@@ -4311,7 +4310,7 @@ linkify = [
     { name = "linkify-it-py" },
 ]
 plugins = [
-    { name = "mdit-py-plugins", marker = "extra == 'extra-9-olmo-eval-olmo-core' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "mdit-py-plugins", marker = "extra == 'extra-9-olmo-eval-agents' or extra == 'extra-9-olmo-eval-clients' or extra == 'extra-9-olmo-eval-olmo-core' or extra != 'extra-9-olmo-eval-openhands' or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
 ]
 
 [[package]]
@@ -4399,8 +4398,8 @@ dependencies = [
     { name = "cycler" },
     { name = "fonttools" },
     { name = "kiwisolver" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands')" },
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands' or extra != 'extra-9-olmo-eval-vllm'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-agents' or extra == 'extra-9-olmo-eval-clients' or extra == 'extra-9-olmo-eval-olmo-core' or extra != 'extra-9-olmo-eval-openhands' or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands'" },
     { name = "packaging" },
     { name = "pillow" },
     { name = "pyparsing" },
@@ -4477,12 +4476,12 @@ dependencies = [
     { name = "jsonschema" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
-    { name = "pyjwt", extra = ["crypto"], marker = "extra == 'extra-9-olmo-eval-agents' or extra == 'extra-9-olmo-eval-openhands' or extra == 'extra-9-olmo-eval-vllm'" },
+    { name = "pyjwt", extra = ["crypto"] },
     { name = "python-multipart" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
     { name = "sse-starlette" },
-    { name = "starlette", version = "0.52.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands')" },
-    { name = "starlette", version = "1.0.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands' or (extra == 'extra-9-olmo-eval-agents' and extra != 'extra-9-olmo-eval-vllm')" },
+    { name = "starlette", version = "0.52.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-agents' or extra == 'extra-9-olmo-eval-clients' or extra == 'extra-9-olmo-eval-olmo-core' or extra != 'extra-9-olmo-eval-openhands' or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "starlette", version = "1.0.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands'" },
     { name = "typing-extensions" },
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
@@ -4534,7 +4533,7 @@ dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
     { name = "pillow" },
     { name = "pydantic" },
-    { name = "pydantic-extra-types", extra = ["pycountry"], marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands')" },
+    { name = "pydantic-extra-types", extra = ["pycountry"], marker = "extra == 'extra-9-olmo-eval-agents' or extra == 'extra-9-olmo-eval-clients' or extra == 'extra-9-olmo-eval-olmo-core' or extra != 'extra-9-olmo-eval-openhands' or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
     { name = "requests" },
     { name = "tiktoken" },
     { name = "typing-extensions" },
@@ -4569,8 +4568,8 @@ dependencies = [
     { name = "click" },
     { name = "grpclib" },
     { name = "protobuf" },
-    { name = "rich", version = "13.9.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-olmo-core' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
-    { name = "rich", version = "14.3.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands' or extra != 'extra-9-olmo-eval-olmo-core'" },
+    { name = "rich", version = "13.9.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-agents' or extra == 'extra-9-olmo-eval-clients' or extra == 'extra-9-olmo-eval-olmo-core' or extra != 'extra-9-olmo-eval-openhands' or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "rich", version = "14.3.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands'" },
     { name = "synchronicity" },
     { name = "toml" },
     { name = "typer" },
@@ -4626,7 +4625,7 @@ version = "1.37.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
-    { name = "pyjwt", extra = ["crypto"], marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands')" },
+    { name = "pyjwt", extra = ["crypto"], marker = "extra == 'extra-9-olmo-eval-agents' or extra == 'extra-9-olmo-eval-clients' or extra == 'extra-9-olmo-eval-olmo-core' or extra != 'extra-9-olmo-eval-openhands' or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
     { name = "requests" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9a/99/d840198ecf6e8057bbc937f129ae940404485d736cda73253bbff9537f01/msal-1.37.0.tar.gz", hash = "sha256:1b1672a33ee467c1d70b341bb16cafd51bb3c817147a95b93263794b03971bec", size = 182444, upload-time = "2026-05-29T19:49:05.561Z" }
@@ -5359,12 +5358,13 @@ dependencies = [
     { name = "click" },
     { name = "datasets" },
     { name = "ifbench" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands')" },
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands' or extra != 'extra-9-olmo-eval-vllm'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-agents' or extra == 'extra-9-olmo-eval-clients' or extra == 'extra-9-olmo-eval-olmo-core' or extra != 'extra-9-olmo-eval-openhands' or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands'" },
     { name = "omegaconf" },
     { name = "prometheus-client" },
-    { name = "rich", version = "13.9.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-olmo-core' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
-    { name = "rich", version = "14.3.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands' or extra != 'extra-9-olmo-eval-olmo-core'" },
+    { name = "rich", version = "13.9.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-agents' or extra == 'extra-9-olmo-eval-clients' or extra == 'extra-9-olmo-eval-olmo-core' or extra != 'extra-9-olmo-eval-openhands' or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "rich", version = "14.3.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands'" },
+    { name = "rouge-score" },
     { name = "setuptools" },
     { name = "sympy" },
     { name = "textual-plot" },
@@ -5402,7 +5402,7 @@ litellm = [
     { name = "litellm" },
 ]
 olmo-core = [
-    { name = "ai2-olmo-core", extra = ["torchao", "transformers"], marker = "extra == 'extra-9-olmo-eval-olmo-core' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "ai2-olmo-core", extra = ["torchao", "transformers"], marker = "extra == 'extra-9-olmo-eval-agents' or extra == 'extra-9-olmo-eval-clients' or extra == 'extra-9-olmo-eval-olmo-core' or extra != 'extra-9-olmo-eval-openhands' or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
 ]
 openhands = [
     { name = "openhands-ai" },
@@ -5429,7 +5429,7 @@ storage = [
 vllm = [
     { name = "opencv-python-headless", marker = "sys_platform != 'darwin'" },
     { name = "torch-c-dlpack-ext", marker = "sys_platform != 'darwin'" },
-    { name = "vllm", extra = ["runai"], marker = "(sys_platform != 'darwin' and extra == 'extra-9-olmo-eval-vllm') or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "vllm", extra = ["runai"], marker = "(sys_platform != 'darwin' and extra == 'extra-9-olmo-eval-agents') or (sys_platform != 'darwin' and extra == 'extra-9-olmo-eval-clients') or (sys_platform != 'darwin' and extra == 'extra-9-olmo-eval-olmo-core') or (sys_platform != 'darwin' and extra != 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
 ]
 
 [package.dev-dependencies]
@@ -5446,7 +5446,7 @@ dev = [
 ]
 vllm = [
     { name = "olmo-eval" },
-    { name = "olmo-eval", extra = ["vllm"], marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands')" },
+    { name = "olmo-eval", extra = ["vllm"], marker = "extra == 'extra-9-olmo-eval-agents' or extra == 'extra-9-olmo-eval-clients' or extra == 'extra-9-olmo-eval-olmo-core' or extra != 'extra-9-olmo-eval-openhands' or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
 ]
 
 [package.metadata]
@@ -5476,6 +5476,7 @@ requires-dist = [
     { name = "prometheus-client", specifier = ">=0.21.0" },
     { name = "psycopg", extras = ["binary"], marker = "extra == 'postgres'", specifier = ">=3.1.0" },
     { name = "rich", specifier = ">=13.7,<15" },
+    { name = "rouge-score", specifier = ">=0.1.2" },
     { name = "scipy", marker = "extra == 'analysis'", specifier = "~=1.17.1" },
     { name = "seaborn", marker = "extra == 'analysis'", specifier = "~=0.13.2" },
     { name = "setuptools", specifier = "<81" },
@@ -6102,10 +6103,10 @@ resolution-markers = [
     "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and extra == 'extra-9-olmo-eval-vllm') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm') or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands')" },
-    { name = "python-dateutil", marker = "(python_full_version >= '3.14' and extra == 'extra-9-olmo-eval-vllm') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm') or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands')" },
-    { name = "pytz", marker = "(python_full_version >= '3.14' and extra == 'extra-9-olmo-eval-vllm') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm') or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands')" },
-    { name = "tzdata", marker = "(python_full_version >= '3.14' and extra == 'extra-9-olmo-eval-vllm') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm') or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and extra == 'extra-9-olmo-eval-agents') or (python_full_version >= '3.14' and extra == 'extra-9-olmo-eval-clients') or (python_full_version >= '3.14' and extra == 'extra-9-olmo-eval-olmo-core') or (python_full_version >= '3.14' and extra != 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "python-dateutil", marker = "(python_full_version >= '3.14' and extra == 'extra-9-olmo-eval-agents') or (python_full_version >= '3.14' and extra == 'extra-9-olmo-eval-clients') or (python_full_version >= '3.14' and extra == 'extra-9-olmo-eval-olmo-core') or (python_full_version >= '3.14' and extra != 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "pytz", marker = "(python_full_version >= '3.14' and extra == 'extra-9-olmo-eval-agents') or (python_full_version >= '3.14' and extra == 'extra-9-olmo-eval-clients') or (python_full_version >= '3.14' and extra == 'extra-9-olmo-eval-olmo-core') or (python_full_version >= '3.14' and extra != 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "tzdata", marker = "(python_full_version >= '3.14' and extra == 'extra-9-olmo-eval-agents') or (python_full_version >= '3.14' and extra == 'extra-9-olmo-eval-clients') or (python_full_version >= '3.14' and extra == 'extra-9-olmo-eval-olmo-core') or (python_full_version >= '3.14' and extra != 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/01/d40b85317f86cf08d853a4f495195c73815fdf205eef3993821720274518/pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b", size = 4495223, upload-time = "2025-09-29T23:34:51.853Z" }
 wheels = [
@@ -6160,10 +6161,10 @@ resolution-markers = [
     "python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and extra == 'extra-9-olmo-eval-vllm') or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands' or extra != 'extra-9-olmo-eval-vllm'" },
-    { name = "python-dateutil", marker = "python_full_version < '3.14' or extra == 'extra-9-olmo-eval-openhands' or extra != 'extra-9-olmo-eval-vllm'" },
-    { name = "tzdata", marker = "(python_full_version < '3.14' and sys_platform == 'emscripten') or (python_full_version < '3.14' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands') or (sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm') or (sys_platform == 'emscripten' and extra == 'extra-9-olmo-eval-openhands') or (sys_platform == 'emscripten' and extra != 'extra-9-olmo-eval-vllm') or (sys_platform == 'win32' and extra == 'extra-9-olmo-eval-openhands') or (sys_platform == 'win32' and extra != 'extra-9-olmo-eval-vllm')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and extra == 'extra-9-olmo-eval-agents') or (python_full_version < '3.14' and extra == 'extra-9-olmo-eval-clients') or (python_full_version < '3.14' and extra == 'extra-9-olmo-eval-olmo-core') or (python_full_version < '3.14' and extra != 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands'" },
+    { name = "python-dateutil", marker = "python_full_version < '3.14' or extra == 'extra-9-olmo-eval-openhands'" },
+    { name = "tzdata", marker = "(python_full_version < '3.14' and sys_platform == 'emscripten') or (python_full_version < '3.14' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands') or (sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm') or (sys_platform == 'emscripten' and extra == 'extra-9-olmo-eval-openhands') or (sys_platform == 'win32' and extra == 'extra-9-olmo-eval-openhands')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/da/99/b342345300f13440fe9fe385c3c481e2d9a595ee3bab4d3219247ac94e9a/pandas-3.0.2.tar.gz", hash = "sha256:f4753e73e34c8d83221ba58f232433fca2748be8b18dbca02d242ed153945043", size = 4645855, upload-time = "2026-03-31T06:48:30.816Z" }
 wheels = [
@@ -10441,8 +10442,8 @@ name = "rank-bm25"
 version = "0.2.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands')" },
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands' or extra != 'extra-9-olmo-eval-vllm'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-agents' or extra == 'extra-9-olmo-eval-clients' or extra == 'extra-9-olmo-eval-olmo-core' or extra != 'extra-9-olmo-eval-openhands' or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fc/0a/f9579384aa017d8b4c15613f86954b92a95a93d641cc849182467cf0bb3b/rank_bm25-0.2.2.tar.gz", hash = "sha256:096ccef76f8188563419aaf384a02f0ea459503fdf77901378d4fd9d87e5e51d", size = 8347, upload-time = "2022-02-16T12:10:52.196Z" }
 wheels = [
@@ -10725,8 +10726,8 @@ resolution-markers = [
     "python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "markdown-it-py", marker = "extra == 'extra-9-olmo-eval-olmo-core' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
-    { name = "pygments", marker = "extra == 'extra-9-olmo-eval-olmo-core' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "markdown-it-py", marker = "extra == 'extra-9-olmo-eval-agents' or extra == 'extra-9-olmo-eval-clients' or extra == 'extra-9-olmo-eval-olmo-core' or extra != 'extra-9-olmo-eval-openhands' or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "pygments", marker = "extra == 'extra-9-olmo-eval-agents' or extra == 'extra-9-olmo-eval-clients' or extra == 'extra-9-olmo-eval-olmo-core' or extra != 'extra-9-olmo-eval-openhands' or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ab/3a/0316b28d0761c6734d6bc14e770d85506c986c85ffb239e688eeaab2c2bc/rich-13.9.4.tar.gz", hash = "sha256:439594978a49a09530cff7ebc4b5c7103ef57baf48d5ea3184f21d9a2befa098", size = 223149, upload-time = "2024-11-01T16:43:57.873Z" }
 wheels = [
@@ -10749,8 +10750,8 @@ resolution-markers = [
     "python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "markdown-it-py", marker = "extra == 'extra-9-olmo-eval-openhands' or extra != 'extra-9-olmo-eval-olmo-core'" },
-    { name = "pygments", marker = "extra == 'extra-9-olmo-eval-openhands' or extra != 'extra-9-olmo-eval-olmo-core'" },
+    { name = "markdown-it-py", marker = "extra == 'extra-9-olmo-eval-openhands'" },
+    { name = "pygments", marker = "extra == 'extra-9-olmo-eval-openhands'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e9/67/cae617f1351490c25a4b8ac3b8b63a4dda609295d8222bad12242dfdc629/rich-14.3.4.tar.gz", hash = "sha256:817e02727f2b25b40ef56f5aa2217f400c8489f79ca8f46ea2b70dd5e14558a9", size = 230524, upload-time = "2026-04-11T02:57:45.419Z" }
 wheels = [
@@ -10776,8 +10777,7 @@ version = "0.19.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
-    { name = "rich", version = "13.9.4", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-vllm') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
-    { name = "rich", version = "14.3.4", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands') or (extra != 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "rich", version = "13.9.4", source = { registry = "https://pypi.org/simple" } },
     { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/ba/dae9e3096651042754da419a4042bc1c75e07d615f9b15066d738838e4df/rich_toolkit-0.19.7.tar.gz", hash = "sha256:133c0915872da91d4c25d85342d5ec1dfacc69b63448af1a08a0d4b4f23ef46e", size = 195877, upload-time = "2026-02-24T16:06:20.555Z" }
@@ -10852,6 +10852,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/3e/87/033eebfbee3ec7d92b3bb1717d8f68c88e6fc7de54537040f3b3a405726f/rignore-0.7.6-cp314-cp314t-win_amd64.whl", hash = "sha256:ca36e59408bec81de75d307c568c2d0d410fb880b1769be43611472c61e85c96", size = 725647, upload-time = "2025-11-05T21:41:44.449Z" },
     { url = "https://files.pythonhosted.org/packages/79/62/b88e5879512c55b8ee979c666ee6902adc4ed05007226de266410ae27965/rignore-0.7.6-cp314-cp314t-win_arm64.whl", hash = "sha256:b83adabeb3e8cf662cabe1931b83e165b88c526fa6af6b3aa90429686e474896", size = 656035, upload-time = "2025-11-05T21:41:31.13Z" },
 ]
+
+[[package]]
+name = "rouge-score"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "absl-py" },
+    { name = "nltk" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-agents' or extra == 'extra-9-olmo-eval-clients' or extra == 'extra-9-olmo-eval-olmo-core' or extra != 'extra-9-olmo-eval-openhands' or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands'" },
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e2/c5/9136736c37022a6ad27fea38f3111eb8f02fe75d067f9a985cc358653102/rouge_score-0.1.2.tar.gz", hash = "sha256:c7d4da2683e68c9abf0135ef915d63a46643666f848e558a1b9f7ead17ff0f04", size = 17400, upload-time = "2022-07-22T22:46:22.909Z" }
 
 [[package]]
 name = "rpds-py"
@@ -11102,8 +11115,8 @@ name = "scipy"
 version = "1.17.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands')" },
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands' or extra != 'extra-9-olmo-eval-vllm'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-agents' or extra == 'extra-9-olmo-eval-clients' or extra == 'extra-9-olmo-eval-olmo-core' or extra != 'extra-9-olmo-eval-openhands' or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [
@@ -11190,10 +11203,10 @@ version = "0.13.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "matplotlib" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands')" },
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands' or extra != 'extra-9-olmo-eval-vllm'" },
-    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and extra == 'extra-9-olmo-eval-vllm') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm') or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands')" },
-    { name = "pandas", version = "3.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' or extra == 'extra-9-olmo-eval-openhands' or extra != 'extra-9-olmo-eval-vllm'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-agents' or extra == 'extra-9-olmo-eval-clients' or extra == 'extra-9-olmo-eval-olmo-core' or extra != 'extra-9-olmo-eval-openhands' or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands'" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and extra == 'extra-9-olmo-eval-agents') or (python_full_version >= '3.14' and extra == 'extra-9-olmo-eval-clients') or (python_full_version >= '3.14' and extra == 'extra-9-olmo-eval-olmo-core') or (python_full_version >= '3.14' and extra != 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "pandas", version = "3.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' or extra == 'extra-9-olmo-eval-openhands'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/86/59/a451d7420a77ab0b98f7affa3a1d78a313d2f7281a57afb1a34bae8ab412/seaborn-0.13.2.tar.gz", hash = "sha256:93e60a40988f4d65e9f4885df477e2fdaff6b73a9ded434c1ab356dd57eefff7", size = 1457696, upload-time = "2024-01-25T13:21:52.551Z" }
 wheels = [
@@ -11355,8 +11368,8 @@ name = "shapely"
 version = "2.1.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands')" },
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands' or extra != 'extra-9-olmo-eval-vllm'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-agents' or extra == 'extra-9-olmo-eval-clients' or extra == 'extra-9-olmo-eval-olmo-core' or extra != 'extra-9-olmo-eval-openhands' or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/4d/bc/0989043118a27cccb4e906a46b7565ce36ca7b57f5a18b78f4f1b0f72d9d/shapely-2.1.2.tar.gz", hash = "sha256:2ed4ecb28320a433db18a5bf029986aa8afcfd740745e78847e330d5d94922a9", size = 315489, upload-time = "2025-09-24T13:51:41.432Z" }
 wheels = [
@@ -11556,8 +11569,8 @@ version = "3.3.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "starlette", version = "0.52.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands')" },
-    { name = "starlette", version = "1.0.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands' or (extra == 'extra-9-olmo-eval-agents' and extra != 'extra-9-olmo-eval-vllm')" },
+    { name = "starlette", version = "0.52.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-agents' or extra == 'extra-9-olmo-eval-clients' or extra == 'extra-9-olmo-eval-olmo-core' or extra != 'extra-9-olmo-eval-openhands' or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "starlette", version = "1.0.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/26/8c/f9290339ef6d79badbc010f067cd769d6601ec11a57d78569c683fb4dd87/sse_starlette-3.3.4.tar.gz", hash = "sha256:aaf92fc067af8a5427192895ac028e947b484ac01edbc3caf00e7e7137c7bef1", size = 32427, upload-time = "2026-03-29T09:00:23.307Z" }
 wheels = [
@@ -11616,8 +11629,8 @@ resolution-markers = [
     "python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "anyio", marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands')" },
-    { name = "typing-extensions", marker = "(python_full_version < '3.13' and extra == 'extra-9-olmo-eval-vllm') or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "anyio", marker = "extra == 'extra-9-olmo-eval-agents' or extra == 'extra-9-olmo-eval-clients' or extra == 'extra-9-olmo-eval-olmo-core' or extra != 'extra-9-olmo-eval-openhands' or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "typing-extensions", marker = "(python_full_version < '3.13' and extra == 'extra-9-olmo-eval-agents') or (python_full_version < '3.13' and extra == 'extra-9-olmo-eval-clients') or (python_full_version < '3.13' and extra == 'extra-9-olmo-eval-olmo-core') or (python_full_version < '3.13' and extra != 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c4/68/79977123bb7be889ad680d79a40f339082c1978b5cfcf62c2d8d196873ac/starlette-0.52.1.tar.gz", hash = "sha256:834edd1b0a23167694292e94f597773bc3f89f362be6effee198165a35d62933", size = 2653702, upload-time = "2026-01-18T13:34:11.062Z" }
 wheels = [
@@ -11640,8 +11653,8 @@ resolution-markers = [
     "python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "anyio", marker = "extra == 'extra-9-olmo-eval-openhands' or extra != 'extra-9-olmo-eval-vllm'" },
-    { name = "typing-extensions", marker = "(python_full_version < '3.13' and extra == 'extra-9-olmo-eval-openhands') or (python_full_version < '3.13' and extra != 'extra-9-olmo-eval-vllm') or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "anyio", marker = "extra == 'extra-9-olmo-eval-openhands'" },
+    { name = "typing-extensions", marker = "(python_full_version < '3.13' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
 wheels = [
@@ -11668,8 +11681,8 @@ dependencies = [
     { name = "pydantic" },
     { name = "python-multipart" },
     { name = "requests" },
-    { name = "rich", version = "13.9.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-olmo-core' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
-    { name = "rich", version = "14.3.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands' or extra != 'extra-9-olmo-eval-olmo-core'" },
+    { name = "rich", version = "13.9.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-agents' or extra == 'extra-9-olmo-eval-clients' or extra == 'extra-9-olmo-eval-olmo-core' or extra != 'extra-9-olmo-eval-openhands' or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "rich", version = "14.3.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands'" },
     { name = "uvicorn" },
 ]
 
@@ -11769,11 +11782,11 @@ resolution-markers = [
     "python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "markdown-it-py", extra = ["linkify", "plugins"], marker = "extra == 'extra-9-olmo-eval-olmo-core' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
-    { name = "platformdirs", marker = "extra == 'extra-9-olmo-eval-olmo-core' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
-    { name = "pygments", marker = "extra == 'extra-9-olmo-eval-olmo-core' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
-    { name = "rich", version = "13.9.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-olmo-core' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
-    { name = "typing-extensions", marker = "extra == 'extra-9-olmo-eval-olmo-core' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "markdown-it-py", extra = ["linkify", "plugins"], marker = "extra == 'extra-9-olmo-eval-agents' or extra == 'extra-9-olmo-eval-clients' or extra == 'extra-9-olmo-eval-olmo-core' or extra != 'extra-9-olmo-eval-openhands' or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "platformdirs", marker = "extra == 'extra-9-olmo-eval-agents' or extra == 'extra-9-olmo-eval-clients' or extra == 'extra-9-olmo-eval-olmo-core' or extra != 'extra-9-olmo-eval-openhands' or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "pygments", marker = "extra == 'extra-9-olmo-eval-agents' or extra == 'extra-9-olmo-eval-clients' or extra == 'extra-9-olmo-eval-olmo-core' or extra != 'extra-9-olmo-eval-openhands' or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "rich", version = "13.9.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-agents' or extra == 'extra-9-olmo-eval-clients' or extra == 'extra-9-olmo-eval-olmo-core' or extra != 'extra-9-olmo-eval-openhands' or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "typing-extensions", marker = "extra == 'extra-9-olmo-eval-agents' or extra == 'extra-9-olmo-eval-clients' or extra == 'extra-9-olmo-eval-olmo-core' or extra != 'extra-9-olmo-eval-openhands' or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a2/30/38b615f7d4b16f6fdd73e4dcd8913e2d880bbb655e68a076e3d91181a7ee/textual-6.2.1.tar.gz", hash = "sha256:4699d8dfae43503b9c417bd2a6fb0da1c89e323fe91c4baa012f9298acaa83e1", size = 1570645, upload-time = "2025-10-01T16:11:24.467Z" }
 wheels = [
@@ -11796,12 +11809,12 @@ resolution-markers = [
     "python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "markdown-it-py", extra = ["linkify"], marker = "extra == 'extra-9-olmo-eval-openhands' or extra != 'extra-9-olmo-eval-olmo-core'" },
-    { name = "mdit-py-plugins", marker = "extra == 'extra-9-olmo-eval-openhands' or extra != 'extra-9-olmo-eval-olmo-core'" },
-    { name = "platformdirs", marker = "extra == 'extra-9-olmo-eval-openhands' or extra != 'extra-9-olmo-eval-olmo-core'" },
-    { name = "pygments", marker = "extra == 'extra-9-olmo-eval-openhands' or extra != 'extra-9-olmo-eval-olmo-core'" },
-    { name = "rich", version = "14.3.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands' or extra != 'extra-9-olmo-eval-olmo-core'" },
-    { name = "typing-extensions", marker = "extra == 'extra-9-olmo-eval-openhands' or extra != 'extra-9-olmo-eval-olmo-core'" },
+    { name = "markdown-it-py", extra = ["linkify"], marker = "extra == 'extra-9-olmo-eval-openhands'" },
+    { name = "mdit-py-plugins", marker = "extra == 'extra-9-olmo-eval-openhands'" },
+    { name = "platformdirs", marker = "extra == 'extra-9-olmo-eval-openhands'" },
+    { name = "pygments", marker = "extra == 'extra-9-olmo-eval-openhands'" },
+    { name = "rich", version = "14.3.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands'" },
+    { name = "typing-extensions", marker = "extra == 'extra-9-olmo-eval-openhands'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/19/89/bec5709fb759f9c784bbcb30b2e3497df3f901691d13c2b864dbf6694a17/textual-8.2.4.tar.gz", hash = "sha256:d4e2b2ddd7157191d00b228592b7c739ea080b7d792fd410f23ca75f05ea76c4", size = 1848933, upload-time = "2026-04-19T04:20:45.845Z" }
 wheels = [
@@ -11813,10 +11826,10 @@ name = "textual-hires-canvas"
 version = "0.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands')" },
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands' or extra != 'extra-9-olmo-eval-vllm'" },
-    { name = "textual", version = "6.2.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-olmo-core' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
-    { name = "textual", version = "8.2.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands' or extra != 'extra-9-olmo-eval-olmo-core'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-agents' or extra == 'extra-9-olmo-eval-clients' or extra == 'extra-9-olmo-eval-olmo-core' or extra != 'extra-9-olmo-eval-openhands' or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands'" },
+    { name = "textual", version = "6.2.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-agents' or extra == 'extra-9-olmo-eval-clients' or extra == 'extra-9-olmo-eval-olmo-core' or extra != 'extra-9-olmo-eval-openhands' or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "textual", version = "8.2.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/20/f0/13f2a30ab7950cc3d5d5a2c893fbe3d40b4d129fd2cd30313260181578c4/textual_hires_canvas-0.14.0.tar.gz", hash = "sha256:0fa512492ddd2cd6c2a970a6beea58f5350f4cf25f40ad14ffd9fa86c6458769", size = 1251440, upload-time = "2026-01-10T22:16:56.708Z" }
 wheels = [
@@ -11828,10 +11841,10 @@ name = "textual-plot"
 version = "0.10.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands')" },
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands' or extra != 'extra-9-olmo-eval-vllm'" },
-    { name = "textual", version = "6.2.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-olmo-core' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
-    { name = "textual", version = "8.2.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands' or extra != 'extra-9-olmo-eval-olmo-core'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-agents' or extra == 'extra-9-olmo-eval-clients' or extra == 'extra-9-olmo-eval-olmo-core' or extra != 'extra-9-olmo-eval-openhands' or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands'" },
+    { name = "textual", version = "6.2.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-agents' or extra == 'extra-9-olmo-eval-clients' or extra == 'extra-9-olmo-eval-olmo-core' or extra != 'extra-9-olmo-eval-openhands' or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "textual", version = "8.2.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands'" },
     { name = "textual-hires-canvas" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a0/c2/13f9f747e83cd0b740d1bf310e89a006316cfb5acb4e5a4136c12f96340b/textual_plot-0.10.1.tar.gz", hash = "sha256:503db96d849134293228419324eb15efbadf1f1927a2e0a229b54e7a7e5d5292", size = 2451096, upload-time = "2026-02-01T13:27:43.658Z" }
@@ -12203,8 +12216,8 @@ version = "5.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "huggingface-hub" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands')" },
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands' or extra != 'extra-9-olmo-eval-vllm'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-agents' or extra == 'extra-9-olmo-eval-clients' or extra == 'extra-9-olmo-eval-olmo-core' or extra != 'extra-9-olmo-eval-openhands' or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands'" },
     { name = "packaging" },
     { name = "pyyaml" },
     { name = "regex" },
@@ -12326,8 +12339,8 @@ name = "trimesh"
 version = "4.12.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands')" },
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands' or extra != 'extra-9-olmo-eval-vllm'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-agents' or extra == 'extra-9-olmo-eval-clients' or extra == 'extra-9-olmo-eval-olmo-core' or extra != 'extra-9-olmo-eval-openhands' or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/79/37/5cb90f04990260d2caceb6093560c6cefafca1ec522c1e43be01ca658244/trimesh-4.12.2.tar.gz", hash = "sha256:c8ca31571ac00b112e4e160e66a2d4c3491df321f056bd33806be0485d1af9d9", size = 842220, upload-time = "2026-05-01T00:57:43.333Z" }
 wheels = [
@@ -12392,8 +12405,8 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
     { name = "click" },
-    { name = "rich", version = "13.9.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-olmo-core' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
-    { name = "rich", version = "14.3.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands' or extra != 'extra-9-olmo-eval-olmo-core'" },
+    { name = "rich", version = "13.9.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-agents' or extra == 'extra-9-olmo-eval-clients' or extra == 'extra-9-olmo-eval-olmo-core' or extra != 'extra-9-olmo-eval-openhands' or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
+    { name = "rich", version = "14.3.4", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-9-olmo-eval-openhands'" },
     { name = "shellingham" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/83/b8/9ebb531b6c2d377af08ac6746a5df3425b21853a5d2260876919b58a2a4a/typer-0.24.2.tar.gz", hash = "sha256:ec070dcfca1408e85ee203c6365001e818c3b7fffe686fd07ff2d68095ca0480", size = 119849, upload-time = "2026-04-22T17:45:34.413Z" }
@@ -12663,7 +12676,7 @@ dependencies = [
     { name = "depyf" },
     { name = "diskcache" },
     { name = "einops" },
-    { name = "fastapi", extra = ["standard"], marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands')" },
+    { name = "fastapi", extra = ["standard"], marker = "extra == 'extra-9-olmo-eval-agents' or extra == 'extra-9-olmo-eval-clients' or extra == 'extra-9-olmo-eval-olmo-core' or extra != 'extra-9-olmo-eval-openhands' or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
     { name = "filelock" },
     { name = "flashinfer-cubin" },
     { name = "flashinfer-python" },
@@ -12673,7 +12686,7 @@ dependencies = [
     { name = "llguidance", marker = "platform_machine == 'aarch64' or platform_machine == 'arm64' or platform_machine == 'ppc64le' or platform_machine == 's390x' or platform_machine == 'x86_64'" },
     { name = "lm-format-enforcer" },
     { name = "mcp" },
-    { name = "mistral-common", extra = ["image"], marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands')" },
+    { name = "mistral-common", extra = ["image"], marker = "extra == 'extra-9-olmo-eval-agents' or extra == 'extra-9-olmo-eval-clients' or extra == 'extra-9-olmo-eval-olmo-core' or extra != 'extra-9-olmo-eval-openhands' or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
     { name = "model-hosting-container-standards" },
     { name = "msgspec" },
     { name = "ninja" },
@@ -12727,7 +12740,7 @@ wheels = [
 
 [package.optional-dependencies]
 runai = [
-    { name = "runai-model-streamer", extra = ["azure", "gcs", "s3"], marker = "extra == 'extra-9-olmo-eval-vllm' or (extra == 'extra-9-olmo-eval-agents' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-clients' and extra == 'extra-9-olmo-eval-openhands') or (extra == 'extra-9-olmo-eval-olmo-core' and extra == 'extra-9-olmo-eval-openhands')" },
+    { name = "runai-model-streamer", extra = ["azure", "gcs", "s3"], marker = "extra == 'extra-9-olmo-eval-agents' or extra == 'extra-9-olmo-eval-clients' or extra == 'extra-9-olmo-eval-olmo-core' or extra != 'extra-9-olmo-eval-openhands' or (extra == 'extra-9-olmo-eval-openhands' and extra == 'extra-9-olmo-eval-vllm')" },
 ]
 
 [[package]]


### PR DESCRIPTION
Targets `jacksonp/ladder`, which already carries the HELMET-plus recall work (squash-merged as `f1abe85`, "Helmet plus recall (#283)"), so this diff is only the incremental 5 commits.

Same content as [jopetty#3](https://github.com/jopetty/olmo-eval/pull/3), rebased onto `ladder` — the one conflict was a competing import in `common/{scorers,metrics}/__init__.py`, where `ladder`'s ngram_copying work (#285) and this branch's ROUGE work both add to the same block. Resolved by keeping both; verified they coexist at import time and that the full test suite still passes.

Extends the HELMET integration beyond recall: the five ICL tasks and two of the three LongQA tasks, at standard HELMET's 4k–128k lengths. `helmet_all__{size}` now spans 8 tasks across three categories.

| category | tasks | lengths |
|---|---|---|
| recall | `json_kv` | 4k–2m (already on `ladder`) |
| longqa | `infbench_qa_eng`, `infbench_choice_eng` | 4k–128k |
| icl | `trec_coarse`, `trec_fine`, `banking77`, `clinic150`, `nlu` | 4k–128k |

These are kept HELMET-namespaced rather than factored into standalone tasks (as RULER was in #276): the length-controlled construction — shot count per length tier, shuffled integer labels, truncation to a token budget — is HELMET's, not a property of the underlying datasets, so they aren't interchangeable with a generic `narrativeqa` or `banking77` task.

## Commits

Each is independently reviewable; metric infrastructure is separate from the tasks that use it.

- `b5fb646` ICL tasks
- `682018e` ICL length caveat + measurement script
- `0bd6f44` ROUGE-L F1/recall scorers and metrics
- `82e33ea` `infbench_qa_eng`
- `3d679d1` `infbench_choice_eng`

## Things worth a reviewer's attention

**Three ICL source datasets no longer load.** `datasets` 4.0 dropped script-based loading, which HELMET relies on via `trust_remote_code`. `CogComp/trec` and `xingkunliuxtracta/nlu_evaluation_data` are repointed to the Hub's auto-converted `refs/convert/parquet` branches; `banking77` to `legacy-datasets/banking77`, since `PolyAI/banking77` hosts only the loading script and no data. Split sizes and label counts were verified against the values HELMET hardcodes (6/50/77/151/68).

**ICL prompts render ~20% short of nominal.** HELMET fit its shot counts against a Llama-2-era tokenizer, so under Olmo 3 they come out at 0.78–0.85× — `icl_*__4096` is really ~3.2–3.5k tokens, `__131072` is ~104–108k. The counts are kept verbatim anyway so results stay comparable to published HELMET; the shortfall is documented in `helmet_tasks.py`, and `scripts/internal/calibrate_helmet_icl_shots.py` measures it (or generates Olmo-3-calibrated counts, if we ever decide comparability isn't worth it). Note this leaves ICL inconsistent with `json_kv`, which *is* Olmo-3-calibrated — a `helmet_all__4096` average mixes a 4.1k-token task with ~3.3k-token ones.

**LongQA truncates with a fixed reference tokenizer (Llama 2, ungated mirror)**, not the model under test. That's what makes every model see the same text, and it matches HELMET. Same nominal-vs-realized caveat as above.

**Two suite-semantics changes** vs. what's currently on `ladder`. `helmet_all__*` now aggregates *category* suites via `AVERAGE_OF_AVERAGES` rather than flat-averaging tasks — otherwise ICL's five tasks would outweigh recall's one 5:1. And it's only registered where more than one category exists: above 128k only `json_kv` extends, so a combined suite there would be a rename of `helmet_recall__*` whose composition silently differs from the same name at shorter lengths, which is how a length sweep becomes a misleading trend line. Use `helmet_recall__*` for the extended tiers.

**Two deliberate deviations from a literal port of `load_infbench`**, both measured rather than assumed:
- HELMET's `>=65536`-token filter is skipped — it's a no-op (shortest InfiniteBench story is ~78k reference tokens, and HELMET itself calls it "just a sanity step"), which lets us sample first and truncate only the rows we keep instead of tokenizing all 351 book-length contexts.
- Truncation is memoized per distinct context, since 351 questions come from just 69 stories.

Demos are still drawn from the full pool, not the sampled subset, so they don't depend on how many instances are evaluated.

## Verification

- **ROUGE** matches HELMET's `calculate_metrics` byte-for-byte across 5 cases (multi-reference, no-overlap, empty prediction).
- **`InfbenchChoiceScorer`** agrees with HELMET's `choice_post_process` on all 11 cases tried — bare/lowercase/trailing-period letters, prefixed (`Answer: B`), embedded (`The answer is B. Paris`), wrong, and empty.
- **ICL answer parser** is byte-identical to HELMET's `parse_output` across 11 cases.
- **ICL correctness**: each instance's demo labels match that instance's own label permutation and the `answer` field agrees (20/20); deterministic per seed; demo label balance correct.
- **LongQA truncation** lands exactly on budget (3886/3886 at 4k, 65326/65326 at 64k).
- `rouge-score` is the only lockfile addition — verified no other package versions moved.
- ruff, ty, and all 820 existing tests pass on the rebased branch.

## Known caveat

`infbench_choice_eng` can render slightly over nominal at the smallest tier (~4109 vs 4096 tokens at 4k) because the options block eats into HELMET's fixed 200-token prompt reserve. This is faithful — HELMET budgets both InfiniteBench subsets identically at `size - 200 - 10` — and is 0.3% at 4k, less above.

## Not included

`narrativeqa` and both Summ tasks (`infbench_sum_eng`, `multi_lexsum`) are LLM-judged in HELMET — `gpt-4-score`/`gpt-4-f1` are their *primary* metrics, so they need judge integration rather than another metric. That's one coherent follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)