### PR TITLE
feat: add weighted suite aggregation

### DIFF
--- a/src/olmo_eval/evals/suites/registry.py
+++ b/src/olmo_eval/evals/suites/registry.py
@@ -6,6 +6,7 @@ collections of related evaluation tasks.
 
 from __future__ import annotations
 
+import math
 import re
 from dataclasses import dataclass
 from enum import StrEnum
@@ -31,12 +32,14 @@ class AggregationStrategy(StrEnum):
         NONE: No aggregation - just collect individual task results.
         AVERAGE: Compute simple average of all task scores.
         AVERAGE_OF_AVERAGES: Average over child suite averages.
+        WEIGHTED_AVERAGE: Average direct children using explicit weights.
         DISPLAY_ONLY: Display child results without computing suite average.
     """
 
     NONE = "none"
     AVERAGE = "average"
     AVERAGE_OF_AVERAGES = "average_of_averages"
+    WEIGHTED_AVERAGE = "weighted_average"
     DISPLAY_ONLY = "display_only"
 
 
@@ -52,12 +55,29 @@ class Suite:
         tasks: Tuple of task names or nested Suite references.
         aggregation: Strategy for combining task results.
         description: Optional human-readable description.
+        weights: Direct-child weights for ``WEIGHTED_AVERAGE`` suites.
     """
 
     name: str
     tasks: tuple[str | Suite, ...]
     aggregation: AggregationStrategy = AggregationStrategy.AVERAGE
     description: str = ""
+    weights: tuple[float, ...] | None = None
+
+    def __post_init__(self) -> None:
+        if self.aggregation == AggregationStrategy.WEIGHTED_AVERAGE:
+            if self.weights is None:
+                raise ValueError("weights are required when aggregation='weighted_average'")
+            if len(self.weights) != len(self.tasks):
+                raise ValueError(
+                    f"weights must match tasks one-for-one: got {len(self.weights)} weights for {len(self.tasks)} tasks"
+                )
+            if any(not math.isfinite(weight) or weight < 0 for weight in self.weights):
+                raise ValueError("weights must be finite and non-negative")
+            if not any(weight > 0 for weight in self.weights):
+                raise ValueError("at least one weight must be positive")
+        elif self.weights is not None:
+            raise ValueError("weights can only be set when aggregation='weighted_average'")
 
     @property
     def expanded_tasks(self) -> tuple[str, ...]:
@@ -161,9 +181,10 @@ def make_suite(
     tasks: tuple[str | Suite, ...],
     aggregation: AggregationStrategy = AggregationStrategy.AVERAGE,
     description: str = "",
+    weights: tuple[float, ...] | None = None,
 ) -> Suite:
     """Create and register a suite."""
-    suite = Suite(name=name, tasks=tasks, aggregation=aggregation, description=description)
+    suite = Suite(name=name, tasks=tasks, aggregation=aggregation, description=description, weights=weights)
     return register(suite)
 
 

--- a/src/olmo_eval/runners/processing/aggregation.py
+++ b/src/olmo_eval/runners/processing/aggregation.py
@@ -140,6 +140,97 @@ def _compute_child_average(
         )
 
 
+def _compute_weighted_child_average(
+    child: str | Any,
+    priority_suffix: str,
+    task_results: dict[str, dict[str, Any]],
+) -> ChildAverageResult | None:
+    """Compute a direct child's score, preserving nested weighted suites."""
+    from olmo_eval.evals.suites.registry import AggregationStrategy, Suite
+
+    if isinstance(child, Suite) and child.aggregation == AggregationStrategy.WEIGHTED_AVERAGE:
+        return _compute_weighted_suite_average(child, priority_suffix, task_results)
+    return _compute_child_average(child, priority_suffix, task_results)
+
+
+def _compute_weighted_suite_average(
+    suite: Any,
+    priority_suffix: str,
+    task_results: dict[str, dict[str, Any]],
+) -> ChildAverageResult | None:
+    """Compute a weighted average over a suite's direct children.
+
+    Each metric is normalized over the weights of children that actually produced
+    that metric. This keeps a missing task from implicitly contributing a zero.
+    Nested weighted suites are recursively reduced before the parent weight is
+    applied.
+    """
+    assert suite.weights is not None
+
+    metric_totals: dict[str, float] = {}
+    metric_weights: dict[str, float] = {}
+    primary_total = 0.0
+    primary_weight = 0.0
+    tasks_included: list[str] = []
+
+    for child, weight in zip(suite.tasks, suite.weights, strict=True):
+        if weight == 0:
+            continue
+        result = _compute_weighted_child_average(child, priority_suffix, task_results)
+        if result is None:
+            continue
+
+        tasks_included.extend(result.tasks)
+        for metric_key, value in _flatten_nested_metrics(result.metrics).items():
+            metric_totals[metric_key] = metric_totals.get(metric_key, 0.0) + value * weight
+            metric_weights[metric_key] = metric_weights.get(metric_key, 0.0) + weight
+
+        if result.primary_score is not None:
+            primary_total += result.primary_score * weight
+            primary_weight += weight
+
+    averaged_flat = {
+        metric_key: total / metric_weights[metric_key]
+        for metric_key, total in metric_totals.items()
+        if metric_weights[metric_key] > 0
+    }
+    if not averaged_flat:
+        return None
+
+    return ChildAverageResult(
+        metrics=_unflatten_metrics(averaged_flat),
+        tasks=tasks_included,
+        primary_score=primary_total / primary_weight if primary_weight > 0 else None,
+        nested_suite=suite,
+        nested_suite_key=f"{suite.name}{priority_suffix}",
+    )
+
+
+def _add_nested_suite_result(
+    suite_aggregations: dict[str, dict[str, Any]],
+    result: ChildAverageResult,
+    parent_suite: str,
+) -> None:
+    """Record a nested suite result using the same shape as top-level aggregates."""
+    if result.nested_suite is None or not result.nested_suite_key:
+        return
+
+    nested_metrics = dict(result.metrics)
+    nested_result: dict[str, Any] = {
+        "metrics": nested_metrics,
+        "tasks": result.tasks,
+        "num_tasks": len(result.tasks),
+        "aggregation": result.nested_suite.aggregation.value,
+        "parent_suite": parent_suite,
+    }
+    if result.nested_suite.weights is not None:
+        nested_result["weights"] = list(result.nested_suite.weights)
+    if result.primary_score is not None:
+        nested_metrics["primary_score"] = {"average": result.primary_score}
+        nested_result["primary_metric"] = "primary_score:average"
+    suite_aggregations[result.nested_suite_key] = nested_result
+
+
 def compute_suite_aggregations(
     task_specs: list[str],
     task_results: dict[str, dict[str, Any]],
@@ -151,6 +242,8 @@ def compute_suite_aggregations(
     - AVERAGE: Simple average of all expanded task scores
     - AVERAGE_OF_AVERAGES: Average over children, where nested suites are
       averaged first (each child gets equal weight)
+    - WEIGHTED_AVERAGE: Weighted average over direct children, recursively
+      preserving weights for nested weighted suites
 
     Handles specs with priority suffixes (@priority).
     When a suite has these suffixes, they are propagated to expanded task lookups.
@@ -163,7 +256,7 @@ def compute_suite_aggregations(
         Dict mapping suite name -> {"metrics": {...}, "tasks": [...], "aggregation": ...}
     """
     from olmo_eval.evals.suites import get_suite, suite_exists
-    from olmo_eval.evals.suites.registry import AggregationStrategy
+    from olmo_eval.evals.suites.registry import AggregationStrategy, Suite
 
     suite_aggregations: dict[str, dict[str, Any]] = {}
 
@@ -183,7 +276,36 @@ def compute_suite_aggregations(
         if suite.aggregation == AggregationStrategy.NONE:
             continue
 
-        if suite.aggregation == AggregationStrategy.AVERAGE_OF_AVERAGES:
+        if suite.aggregation == AggregationStrategy.WEIGHTED_AVERAGE:
+            weighted_result = _compute_weighted_suite_average(suite, priority_suffix, task_results)
+            if weighted_result is None:
+                continue
+
+            aggregated_metrics = dict(weighted_result.metrics)
+            nested_suites_included: list[str] = []
+            assert suite.weights is not None
+            for child, weight in zip(suite.tasks, suite.weights, strict=True):
+                if weight == 0 or not isinstance(child, Suite):
+                    continue
+                child_result = _compute_weighted_child_average(child, priority_suffix, task_results)
+                if child_result is None or not child_result.nested_suite_key:
+                    continue
+                nested_suites_included.append(child_result.nested_suite_key)
+                _add_nested_suite_result(suite_aggregations, child_result, spec)
+
+            suite_result: dict[str, Any] = {
+                "metrics": aggregated_metrics,
+                "tasks": weighted_result.tasks,
+                "num_tasks": len(weighted_result.tasks),
+                "nested_suites": nested_suites_included,
+                "aggregation": suite.aggregation.value,
+                "weights": list(suite.weights),
+            }
+            if weighted_result.primary_score is not None:
+                aggregated_metrics["primary_score"] = {"average": weighted_result.primary_score}
+                suite_result["primary_metric"] = "primary_score:average"
+            suite_aggregations[spec] = suite_result
+        elif suite.aggregation == AggregationStrategy.AVERAGE_OF_AVERAGES:
             # Average of averages: each child (task or nested suite) gets equal weight
             # Process each child separately, then average the child averages
             child_averages: dict[str, list[float]] = {}  # Flat "metric:scorer" -> values
@@ -213,20 +335,7 @@ def compute_suite_aggregations(
                 # If this child is a nested Suite, also report its aggregation separately
                 if result.nested_suite is not None and result.nested_suite_key:
                     nested_suites_included.append(result.nested_suite_key)
-                    nested_result: dict[str, Any] = {
-                        "metrics": result.metrics,
-                        "tasks": result.tasks,
-                        "num_tasks": len(result.tasks),
-                        "aggregation": result.nested_suite.aggregation.value,
-                        "parent_suite": spec,
-                    }
-                    if result.primary_score is not None:
-                        nested_result["metrics"] = dict(result.metrics)
-                        nested_result["metrics"]["primary_score"] = {
-                            "average": result.primary_score
-                        }
-                        nested_result["primary_metric"] = "primary_score:average"
-                    suite_aggregations[result.nested_suite_key] = nested_result
+                    _add_nested_suite_result(suite_aggregations, result, spec)
 
             if not child_averages:
                 continue
@@ -237,7 +346,7 @@ def compute_suite_aggregations(
             }
             aggregated_metrics = _unflatten_metrics(averaged_flat)
 
-            suite_result: dict[str, Any] = {
+            suite_result = {
                 "metrics": aggregated_metrics,
                 "tasks": all_tasks_included,
                 "num_tasks": len(all_tasks_included),

--- a/tests/test_weighted_suite_aggregation.py
+++ b/tests/test_weighted_suite_aggregation.py
@@ -1,0 +1,121 @@
+"""Regression tests for weighted suite aggregation."""
+
+import pytest
+
+from olmo_eval.evals.suites.registry import _REGISTRY, AggregationStrategy, Suite, register
+from olmo_eval.runners.processing.aggregation import compute_suite_aggregations
+
+
+@pytest.fixture
+def isolated_suite_registry():
+    original = _REGISTRY.copy()
+    _REGISTRY.clear()
+    try:
+        yield
+    finally:
+        _REGISTRY.clear()
+        _REGISTRY.update(original)
+
+
+def _result(score: float) -> dict:
+    return {
+        "metrics": {"accuracy": {"exact": score}},
+        "primary_metric": "accuracy:exact",
+    }
+
+
+def test_weighted_average_uses_direct_child_weights(isolated_suite_registry):
+    register(
+        Suite(
+            name="weighted",
+            tasks=("a", "b"),
+            aggregation=AggregationStrategy.WEIGHTED_AVERAGE,
+            weights=(0.75, 0.25),
+        )
+    )
+
+    results = compute_suite_aggregations(
+        ["weighted"],
+        {"a": _result(0.8), "b": _result(0.2)},
+    )
+
+    weighted = results["weighted"]
+    assert weighted["metrics"]["accuracy"]["exact"] == pytest.approx(0.65)
+    assert weighted["metrics"]["primary_score"]["average"] == pytest.approx(0.65)
+    assert weighted["weights"] == [0.75, 0.25]
+
+
+def test_weighted_average_renormalizes_when_child_is_missing(isolated_suite_registry):
+    register(
+        Suite(
+            name="weighted",
+            tasks=("a", "b"),
+            aggregation=AggregationStrategy.WEIGHTED_AVERAGE,
+            weights=(0.75, 0.25),
+        )
+    )
+
+    results = compute_suite_aggregations(["weighted"], {"a": _result(0.8)})
+
+    assert results["weighted"]["metrics"]["accuracy"]["exact"] == pytest.approx(0.8)
+
+
+def test_nested_weighted_suites_preserve_internal_weights(isolated_suite_registry):
+    inner = Suite(
+        name="inner",
+        tasks=("a", "b"),
+        aggregation=AggregationStrategy.WEIGHTED_AVERAGE,
+        weights=(0.25, 0.75),
+    )
+    outer = Suite(
+        name="outer",
+        tasks=(inner, "c"),
+        aggregation=AggregationStrategy.WEIGHTED_AVERAGE,
+        weights=(0.4, 0.6),
+    )
+    register(outer)
+
+    results = compute_suite_aggregations(
+        ["outer"],
+        {"a": _result(1.0), "b": _result(0.0), "c": _result(0.5)},
+    )
+
+    assert results["inner"]["metrics"]["accuracy"]["exact"] == pytest.approx(0.25)
+    assert results["outer"]["metrics"]["accuracy"]["exact"] == pytest.approx(0.4)
+    assert results["outer"]["nested_suites"] == ["inner"]
+
+
+def test_weighted_suite_validates_weights():
+    with pytest.raises(ValueError, match="weights are required"):
+        Suite(
+            name="missing",
+            tasks=("a",),
+            aggregation=AggregationStrategy.WEIGHTED_AVERAGE,
+        )
+
+    with pytest.raises(ValueError, match="weights must match tasks"):
+        Suite(
+            name="mismatch",
+            tasks=("a", "b"),
+            aggregation=AggregationStrategy.WEIGHTED_AVERAGE,
+            weights=(1.0,),
+        )
+
+    with pytest.raises(ValueError, match="finite and non-negative"):
+        Suite(
+            name="negative",
+            tasks=("a",),
+            aggregation=AggregationStrategy.WEIGHTED_AVERAGE,
+            weights=(-1.0,),
+        )
+
+    with pytest.raises(ValueError, match="at least one weight"):
+        Suite(
+            name="zero",
+            tasks=("a", "b"),
+            aggregation=AggregationStrategy.WEIGHTED_AVERAGE,
+            weights=(0.0, 0.0),
+        )
+
+    with pytest.raises(ValueError, match="weights can only be set"):
+        Suite(name="wrong-strategy", tasks=("a",), weights=(1.0,))


### PR DESCRIPTION
## Description

Adds explicit weighted aggregation for evaluation suites, including nested weighted suites.

- adds `AggregationStrategy.WEIGHTED_AVERAGE`
- adds direct-child `weights` to `Suite` with construction-time validation
- normalizes each metric over children that actually produced that metric, so missing results are not treated as zero
- recursively preserves a nested weighted suite's internal weighting before applying its parent weight
- reports configured weights in aggregate output
- adds focused regression coverage for direct weights, missing children, nested weights, and invalid configurations

Closes #84

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Testing

- [ ] Unit tests pass locally (`pytest tests/ --ignore=tests/integration/`)
- [ ] Integration tests pass (if applicable)
- [x] New tests added for new functionality

Local dependency-backed test execution is not available in this environment; repository CI should run the unit, lint, format, and type checks.

## Checklist

- [x] My code follows the project's existing style and aggregation conventions
- [x] I have performed a self-review of the code changes
- [x] Documentation changes are not required for this API addition beyond inline type/docstring updates
- [ ] My changes generate no new warnings
- [x] No dependent changes are required