### PR TITLE
Fix Hugging Face stop-sequence decoding

### DIFF
--- a/src/olmo_eval/inference/providers/huggingface.py
+++ b/src/olmo_eval/inference/providers/huggingface.py
@@ -136,18 +136,30 @@ class HuggingFaceProvider(InferenceProvider):
         self, tokens: torch.Tensor, stop_sequences: tuple[str, ...] | None
     ) -> tuple[torch.Tensor, str]:
         """Truncate generated tokens at first stop sequence."""
+        decoded = self.tokenizer.decode(tokens, skip_special_tokens=True)
         if not stop_sequences:
-            return tokens, self.tokenizer.decode(tokens, skip_special_tokens=True)
+            return tokens, decoded
 
-        decoded_parts: list[str] = []
-        for idx, token in enumerate(tokens):
-            decoded_parts.append(self.tokenizer.decode(token, skip_special_tokens=True))
-            decoded = "".join(decoded_parts)
-            for stop in stop_sequences:
-                if stop in decoded:
-                    return tokens[: idx + 1], decoded.split(stop)[0]
+        stop_matches = [
+            (position, stop)
+            for stop in stop_sequences
+            if (position := decoded.find(stop)) >= 0
+        ]
+        if not stop_matches:
+            return tokens, decoded
 
-        return tokens, "".join(decoded_parts)
+        stop_position, first_stop = min(stop_matches, key=lambda match: match[0])
+
+        # Decode token prefixes rather than individual tokens. Some tokenizers
+        # need surrounding token context to turn byte-level markers into their
+        # actual text representation, so concatenating per-token decodes can
+        # corrupt generated text and miss stop sequences.
+        for idx in range(1, len(tokens) + 1):
+            prefix = self.tokenizer.decode(tokens[:idx], skip_special_tokens=True)
+            if first_stop in prefix:
+                return tokens[:idx], decoded[:stop_position]
+
+        return tokens, decoded[:stop_position]
 
     def generate(
         self,

--- a/tests/providers/test_huggingface_provider.py
+++ b/tests/providers/test_huggingface_provider.py
@@ -33,3 +33,40 @@ def test_uncapped_with_no_prompt_uses_full_context(provider: HuggingFaceProvider
 def test_uncapped_floors_at_one_when_prompt_exceeds_context(provider: HuggingFaceProvider) -> None:
     kwargs = provider._build_generate_kwargs(SamplingParams(max_tokens=None), prompt_len=5000)
     assert kwargs["max_new_tokens"] == 1
+
+
+def test_stop_decoding_preserves_tokenizer_context(provider: HuggingFaceProvider) -> None:
+    class ContextAwareTokenizer:
+        pieces = {1: "Okay", 2: "Ġso", 3: "ĊSTOP", 4: "Ġignored"}
+
+        def decode(self, tokens, *, skip_special_tokens: bool) -> str:
+            del skip_special_tokens
+            if isinstance(tokens, int):
+                return self.pieces[tokens]
+            text = "".join(self.pieces[token] for token in tokens)
+            return text.replace("Ġ", " ").replace("Ċ", "\n")
+
+    provider.tokenizer = ContextAwareTokenizer()
+
+    tokens, text = provider._truncate_at_stop([1, 2, 3, 4], ("\nSTOP",))
+
+    assert tokens == [1, 2, 3]
+    assert text == "Okay so"
+
+
+def test_stop_decoding_uses_earliest_stop(provider: HuggingFaceProvider) -> None:
+    class Tokenizer:
+        pieces = {1: "alpha", 2: " END", 3: " later STOP"}
+
+        def decode(self, tokens, *, skip_special_tokens: bool) -> str:
+            del skip_special_tokens
+            if isinstance(tokens, int):
+                return self.pieces[tokens]
+            return "".join(self.pieces[token] for token in tokens)
+
+    provider.tokenizer = Tokenizer()
+
+    tokens, text = provider._truncate_at_stop([1, 2, 3], ("STOP", "END"))
+
+    assert tokens == [1, 2]
+    assert text == "alpha "


### PR DESCRIPTION
Fixes #241.

`HuggingFaceProvider._truncate_at_stop()` decoded generated tokens one at a time and concatenated the resulting strings whenever stop sequences were configured. Context-sensitive byte-level tokenizers can require surrounding tokens to render markers such as whitespace and newlines correctly, so per-token decoding can surface artifacts such as `Ġ` / `Ċ` and can also make textual stop matching unreliable.

This change decodes the generated sequence as a whole, finds the earliest textual stop in that correctly decoded output, and then decodes token prefixes only to map the stop back to the token boundary. The existing behavior of retaining the token that completes the stop sequence is preserved for downstream logprob accounting.

Regression coverage includes a context-sensitive tokenizer that renders byte-level markers only when decoding a sequence, plus coverage for choosing the earliest of multiple stop sequences.