### PR TITLE
feat: support prompt truncation across inference providers

### DIFF
--- a/src/olmo_eval/inference/providers/huggingface.py
+++ b/src/olmo_eval/inference/providers/huggingface.py
@@ -14,7 +14,7 @@ from olmo_eval.common.types import (
     SamplingParams,
 )
 from olmo_eval.inference.base import InferenceProvider
-from olmo_eval.inference.tokenizer_utils import encode_context_and_continuation
+from olmo_eval.inference.tokenizer_utils import encode_context_and_continuation, truncate_token_ids
 
 logger = get_logger(__name__)
 
@@ -105,6 +105,28 @@ class HuggingFaceProvider(InferenceProvider):
                 return value
         return 2048
 
+    def _max_input_tokens(self, params: SamplingParams) -> int:
+        """Resolve the input budget used by ``truncate_prompt_tokens=-1``."""
+        reserved_output = params.max_tokens if params.max_tokens is not None else 1
+        return max(self._context_length() - reserved_output, 1)
+
+    def _prompt_token_ids(self, prompt: str, params: SamplingParams) -> list[int]:
+        token_ids = self.tokenizer.encode(prompt, add_special_tokens=True)
+        return truncate_token_ids(
+            token_ids,
+            params.truncate_prompt_tokens,
+            params.truncation_side,
+            tokenizer=self.tokenizer,
+            max_input_tokens=self._max_input_tokens(params),
+        )
+
+    def _encode_prompt(self, prompt: str, params: SamplingParams) -> dict[str, torch.Tensor]:
+        import torch
+
+        token_ids = self._prompt_token_ids(prompt, params)
+        input_ids = torch.tensor([token_ids], dtype=torch.long, device=self.device)
+        return {"input_ids": input_ids, "attention_mask": torch.ones_like(input_ids)}
+
     def _build_generate_kwargs(self, params: SamplingParams, prompt_len: int = 0) -> dict[str, Any]:
         """Convert SamplingParams to HuggingFace generate kwargs."""
         # Use explicit do_sample flag, overriding temperature-based inference
@@ -157,17 +179,11 @@ class HuggingFaceProvider(InferenceProvider):
         import torch
 
         params = self._default_sampling_params(sampling_params)
-        if params.truncate_prompt_tokens is not None or params.truncation_side is not None:
-            logger.warning(
-                "truncate_prompt_tokens or truncation_side has been set in the params, "
-                "but is not supported for the HuggingFaceProvider and will not be used."
-            )
-        gen_kwargs = self._build_generate_kwargs(params)
 
         results = []
         for request in requests:
             prompt = request.prompt
-            encoded = self.tokenizer(prompt, return_tensors="pt").to(self.device)
+            encoded = self._encode_prompt(prompt, params)
             prompt_len = encoded["input_ids"].shape[1]
             gen_kwargs = self._build_generate_kwargs(params, prompt_len)
 
@@ -228,15 +244,17 @@ class HuggingFaceProvider(InferenceProvider):
             return None
 
         if request.request_type != RequestType.LOGLIKELIHOOD:
-            # Pass the prompt length so an uncapped (max_tokens=None) trace shows the
-            # same per-prompt max_new_tokens budget that generate() will use.
-            prompt_len = len(self.tokenizer.encode(request.prompt)) if request.prompt else 0
+            prompt_len = len(self._prompt_token_ids(request.prompt, params)) if request.prompt else 0
             trace["provider"] = "HuggingFaceProvider"
             trace["endpoint"] = "transformers.generate"
             trace["generation_kwargs"] = {
                 "max_gen_toks": params.max_tokens,
                 **self._build_generate_kwargs(params, prompt_len),
             }
+            if params.truncate_prompt_tokens is not None:
+                trace["generation_kwargs"]["truncate_prompt_tokens"] = params.truncate_prompt_tokens
+            if params.truncation_side is not None:
+                trace["generation_kwargs"]["truncation_side"] = params.truncation_side
             trace["stop_sequences"] = list(params.stop_sequences or ())
         return trace
 
@@ -248,11 +266,6 @@ class HuggingFaceProvider(InferenceProvider):
         import torch
 
         params = self._default_sampling_params(sampling_params)
-        if params.truncate_prompt_tokens is not None or params.truncation_side is not None:
-            logger.warning(
-                "truncate_prompt_tokens or truncation_side has been set in the params, "
-                "but is not supported for the HuggingFaceProvider and will not be used."
-            )
         results = []
         for request in requests:
             request_outputs = []
@@ -262,6 +275,14 @@ class HuggingFaceProvider(InferenceProvider):
                 # Use shared utility for BOS handling and trailing space logic
                 context_enc, continuation_enc = encode_context_and_continuation(
                     self.tokenizer, prompt, continuation
+                )
+                max_length = request.max_length or self._context_length()
+                context_enc = truncate_token_ids(
+                    context_enc,
+                    params.truncate_prompt_tokens,
+                    params.truncation_side,
+                    tokenizer=self.tokenizer,
+                    max_input_tokens=max(max_length - len(continuation_enc), 1),
                 )
 
                 # Build full sequence as tensor

--- a/src/olmo_eval/inference/providers/litellm.py
+++ b/src/olmo_eval/inference/providers/litellm.py
@@ -10,6 +10,7 @@ from olmo_eval.common.logging import get_logger
 from olmo_eval.common.types import LMOutput, LMRequest, LogProbEntry, RequestType, SamplingParams
 from olmo_eval.inference.base import InferenceProvider
 from olmo_eval.inference.retry import retry_with_backoff
+from olmo_eval.inference.tokenizer_utils import resolve_prompt_truncation_limit, resolve_truncation_side
 from olmo_eval.inference.utils import run_async
 
 if TYPE_CHECKING:
@@ -109,17 +110,89 @@ class LiteLLMProvider(InferenceProvider):
 
         return self._client
 
+    def _max_input_tokens(self, request: LMRequest, params: SamplingParams) -> int | None:
+        """Best-effort input budget for ``truncate_prompt_tokens=-1``."""
+        if request.max_length is not None:
+            reserved_output = params.max_tokens if params.max_tokens is not None else 0
+            return max(request.max_length - reserved_output, 1)
+
+        try:
+            model_info = self._litellm.get_model_info(self.model_name)
+        except Exception:
+            return None
+        max_input_tokens = model_info.get("max_input_tokens") if isinstance(model_info, dict) else None
+        return max_input_tokens if isinstance(max_input_tokens, int) and max_input_tokens > 0 else None
+
+    def _truncate_messages(
+        self,
+        messages: list[dict[str, Any]],
+        request: LMRequest,
+        params: SamplingParams,
+    ) -> list[dict[str, Any]]:
+        """Truncate message content while preserving a valid chat-message structure."""
+        if params.truncate_prompt_tokens is None:
+            return [dict(message) for message in messages]
+
+        limit = resolve_prompt_truncation_limit(
+            params.truncate_prompt_tokens,
+            max_input_tokens=self._max_input_tokens(request, params),
+        )
+        assert limit is not None
+        side = resolve_truncation_side(params.truncation_side, default="right")
+        truncated = [dict(message) for message in messages]
+
+        def token_count() -> int:
+            return int(self._litellm.token_counter(model=self.model_name, messages=truncated))
+
+        current_count = token_count()
+        if current_count <= limit:
+            return truncated
+
+        indices = range(len(truncated)) if side == "left" else range(len(truncated) - 1, -1, -1)
+        for index in indices:
+            content = truncated[index].get("content")
+            if not isinstance(content, str) or not content:
+                continue
+            token_ids = list(self._litellm.encode(model=self.model_name, text=content))
+            if not token_ids:
+                continue
+            excess = max(current_count - limit, 0)
+            remove_count = min(excess, len(token_ids))
+            if remove_count <= 0:
+                break
+            kept = token_ids[remove_count:] if side == "left" else token_ids[:-remove_count]
+            truncated[index]["content"] = self._litellm.decode(model=self.model_name, tokens=kept)
+            current_count = token_count()
+            if current_count <= limit:
+                return truncated
+
+        # Chat-template overhead can itself exceed the requested limit after all
+        # textual content is exhausted. Drop complete messages from the requested
+        # truncation side while retaining at least one structurally valid message.
+        while current_count > limit and len(truncated) > 1:
+            if side == "left":
+                truncated.pop(0)
+            else:
+                truncated.pop()
+            current_count = token_count()
+
+        if current_count > limit:
+            raise ValueError(
+                f"LiteLLM prompt cannot fit within truncate_prompt_tokens={limit}; "
+                f"chat-template overhead is {current_count} tokens."
+            )
+        return truncated
+
     async def _generate_single_impl(
         self, request: LMRequest, params: SamplingParams
     ) -> list[LMOutput]:
         """Generate completions for a single request."""
-        # Build messages from request
         if request.messages:
             messages = [dict(m) for m in request.messages]
         else:
             messages = [{"role": "user", "content": request.prompt}]
+        messages = self._truncate_messages(messages, request, params)
 
-        # Prepare API kwargs
         kwargs: dict[str, Any] = {
             "api_base": self.api_base,
             "model": self.model_name,
@@ -127,20 +200,14 @@ class LiteLLMProvider(InferenceProvider):
             "n": params.num_samples,
             **self.api_kwargs,
         }
-        # max_tokens=None means "uncapped"; omit the field so the API uses its
-        # own context-bounded default rather than receiving a literal null.
         if params.max_tokens is not None:
             kwargs["max_completion_tokens"] = params.max_tokens
 
-        # Always send temperature explicitly to avoid server defaults (OpenAI API defaults to 1.0)
         kwargs["temperature"] = params.temperature
         if params.stop_sequences:
             kwargs["stop"] = list(params.stop_sequences)[:_MAX_STOP_SEQUENCES]
-        # Always request logprobs for metrics computation
         kwargs["logprobs"] = True
-        kwargs["top_logprobs"] = (
-            1  # NOTE: workaround for litellm proxy issue https://github.com/BerriAI/litellm/issues/21932
-        )
+        kwargs["top_logprobs"] = 1
 
         response = await self._litellm.acompletion(**kwargs)
 
@@ -148,7 +215,6 @@ class LiteLLMProvider(InferenceProvider):
         for choice in response.choices:
             text = choice.message.content or ""
 
-            # Convert logprobs to standard format
             logprob_entries: list[LogProbEntry] | None = None
             metadata: dict[str, Any] = {}
             logprobs_data = getattr(choice, "logprobs", None)
@@ -161,7 +227,6 @@ class LiteLLMProvider(InferenceProvider):
                         entry["bytes"] = lp_bytes
                     logprob_entries.append(entry)
 
-                # Compute metadata from logprobs
                 sum_logits = sum(entry["logprob"] for entry in logprob_entries)
                 num_tokens = len(logprob_entries)
                 metadata = {
@@ -194,6 +259,10 @@ class LiteLLMProvider(InferenceProvider):
                 "logprobs": True,
                 "top_logprobs": 1,
             }
+            if params.truncate_prompt_tokens is not None:
+                trace["generation_kwargs"]["truncate_prompt_tokens"] = params.truncate_prompt_tokens
+            if params.truncation_side is not None:
+                trace["generation_kwargs"]["truncation_side"] = params.truncation_side
             trace["stop_sequences"] = []
             return trace
 
@@ -209,6 +278,10 @@ class LiteLLMProvider(InferenceProvider):
         }
         if params.top_p is not None:
             trace["generation_kwargs"]["top_p"] = params.top_p
+        if params.truncate_prompt_tokens is not None:
+            trace["generation_kwargs"]["truncate_prompt_tokens"] = params.truncate_prompt_tokens
+        if params.truncation_side is not None:
+            trace["generation_kwargs"]["truncation_side"] = params.truncation_side
         trace["stop_sequences"] = list(params.stop_sequences or ())[:_MAX_STOP_SEQUENCES]
         return trace
 
@@ -229,18 +302,7 @@ class LiteLLMProvider(InferenceProvider):
         requests: list[LMRequest],
         sampling_params: SamplingParams | None = None,
     ) -> list[list[LMOutput]]:
-        """Async generate completions.
-
-        This is the native async implementation that should be used
-        in async contexts to avoid nested event loops.
-
-        Args:
-            requests: Batch of requests to process.
-            sampling_params: Sampling configuration.
-
-        Returns:
-            List of output lists, one per request.
-        """
+        """Async generate completions."""
         from olmo_eval.common.progress import ProgressLogger
         from olmo_eval.inference.dispatch import dispatch_concurrent
 
@@ -250,11 +312,6 @@ class LiteLLMProvider(InferenceProvider):
         )
 
         params = self._default_sampling_params(sampling_params)
-        if params.truncate_prompt_tokens is not None or params.truncation_side is not None:
-            logger.warning(
-                "truncate_prompt_tokens or truncation_side has been set in the params, "
-                "but is not supported for the LiteLLMProvider and will not be used."
-            )
         progress = ProgressLogger(total=len(requests), desc="Generating", logger=logger)
 
         async def process(req: LMRequest) -> list[LMOutput]:
@@ -278,17 +335,7 @@ class LiteLLMProvider(InferenceProvider):
         requests: list[LMRequest],
         sampling_params: SamplingParams | None = None,
     ) -> list[list[LMOutput]]:
-        """Generate completions (sync wrapper).
-
-        For async contexts, prefer using agenerate() directly.
-
-        Args:
-            requests: Batch of requests to process.
-            sampling_params: Sampling configuration.
-
-        Returns:
-            List of output lists, one per request.
-        """
+        """Generate completions (sync wrapper)."""
         return run_async(self.agenerate(requests, sampling_params))
 
     async def _logprobs_single_impl(
@@ -307,15 +354,18 @@ class LiteLLMProvider(InferenceProvider):
         cont_prompts = request.continuation_prompts
         for i, continuation in enumerate(request.continuations or ()):
             content = cont_prompts[i] if cont_prompts else default_content
+            messages = self._truncate_messages(
+                [{"role": "user", "content": content}], request, params
+            )
 
             response = await self._litellm.acompletion(
                 api_base=self.api_base,
                 model=self.model_name,
-                messages=[{"role": "user", "content": content}],
+                messages=messages,
                 max_completion_tokens=50,
                 temperature=params.temperature,
                 logprobs=True,
-                top_logprobs=1,  # NOTE: workaround for litellm proxy issue https://github.com/BerriAI/litellm/issues/21932
+                top_logprobs=1,
                 **self.api_kwargs,
             )
 
@@ -363,18 +413,7 @@ class LiteLLMProvider(InferenceProvider):
         requests: list[LMRequest],
         sampling_params: SamplingParams | None = None,
     ) -> list[list[LMOutput]]:
-        """Async compute logprobs for continuations.
-
-        Note: Most API providers don't support true continuation logprobs.
-        This implementation provides an approximation by generating a response
-        and returning those logprobs.
-
-        Args:
-            requests: Batch of requests with continuations to score.
-
-        Returns:
-            List of output lists with logprobs populated.
-        """
+        """Async compute logprobs for continuations."""
         from olmo_eval.common.progress import ProgressLogger
         from olmo_eval.inference.dispatch import dispatch_concurrent
 
@@ -384,11 +423,6 @@ class LiteLLMProvider(InferenceProvider):
         )
 
         params = self._default_sampling_params(sampling_params)
-        if params.truncate_prompt_tokens is not None or params.truncation_side is not None:
-            logger.warning(
-                "truncate_prompt_tokens or truncation_side has been set in the params, "
-                "but is not supported for the LiteLLMProvider and will not be used."
-            )
         progress = ProgressLogger(total=len(requests), desc="Logprobs", logger=logger)
 
         def on_progress(done: int, total: int) -> None:
@@ -409,18 +443,5 @@ class LiteLLMProvider(InferenceProvider):
         requests: list[LMRequest],
         sampling_params: SamplingParams | None = None,
     ) -> list[list[LMOutput]]:
-        """Compute logprobs for continuations (sync wrapper).
-
-        Note: Most API providers don't support true continuation logprobs.
-        This implementation provides an approximation by generating a response
-        and returning those logprobs.
-
-        For async contexts, prefer using alogprobs() directly.
-
-        Args:
-            requests: Batch of requests with continuations to score.
-
-        Returns:
-            List of output lists with logprobs populated.
-        """
+        """Compute logprobs for continuations (sync wrapper)."""
         return run_async(self.alogprobs(requests, sampling_params))

--- a/src/olmo_eval/inference/providers/litellm.py
+++ b/src/olmo_eval/inference/providers/litellm.py
@@ -129,7 +129,7 @@ class LiteLLMProvider(InferenceProvider):
         request: LMRequest,
         params: SamplingParams,
     ) -> list[dict[str, Any]]:
-        """Truncate message content while preserving a valid chat-message structure."""
+        """Truncate prompt content while preserving valid chat-message structure."""
         if params.truncate_prompt_tokens is None:
             return [dict(message) for message in messages]
 
@@ -166,14 +166,10 @@ class LiteLLMProvider(InferenceProvider):
             if current_count <= limit:
                 return truncated
 
-        # Chat-template overhead can itself exceed the requested limit after all
-        # textual content is exhausted. Drop complete messages from the requested
-        # truncation side while retaining at least one structurally valid message.
+        # Chat-template overhead can remain after all textual content is exhausted.
+        # Drop complete messages from the requested side while retaining at least one.
         while current_count > limit and len(truncated) > 1:
-            if side == "left":
-                truncated.pop(0)
-            else:
-                truncated.pop()
+            truncated.pop(0 if side == "left" else -1)
             current_count = token_count()
 
         if current_count > limit:
@@ -187,12 +183,14 @@ class LiteLLMProvider(InferenceProvider):
         self, request: LMRequest, params: SamplingParams
     ) -> list[LMOutput]:
         """Generate completions for a single request."""
+        # Build messages from request
         if request.messages:
             messages = [dict(m) for m in request.messages]
         else:
             messages = [{"role": "user", "content": request.prompt}]
         messages = self._truncate_messages(messages, request, params)
 
+        # Prepare API kwargs
         kwargs: dict[str, Any] = {
             "api_base": self.api_base,
             "model": self.model_name,
@@ -200,14 +198,20 @@ class LiteLLMProvider(InferenceProvider):
             "n": params.num_samples,
             **self.api_kwargs,
         }
+        # max_tokens=None means "uncapped"; omit the field so the API uses its
+        # own context-bounded default rather than receiving a literal null.
         if params.max_tokens is not None:
             kwargs["max_completion_tokens"] = params.max_tokens
 
+        # Always send temperature explicitly to avoid server defaults (OpenAI API defaults to 1.0)
         kwargs["temperature"] = params.temperature
         if params.stop_sequences:
             kwargs["stop"] = list(params.stop_sequences)[:_MAX_STOP_SEQUENCES]
+        # Always request logprobs for metrics computation
         kwargs["logprobs"] = True
-        kwargs["top_logprobs"] = 1
+        kwargs["top_logprobs"] = (
+            1  # NOTE: workaround for litellm proxy issue https://github.com/BerriAI/litellm/issues/21932
+        )
 
         response = await self._litellm.acompletion(**kwargs)
 
@@ -215,6 +219,7 @@ class LiteLLMProvider(InferenceProvider):
         for choice in response.choices:
             text = choice.message.content or ""
 
+            # Convert logprobs to standard format
             logprob_entries: list[LogProbEntry] | None = None
             metadata: dict[str, Any] = {}
             logprobs_data = getattr(choice, "logprobs", None)
@@ -227,6 +232,7 @@ class LiteLLMProvider(InferenceProvider):
                         entry["bytes"] = lp_bytes
                     logprob_entries.append(entry)
 
+                # Compute metadata from logprobs
                 sum_logits = sum(entry["logprob"] for entry in logprob_entries)
                 num_tokens = len(logprob_entries)
                 metadata = {
@@ -302,7 +308,18 @@ class LiteLLMProvider(InferenceProvider):
         requests: list[LMRequest],
         sampling_params: SamplingParams | None = None,
     ) -> list[list[LMOutput]]:
-        """Async generate completions."""
+        """Async generate completions.
+
+        This is the native async implementation that should be used
+        in async contexts to avoid nested event loops.
+
+        Args:
+            requests: Batch of requests to process.
+            sampling_params: Sampling configuration.
+
+        Returns:
+            List of output lists, one per request.
+        """
         from olmo_eval.common.progress import ProgressLogger
         from olmo_eval.inference.dispatch import dispatch_concurrent
 
@@ -335,7 +352,17 @@ class LiteLLMProvider(InferenceProvider):
         requests: list[LMRequest],
         sampling_params: SamplingParams | None = None,
     ) -> list[list[LMOutput]]:
-        """Generate completions (sync wrapper)."""
+        """Generate completions (sync wrapper).
+
+        For async contexts, prefer using agenerate() directly.
+
+        Args:
+            requests: Batch of requests to process.
+            sampling_params: Sampling configuration.
+
+        Returns:
+            List of output lists, one per request.
+        """
         return run_async(self.agenerate(requests, sampling_params))
 
     async def _logprobs_single_impl(
@@ -365,7 +392,7 @@ class LiteLLMProvider(InferenceProvider):
                 max_completion_tokens=50,
                 temperature=params.temperature,
                 logprobs=True,
-                top_logprobs=1,
+                top_logprobs=1,  # NOTE: workaround for litellm proxy issue https://github.com/BerriAI/litellm/issues/21932
                 **self.api_kwargs,
             )
 
@@ -413,7 +440,18 @@ class LiteLLMProvider(InferenceProvider):
         requests: list[LMRequest],
         sampling_params: SamplingParams | None = None,
     ) -> list[list[LMOutput]]:
-        """Async compute logprobs for continuations."""
+        """Async compute logprobs for continuations.
+
+        Note: Most API providers don't support true continuation logprobs.
+        This implementation provides an approximation by generating a response
+        and returning those logprobs.
+
+        Args:
+            requests: Batch of requests with continuations to score.
+
+        Returns:
+            List of output lists with logprobs populated.
+        """
         from olmo_eval.common.progress import ProgressLogger
         from olmo_eval.inference.dispatch import dispatch_concurrent
 
@@ -443,5 +481,18 @@ class LiteLLMProvider(InferenceProvider):
         requests: list[LMRequest],
         sampling_params: SamplingParams | None = None,
     ) -> list[list[LMOutput]]:
-        """Compute logprobs for continuations (sync wrapper)."""
+        """Compute logprobs for continuations (sync wrapper).
+
+        Note: Most API providers don't support true continuation logprobs.
+        This implementation provides an approximation by generating a response
+        and returning those logprobs.
+
+        For async contexts, prefer using alogprobs() directly.
+
+        Args:
+            requests: Batch of requests with continuations to score.
+
+        Returns:
+            List of output lists with logprobs populated.
+        """
         return run_async(self.alogprobs(requests, sampling_params))

--- a/src/olmo_eval/inference/providers/olmo_core.py
+++ b/src/olmo_eval/inference/providers/olmo_core.py
@@ -16,6 +16,7 @@ from olmo_eval.inference.base import InferenceProvider
 from olmo_eval.inference.tokenizer_utils import (
     encode_context_and_continuation,
     get_bos_token_ids,
+    truncate_token_ids,
 )
 
 if TYPE_CHECKING:
@@ -297,6 +298,26 @@ class OlmoCoreProvider(InferenceProvider):
             return get_bos_token_ids(self.tokenizer, fallback_to_eos=True) + token_ids
         return token_ids
 
+    def _apply_requested_prompt_truncation(
+        self,
+        token_ids: list[int],
+        params: SamplingParams,
+        *,
+        max_input_tokens: int | None = None,
+    ) -> list[int]:
+        if params.truncate_prompt_tokens is None:
+            return token_ids
+        if max_input_tokens is None:
+            reserved_output = params.max_tokens if params.max_tokens is not None else 1
+            max_input_tokens = max(self.max_length - reserved_output, 1)
+        return truncate_token_ids(
+            token_ids,
+            params.truncate_prompt_tokens,
+            params.truncation_side,
+            tokenizer=self.tokenizer,
+            max_input_tokens=max_input_tokens,
+        )
+
     def _format_prompt(self, request: LMRequest) -> str:
         if request.request_type == RequestType.CHAT and request.messages:
             if not hasattr(self.tokenizer, "apply_chat_template"):
@@ -421,12 +442,7 @@ class OlmoCoreProvider(InferenceProvider):
         params: SamplingParams,
         prompt_token_ids: list[list[int]],
     ) -> SamplingParams:
-        """Resolve an uncapped (``max_tokens=None``) request to a concrete budget.
-
-        "Uncapped" means generate to the model's context limit, so reserve the
-        room left after the longest prompt. Downstream length validation and
-        truncation then operate on a concrete int.
-        """
+        """Resolve an uncapped (``max_tokens=None``) request to a concrete budget."""
         if params.max_tokens is not None:
             return params
         longest_prompt = max((len(ids) for ids in prompt_token_ids), default=0)
@@ -536,11 +552,6 @@ class OlmoCoreProvider(InferenceProvider):
             return []
 
         params = self._default_sampling_params(sampling_params)
-        if params.truncate_prompt_tokens is not None or params.truncation_side is not None:
-            logger.warning(
-                "truncate_prompt_tokens or truncation_side has been set in the params, "
-                "but is not supported for the OlmoCoreProvider and will not be used."
-            )
         results: list[list[LMOutput]] = []
         try:
             for chunk in self._iter_chunks(requests):
@@ -563,6 +574,10 @@ class OlmoCoreProvider(InferenceProvider):
                 logger.info(f"Prompt {i}:\n{prompt}")
 
         encoded_prompts = [self._encode_prompt(prompt) for prompt in prompt_strs]
+        encoded_prompts = [
+            self._apply_requested_prompt_truncation(token_ids, params)
+            for token_ids in encoded_prompts
+        ]
         params = self._resolve_max_tokens(params, encoded_prompts)
         generation_kwargs = self._build_generation_kwargs(params)
         prompt_token_ids = self._left_truncate_prompts_for_generation(encoded_prompts, params)
@@ -620,6 +635,10 @@ class OlmoCoreProvider(InferenceProvider):
             trace["generation_kwargs"] = {
                 "temperature": params.temperature,
             }
+            if params.truncate_prompt_tokens is not None:
+                trace["generation_kwargs"]["truncate_prompt_tokens"] = params.truncate_prompt_tokens
+            if params.truncation_side is not None:
+                trace["generation_kwargs"]["truncation_side"] = params.truncation_side
             trace["stop_sequences"] = []
             return trace
 
@@ -632,6 +651,10 @@ class OlmoCoreProvider(InferenceProvider):
             "completions_only": False,
             "max_length": "<padded_prompt_length + max_tokens>",
         }
+        if params.truncate_prompt_tokens is not None:
+            trace["generation_kwargs"]["truncate_prompt_tokens"] = params.truncate_prompt_tokens
+        if params.truncation_side is not None:
+            trace["generation_kwargs"]["truncation_side"] = params.truncation_side
         trace["stop_sequences"] = list(params.stop_sequences or ())
         return trace
 
@@ -641,23 +664,20 @@ class OlmoCoreProvider(InferenceProvider):
         sampling_params: SamplingParams | None = None,
     ) -> list[list[LMOutput]]:
         params = self._default_sampling_params(sampling_params)
-        if params.truncate_prompt_tokens is not None or params.truncation_side is not None:
-            logger.warning(
-                "truncate_prompt_tokens or truncation_side has been set in the params, "
-                "but is not supported for the OlmoCoreProvider and will not be used."
-            )
-        del sampling_params
-        del params
         if not requests:
             return []
 
         self._free_inference_cache()
         results: list[list[LMOutput]] = []
         for chunk in self._iter_chunks(requests):
-            results.extend(self._logprobs_chunk(chunk))
+            results.extend(self._logprobs_chunk(chunk, params))
         return results
 
-    def _logprob_inputs_for_request(self, request: LMRequest) -> list[core_utils.LogprobInput]:
+    def _logprob_inputs_for_request(
+        self,
+        request: LMRequest,
+        params: SamplingParams,
+    ) -> list[core_utils.LogprobInput]:
         max_len = request.max_length or self.max_length
         if max_len <= 0:
             raise ValueError("OlmoCoreProvider requires max_length > 0 for logprobs")
@@ -669,6 +689,11 @@ class OlmoCoreProvider(InferenceProvider):
             context_ids, continuation_ids = self._encode_logprob_context_and_continuation(
                 prompt,
                 continuation,
+            )
+            context_ids = self._apply_requested_prompt_truncation(
+                context_ids,
+                params,
+                max_input_tokens=max(max_len - len(continuation_ids), 1),
             )
             if not continuation_ids:
                 rows.append(
@@ -754,10 +779,14 @@ class OlmoCoreProvider(InferenceProvider):
             },
         )
 
-    def _logprobs_chunk(self, requests: list[LMRequest]) -> list[list[LMOutput]]:
+    def _logprobs_chunk(
+        self,
+        requests: list[LMRequest],
+        params: SamplingParams,
+    ) -> list[list[LMOutput]]:
         import torch
 
-        rows_by_request = [self._logprob_inputs_for_request(request) for request in requests]
+        rows_by_request = [self._logprob_inputs_for_request(request, params) for request in requests]
         token_inputs = [row.input_ids for rows in rows_by_request for row in rows]
 
         if token_inputs:

--- a/src/olmo_eval/inference/providers/vllm.py
+++ b/src/olmo_eval/inference/providers/vllm.py
@@ -11,7 +11,7 @@ from olmo_eval.common.debug import is_debug_provider, is_debug_requests
 from olmo_eval.common.types import LMOutput, LMRequest, LogProbEntry, RequestType, SamplingParams
 from olmo_eval.inference.base import InferenceProvider
 from olmo_eval.inference.hf_cache import refresh_hf_cache
-from olmo_eval.inference.tokenizer_utils import encode_context_and_continuation
+from olmo_eval.inference.tokenizer_utils import encode_context_and_continuation, truncate_token_ids
 
 logger = logging.getLogger(__name__)
 
@@ -121,13 +121,11 @@ class VLLMProvider(InferenceProvider):
                 before initializing vLLM.
             **engine_kwargs: Additional arguments passed to vLLM LLM engine.
         """
-        # Set vLLM logging level - DEBUG if OLMO_EVAL_DEBUG_PROVIDER=1, otherwise WARNING
         if is_debug_provider():
             os.environ["VLLM_LOGGING_LEVEL"] = "DEBUG"
         else:
             os.environ.setdefault("VLLM_LOGGING_LEVEL", "WARNING")
 
-        # Configure vLLM logger with worker_id if provided
         if worker_id:
             _configure_vllm_logger(worker_id)
 
@@ -164,23 +162,14 @@ class VLLMProvider(InferenceProvider):
                 )
 
         engine_kwargs.setdefault("gpu_memory_utilization", 0.8)
-
-        # Configure attention backend if specified (e.g., FLASHINFER, FLASH_ATTN)
         if attention_backend:
             engine_kwargs.setdefault("attention_backend", attention_backend)
-
-        # Use separate tokenizer if specified
         if tokenizer:
             engine_kwargs.setdefault("tokenizer", tokenizer)
-
-        # Disable tqdm loading bar by default, enable with --debug-provider
         engine_kwargs.setdefault("use_tqdm_on_load", is_debug_provider())
 
         # Extract add_bos_token before passing to LLM (not a valid vLLM EngineArgs parameter).
-        # When False, prompts will be pre-tokenized without special tokens and passed as token IDs,
-        # matching the old framework's behavior (tokenizer(text, add_special_tokens=False)).
         self._add_bos_token: bool | None = engine_kwargs.pop("add_bos_token", None)
-
         self.llm: LLM = LLM(model=model_name, **engine_kwargs)
 
     @property
@@ -194,42 +183,44 @@ class VLLMProvider(InferenceProvider):
         """Get the tokenizer for this provider."""
         return self.llm.get_tokenizer()
 
-    def _encode_pair(self, context: str, continuation: str) -> tuple[list[int], list[int]]:
-        """Encode context and continuation separately (robust to non-additive tokenization).
+    def _max_input_tokens(self, params: SamplingParams) -> int:
+        reserved_output = params.max_tokens if params.max_tokens is not None else 1
+        return max(self.max_length - reserved_output, 1)
 
-        Matches lm_eval behavior: trailing spaces from context are moved to continuation
-        before tokenization to ensure consistent token boundaries.
-        """
+    def _prompt_token_ids(self, prompt: str, params: SamplingParams) -> list[int]:
         tokenizer = self.llm.get_tokenizer()
+        encode_kwargs: dict[str, Any] = {}
+        if self._add_bos_token is not None:
+            encode_kwargs["add_special_tokens"] = self._add_bos_token
+        token_ids = tokenizer.encode(prompt, **encode_kwargs)
+        return truncate_token_ids(
+            token_ids,
+            params.truncate_prompt_tokens,
+            params.truncation_side,
+            tokenizer=tokenizer,
+            max_input_tokens=self._max_input_tokens(params),
+        )
 
-        # Match lm_eval behavior: move trailing spaces from context to continuation
+    def _encode_pair(self, context: str, continuation: str) -> tuple[list[int], list[int]]:
+        """Encode context and continuation separately (robust to non-additive tokenization)."""
+        tokenizer = self.llm.get_tokenizer()
         n_spaces = len(context) - len(context.rstrip())
         if n_spaces > 0:
             continuation = context[-n_spaces:] + continuation
             context = context[:-n_spaces]
-
         whole_enc = tokenizer.encode(context + continuation, add_special_tokens=False)
         context_enc = tokenizer.encode(context, add_special_tokens=False)
         continuation_enc = whole_enc[len(context_enc) :]
-
         return context_enc, continuation_enc
 
     def _build_sampling_params(self, params: SamplingParams) -> Any:
         """Convert SamplingParams to vLLM SamplingParams."""
         from vllm import SamplingParams as VLLMSamplingParams
 
-        # Handle do_sample=False (greedy decoding)
         temperature = 0.0 if not params.do_sample else params.temperature
         top_p = None if not params.do_sample else params.top_p
         top_k = None if not params.do_sample else params.top_k
-
-        # vLLM natively accepts max_tokens=None as "generate to the context limit",
-        # matching our uncapped contract, so pass it through unchanged.
-        kwargs: dict[str, Any] = {
-            "max_tokens": params.max_tokens,
-            "n": params.num_samples,
-        }
-
+        kwargs: dict[str, Any] = {"max_tokens": params.max_tokens, "n": params.num_samples}
         if temperature is not None:
             kwargs["temperature"] = temperature
         if top_p is not None:
@@ -238,9 +229,7 @@ class VLLMProvider(InferenceProvider):
             kwargs["top_k"] = top_k
         if params.stop_sequences:
             kwargs["stop"] = list(params.stop_sequences)
-        # Always request logprobs (default to 1) for metrics computation
         kwargs["logprobs"] = params.logprobs if params.logprobs is not None else 1
-
         return VLLMSamplingParams(**kwargs)
 
     def _format_prompt(self, request: LMRequest) -> str:
@@ -250,11 +239,8 @@ class VLLMProvider(InferenceProvider):
             if not hasattr(tokenizer, "apply_chat_template"):
                 raise ValueError("CHAT requests require a tokenizer with apply_chat_template")
             return tokenizer.apply_chat_template(
-                list(request.messages),
-                tokenize=False,
-                add_generation_prompt=True,
+                list(request.messages), tokenize=False, add_generation_prompt=True
             )
-
         return request.prompt
 
     def generate(
@@ -263,32 +249,22 @@ class VLLMProvider(InferenceProvider):
         sampling_params: SamplingParams | None = None,
     ) -> list[list[LMOutput]]:
         params = self._default_sampling_params(sampling_params)
-        if params.truncate_prompt_tokens is not None or params.truncation_side is not None:
-            logger.warning(
-                "truncate_prompt_tokens or truncation_side has been set in the params, "
-                "but is not supported for the VLLMProvider and will not be used."
-            )
         vllm_params = self._build_sampling_params(params)
-
         prompt_strs = [self._format_prompt(req) for req in requests]
 
         if is_debug_requests():
             for i, prompt in enumerate(prompt_strs):
                 logger.info(f"Prompt {i}:\n{prompt}")
 
-        # When add_bos_token=False, pre-tokenize without special tokens and pass token IDs.
-        # This bypasses vLLM's internal tokenization, matching the old framework behavior of
-        # calling tokenizer(text, add_special_tokens=False) before passing to vLLM.
-        if self._add_bos_token is False:
-            tokenizer = self.llm.get_tokenizer()
+        # Prompt truncation requires token IDs so the caller-requested side can be
+        # applied before vLLM sees the request. add_bos_token=False already uses this path.
+        if params.truncate_prompt_tokens is not None or self._add_bos_token is False:
             vllm_prompts: list = [
-                {"prompt_token_ids": tokenizer.encode(p, add_special_tokens=False)}
-                for p in prompt_strs
+                {"prompt_token_ids": self._prompt_token_ids(prompt, params)} for prompt in prompt_strs
             ]
         else:
             vllm_prompts = prompt_strs
 
-        # Disable tqdm progress bar - we use our own worker-scoped logging
         outputs: list[RequestOutput] = self.llm.generate(vllm_prompts, vllm_params, use_tqdm=False)
 
         results: list[list[LMOutput]] = []
@@ -296,8 +272,6 @@ class VLLMProvider(InferenceProvider):
             request_outputs: list[LMOutput] = []
             for completion in output.outputs:
                 logprobs = _convert_logprobs(completion.logprobs)
-
-                # Compute metadata from logprobs
                 metadata: dict[str, Any] = {}
                 if logprobs:
                     sum_logits = sum(entry.get("logprob", 0.0) for entry in logprobs)
@@ -307,16 +281,8 @@ class VLLMProvider(InferenceProvider):
                         "num_tokens": num_tokens,
                         "num_tokens_all": num_tokens,
                     }
-
-                request_outputs.append(
-                    LMOutput(
-                        text=completion.text,
-                        logprobs=logprobs,
-                        metadata=metadata,
-                    )
-                )
+                request_outputs.append(LMOutput(text=completion.text, logprobs=logprobs, metadata=metadata))
             results.append(request_outputs)
-
         return results
 
     def describe_request(
@@ -338,6 +304,10 @@ class VLLMProvider(InferenceProvider):
                 "temperature": params.temperature,
                 "prompt_logprobs": 1,
             }
+            if params.truncate_prompt_tokens is not None:
+                trace["generation_kwargs"]["truncate_prompt_tokens"] = params.truncate_prompt_tokens
+            if params.truncation_side is not None:
+                trace["generation_kwargs"]["truncation_side"] = params.truncation_side
             trace["stop_sequences"] = []
             trace["input_mode"] = "prompt_token_ids"
             return trace
@@ -356,8 +326,16 @@ class VLLMProvider(InferenceProvider):
             trace["generation_kwargs"]["top_p"] = vllm_params.top_p
         if getattr(vllm_params, "top_k", None) is not None:
             trace["generation_kwargs"]["top_k"] = vllm_params.top_k
+        if params.truncate_prompt_tokens is not None:
+            trace["generation_kwargs"]["truncate_prompt_tokens"] = params.truncate_prompt_tokens
+        if params.truncation_side is not None:
+            trace["generation_kwargs"]["truncation_side"] = params.truncation_side
         trace["stop_sequences"] = list(params.stop_sequences or ())
-        trace["input_mode"] = "prompt_token_ids" if self._add_bos_token is False else "text"
+        trace["input_mode"] = (
+            "prompt_token_ids"
+            if params.truncate_prompt_tokens is not None or self._add_bos_token is False
+            else "text"
+        )
         return trace
 
     def logprobs(
@@ -368,11 +346,6 @@ class VLLMProvider(InferenceProvider):
         from vllm import SamplingParams as VLLMSamplingParams
 
         params = self._default_sampling_params(sampling_params)
-        if params.truncate_prompt_tokens is not None or params.truncation_side is not None:
-            logger.warning(
-                "truncate_prompt_tokens or truncation_side has been set in the params, "
-                "but is not supported for the VLLMProvider and will not be used."
-            )
         vllm_params = VLLMSamplingParams(
             prompt_logprobs=1,
             max_tokens=1,
@@ -381,13 +354,10 @@ class VLLMProvider(InferenceProvider):
 
         tokenizer = self.llm.get_tokenizer()
         default_max_len = self.max_length
-
-        # Build token sequences for all continuations
         token_inputs: list[list[int]] = []
-        request_meta: list[tuple[int, int, int]] = []  # (ctxlen, num_tokens_all, overflow)
+        request_meta: list[tuple[int, int, int]] = []
 
         for request in requests:
-            # Use per-request max_length if set (e.g., from task config), else provider default.
             max_len = request.max_length or default_max_len
             continuations = request.continuations or ()
             cont_prompts = request.continuation_prompts
@@ -396,22 +366,22 @@ class VLLMProvider(InferenceProvider):
                 context_enc, continuation_enc = encode_context_and_continuation(
                     tokenizer, prompt, continuation
                 )
+                context_enc = truncate_token_ids(
+                    context_enc,
+                    params.truncate_prompt_tokens,
+                    params.truncation_side,
+                    tokenizer=tokenizer,
+                    max_input_tokens=max(max_len - len(continuation_enc), 1),
+                )
 
-                # Calculate overflow and left-truncate to max_length - 1
                 full_len = len(context_enc) + len(continuation_enc)
                 overflow = full_len - (max_len - 1)
                 inp = (context_enc + continuation_enc)[-(max_len - 1) :]
-
-                # Adjust ctxlen based on overflow
-                ctxlen = len(context_enc) - max(0, overflow)
-                ctxlen = max(0, ctxlen)  # Ensure non-negative
+                ctxlen = max(0, len(context_enc) - max(0, overflow))
 
                 token_inputs.append(inp)
                 request_meta.append((ctxlen, len(inp), overflow))
 
-        # Call vLLM with token IDs instead of strings
-        # Pass as list of dicts with prompt_token_ids key
-        # Disable tqdm progress bar - we use our own worker-scoped logging
         prompts = [{"prompt_token_ids": tokens} for tokens in token_inputs]
 
         if is_debug_requests():
@@ -419,8 +389,6 @@ class VLLMProvider(InferenceProvider):
             logger.info(f"Sampling params: {vllm_params}")
 
         outputs: list[RequestOutput] = self.llm.generate(prompts, vllm_params, use_tqdm=False)
-
-        # Parse results back to per-request structure
         output_iter = iter(outputs)
         meta_iter = iter(request_meta)
         tokens_iter = iter(token_inputs)
@@ -429,43 +397,31 @@ class VLLMProvider(InferenceProvider):
         for request in requests:
             continuations = request.continuations or ()
             request_outputs = []
-
             for continuation in continuations:
                 output = next(output_iter)
                 ctxlen, num_tokens_all, overflow = next(meta_iter)
                 inp = next(tokens_iter)
-
                 logprob_entries: list[LogProbEntry] = []
                 total = 0.0
                 is_greedy = True
 
                 prompt_logprobs = output.prompt_logprobs or []
-                # Skip the first ctxlen positions (context tokens)
                 cont_logprobs = prompt_logprobs[ctxlen:] if ctxlen < len(prompt_logprobs) else []
-                # Get continuation token IDs from the actual input
                 cont_tokens = inp[ctxlen:]
 
                 for token_id, token_probs in zip(cont_tokens, cont_logprobs, strict=True):
                     if not token_probs:
                         continue
-
-                    # Check if this token is the argmax (greedy choice).
-                    # Must check BEFORE the lp_obj gate so we catch non-greedy tokens
-                    # even when they aren't in the top-k returned by prompt_logprobs.
                     if is_greedy:
                         max_token_id = max(
-                            token_probs.keys(),
-                            key=lambda tid: _coerce_logprob_to_num(token_probs[tid]),
+                            token_probs.keys(), key=lambda tid: _coerce_logprob_to_num(token_probs[tid])
                         )
                         if max_token_id != token_id:
                             is_greedy = False
-
-                    # Look up logprob for the actual continuation token (not first key in dict)
                     lp_obj = token_probs.get(token_id)
                     if lp_obj is None:
                         continue
                     logprob_val = _coerce_logprob_to_num(lp_obj)
-
                     token_str = _get_token_string(lp_obj, token_id, tokenizer)
                     logprob_entries.append(
                         {
@@ -483,16 +439,14 @@ class VLLMProvider(InferenceProvider):
                         logprobs=logprob_entries,
                         metadata={
                             "total_logprob": total,
-                            "sum_logits": total,  # Alias for compatibility
+                            "sum_logits": total,
                             "num_tokens": num_tokens,
                             "num_tokens_all": num_tokens_all,
                             "is_greedy": is_greedy,
                         },
                     )
                 )
-
             results.append(request_outputs)
-
         return results
 
     async def agenerate(
@@ -500,17 +454,7 @@ class VLLMProvider(InferenceProvider):
         requests: list[LMRequest],
         sampling_params: SamplingParams | None = None,
     ) -> list[list[LMOutput]]:
-        """Async generate completions.
-
-        Runs the synchronous vLLM generate in a thread pool to avoid blocking.
-
-        Args:
-            requests: Batch of requests to process.
-            sampling_params: Sampling configuration.
-
-        Returns:
-            List of output lists, one per request.
-        """
+        """Async generate completions."""
         return await asyncio.to_thread(self.generate, requests, sampling_params)
 
     async def alogprobs(
@@ -518,14 +462,5 @@ class VLLMProvider(InferenceProvider):
         requests: list[LMRequest],
         sampling_params: SamplingParams | None = None,
     ) -> list[list[LMOutput]]:
-        """Async compute logprobs for continuations.
-
-        Runs the synchronous vLLM logprobs in a thread pool to avoid blocking.
-
-        Args:
-            requests: Batch of requests with continuations to score.
-
-        Returns:
-            List of output lists with logprobs populated.
-        """
+        """Async compute logprobs for continuations."""
         return await asyncio.to_thread(self.logprobs, requests, sampling_params)

--- a/src/olmo_eval/inference/providers/vllm.py
+++ b/src/olmo_eval/inference/providers/vllm.py
@@ -121,11 +121,13 @@ class VLLMProvider(InferenceProvider):
                 before initializing vLLM.
             **engine_kwargs: Additional arguments passed to vLLM LLM engine.
         """
+        # Set vLLM logging level - DEBUG if OLMO_EVAL_DEBUG_PROVIDER=1, otherwise WARNING
         if is_debug_provider():
             os.environ["VLLM_LOGGING_LEVEL"] = "DEBUG"
         else:
             os.environ.setdefault("VLLM_LOGGING_LEVEL", "WARNING")
 
+        # Configure vLLM logger with worker_id if provided
         if worker_id:
             _configure_vllm_logger(worker_id)
 
@@ -162,14 +164,23 @@ class VLLMProvider(InferenceProvider):
                 )
 
         engine_kwargs.setdefault("gpu_memory_utilization", 0.8)
+
+        # Configure attention backend if specified (e.g., FLASHINFER, FLASH_ATTN)
         if attention_backend:
             engine_kwargs.setdefault("attention_backend", attention_backend)
+
+        # Use separate tokenizer if specified
         if tokenizer:
             engine_kwargs.setdefault("tokenizer", tokenizer)
+
+        # Disable tqdm loading bar by default, enable with --debug-provider
         engine_kwargs.setdefault("use_tqdm_on_load", is_debug_provider())
 
         # Extract add_bos_token before passing to LLM (not a valid vLLM EngineArgs parameter).
+        # When False, prompts will be pre-tokenized without special tokens and passed as token IDs,
+        # matching the old framework's behavior (tokenizer(text, add_special_tokens=False)).
         self._add_bos_token: bool | None = engine_kwargs.pop("add_bos_token", None)
+
         self.llm: LLM = LLM(model=model_name, **engine_kwargs)
 
     @property
@@ -184,10 +195,12 @@ class VLLMProvider(InferenceProvider):
         return self.llm.get_tokenizer()
 
     def _max_input_tokens(self, params: SamplingParams) -> int:
+        """Resolve the input budget used by ``truncate_prompt_tokens=-1``."""
         reserved_output = params.max_tokens if params.max_tokens is not None else 1
         return max(self.max_length - reserved_output, 1)
 
     def _prompt_token_ids(self, prompt: str, params: SamplingParams) -> list[int]:
+        """Tokenize and apply caller-requested prompt truncation."""
         tokenizer = self.llm.get_tokenizer()
         encode_kwargs: dict[str, Any] = {}
         if self._add_bos_token is not None:
@@ -202,25 +215,41 @@ class VLLMProvider(InferenceProvider):
         )
 
     def _encode_pair(self, context: str, continuation: str) -> tuple[list[int], list[int]]:
-        """Encode context and continuation separately (robust to non-additive tokenization)."""
+        """Encode context and continuation separately (robust to non-additive tokenization).
+
+        Matches lm_eval behavior: trailing spaces from context are moved to continuation
+        before tokenization to ensure consistent token boundaries.
+        """
         tokenizer = self.llm.get_tokenizer()
+
+        # Match lm_eval behavior: move trailing spaces from context to continuation
         n_spaces = len(context) - len(context.rstrip())
         if n_spaces > 0:
             continuation = context[-n_spaces:] + continuation
             context = context[:-n_spaces]
+
         whole_enc = tokenizer.encode(context + continuation, add_special_tokens=False)
         context_enc = tokenizer.encode(context, add_special_tokens=False)
         continuation_enc = whole_enc[len(context_enc) :]
+
         return context_enc, continuation_enc
 
     def _build_sampling_params(self, params: SamplingParams) -> Any:
         """Convert SamplingParams to vLLM SamplingParams."""
         from vllm import SamplingParams as VLLMSamplingParams
 
+        # Handle do_sample=False (greedy decoding)
         temperature = 0.0 if not params.do_sample else params.temperature
         top_p = None if not params.do_sample else params.top_p
         top_k = None if not params.do_sample else params.top_k
-        kwargs: dict[str, Any] = {"max_tokens": params.max_tokens, "n": params.num_samples}
+
+        # vLLM natively accepts max_tokens=None as "generate to the context limit",
+        # matching our uncapped contract, so pass it through unchanged.
+        kwargs: dict[str, Any] = {
+            "max_tokens": params.max_tokens,
+            "n": params.num_samples,
+        }
+
         if temperature is not None:
             kwargs["temperature"] = temperature
         if top_p is not None:
@@ -229,7 +258,9 @@ class VLLMProvider(InferenceProvider):
             kwargs["top_k"] = top_k
         if params.stop_sequences:
             kwargs["stop"] = list(params.stop_sequences)
+        # Always request logprobs (default to 1) for metrics computation
         kwargs["logprobs"] = params.logprobs if params.logprobs is not None else 1
+
         return VLLMSamplingParams(**kwargs)
 
     def _format_prompt(self, request: LMRequest) -> str:
@@ -239,8 +270,11 @@ class VLLMProvider(InferenceProvider):
             if not hasattr(tokenizer, "apply_chat_template"):
                 raise ValueError("CHAT requests require a tokenizer with apply_chat_template")
             return tokenizer.apply_chat_template(
-                list(request.messages), tokenize=False, add_generation_prompt=True
+                list(request.messages),
+                tokenize=False,
+                add_generation_prompt=True,
             )
+
         return request.prompt
 
     def generate(
@@ -250,21 +284,30 @@ class VLLMProvider(InferenceProvider):
     ) -> list[list[LMOutput]]:
         params = self._default_sampling_params(sampling_params)
         vllm_params = self._build_sampling_params(params)
+
         prompt_strs = [self._format_prompt(req) for req in requests]
 
         if is_debug_requests():
             for i, prompt in enumerate(prompt_strs):
                 logger.info(f"Prompt {i}:\n{prompt}")
 
-        # Prompt truncation requires token IDs so the caller-requested side can be
-        # applied before vLLM sees the request. add_bos_token=False already uses this path.
-        if params.truncate_prompt_tokens is not None or self._add_bos_token is False:
+        # Prompt truncation requires pre-tokenized inputs so the requested side is applied
+        # deterministically before vLLM sees the request. add_bos_token=False already uses
+        # the same token-ID path for compatibility with the old framework.
+        if params.truncate_prompt_tokens is not None:
             vllm_prompts: list = [
-                {"prompt_token_ids": self._prompt_token_ids(prompt, params)} for prompt in prompt_strs
+                {"prompt_token_ids": self._prompt_token_ids(p, params)} for p in prompt_strs
+            ]
+        elif self._add_bos_token is False:
+            tokenizer = self.llm.get_tokenizer()
+            vllm_prompts = [
+                {"prompt_token_ids": tokenizer.encode(p, add_special_tokens=False)}
+                for p in prompt_strs
             ]
         else:
             vllm_prompts = prompt_strs
 
+        # Disable tqdm progress bar - we use our own worker-scoped logging
         outputs: list[RequestOutput] = self.llm.generate(vllm_prompts, vllm_params, use_tqdm=False)
 
         results: list[list[LMOutput]] = []
@@ -272,6 +315,8 @@ class VLLMProvider(InferenceProvider):
             request_outputs: list[LMOutput] = []
             for completion in output.outputs:
                 logprobs = _convert_logprobs(completion.logprobs)
+
+                # Compute metadata from logprobs
                 metadata: dict[str, Any] = {}
                 if logprobs:
                     sum_logits = sum(entry.get("logprob", 0.0) for entry in logprobs)
@@ -281,8 +326,16 @@ class VLLMProvider(InferenceProvider):
                         "num_tokens": num_tokens,
                         "num_tokens_all": num_tokens,
                     }
-                request_outputs.append(LMOutput(text=completion.text, logprobs=logprobs, metadata=metadata))
+
+                request_outputs.append(
+                    LMOutput(
+                        text=completion.text,
+                        logprobs=logprobs,
+                        metadata=metadata,
+                    )
+                )
             results.append(request_outputs)
+
         return results
 
     def describe_request(
@@ -354,10 +407,13 @@ class VLLMProvider(InferenceProvider):
 
         tokenizer = self.llm.get_tokenizer()
         default_max_len = self.max_length
+
+        # Build token sequences for all continuations
         token_inputs: list[list[int]] = []
-        request_meta: list[tuple[int, int, int]] = []
+        request_meta: list[tuple[int, int, int]] = []  # (ctxlen, num_tokens_all, overflow)
 
         for request in requests:
+            # Use per-request max_length if set (e.g., from task config), else provider default.
             max_len = request.max_length or default_max_len
             continuations = request.continuations or ()
             cont_prompts = request.continuation_prompts
@@ -374,14 +430,21 @@ class VLLMProvider(InferenceProvider):
                     max_input_tokens=max(max_len - len(continuation_enc), 1),
                 )
 
+                # Calculate overflow and left-truncate to max_length - 1
                 full_len = len(context_enc) + len(continuation_enc)
                 overflow = full_len - (max_len - 1)
                 inp = (context_enc + continuation_enc)[-(max_len - 1) :]
-                ctxlen = max(0, len(context_enc) - max(0, overflow))
+
+                # Adjust ctxlen based on overflow
+                ctxlen = len(context_enc) - max(0, overflow)
+                ctxlen = max(0, ctxlen)  # Ensure non-negative
 
                 token_inputs.append(inp)
                 request_meta.append((ctxlen, len(inp), overflow))
 
+        # Call vLLM with token IDs instead of strings
+        # Pass as list of dicts with prompt_token_ids key
+        # Disable tqdm progress bar - we use our own worker-scoped logging
         prompts = [{"prompt_token_ids": tokens} for tokens in token_inputs]
 
         if is_debug_requests():
@@ -389,6 +452,8 @@ class VLLMProvider(InferenceProvider):
             logger.info(f"Sampling params: {vllm_params}")
 
         outputs: list[RequestOutput] = self.llm.generate(prompts, vllm_params, use_tqdm=False)
+
+        # Parse results back to per-request structure
         output_iter = iter(outputs)
         meta_iter = iter(request_meta)
         tokens_iter = iter(token_inputs)
@@ -397,31 +462,43 @@ class VLLMProvider(InferenceProvider):
         for request in requests:
             continuations = request.continuations or ()
             request_outputs = []
+
             for continuation in continuations:
                 output = next(output_iter)
                 ctxlen, num_tokens_all, overflow = next(meta_iter)
                 inp = next(tokens_iter)
+
                 logprob_entries: list[LogProbEntry] = []
                 total = 0.0
                 is_greedy = True
 
                 prompt_logprobs = output.prompt_logprobs or []
+                # Skip the first ctxlen positions (context tokens)
                 cont_logprobs = prompt_logprobs[ctxlen:] if ctxlen < len(prompt_logprobs) else []
+                # Get continuation token IDs from the actual input
                 cont_tokens = inp[ctxlen:]
 
                 for token_id, token_probs in zip(cont_tokens, cont_logprobs, strict=True):
                     if not token_probs:
                         continue
+
+                    # Check if this token is the argmax (greedy choice).
+                    # Must check BEFORE the lp_obj gate so we catch non-greedy tokens
+                    # even when they aren't in the top-k returned by prompt_logprobs.
                     if is_greedy:
                         max_token_id = max(
-                            token_probs.keys(), key=lambda tid: _coerce_logprob_to_num(token_probs[tid])
+                            token_probs.keys(),
+                            key=lambda tid: _coerce_logprob_to_num(token_probs[tid]),
                         )
                         if max_token_id != token_id:
                             is_greedy = False
+
+                    # Look up logprob for the actual continuation token (not first key in dict)
                     lp_obj = token_probs.get(token_id)
                     if lp_obj is None:
                         continue
                     logprob_val = _coerce_logprob_to_num(lp_obj)
+
                     token_str = _get_token_string(lp_obj, token_id, tokenizer)
                     logprob_entries.append(
                         {
@@ -439,14 +516,16 @@ class VLLMProvider(InferenceProvider):
                         logprobs=logprob_entries,
                         metadata={
                             "total_logprob": total,
-                            "sum_logits": total,
+                            "sum_logits": total,  # Alias for compatibility
                             "num_tokens": num_tokens,
                             "num_tokens_all": num_tokens_all,
                             "is_greedy": is_greedy,
                         },
                     )
                 )
+
             results.append(request_outputs)
+
         return results
 
     async def agenerate(
@@ -454,7 +533,17 @@ class VLLMProvider(InferenceProvider):
         requests: list[LMRequest],
         sampling_params: SamplingParams | None = None,
     ) -> list[list[LMOutput]]:
-        """Async generate completions."""
+        """Async generate completions.
+
+        Runs the synchronous vLLM generate in a thread pool to avoid blocking.
+
+        Args:
+            requests: Batch of requests to process.
+            sampling_params: Sampling configuration.
+
+        Returns:
+            List of output lists, one per request.
+        """
         return await asyncio.to_thread(self.generate, requests, sampling_params)
 
     async def alogprobs(
@@ -462,5 +551,14 @@ class VLLMProvider(InferenceProvider):
         requests: list[LMRequest],
         sampling_params: SamplingParams | None = None,
     ) -> list[list[LMOutput]]:
-        """Async compute logprobs for continuations."""
+        """Async compute logprobs for continuations.
+
+        Runs the synchronous vLLM logprobs in a thread pool to avoid blocking.
+
+        Args:
+            requests: Batch of requests with continuations to score.
+
+        Returns:
+            List of output lists with logprobs populated.
+        """
         return await asyncio.to_thread(self.logprobs, requests, sampling_params)

--- a/src/olmo_eval/inference/tokenizer_utils.py
+++ b/src/olmo_eval/inference/tokenizer_utils.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Literal
 
 
 def get_bos_token_ids(tokenizer: Any, *, fallback_to_eos: bool = True) -> list[int]:
@@ -56,6 +56,69 @@ def get_context_token_ids(
     return tokenizer.encode(context, add_special_tokens=False)
 
 
+def resolve_prompt_truncation_limit(
+    truncate_prompt_tokens: int | None,
+    *,
+    max_input_tokens: int | None = None,
+) -> int | None:
+    """Resolve a prompt-token limit, including vLLM's ``-1`` convention."""
+    if truncate_prompt_tokens is None:
+        return None
+    if truncate_prompt_tokens == -1:
+        if max_input_tokens is None or max_input_tokens <= 0:
+            raise ValueError("truncate_prompt_tokens=-1 requires a positive max_input_tokens")
+        return max_input_tokens
+    if truncate_prompt_tokens <= 0:
+        raise ValueError("truncate_prompt_tokens must be a positive integer, -1, or None")
+    return truncate_prompt_tokens
+
+
+def resolve_truncation_side(
+    truncation_side: Literal["left", "right"] | None,
+    *,
+    tokenizer: Any | None = None,
+    default: Literal["left", "right"] = "right",
+) -> Literal["left", "right"]:
+    """Resolve the requested side, falling back to the tokenizer's default."""
+    if truncation_side is not None:
+        return truncation_side
+    tokenizer_side = getattr(tokenizer, "truncation_side", None)
+    if tokenizer_side in ("left", "right"):
+        return tokenizer_side
+    return default
+
+
+def truncate_token_ids(
+    token_ids: list[int],
+    truncate_prompt_tokens: int | None,
+    truncation_side: Literal["left", "right"] | None = None,
+    *,
+    tokenizer: Any | None = None,
+    max_input_tokens: int | None = None,
+    default_side: Literal["left", "right"] = "right",
+) -> list[int]:
+    """Truncate prompt token IDs using vLLM-compatible side semantics.
+
+    ``left`` removes tokens from the beginning and keeps the last N tokens.
+    ``right`` removes tokens from the end and keeps the first N tokens.
+    """
+    limit = resolve_prompt_truncation_limit(
+        truncate_prompt_tokens,
+        max_input_tokens=max_input_tokens,
+    )
+    if limit is None or len(token_ids) <= limit:
+        return list(token_ids)
+
+    side = resolve_truncation_side(
+        truncation_side,
+        tokenizer=tokenizer,
+        default=default_side,
+    )
+    if side == "left":
+        return list(token_ids[-limit:])
+    return list(token_ids[:limit])
+
+
 def encode_context_and_continuation(
     tokenizer: Any,
     context: str,
@@ -73,7 +136,7 @@ def encode_context_and_continuation(
 
     Args:
         tokenizer: A tokenizer object with encode method.
-        context: The context/prompt string.
+        context: The context string to tokenize.
         continuation: The continuation string to evaluate.
         use_bos_for_empty: If True and context is empty, use BOS token as context.
         fallback_to_eos: If True and BOS is None, use EOS token ID instead.

--- a/tests/providers/test_prompt_truncation.py
+++ b/tests/providers/test_prompt_truncation.py
@@ -1,0 +1,139 @@
+"""Focused tests for provider prompt truncation semantics."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from olmo_eval.common.types import LMRequest, RequestType, SamplingParams
+from olmo_eval.inference.providers.huggingface import HuggingFaceProvider
+from olmo_eval.inference.providers.litellm import LiteLLMProvider
+from olmo_eval.inference.providers.olmo_core import OlmoCoreProvider
+from olmo_eval.inference.providers.vllm import VLLMProvider
+from olmo_eval.inference.tokenizer_utils import truncate_token_ids
+
+
+class FakeTokenizer:
+    bos_token_id = 99
+    eos_token_id = 0
+    truncation_side = "left"
+
+    def encode(self, text: str, add_special_tokens: bool = False) -> list[int]:
+        ids = list(range(1, len(text) + 1))
+        return ([self.bos_token_id] + ids) if add_special_tokens else ids
+
+    def decode(self, token_ids, **kwargs) -> str:
+        del kwargs
+        return "".join(chr(int(token_id)) for token_id in token_ids)
+
+
+class FakeLiteLLM:
+    @staticmethod
+    def encode(model: str, text: str) -> list[int]:
+        del model
+        return list(text.encode("utf-8"))
+
+    @staticmethod
+    def decode(model: str, tokens: list[int]) -> str:
+        del model
+        return bytes(tokens).decode("utf-8")
+
+    @staticmethod
+    def token_counter(model: str, messages: list[dict]) -> int:
+        del model
+        return 2 * len(messages) + sum(
+            len(message.get("content", ""))
+            for message in messages
+            if isinstance(message.get("content"), str)
+        )
+
+    @staticmethod
+    def get_model_info(model: str) -> dict[str, int]:
+        del model
+        return {"max_input_tokens": 8}
+
+
+def test_truncate_token_ids_matches_vllm_side_semantics():
+    token_ids = [1, 2, 3, 4, 5]
+
+    assert truncate_token_ids(token_ids, 3, "left") == [3, 4, 5]
+    assert truncate_token_ids(token_ids, 3, "right") == [1, 2, 3]
+
+    tokenizer = FakeTokenizer()
+    assert truncate_token_ids(token_ids, 3, None, tokenizer=tokenizer) == [3, 4, 5]
+    assert truncate_token_ids(token_ids, -1, "right", max_input_tokens=2) == [1, 2]
+
+
+def test_truncate_token_ids_rejects_invalid_limits():
+    with pytest.raises(ValueError, match="positive integer"):
+        truncate_token_ids([1, 2], 0)
+    with pytest.raises(ValueError, match="requires a positive max_input_tokens"):
+        truncate_token_ids([1, 2], -1)
+
+
+def test_huggingface_provider_truncates_pre_tokenized_prompt():
+    provider = object.__new__(HuggingFaceProvider)
+    provider.tokenizer = FakeTokenizer()
+    provider.model = SimpleNamespace(config=SimpleNamespace(max_position_embeddings=16))
+
+    params = SamplingParams(max_tokens=1, truncate_prompt_tokens=3, truncation_side="left")
+    assert provider._prompt_token_ids("abcdef", params) == [4, 5, 6]
+
+
+def test_vllm_provider_truncates_prompt_ids_without_reencoding():
+    tokenizer = FakeTokenizer()
+    provider = object.__new__(VLLMProvider)
+    provider.llm = SimpleNamespace(
+        get_tokenizer=lambda: tokenizer,
+        llm_engine=SimpleNamespace(model_config=SimpleNamespace(max_model_len=16)),
+    )
+    provider._add_bos_token = False
+
+    params = SamplingParams(max_tokens=1, truncate_prompt_tokens=3, truncation_side="right")
+    assert provider._prompt_token_ids("abcdef", params) == [1, 2, 3]
+
+
+def test_olmo_core_provider_uses_requested_side():
+    provider = object.__new__(OlmoCoreProvider)
+    provider.tokenizer = FakeTokenizer()
+    provider.max_length = 16
+
+    params = SamplingParams(max_tokens=1, truncate_prompt_tokens=3, truncation_side="left")
+    assert provider._apply_requested_prompt_truncation([1, 2, 3, 4, 5], params) == [3, 4, 5]
+
+
+def test_litellm_provider_truncates_message_content_and_preserves_structure():
+    provider = object.__new__(LiteLLMProvider)
+    provider.model_name = "fake/model"
+    provider._litellm = FakeLiteLLM()
+    request = LMRequest(request_type=RequestType.CHAT, max_length=8)
+
+    right = provider._truncate_messages(
+        [{"role": "user", "content": "abcdef"}],
+        request,
+        SamplingParams(max_tokens=1, truncate_prompt_tokens=5, truncation_side="right"),
+    )
+    left = provider._truncate_messages(
+        [{"role": "user", "content": "abcdef"}],
+        request,
+        SamplingParams(max_tokens=1, truncate_prompt_tokens=5, truncation_side="left"),
+    )
+
+    assert right == [{"role": "user", "content": "abc"}]
+    assert left == [{"role": "user", "content": "def"}]
+
+
+def test_litellm_minus_one_uses_request_input_budget():
+    provider = object.__new__(LiteLLMProvider)
+    provider.model_name = "fake/model"
+    provider._litellm = FakeLiteLLM()
+    request = LMRequest(request_type=RequestType.CHAT, max_length=6)
+
+    truncated = provider._truncate_messages(
+        [{"role": "user", "content": "abcdef"}],
+        request,
+        SamplingParams(max_tokens=1, truncate_prompt_tokens=-1, truncation_side="right"),
+    )
+
+    # max_length 6 minus one output token leaves a five-token prompt budget;
+    # the fake chat template contributes two overhead tokens, so content keeps three.
+    assert truncated == [{"role": "user", "content": "abc"}]


### PR DESCRIPTION
## Description

Adds `truncate_prompt_tokens` / `truncation_side` support to the non-server inference providers so they match the truncation controls already available through `vllm_server`.

- adds shared token-ID truncation helpers with vLLM-compatible left/right semantics and `-1` handling
- applies truncation before generation in Hugging Face, inline vLLM, LiteLLM, and OLMo-core providers
- preserves continuation tokens when truncating log-likelihood contexts
- uses provider/tokenizer context limits for `truncate_prompt_tokens=-1`
- keeps LiteLLM chat requests structurally valid while trimming message content
- includes truncation settings in request traces
- adds focused regression coverage across all four providers

Closes #273

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Testing

- [ ] Unit tests pass locally (`pytest tests/ --ignore=tests/integration/`)
- [ ] Integration tests pass (if applicable)
- [x] New tests added for new functionality

Local dependency-backed test execution is not available in this environment; repository CI should run the unit, lint, formatting, and type checks.

## Checklist

- [x] My code follows the project's existing provider and sampling conventions
- [x] I have performed a self-review of the code changes
- [x] No user-facing documentation change is required beyond the existing `SamplingParams` fields
- [ ] My changes generate no new warnings
- [x] No dependent changes are required