### PR TITLE
Adding CTC Suite (upcoming release) to olmo eval

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,6 +158,9 @@ vllm = [
 [tool.ruff]
 line-length = 100
 target-version = "py312"
+# Vendored ctc-suite format/spec code is kept byte-faithful to its upstream (golden-fixture
+# tested there); it is excluded rather than restyled.
+extend-exclude = ["src/olmo_eval/evals/tasks/ctc_suite/_vendor"]
 
 [tool.ruff.lint]
 select = [

--- a/src/olmo_eval/evals/suites/ctc.py
+++ b/src/olmo_eval/evals/suites/ctc.py
@@ -1,0 +1,75 @@
+"""Suites for the CTC long-context family: one flag instead of 22 (or 187).
+
+Naming:
+
+* ``ctc:figure``   -- every task at its 2k-32k ladder (the paper grid; 108 runs)
+* ``ctc:xlong``    -- every task's rungs ABOVE 32k (64k-1M where built; 62 runs)
+* ``ctc:r32k`` ... -- every task that has that rung, at that rung (one context-length column)
+* ``ctc:nq`` ...   -- one task's full ladder, every rung (one row)
+* ``ctc``          -- everything (170 runs; know what you are asking for)
+
+Aggregation is DISPLAY_ONLY throughout: the tasks carry heterogeneous metrics (f1, pair f1,
+kendall tau, ce_pos_recall, partial credit), and averaging those into one number would be
+exactly the kind of quiet nonsense the per-task metric declarations exist to prevent.
+"""
+
+from __future__ import annotations
+
+from olmo_eval.evals.suites.registry import AggregationStrategy, Suite, register
+from olmo_eval.evals.tasks.ctc_suite import ROSTER, RUNG_TOKENS
+
+_DISPLAY = AggregationStrategy.DISPLAY_ONLY
+
+_BASE = tuple(r for r in RUNG_TOKENS if RUNG_TOKENS[r] <= 32768)
+_XLONG = tuple(r for r in RUNG_TOKENS if RUNG_TOKENS[r] > 32768)
+
+_FIGURE = register(
+    Suite(
+        name="ctc:figure",
+        tasks=tuple(
+            f"{name}:{rung}" for name, row in ROSTER.items() for rung in row.rungs if rung in _BASE
+        ),
+        aggregation=_DISPLAY,
+        description="All 22 CTC tasks over the 2k-32k figure ladder.",
+    )
+)
+
+_XLONG_SUITE = register(
+    Suite(
+        name="ctc:xlong",
+        tasks=tuple(
+            f"{name}:{rung}" for name, row in ROSTER.items() for rung in row.rungs if rung in _XLONG
+        ),
+        aggregation=_DISPLAY,
+        description="Every task's rungs above 32k (64k-1M where the source corpus allows).",
+    )
+)
+
+for _rung in RUNG_TOKENS:
+    register(
+        Suite(
+            name=f"ctc:{_rung}",
+            tasks=tuple(f"{name}:{_rung}" for name, row in ROSTER.items() if _rung in row.rungs),
+            aggregation=_DISPLAY,
+            description=f"Every CTC task that has a {_rung} rung, at {_rung}.",
+        )
+    )
+
+for _name, _row in ROSTER.items():
+    register(
+        Suite(
+            name=f"ctc:{_name.removeprefix('ctc_')}",
+            tasks=tuple(f"{_name}:{rung}" for rung in _row.rungs),
+            aggregation=_DISPLAY,
+            description=f"The full {_name} ladder ({len(_row.rungs)} rungs).",
+        )
+    )
+
+register(
+    Suite(
+        name="ctc",
+        tasks=(_FIGURE, _XLONG_SUITE),  # Suite objects: string entries would be read as task names
+        aggregation=_DISPLAY,
+        description="The entire CTC suite: 22 tasks x every built rung.",
+    )
+)

--- a/src/olmo_eval/evals/tasks/ctc_suite/README.md
+++ b/src/olmo_eval/evals/tasks/ctc_suite/README.md
@@ -1,0 +1,84 @@
+# CTC suite: 22 long-context tasks, ladders from 2k to 1M tokens
+
+Each task puts a corpus of N documents in-prompt and asks a question whose difficulty scales with
+how much of the corpus must be tracked *simultaneously* — from O(N) retrieval, through O(N²)
+relational tasks (find every contradicting pair), to O(NM)/O(N³) structural ones (cluster
+everything, find planted triples). Every task has a context ladder; a rung label is the measured
+median prompt length through the reference prompt path, not a document count.
+
+## Quickstart
+
+```bash
+export HF_TOKEN=...        # needs read access to PrasannSinghal/ctc-suite-eval (private)
+
+# preview without a model
+uv run olmo-eval run -m mock -t ctc_contradiction:r32k --dry-run
+
+# one task, one rung
+uv run olmo-eval run -m <model> -t ctc_nq:r64k --save-predictions
+
+# suites
+uv run olmo-eval run -m <model> -t ctc:figure     # all 22 tasks, 2k-32k grid (108 runs)
+uv run olmo-eval run -m <model> -t ctc:r128k      # every task at 128k (one x-axis column)
+uv run olmo-eval run -m <model> -t ctc:oolong     # one task's whole ladder
+uv run olmo-eval run -m <model> -t ctc:xlong      # everything above 32k (69 runs)
+uv run olmo-eval run -m <model> -t ctc            # all 177 task x rung combinations
+```
+
+A bare task name (`-t ctc_nq`) evaluates the 32k rung. Suite aggregation is DISPLAY_ONLY on
+purpose: the metrics are heterogeneous (f1, pair f1, kendall tau, ce_pos_recall, partial credit)
+and a cross-task average would be meaningless.
+
+## The 22 tasks
+
+| task | class | metric | ladder top | notes |
+|---|---|---|---|---|
+| ctc_fiqa, ctc_nq, ctc_hpqa, ctc_msmarco, ctc_scifact, ctc_obliq, ctc_niah | O(N) | f1 (gold ids) | 1M (msmarco 512k) | retrieval family |
+| ctc_rerank | O(N) | **ce_pos_recall** | 512k | see metric note below |
+| ctc_oolong | O(N) | partial credit | 1M | aggregate questions over a line stream |
+| ctc_outlier_amzn, ctc_outlier_fixedm | O(N) | f1 (set) | 1M / 512k | fixed-K controls |
+| ctc_outlier | O(NM) | f1 (set) | 1M | K grows with N (~n/9) — the scale-K row |
+| ctc_qdmatch_fiqa/nq/hpqa | O(N²) | pair f1 | 512k / 1M / 256k | query↔document matching |
+| ctc_contradiction | O(N²) | f1 (pairs) | 1M | PubMed claims, IID realistic mode |
+| ctc_absence, ctc_xabsence | O(N²) | f1 (set) | 16k / 32k | deletion / exact-copy-orphan detection |
+| ctc_strmatch | O(N²) | f1 (pairs) | 32k | planted shared word-runs |
+| ctc_reorder | O(N²) | kendall tau | 16k | restore reading order |
+| ctc_grouping | O(NM) | pairwise f1 | 32k | cluster abstracts |
+| ctc_textgroups | O(N³) | f1 (groups) | 32k | planted feature-sum triples |
+
+Ladder tops below 1M are **source-corpus ceilings, not laziness** — e.g. qdmatch_hpqa exhausts all
+4,000 labeled HotpotQA units at 256k; absence/reorder are bounded by contiguous-book length. Each
+cap is documented on its RosterRow.
+
+## Numbers that must travel with results
+
+- Rungs ≥256k hold **125 examples** (seeded subsample; SE ≈ ±0.041 at f1≈0.7). `ctc_scifact` is
+  300 and `ctc_obliq` 126 at every rung. Everything else is 500. Quote sizes inline.
+- **rerank's metric is ce_pos_recall**: the fraction of documents with cross-encoder score > 0
+  (median 3, p90 5 per example) present in the model's first 10 emitted ids. Single-qrel MRR@10
+  saturates at ~0.98 and is emitted only as a secondary. Relevance in this data is bimodal
+  (nothing between CE −5 and 0), which is also why an NDCG@10 over CE gains would collapse to
+  the top-3 — measured before this metric was chosen.
+- `ctc_parse_ok` is stored per output: a parse-rate collapse is a decoding/stopping regression
+  wearing an accuracy drop's clothes. Check it before believing a low score.
+- Contexts ≥256k exceed most models' native windows; the serving side (YaRN etc.) is the caller's
+  responsibility and belongs next to any reported number.
+
+## Design and provenance
+
+- Prompt templates, parsers, metrics, gold-index conventions and stop rules are **vendored
+  byte-faithful** under `_vendor/` from the `ctc` package (AI2 OLMo-core branch `prasann/ctc`),
+  where they are golden-fixture-tested against the implementation that produced the suite's
+  published numbers. Fix upstream and re-vendor; do not edit `_vendor/` (it is ruff-excluded to
+  stay diffable).
+- Scoring mirrors the reference runner call-for-call: stop-rule cleanup →
+  `spec.parse(text, n_docs)` → `spec.score(parsed, gold)` with the spec's declared gold field.
+- Gold conventions are pinned by test: the pair family stores 1-based indices, the retrieval
+  family 0-based, and answering with the wrong base scores zero silently — the class of bug the
+  vendoring exists to prevent (`tests/evals/tasks/test_ctc_suite.py`).
+- Data: `PrasannSinghal/ctc-suite-eval` (private HF; parquet, one config per task, one split per
+  rung). `CTC_SUITE_DATA_ROOT=/path` substitutes a local `<subset>/rung_<tokens>.jsonl` tree at
+  load time. Hub copies strip builder-metadata keys and serialize the free-form `meta` dict to a
+  JSON string (schema stability across splits); grading reads neither.
+- Data generation, ladder builders, and per-rung realized-token measurements live in the OLMo-core
+  working repo (`debug/ctc_1m_ladders/REPORT.md` is the build provenance record).

--- a/src/olmo_eval/evals/tasks/ctc_suite/README.md
+++ b/src/olmo_eval/evals/tasks/ctc_suite/README.md
@@ -9,7 +9,7 @@ median prompt length through the reference prompt path, not a document count.
 ## Quickstart
 
 ```bash
-export HF_TOKEN=...        # needs read access to PrasannSinghal/ctc-suite-eval (private)
+# no token needed: the dataset (PrasannSinghal/ctc-suite-eval) is public
 
 # preview without a model
 uv run olmo-eval run -m mock -t ctc_contradiction:r32k --dry-run
@@ -76,8 +76,8 @@ cap is documented on its RosterRow.
 - Gold conventions are pinned by test: the pair family stores 1-based indices, the retrieval
   family 0-based, and answering with the wrong base scores zero silently — the class of bug the
   vendoring exists to prevent (`tests/evals/tasks/test_ctc_suite.py`).
-- Data: `PrasannSinghal/ctc-suite-eval` (private HF; parquet, one config per task, one split per
-  rung). `CTC_SUITE_DATA_ROOT=/path` substitutes a local `<subset>/rung_<tokens>.jsonl` tree at
+- Data: `PrasannSinghal/ctc-suite-eval` (public HF; parquet, one config per task, one split per
+  rung). Gold answers included: exclude from pretraining corpora. `CTC_SUITE_DATA_ROOT=/path` substitutes a local `<subset>/rung_<tokens>.jsonl` tree at
   load time. Hub copies strip builder-metadata keys and serialize the free-form `meta` dict to a
   JSON string (schema stability across splits); grading reads neither.
 - Data generation, ladder builders, and per-rung realized-token measurements live in the OLMo-core

--- a/src/olmo_eval/evals/tasks/ctc_suite/__init__.py
+++ b/src/olmo_eval/evals/tasks/ctc_suite/__init__.py
@@ -1,0 +1,372 @@
+"""
+The CTC (corpus-tracking-capacity) long-context suite: 22 tasks, context ladders from 2k to 1M
+tokens.
+
+Each task gives the model a corpus of N documents in-prompt and asks a question whose difficulty
+scales with how much of the corpus must be *simultaneously* tracked -- from O(N) retrieval (find
+the answer-bearing passage) to O(N^2) relational tasks (find every contradicting pair) and O(NM)
+structural ones (cluster everything). Every task has a ladder of context rungs; a rung label is the
+measured median prompt length through the reference prompt path, not a document count.
+
+**Provenance.** Prompt templates, answer parsers, per-task metrics, gold-index conventions and stop
+rules are vendored verbatim from the ``ctc`` package (AI2 OLMo-core branch ``prasann/ctc``) under
+``_vendor/``, where they are golden-fixture-tested against the pre-migration implementation that
+produced the suite's published numbers. Do not edit the vendored files here; fix upstream and
+re-vendor. One spec (plain ``grouping``) is registered locally below from the vendored factory.
+
+**Data.** Private HF dataset ``PrasannS/ctc-suite-eval``: one config per task, one split per rung
+(``r2k`` ... ``r1m``). Set ``CTC_SUITE_DATA_ROOT=/path/to/ladders`` to read local
+``<task>/rung_<tokens>.jsonl`` files instead (same files the HF dataset is built from).
+
+**Comparability notes.**
+
+* Rungs at 256k and above carry ``eval_size=125`` (seeded subsample of the same question set;
+  binomial SE ~ +/-0.041 at f1~0.7) -- quote the size next to any number from them. ``scifact``
+  is 300 examples and ``obliq_twitter`` 126 at every rung; same rule.
+* Prompts here are the plain-text prompt path (``spec.build_prompt``). The original suite's
+  vLLM/native runs additionally wrapped each document in Qwen-reserved marker tokens at
+  tokenization time; scores are therefore comparable *within* this harness, and near but not
+  bit-identical to the historical grid.
+* ``query_position`` is pinned to ``"both"`` -- the setting every published rung was graded with.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+from typing import Any
+
+from olmo_eval.common.metrics.base import Metric
+from olmo_eval.common.scorers.base import Scorer
+from olmo_eval.common.types import Instance, LMOutput, LMRequest, RequestType, SamplingParams
+from olmo_eval.data import DataSource
+from olmo_eval.evals.tasks.common import Task, register, register_variant
+
+from ._vendor.ctc.eval.stopping import STOP_PRESETS
+from ._vendor.ctc.eval.stopping import apply as _apply_stop
+from ._vendor.ctc.format import registry as _ctc_registry
+from ._vendor.ctc.format.prompts import GROUPING_INSTRUCTION
+from ._vendor.ctc.tasks import load_all as _load_all_specs
+from ._vendor.ctc.tasks._grouping import make_grouping_spec
+
+__all__ = ["HF_DATASET", "ROSTER", "CTCScorer", "CTCMeanMetric", "CTCSuiteTask"]
+
+#: Private HF dataset holding every rung file. One config per ROSTER row, one split per rung.
+HF_DATASET = "PrasannS/ctc-suite-eval"
+
+#: Env var pointing at a local ladder tree (``<subset>/rung_<tokens>.jsonl``) for offline runs.
+DATA_ROOT_ENV = "CTC_SUITE_DATA_ROOT"
+
+#: The setting every published rung was graded with. Tasks that hardcode their own position
+#: (qdmatch, grouping, outlier) ignore this, and declare so via ``honors_query_position``.
+QUERY_POSITION = "both"
+
+# Import the vendored spec registrations (side-effect: populates the ctc registry).
+_load_all_specs()
+
+# Plain ``grouping`` (OpenAlex, unlabeled clusters) is in the suite roster but not in the vendored
+# canonical set -- register it from the vendored factory, mirroring grouping_labeled minus labels.
+if "grouping" not in _ctc_registry.names():
+    _ctc_registry.register(
+        make_grouping_spec(
+            name="grouping",
+            description="Partition abstracts into their (unnamed) field clusters.",
+            instruction=GROUPING_INSTRUCTION,
+            rungs=("2k", "4k", "8k", "16k", "32k"),
+            query_builder=lambda ex: (
+                f"{GROUPING_INSTRUCTION}\n\n{ex['queries'][0]}"
+                if ex.get("queries")
+                else GROUPING_INSTRUCTION
+            ),
+            sources=("openalex",),
+        )
+    )
+
+
+#: Rung label -> token budget in the local filenames. ``contradiction_iid`` aliases r2k to 2560:
+#: its 2048-doc-count file sat below the training minimum, so the IID ladder starts one step up
+#: (the remap is explicit in the source repo's ``build_suite_table.py`` as well).
+RUNG_TOKENS: dict[str, int] = {
+    "r2k": 2048,
+    "r4k": 4096,
+    "r8k": 8192,
+    "r16k": 16384,
+    "r32k": 32768,
+    "r64k": 65536,
+    "r128k": 131072,
+    "r256k": 262144,
+    "r512k": 524288,
+    "r1m": 1048576,
+}
+
+_LADDER_2K_32K = ("r2k", "r4k", "r8k", "r16k", "r32k")
+_LADDER_FULL = tuple(RUNG_TOKENS)  # 2k .. 1m
+_LADDER_TO_512K = _LADDER_FULL[:-1]
+
+
+@dataclass(frozen=True)
+class RosterRow:
+    """One row of the 22-task suite.
+
+    :param subset: HF config name == local ladder directory name.
+    :param spec: The vendored :class:`TaskSpec` that formats and grades this row.
+    :param rungs: Rung labels with data, ascending.
+    :param eval_size: ``{rung_label: rows}`` for any rung below the 500-example floor. A number
+        quoted from one of these must carry the size inline -- a small eval inflates noise into
+        apparent findings.
+    :param rung_alias: Rung label -> token budget override for the local filename.
+    :param note: Anything a reader of the numbers has to know.
+    """
+
+    subset: str
+    spec: str
+    rungs: tuple[str, ...] = _LADDER_2K_32K
+    eval_size: dict[str, int] = field(default_factory=dict)
+    rung_alias: dict[str, int] = field(default_factory=dict)
+    note: str = ""
+
+
+_SUB500_XLONG = {"r256k": 125, "r512k": 125, "r1m": 125}
+
+#: The frozen 22-row roster (records/ctc-final-suite.md, 2026-08-12). Row order is figure order.
+ROSTER: dict[str, RosterRow] = {
+    "ctc_fiqa": RosterRow(
+        subset="fiqa", spec="retrieval", rungs=_LADDER_FULL, eval_size=dict(_SUB500_XLONG)
+    ),
+    "ctc_nq": RosterRow(
+        subset="nq", spec="retrieval", rungs=_LADDER_FULL, eval_size=dict(_SUB500_XLONG)
+    ),
+    "ctc_hpqa": RosterRow(
+        subset="hotpotqa", spec="retrieval", rungs=_LADDER_FULL, eval_size=dict(_SUB500_XLONG)
+    ),
+    "ctc_qdmatch_fiqa": RosterRow(
+        subset="qdmatch_fiqa",
+        spec="qdmatch",
+        rungs=_LADDER_TO_512K,
+        eval_size=dict(_SUB500_XLONG),
+        note="caps at 512k: the 6,148 recoverable BEIR-FiQA units are the whole labeled universe, "
+        "and a 1M example needs ~8k distinct units",
+    ),
+    "ctc_qdmatch_nq": RosterRow(
+        subset="qdmatch_nq", spec="qdmatch", rungs=_LADDER_FULL, eval_size=dict(_SUB500_XLONG)
+    ),
+    "ctc_qdmatch_hpqa": RosterRow(
+        subset="qdmatch_hpqa", spec="qdmatch", rungs=_LADDER_TO_512K, eval_size=dict(_SUB500_XLONG)
+    ),
+    "ctc_outlier_amzn": RosterRow(
+        subset="outlier_amzn", spec="outlier", rungs=_LADDER_FULL, eval_size=dict(_SUB500_XLONG)
+    ),
+    "ctc_outlier": RosterRow(
+        subset="outlier",
+        spec="outlier",
+        rungs=_LADDER_FULL,
+        eval_size=dict(_SUB500_XLONG),
+        note="64k+ rungs are the true scale-K construction (K ~ n/9); the retired fixed-K xlong "
+        "files are not used",
+    ),
+    "ctc_outlier_fixedm": RosterRow(
+        subset="outlier_fixedM",
+        spec="outlier",
+        note="K pinned at 3 -- the control for the scale-K row",
+    ),
+    "ctc_oolong": RosterRow(
+        subset="oolong", spec="oolong", rungs=_LADDER_FULL, eval_size=dict(_SUB500_XLONG)
+    ),
+    "ctc_grouping": RosterRow(subset="grouping", spec="grouping"),
+    "ctc_absence": RosterRow(
+        subset="absence_gutenberg",
+        spec="absence",
+        rungs=("r2k", "r4k", "r8k", "r16k"),
+        note="corpus is a contiguous Gutenberg passage; rung ceiling is bounded by book length",
+    ),
+    "ctc_xabsence": RosterRow(subset="xabsence", spec="xabsence"),
+    "ctc_rerank": RosterRow(
+        subset="rerank", spec="rerank", rungs=_LADDER_TO_512K, eval_size=dict(_SUB500_XLONG)
+    ),
+    "ctc_msmarco": RosterRow(
+        subset="msmarco", spec="retrieval", rungs=_LADDER_TO_512K, eval_size=dict(_SUB500_XLONG)
+    ),
+    "ctc_reorder": RosterRow(
+        subset="reorder",
+        spec="reorder",
+        rungs=("r2k", "r4k", "r8k", "r16k"),
+        note="chunks are contiguous in one book; rung ceiling is bounded by book length",
+    ),
+    "ctc_obliq": RosterRow(
+        subset="obliq_twitter",
+        spec="retrieval",
+        rungs=_LADDER_FULL,
+        eval_size={**{r: 126 for r in _LADDER_FULL[:7]}, "r256k": 125, "r512k": 125, "r1m": 125},
+        note="126 examples at every rung -- flag the size inline",
+    ),
+    "ctc_niah": RosterRow(
+        subset="niah", spec="retrieval", rungs=_LADDER_FULL, eval_size=dict(_SUB500_XLONG)
+    ),
+    "ctc_contradiction": RosterRow(
+        subset="contradiction_iid",
+        spec="contradiction",
+        rungs=_LADDER_FULL,
+        eval_size=dict(_SUB500_XLONG),
+        rung_alias={"r2k": 2560},
+        note="the IID realistic-mode ladder; never mix with the retired both-mode ladder",
+    ),
+    "ctc_strmatch": RosterRow(subset="strmatch", spec="strmatch"),
+    "ctc_textgroups": RosterRow(subset="textgroups", spec="textgroups"),
+    "ctc_scifact": RosterRow(
+        subset="scifact",
+        spec="retrieval",
+        eval_size={r: 300 for r in _LADDER_2K_32K},
+        note="300 examples at every rung -- flag the size inline",
+    ),
+}
+
+#: Which rung a bare task name (no variant) evaluates: the top of the 2k-32k figure ladder.
+DEFAULT_RUNG = "r32k"
+
+
+def _resolve_spec(spec_name: str):
+    return _ctc_registry.get(spec_name)
+
+
+def _data_source(row: RosterRow, rung: str) -> DataSource:
+    """The canonical HF source. The split IS the rung label, which is also how
+    :meth:`CTCSuiteTask._load_instances` knows which local file to substitute when
+    ``CTC_SUITE_DATA_ROOT`` is set (checked at load time, not import time)."""
+    return DataSource(path=HF_DATASET, subset=row.subset, split=rung)
+
+
+@dataclass(frozen=True)
+class CTCScorer(Scorer):
+    """Parse a generation with the task's own parser and score it with the task's own metric.
+
+    The three calls mirror the reference runner exactly: stop-rule cleanup, then
+    ``spec.parse(text, n_docs)``, then ``spec.score(parsed, gold)`` where the gold field is the
+    spec's declared one (``gold_doc_indices`` for most tasks, ``gold_pairs`` for qdmatch). A
+    ``None`` parse scores 0 on every metric, which is the reference behaviour -- but parse *rate*
+    should be watched separately: a parse-rate collapse is a decoding/stopping regression wearing
+    an accuracy drop's clothes.
+    """
+
+    name: str = "ctc"
+    spec_name: str = ""
+
+    def score(self, instance: Instance, output: LMOutput) -> float:
+        spec = _resolve_spec(self.spec_name)
+        example = instance.metadata["example"]
+        cleaned = _apply_stop(output.text or "", STOP_PRESETS[spec.stop])
+        parsed = spec.parse(cleaned, len(example["documents"]))
+        gold_field = spec.extra.get("gold_field", "gold_doc_indices")
+        # When the declared field is absent or empty (oolong's gold lives in _meta.gold_list /
+        # answers), hand score() the whole example -- the specs that need that path document
+        # accepting "the example carrying them".
+        gold = example.get(gold_field) or example
+        scored = spec.score(parsed, gold)
+        value = scored.get(spec.primary_metric, 0.0)
+        if output.metadata is None:
+            output.metadata = {}
+        output.metadata["ctc_parse_ok"] = parsed is not None
+        output.metadata["ctc_all_metrics"] = {k: float(v) for k, v in scored.items()}
+        return float(value)
+
+
+@dataclass(frozen=True, slots=True)
+class CTCMeanMetric(Metric):
+    """Mean of the task's primary metric across responses (named for that metric, e.g. mrr@10)."""
+
+    name: str = "ctc"
+    scorer: type[Scorer] | Scorer = CTCScorer()
+
+    def compute(self, responses) -> float:
+        if not responses:
+            return 0.0
+        scorer_name = self.scorer().name
+        total = sum(r.scores.get(scorer_name, 0.0) for r in responses)
+        return total / len(responses)
+
+
+class CTCSuiteTask(Task):
+    """Base class for every suite row. Subclasses set ``row_name`` and inherit everything else."""
+
+    row_name: str = ""
+
+    @property
+    def row(self) -> RosterRow:
+        return ROSTER[self.row_name]
+
+    @property
+    def spec(self):
+        return _resolve_spec(self.row.spec)
+
+    @property
+    def instances(self) -> Iterator[Instance]:
+        yield from self._load_instances_cached()
+
+    def _load_instances(self, split: str | None = None) -> Iterator[Instance]:
+        """Same as the base loader, except ``CTC_SUITE_DATA_ROOT`` (read here, at load time)
+        substitutes the local ``<subset>/rung_<tokens>.jsonl`` file for the HF split -- for
+        offline runs and for validating a ladder before it is uploaded."""
+        root = os.environ.get(DATA_ROOT_ENV)
+        if not root:
+            yield from super()._load_instances(split=split)
+            return
+        from olmo_eval.data import DataLoader
+
+        rung = self.config.data_source.split  # the split label IS the rung label
+        tokens = self.row.rung_alias.get(rung, RUNG_TOKENS[rung])
+        path = os.path.join(root, self.row.subset, f"rung_{tokens}.jsonl")
+        source = DataSource(path=path, split="train")  # a bare JSONL is a single unnamed split
+        for index, doc in enumerate(DataLoader().load(source)):
+            instance = self.process_doc(doc, index)
+            if instance is not None:
+                yield instance
+
+    def process_doc(self, doc: dict[str, Any], index: int = 0) -> Instance | None:
+        # The raw unified example travels whole: the prompt builder, parser and scorer all read
+        # different parts of it, and slicing it here is how field conventions historically drifted.
+        return Instance(
+            question=doc["queries"][0] if doc.get("queries") else "",
+            gold_answer=None,
+            metadata={"id": index, "example": doc},
+        )
+
+    def format_request(self, instance: Instance) -> LMRequest:
+        prompt = self.spec.build_prompt(instance.metadata["example"], query_position=QUERY_POSITION)
+        return LMRequest(request_type=RequestType.COMPLETION, prompt=prompt)
+
+    def get_sampling_params(self, instance: Instance) -> SamplingParams | None:
+        # No decode-time text stops on purpose: the reference stop rules suppress text stops
+        # inside unclosed <think> blocks and before first content, which a decode-time stop string
+        # cannot honour. The same rules run post-hoc in CTCScorer instead; the only cost is decode
+        # tokens on models that never emit EOS, bounded by max_tokens.
+        stop = STOP_PRESETS[self.spec.stop]
+        return SamplingParams(
+            max_tokens=max(stop.max_new_tokens, self.spec.max_new_tokens),
+            temperature=0,
+        )
+
+
+def _make_row_task(task_name: str, row: RosterRow) -> None:
+    spec = _resolve_spec(row.spec)
+    metric = CTCMeanMetric(name=spec.primary_metric, scorer=CTCScorer(spec_name=row.spec))
+
+    cls = type(
+        f"CTC_{row.subset}",
+        (CTCSuiteTask,),
+        {
+            "__doc__": f"CTC suite row {row.subset!r} ({row.spec} spec). {row.note}".strip(),
+            "row_name": task_name,
+            "data_source": _data_source(
+                row, DEFAULT_RUNG if DEFAULT_RUNG in row.rungs else row.rungs[-1]
+            ),
+            "metrics": (metric,),
+            "primary_metric": metric,
+        },
+    )
+    register(task_name)(cls)
+    for rung in row.rungs:
+        register_variant(task_name, rung, data_source=_data_source(row, rung))
+
+
+for _name, _row in ROSTER.items():
+    _make_row_task(_name, _row)

--- a/src/olmo_eval/evals/tasks/ctc_suite/__init__.py
+++ b/src/olmo_eval/evals/tasks/ctc_suite/__init__.py
@@ -269,11 +269,14 @@ class CTCScorer(Scorer):
         example = instance.metadata["example"]
         cleaned = _apply_stop(output.text or "", STOP_PRESETS[spec.stop])
         parsed = spec.parse(cleaned, len(example["documents"]))
-        gold_field = spec.extra.get("gold_field", "gold_doc_indices")
-        # When the declared field is absent or empty (oolong's gold lives in _meta.gold_list /
-        # answers), hand score() the whole example -- the specs that need that path document
-        # accepting "the example carrying them".
-        gold = example.get(gold_field) or example
+        # Gold resolution mirrors the reference runner: the whole example when the spec asks
+        # for it (rerank's scorer needs ce_scores), else the declared field, else the example
+        # again when that field is absent/empty (oolong's gold lives in _meta.gold_list).
+        if spec.extra.get("score_takes_example"):
+            gold = example
+        else:
+            gold_field = spec.extra.get("gold_field", "gold_doc_indices")
+            gold = example.get(gold_field) or example
         scored = spec.score(parsed, gold)
         value = scored.get(spec.primary_metric, 0.0)
         if output.metadata is None:

--- a/src/olmo_eval/evals/tasks/ctc_suite/__init__.py
+++ b/src/olmo_eval/evals/tasks/ctc_suite/__init__.py
@@ -14,7 +14,7 @@ rules are vendored verbatim from the ``ctc`` package (AI2 OLMo-core branch ``pra
 produced the suite's published numbers. Do not edit the vendored files here; fix upstream and
 re-vendor. One spec (plain ``grouping``) is registered locally below from the vendored factory.
 
-**Data.** Private HF dataset ``PrasannSinghal/ctc-suite-eval``: one config per task, one split
+**Data.** Public HF dataset ``PrasannSinghal/ctc-suite-eval``: one config per task, one split
 per rung (``r2k`` ... ``r1m``). Set ``CTC_SUITE_DATA_ROOT=/path/to/ladders`` to read local
 ``<task>/rung_<tokens>.jsonl`` files instead (same files the HF dataset is built from).
 
@@ -52,7 +52,7 @@ from ._vendor.ctc.tasks._grouping import make_grouping_spec
 
 __all__ = ["HF_DATASET", "ROSTER", "CTCScorer", "CTCMeanMetric", "CTCSuiteTask"]
 
-#: Private HF dataset holding every rung file. One config per ROSTER row, one split per rung.
+#: Public HF dataset holding every rung file. One config per ROSTER row, one split per rung.
 HF_DATASET = "PrasannSinghal/ctc-suite-eval"
 
 #: Env var pointing at a local ladder tree (``<subset>/rung_<tokens>.jsonl``) for offline runs.

--- a/src/olmo_eval/evals/tasks/ctc_suite/__init__.py
+++ b/src/olmo_eval/evals/tasks/ctc_suite/__init__.py
@@ -187,7 +187,13 @@ ROSTER: dict[str, RosterRow] = {
         rungs=("r2k", "r4k", "r8k", "r16k"),
         note="corpus is a contiguous Gutenberg passage; rung ceiling is bounded by book length",
     ),
-    "ctc_xabsence": RosterRow(subset="xabsence", spec="xabsence"),
+    "ctc_xabsence": RosterRow(
+        subset="xabsence",
+        spec="xabsence",
+        note="the one-sided EXACT-COPY Gutenberg build (2026-08-14): B-side twins are "
+        "byte-identical and orphans sit A-side only. Supersedes the PubMed paraphrase build, "
+        "kept in the dataset as the xabsence_paraphrase config",
+    ),
     "ctc_rerank": RosterRow(
         subset="rerank", spec="rerank", rungs=_LADDER_TO_512K, eval_size=dict(_SUB500_XLONG)
     ),

--- a/src/olmo_eval/evals/tasks/ctc_suite/__init__.py
+++ b/src/olmo_eval/evals/tasks/ctc_suite/__init__.py
@@ -14,7 +14,7 @@ rules are vendored verbatim from the ``ctc`` package (AI2 OLMo-core branch ``pra
 produced the suite's published numbers. Do not edit the vendored files here; fix upstream and
 re-vendor. One spec (plain ``grouping``) is registered locally below from the vendored factory.
 
-**Data.** Private HF dataset ``PrasannS/ctc-suite-eval``: one config per task, one split per rung
+**Data.** Private HF dataset ``PrasannSinghal/ctc-suite-eval``: one config per task, one split per rung
 (``r2k`` ... ``r1m``). Set ``CTC_SUITE_DATA_ROOT=/path/to/ladders`` to read local
 ``<task>/rung_<tokens>.jsonl`` files instead (same files the HF dataset is built from).
 
@@ -53,7 +53,7 @@ from ._vendor.ctc.tasks._grouping import make_grouping_spec
 __all__ = ["HF_DATASET", "ROSTER", "CTCScorer", "CTCMeanMetric", "CTCSuiteTask"]
 
 #: Private HF dataset holding every rung file. One config per ROSTER row, one split per rung.
-HF_DATASET = "PrasannS/ctc-suite-eval"
+HF_DATASET = "PrasannSinghal/ctc-suite-eval"
 
 #: Env var pointing at a local ladder tree (``<subset>/rung_<tokens>.jsonl``) for offline runs.
 DATA_ROOT_ENV = "CTC_SUITE_DATA_ROOT"

--- a/src/olmo_eval/evals/tasks/ctc_suite/__init__.py
+++ b/src/olmo_eval/evals/tasks/ctc_suite/__init__.py
@@ -322,11 +322,18 @@ class CTCSuiteTask(Task):
         """Same as the base loader, except ``CTC_SUITE_DATA_ROOT`` (read here, at load time)
         substitutes the local ``<subset>/rung_<tokens>.jsonl`` file for the HF split -- for
         offline runs and for validating a ladder before it is uploaded."""
+        from olmo_eval.data import DataLoader
+
         root = os.environ.get(DATA_ROOT_ENV)
         if not root:
-            yield from super()._load_instances(split=split)
+            # Use the variant's DataSource AS-IS: its split IS the rung label. The base loader
+            # would route through config.get_data_source(), which substitutes the config-level
+            # default split ("test") and 404s -- this suite has no "test" split anywhere.
+            for index, doc in enumerate(DataLoader().load(self.config.data_source)):
+                instance = self.process_doc(doc, index)
+                if instance is not None:
+                    yield instance
             return
-        from olmo_eval.data import DataLoader
 
         rung = self.config.data_source.split  # the split label IS the rung label
         tokens = self.row.rung_alias.get(rung, RUNG_TOKENS[rung])

--- a/src/olmo_eval/evals/tasks/ctc_suite/__init__.py
+++ b/src/olmo_eval/evals/tasks/ctc_suite/__init__.py
@@ -172,7 +172,10 @@ ROSTER: dict[str, RosterRow] = {
     "ctc_outlier_fixedm": RosterRow(
         subset="outlier_fixedM",
         spec="outlier",
-        note="K pinned at 3 -- the control for the scale-K row",
+        rungs=_LADDER_TO_512K,
+        eval_size=dict(_SUB500_XLONG),
+        note="K pinned at 3 -- the control for the scale-K row. Caps at 512k: three majority "
+        "topics need ~2,400 same-topic chunks each at 1M and the wiki pool cannot supply that",
     ),
     "ctc_oolong": RosterRow(
         subset="oolong", spec="oolong", rungs=_LADDER_FULL, eval_size=dict(_SUB500_XLONG)

--- a/src/olmo_eval/evals/tasks/ctc_suite/__init__.py
+++ b/src/olmo_eval/evals/tasks/ctc_suite/__init__.py
@@ -152,7 +152,11 @@ ROSTER: dict[str, RosterRow] = {
         subset="qdmatch_nq", spec="qdmatch", rungs=_LADDER_FULL, eval_size=dict(_SUB500_XLONG)
     ),
     "ctc_qdmatch_hpqa": RosterRow(
-        subset="qdmatch_hpqa", spec="qdmatch", rungs=_LADDER_TO_512K, eval_size=dict(_SUB500_XLONG)
+        subset="qdmatch_hpqa",
+        spec="qdmatch",
+        rungs=_LADDER_FULL[:-2],
+        eval_size=dict(_SUB500_XLONG),
+        note="caps at 256k: 4,000 recoverable HotpotQA units, and a 512k example needs ~7k",
     ),
     "ctc_outlier_amzn": RosterRow(
         subset="outlier_amzn", spec="outlier", rungs=_LADDER_FULL, eval_size=dict(_SUB500_XLONG)

--- a/src/olmo_eval/evals/tasks/ctc_suite/__init__.py
+++ b/src/olmo_eval/evals/tasks/ctc_suite/__init__.py
@@ -14,8 +14,8 @@ rules are vendored verbatim from the ``ctc`` package (AI2 OLMo-core branch ``pra
 produced the suite's published numbers. Do not edit the vendored files here; fix upstream and
 re-vendor. One spec (plain ``grouping``) is registered locally below from the vendored factory.
 
-**Data.** Private HF dataset ``PrasannSinghal/ctc-suite-eval``: one config per task, one split per rung
-(``r2k`` ... ``r1m``). Set ``CTC_SUITE_DATA_ROOT=/path/to/ladders`` to read local
+**Data.** Private HF dataset ``PrasannSinghal/ctc-suite-eval``: one config per task, one split
+per rung (``r2k`` ... ``r1m``). Set ``CTC_SUITE_DATA_ROOT=/path/to/ladders`` to read local
 ``<task>/rung_<tokens>.jsonl`` files instead (same files the HF dataset is built from).
 
 **Comparability notes.**

--- a/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/__init__.py
+++ b/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/__init__.py
@@ -1,0 +1,9 @@
+"""
+Corpus-reasoning task generation and evaluation.
+
+Independent of olmo-core by construction: nothing in this package imports it except
+:mod:`ctc.eval.backends.native` and :mod:`ctc.eval.masking.native`, both behind the ``native``
+extra. That is what lets ``pip install ctc`` work on a machine with no GPU and no compiler.
+"""
+
+__version__ = "0.1.0"

--- a/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/data/__init__.py
+++ b/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/data/__init__.py
@@ -1,0 +1,1 @@
+"""Vendored subset: only the ladder tables (pure data). Generators are NOT vendored."""

--- a/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/data/ladders.py
+++ b/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/data/ladders.py
@@ -1,0 +1,233 @@
+"""
+Rung -> document count, per task. The calibration table for the CTC suite.
+
+A rung is a *token* budget; a generator takes a *document* count. This table is the bridge, and it
+is per task because a contradiction claim is ~42 tokens while a BEIR SciFact abstract is ~365 -- the
+same "8k" means 187 documents for one and 21 for the other.
+
+**Getting this wrong is not a sizing nuisance, it is a mislabelled axis.** The pre-migration
+contradiction ladder was fit against a filler pool that turned out to be 92-99.6% FEVER/wiki rather
+than PubMed. Wikipedia trivia claims tokenize at ~22.8 tok/doc against PubMed's ~43, so re-running
+the same document counts against the corrected pool overshot every rung by ~1.8x -- the file called
+``rung_2048`` actually rendered to 3413 tokens, and ``32k`` to 61461. Every number plotted against
+that axis was plotted against the wrong x.
+
+So each row records how it was calibrated, and ``estimated`` rows are exactly the ones to re-measure
+before quoting a length. The authority for un-ported tasks remains
+``src/scripts/data/ctc_suite/BUILD_MATRIX.md`` in the pre-migration tree; rows land here as their
+generators do. This module is the single source: contradiction's spec derives its
+``CLAIMS_PER_RUNG`` -- and hence its ``extra["claims_per_rung"]`` -- from the row below rather than
+declaring a copy. That ladder has already been wrong once, and two copies of it drift.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+from ..format import rungs as rung_util
+
+__all__ = ["LADDERS", "docs_for_rung", "rungs_for", "max_rung"]
+
+#: task -> {rung label: documents per example}. Synthetic tasks tokenize 1.5-3x higher per
+#: character than natural text, which is why their per-document estimates are so much lower than
+#: the retrieval tasks'. ``oolong`` is the exception in kind rather than degree: its value is a
+#: **token budget**, because its items are lines inside one document rather than documents.
+LADDERS: Dict[str, Dict[str, int]] = {
+    # ── pure synthetic ──
+    # ~25-30 tok/claim. BUILD_MATRIX recommends capping at n1000 and letting 32k run slightly short.
+    "cycle": {"2k": 60, "4k": 130, "8k": 270, "16k": 550, "32k": 1100},
+    # ~15-20 tok/expression -- the shortest documents in the suite, hence the largest counts.
+    "groups4": {"2k": 100, "4k": 210, "8k": 440, "16k": 900, "32k": 1800},
+    "mathmatch": {"2k": 48, "4k": 105, "8k": 220, "16k": 450, "32k": 900},
+    # ~27 tok/string at str_len=10, tokenizer-MEASURED (2022/4080/8201/16459/33193 median prompt
+    # tokens, every rung within 1.3% of its label). NOT the BUILD_MATRIX row-20 counts
+    # (38/82/170/350/700), which that row itself flagged `synth x1.5-3 ... calibrate before
+    # freezing n values`: the multiplier is not there. Re-measuring the SHIPPED
+    # `eval_rungs/strmatch/rung_{2048,32768}.jsonl` gives 1119 and 18696 median tokens against
+    # labels of 2048 and 32768 -- every shipped strmatch rung is ~0.56x its label, so a strmatch
+    # point plotted at 32k was really a 19k point. The wiki vocabulary those files used and the
+    # frozen wordlist here tokenize almost identically (26.7-29.5 vs 27.3-30.9 tok/doc), so this
+    # row is a recalibration, not a consequence of the vocabulary swap.
+    "strmatch": {"2k": 72, "4k": 149, "8k": 301, "16k": 606, "32k": 1216},
+    # ~150 tok/passage: the feature must be spread densely over several sentences, so a textgroups
+    # document is an order of magnitude longer than a groups4 one at the same task shape.
+    "textgroups": {"2k": 11, "4k": 24, "8k": 50, "16k": 103, "32k": 210},
+    # ── the five in-distribution CTC-suite ladders ──
+    # ~43 tok/claim, tokenizer-MEASURED at 1925/3933/8052/16074/32397 median tokens against a
+    # PubMed-only filler pool. NOT the pre-migration `contra` row (40/88/190/385/765), which was
+    # fit against a pool that was 92-99.6% FEVER/wiki: Wikipedia trivia claims tokenize at ~22.8
+    # tok/doc, so re-running those counts against the corrected pool overshoots every rung by
+    # ~1.8x (n=77 measured 3413 tokens, not 2048; n=1423 measured 61461, not 32768).
+    "contradiction": {"2k": 44, "4k": 92, "8k": 187, "16k": 379, "32k": 762},
+    # ~42 tok/claim, tokenizer-MEASURED (2044/3980/8099/16648/32897 median prompt tokens). Its own
+    # BUILD_MATRIX row (17) was struck out when the task was dropped from the suite, so there is no
+    # pre-migration ladder to inherit -- but the corpus is contradiction's, at the same document
+    # shape, and the two fits agree to within 3% at every rung (46/95/193/390/784 vs 44/92/187/
+    # 379/762), which is the cross-check that says the fit is measuring the corpus and not noise.
+    "redundancy": {"2k": 46, "4k": 95, "8k": 193, "16k": 390, "32k": 784},
+    "nq": {"2k": 11, "4k": 23, "8k": 48, "16k": 100, "32k": 200},  # ~160 tok/passage
+    # ~113 tok/paragraph, tokenizer-MEASURED. NOT the BUILD_MATRIX row-2 counts (11/24/50/100/205),
+    # which the 2026-07-19 "FIX2" recalibration found undershooting their labels by 0.64-0.69x: a
+    # least-squares fit over the built rungs gave `tokens ~= 66.6 + 113.36 * n_docs`, and the
+    # rebuilt 17/36/72 re-measured at 1954/4124/8240 median tokens (ratios 0.954/1.007/1.006). The
+    # shipped `eval_rungs/hotpotqa/rung_{2048,4096,8192,16384}.jsonl` carry exactly 17/36/72/144
+    # documents. 32k is the same fit extrapolated one rung past the shipped ladder.
+    "hotpotqa": {"2k": 17, "4k": 36, "8k": 72, "16k": 144, "32k": 288},
+    "outlier": {"2k": 14, "4k": 28, "8k": 57, "16k": 115, "32k": 220},  # ~140 tok/passage
+    # ~100-160 tok/passage, the widest uncertainty band here: BUILD_MATRIX gives a range per rung
+    # (13-18 / 25-38 / 50-78 / 100-158 / 200-315) and these are its midpoints. Re-measure before
+    # quoting a rerank context length.
+    "rerank": {"2k": 15, "4k": 30, "8k": 62, "16k": 125, "32k": 250},
+    # TOKEN budgets, not document counts. The generator draws items until the budget is met.
+    "oolong": {"2k": 2048, "4k": 4096, "8k": 8192, "16k": 16384, "32k": 32768},
+    # ── the absence family ──
+    # ~76 tok/sentence, tokenizer-MEASURED. NOT BUILD_MATRIX row 18's ~20/sentence ->
+    # {90,180,360,720,1440}: that estimate charges each sentence once, and an absence prompt
+    # carries the whole corpus TWICE -- numbered as Version A, then again inside the second
+    # version. The shipped `absence_eval_gutenberg_n{10,50,200}_k3.jsonl` measure 548/3117/14790
+    # median Qwen3 tokens, giving `tokens ~= -412 + 75.7 * n_docs`, so the estimated ladder
+    # overshoots by ~3.4x and the staged `n1440` file is a ~109k-token file labelled 32k.
+    "absence": {"2k": 32, "4k": 60, "8k": 114, "16k": 222, "32k": 438},
+    # ~33 tok/claim, tokenizer-MEASURED, and ODD on purpose: an example is 2P+k documents, so an
+    # even rung with the default k=3 would round down to one document under its label. NOT
+    # BUILD_MATRIX row 22's P18/P39/P81/P165/P333 (39/81/165/333/669 documents at an estimated ~95
+    # tok/pair); the shipped `xabsence_eval_pubmed_p{8,18,48}_k3.jsonl` measure 772/1394/3424
+    # median tokens at 19/39/99 documents, giving `tokens ~= 120 + 33.3 * n_docs`.
+    "xabsence": {"2k": 59, "4k": 119, "8k": 243, "16k": 489, "32k": 981},
+    # ── the ladders whose rungs are drawn independently (gold covers every document) ──
+    # ~151 tok/passage, tokenizer-MEASURED over THIS generator's own output rather than over the
+    # shipped files: a 96-example build at n=14/58/233 measures 2178/8890/35333 median prompt
+    # tokens, giving `tokens ~= 84 + 151.3 * n_docs`. The shipped
+    # `reorder_gutenberg100w_n{5,20,50}_eval_500.jsonl` fit 140.5/passage with their whitespace
+    # collapsed, i.e. ~7% lower -- the ported chunker closes a passage on whole SENTENCES once it
+    # reaches 100 words, so it overshoots the target by the length of the closing sentence
+    # (measured median 112 words, p95 143). Both fits bracket BUILD_MATRIX row 24
+    # (12/27/57/116/234).
+    # NOTE the ANSWER is what binds at the top of this ladder, not the prompt: the target is a
+    # permutation of n ids at ~4.5 tokens each, so 32k needs ~980 decode tokens. That is why the
+    # spec raises max_new_tokens to 2048; at the pre-migration 1024 the 32k target does not fit and
+    # every example at that rung parses as None.
+    "reorder": {"2k": 13, "4k": 27, "8k": 54, "16k": 108, "32k": 216},
+    # ~183 tok/abstract (title + a 120-word abstract), tokenizer-MEASURED over this generator's own
+    # output: 2210/8215/32184 median prompt tokens at n=11/44/175, giving
+    # `tokens ~= 187 + 182.8 * n_docs`. The shipped `openalex_grouping_n{20,100}_levels_eval_*`
+    # files fit 187.0/abstract, i.e. the same corpus measured the same way. BUILD_MATRIX row 14
+    # estimated ~180 tok/doc net of a ~300-token overhead allowance, landing on 9/20/42/85/170.
+    "grouping_labeled": {"2k": 10, "4k": 21, "8k": 44, "16k": 89, "32k": 178},
+    # ITEMS (M queries + N documents), NOT the `q` of BUILD_MATRIX rows 21a/21b -- an example
+    # renders 2q items and both the ladder and `ctc.data.build.shrink` measure `len(documents)`.
+    # ~88 tok/item, tokenizer-MEASURED over this generator's own output: 2135/8206/33002 median
+    # prompt tokens at n=21/92/374, giving `tokens ~= 231 + 87.58 * n_docs`. The shipped
+    # `qdmatch_eval_nq_q{20,50,100,250}_*_separate.jsonl` files fit 87.06/item -- the same number,
+    # which is expected since both draw NQ gold passages -- and that is also BUILD_MATRIX's
+    # "~175 per (query+doc) unit". Its q9/q20/q42/q87/q178 (= 18/40/84/174/356 items) sit ~5% low
+    # because that row also charged a ~300-token query/answer overhead.
+    "qdmatch_nq": {"2k": 21, "4k": 44, "8k": 91, "16k": 184, "32k": 372},
+    # HotpotQA paragraphs run a little longer than NQ's 100-word DPR chunks, but the shipped hpqa
+    # files were built at the same item counts as the NQ ones and no separate fit exists; measure
+    # before quoting a hpqa context length.
+    "qdmatch_hpqa": {"2k": 21, "4k": 44, "8k": 91, "16k": 184, "32k": 372},
+    # ── the four held-out (OOD) ladders ──
+    "fiqa": {"2k": 4, "4k": 9, "8k": 19, "16k": 40, "32k": 80},  # ~400 tok/post
+    "scifact": {"2k": 5, "4k": 10, "8k": 21, "16k": 43, "32k": 88},  # ~365 tok/abstract
+    "outlier_review": {"2k": 20, "4k": 40, "8k": 80, "16k": 160, "32k": 320},  # ~100 tok/review
+    # ~20 tok/claim: a one-line FEVER claim is half the length of a PubMed one, which is why this
+    # row is ~2x contradiction's at every rung. Matches the shipped
+    # `contradiction_eval_fever_plain_n{100,408,820,1642}` files.
+    "contra_fever": {"2k": 100, "4k": 204, "8k": 408, "16k": 820, "32k": 1642},
+}
+
+#: How each row was arrived at. ``estimated`` means an offline per-document token estimate, not a
+#: measurement against the real tokenizer -- re-measure before quoting a context length.
+CALIBRATION: Dict[str, str] = {
+    "cycle": "estimated",
+    "groups4": "estimated",
+    "mathmatch": "estimated",
+    "strmatch": (
+        "measured (Qwen3 tokenizer, frozen wordlist); REPLACES BUILD_MATRIX row 20, whose "
+        "38/82/170/350/700 renders to ~0.56x of every rung label"
+    ),
+    "textgroups": "estimated",
+    "contradiction": "measured (Qwen3 tokenizer, PubMed-only filler pool)",
+    "redundancy": (
+        "measured (Qwen3 tokenizer, PubMed pool); no pre-migration row -- the task was "
+        "dropped from the suite before its ladder was fit"
+    ),
+    "nq": "estimated (BUILD_MATRIX row 1)",
+    "hotpotqa": (
+        "measured 2k/4k/8k (FIX2 recalibration, 1954/4124/8240 median tokens); 16k/32k from the "
+        "same fitted 66.6 + 113.36*n, 16k built and shipped, 32k extrapolated"
+    ),
+    "outlier": "estimated (BUILD_MATRIX row 11; matches the shipped n14-220 files)",
+    "rerank": "estimated, wide (BUILD_MATRIX rows 9/10 give a range; these are its midpoints)",
+    "oolong": "exact (the value IS the token budget the generator fills)",
+    "absence": (
+        "measured (Qwen3 tokenizer over the shipped gutenberg n10/n50/n200 files, fitted "
+        "-412.3 + 75.74*n); replaces BUILD_MATRIX row 18's ~3.4x-overshooting estimate"
+    ),
+    "xabsence": (
+        "measured (Qwen3 tokenizer over the shipped pubmed p8/p18/p48 files, fitted "
+        "120.1 + 33.31*n); replaces BUILD_MATRIX row 22's ~1.4x-overshooting estimate"
+    ),
+    "reorder": (
+        "measured (Qwen3 tokenizer over a 96-example build of THIS generator at n=14/58/233, "
+        "fitted 83.8 + 151.31*n); brackets BUILD_MATRIX row 24 with the shipped-file fit"
+    ),
+    "grouping_labeled": (
+        "measured (Qwen3 tokenizer over a 96-example build of THIS generator at n=11/44/175, "
+        "fitted 186.8 + 182.82*n); agrees with the shipped openalex n20/n100 files at 187.0/doc"
+    ),
+    "qdmatch_nq": (
+        "measured (Qwen3 tokenizer over a 96-example build of THIS generator at n=21/92/374 "
+        "ITEMS, fitted 230.6 + 87.58*n); agrees with the shipped nq q20-q250 files at 87.06/item"
+    ),
+    "qdmatch_hpqa": (
+        "estimated: the qdmatch_nq fit, reused. The shipped hpqa files were built at the same item "
+        "counts but were never separately measured -- HotpotQA paragraphs are not DPR chunks"
+    ),
+    "fiqa": "estimated (BUILD_MATRIX row 8)",
+    "scifact": "estimated (BUILD_MATRIX row 7)",
+    "outlier_review": "estimated (BUILD_MATRIX row 12)",
+    "contra_fever": "measured (matches the shipped fever_plain ladder)",
+}
+
+
+def rungs_for(task: str) -> List[str]:
+    """
+    :param task: Task name.
+
+    :returns: Its rung labels, ascending by context length.
+
+    :raises KeyError: If the task has no ladder.
+    """
+    if task not in LADDERS:
+        raise KeyError(
+            f"no rung ladder for {task!r}; have {', '.join(sorted(LADDERS))}. Un-ported tasks keep "
+            "their ladder in the pre-migration BUILD_MATRIX.md."
+        )
+    return rung_util.sort_rungs(LADDERS[task])
+
+
+def docs_for_rung(task: str, rung: str) -> int:
+    """
+    :param task: Task name.
+    :param rung: Rung label, in any accepted spelling (``"32k"``, ``"32768"``).
+
+    :returns: Documents per example at that rung.
+
+    :raises KeyError: If the task or rung is unknown.
+    """
+    ladder = {rung_util.normalize(k): v for k, v in LADDERS[task].items()}
+    label = rung_util.normalize(rung)
+    if label not in ladder:
+        raise KeyError(f"{task} has no rung {label!r}; has {', '.join(rungs_for(task))}")
+    return ladder[label]
+
+
+def max_rung(task: str) -> str:
+    """
+    :param task: Task name.
+
+    :returns: Its longest rung -- where a nested eval ladder is built before being shrunk down.
+    """
+    return rungs_for(task)[-1]

--- a/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/eval/__init__.py
+++ b/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/eval/__init__.py
@@ -1,0 +1,1 @@
+"""Vendored subset: only the stop-rule presets. The runner/backends are NOT vendored."""

--- a/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/eval/stopping.py
+++ b/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/eval/stopping.py
@@ -1,0 +1,190 @@
+"""
+When to stop generating, and what to keep afterwards.
+
+Stopping is where a surprising share of this project's bad numbers came from. It is pure string
+handling with no model involved, yet every mistake in it looks exactly like the model failing:
+
+* **Stopping too early.** A newline stop applied to a checkpoint that opens with ``<think>`` cuts
+  the generation at the first newline *inside* the reasoning block, so the answer -- which comes
+  after ``</think>`` -- is never emitted. The task reads as a total collapse.
+* **Not stopping at all.** No-cot checkpoints frequently never emit EOS. Left to run to
+  ``max_new_tokens`` they answer correctly and then ramble, and the ramble is what a lenient parser
+  scores. This is why set-answer tasks stop at the closing ``]]``.
+* **Stopping on the model clearing its throat.** Models routinely emit a formatting newline
+  *before* the answer. A newline stop that fires there returns an empty string for every example --
+  obliq and retrieval both scored around chance, with every generation empty, until this was found.
+* **Keeping the wrong span.** When a model does emit ``<think>``, the reasoning must be stripped
+  before parsing, or a parser scanning for ids finds the ones the model was *considering* rather
+  than the ones it concluded with.
+
+So the rules live here, in one place, testable without a GPU, rather than being re-derived per
+evaluator. Two rules carry most of the weight:
+
+    **A text stop never fires inside an unclosed ``<think>`` block**, and **never fires before any
+    real content has been produced.**
+
+Between them they separate "the model failed" from "we truncated it".
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+__all__ = ["StopCondition", "STOP_PRESETS", "strip_think", "apply"]
+
+THINK_OPEN = "<think>"
+THINK_CLOSE = "</think>"
+
+
+@dataclass(frozen=True)
+class StopCondition:
+    """
+    How generation ends for one task.
+
+    :param eos: Stop when the model emits the EOS token. Always honoured, and always safe.
+    :param text_stops: Substrings that end generation when they appear. Checked against the decoded
+        text, and **suppressed inside an unclosed** ``<think>`` block.
+    :param keep_stop: Whether the matched substring stays in the output. ``True`` for a closing
+        delimiter like ``]]`` which the parser needs; ``False`` for a newline, which it does not.
+    :param strip_think: Remove a ``<think>...</think>`` block before parsing.
+    :param require_content: Suppress text stops until some non-whitespace content exists. Defends
+        against the leading formatting newline described in the module docstring, which otherwise
+        returns an empty generation for every example.
+    :param require_before: Suppress text stops until this substring appears (case-insensitive).
+        Used by oolong, whose answer follows a templated ``answer:`` line, so an earlier newline is
+        part of the preamble rather than the end of the answer.
+    :param max_new_tokens: Decode budget. Sized too small, a correct answer is truncated into a
+        parse failure -- which reads as a capability limit rather than a config mistake.
+    """
+
+    eos: bool = True
+    text_stops: Tuple[str, ...] = ()
+    keep_stop: bool = True
+    strip_think: bool = True
+    require_content: bool = True
+    require_before: Optional[str] = None
+    max_new_tokens: int = 512
+
+    def __post_init__(self) -> None:
+        if self.max_new_tokens <= 0:
+            raise ValueError("max_new_tokens must be positive")
+        if not self.eos and not self.text_stops:
+            raise ValueError(
+                "a StopCondition with neither eos nor text_stops can only end at max_new_tokens, "
+                "which lets a no-cot checkpoint ramble past a correct answer"
+            )
+
+
+#: Named presets, mirroring the pre-migration evaluators' ``stop`` field.
+STOP_PRESETS = {
+    # Set-answer tasks: the pair family (contradiction, redundancy, strmatch, mathmatch) and the
+    # cycle family (cycle, groups4, textgroups). The answer is single-line JSON, so BOTH terminators
+    # are needed and the earliest wins:
+    #
+    #   "]]"  ends a populated answer like [[1, 4], [3, 7]] exactly, and is kept because the parser
+    #         needs the closing bracket.
+    #   "\n"  ends an EMPTY answer -- "[]" contains no "]]", so a "]]"-only rule would never fire,
+    #         the model would ramble to the budget, and parse_pairs would return None. A correct
+    #         "there are no pairs" answer would be recorded as a parse failure.
+    #
+    # The trailing newline is harmless to the parsers, which tolerate surrounding whitespace.
+    "pairs": StopCondition(text_stops=("]]", "\n"), keep_stop=True, max_new_tokens=512),
+    # Short free-text answers. The answer is one line; the newline is not part of it.
+    "newline": StopCondition(text_stops=("\n",), keep_stop=False, max_new_tokens=64),
+    # Long structured answers (grouping, reorder) where EOS is genuinely emitted and any text stop
+    # would cut a valid multi-line answer short.
+    "eos": StopCondition(text_stops=(), max_new_tokens=2048),
+    # oolong: the answer follows a templated "answer:" line, so a newline before that is preamble.
+    "oolong": StopCondition(
+        text_stops=("\n",), keep_stop=False, require_before="answer:", max_new_tokens=256
+    ),
+}
+
+
+def _in_unclosed_think(text: str) -> bool:
+    """
+    Whether ``text`` currently sits inside an unclosed ``<think>`` block.
+
+    :param text: Text generated so far.
+
+    :returns: True when the last ``<think>`` has no matching ``</think>`` after it.
+    """
+    open_at = text.rfind(THINK_OPEN)
+    if open_at == -1:
+        return False
+    return THINK_CLOSE not in text[open_at:]
+
+
+def strip_think(text: str) -> str:
+    """
+    Drop a reasoning block, keeping what the model concluded.
+
+    :param text: Raw generation.
+
+    :returns: The text after ``</think>`` when present. An *unclosed* ``<think>`` returns the text
+        unchanged rather than empty -- the model was cut off mid-reasoning, and returning "" would
+        record that as a confident empty answer instead of a truncation.
+    """
+    if THINK_CLOSE in text:
+        return text.split(THINK_CLOSE, 1)[1]
+    return text
+
+
+def should_stop(text: str, cond: StopCondition) -> Optional[int]:
+    """
+    Whether generation should end, given the text produced so far.
+
+    :param text: Decoded text generated so far.
+    :param cond: The task's stop condition.
+
+    :returns: The index just past the matched stop substring (so the caller can truncate), or
+        ``None`` to keep generating.
+    """
+    if _in_unclosed_think(text):
+        # A stop token inside the reasoning block is not the end of the answer; the answer has not
+        # started yet.
+        return None
+    # When a marker gates stopping, the search must also START after it. Gating alone is not
+    # enough: the first newline in an oolong generation is in the preamble, so searching from
+    # position 0 would end the answer before it began.
+    search_from = 0
+    if cond.require_before is not None:
+        marker_at = text.lower().find(cond.require_before.lower())
+        if marker_at == -1:
+            return None
+        search_from = marker_at + len(cond.require_before)
+
+    best: Optional[int] = None
+    for stop in cond.text_stops:
+        at = text.find(stop, search_from)
+        while at != -1:
+            # A stop is only real once something has been said. Without this, the formatting
+            # newline that models emit before answering ends generation immediately and every
+            # example scores on an empty string.
+            if cond.require_content and not text[:at].strip():
+                at = text.find(stop, at + 1)
+                continue
+            end = at + len(stop) if cond.keep_stop else at
+            best = end if best is None else min(best, end)
+            break
+    return best
+
+
+def apply(text: str, cond: StopCondition) -> str:
+    """
+    Truncate and clean a finished generation.
+
+    Applies the same rules the decode loop applies incrementally, so a backend that cannot check
+    mid-stream (a batched or remote one) still produces the same string as the token-by-token path.
+    That equivalence is what makes cross-backend score parity meaningful.
+
+    :param text: The raw generation.
+    :param cond: The task's stop condition.
+
+    :returns: The text a parser should see.
+    """
+    if cond.strip_think:
+        text = strip_think(text)
+    at = should_stop(text, cond)
+    return text if at is None else text[:at]

--- a/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/format/__init__.py
+++ b/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/format/__init__.py
@@ -1,0 +1,35 @@
+"""
+The shared contract: what data generation and evaluation must agree on.
+
+Prompt templates, document serialization, the task registry, answer parsers, metrics, and the
+train/eval format fingerprint. Pure Python -- no torch, no transformers, no olmo_core -- so every
+other module can depend on it freely. One definition each, read by both halves of the pipeline.
+
+Two layers of protection against drift, guarding different things:
+
+* :mod:`ctc.format.fingerprint` guards **a checkpoint against the data it will be graded on**, at
+  runtime. It catches a config that no longer matches how the model was trained.
+* ``ctc/tests/format/test_golden_parity.py`` guards **this code against itself**, at test time,
+  using a byte-level snapshot of the pre-migration implementation. It catches an edit here that
+  would change what any of it emits.
+
+Neither subsumes the other: correct code can be pointed at the wrong checkpoint, and the right
+checkpoint can be fed by quietly-changed code.
+"""
+
+from . import documents, fingerprint, metrics, parsing, prompts, registry, rungs
+from .fingerprint import FormatFingerprint, FormatMismatchError
+from .registry import TaskSpec
+
+__all__ = [
+    "documents",
+    "fingerprint",
+    "metrics",
+    "parsing",
+    "prompts",
+    "registry",
+    "rungs",
+    "FormatFingerprint",
+    "FormatMismatchError",
+    "TaskSpec",
+]

--- a/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/format/assemble.py
+++ b/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/format/assemble.py
@@ -1,0 +1,236 @@
+"""
+Prompt assembly: a unified-format example becomes the exact text a model sees.
+
+**This module's output is the training data.** Every shard we have tokenized was produced by
+running examples through the pre-migration equivalent of this code, so a one-character difference
+here makes newly built data incompatible with every checkpoint trained before it — and the failure
+mode is a quiet accuracy drop, not an error. The 16 cases pinned in
+``ctc/tests/fixtures/golden_format.json`` were snapshotted from that implementation *before* this
+one was written, so they are an independent target rather than a description of this code.
+
+The assembled text has one of two shapes, decided by the task, not by a caller:
+
+``unified``
+    A generic alpaca header, with the task instruction itself occupying the positioned slot next to
+    the documents. Used by the 11 tasks that have **no per-example query** — for contradiction,
+    "find every contradicting pair" *is* the whole ask, so there is nothing else to position.
+
+``classic``
+    The task instruction in the alpaca header, and the per-example question positioned. Used by the
+    9 tasks that carry a real question: retrieval, qa, oolong, grouping, grouping_labeled, outlier,
+    rerank, summarization, cot_retrieval.
+
+The pre-migration code also had a ``unified_prompt`` argument that could force the unified shape
+onto any task. It was never enabled in any config, so the hardcoded task set was the entire
+behaviour; that set is now declared per task as :attr:`~ctc.format.registry.TaskSpec.unified`.
+
+What lives elsewhere, deliberately:
+
+* The **per-task query text** — which instruction, and in what order relative to the example's own
+  question — is a property of one task and lives in that task's ``spec.py`` as ``build_query``.
+  The old chain of 17 ``if task ==`` branches hid real per-task quirks: ``cycle`` and ``ruler`` put
+  the example's question *before* the instruction, everything else puts it after.
+* The **per-task target** likewise lives in ``spec.py`` as ``build_target``.
+* **Document serialization** is :mod:`ctc.format.documents`.
+
+Ported from ``corpus_reasoning/lib/data_format.py`` (``build_prompt`` / ``build_prompt_parts``) and
+``corpus_reasoning/lib/io.py`` (the alpaca template), minus the CoT paths.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence, Tuple
+
+from .documents import format_documents
+
+__all__ = [
+    "ALPACA_TEMPLATE",
+    "QUERY_POSITIONS",
+    "format_alpaca_prompt",
+    "insert_dummy_tokens",
+    "build_questions_block",
+    "assemble",
+    "assemble_parts",
+]
+
+#: The wrapper every trained model expects. Byte-identical to the pre-migration template — the
+#: models were trained on these exact tokens, down to the newlines.
+ALPACA_TEMPLATE = (
+    "Below is an instruction that describes a task, paired with an input "
+    "that provides further context. Write a response that appropriately "
+    "completes the request.\n\n"
+    "### Instruction:\n{instruction}\n\n"
+    "### Input:\n{input}\n\n"
+    "### Response:\n"
+)
+
+#: Where the positioned text sits relative to the documents. All three are in real use; ``"both"``
+#: repeats the whole block on the far side of the documents, which costs context budget at every
+#: rung and matters most on the long ladders.
+QUERY_POSITIONS = ("before", "after", "both")
+
+Example = Mapping[str, Any]
+
+
+def format_alpaca_prompt(instruction: str, input_text: str) -> str:
+    """
+    Wrap an instruction and input in the alpaca template.
+
+    :param instruction: The ``### Instruction:`` body.
+    :param input_text: The ``### Input:`` body.
+
+    :returns: The full prompt, ending with ``### Response:\\n``.
+    """
+    return ALPACA_TEMPLATE.format(instruction=instruction, input=input_text)
+
+
+def insert_dummy_tokens(
+    input_text: str,
+    before_dummy: int = 0,
+    after_dummy: int = 0,
+    dummy_token: str = "* ",
+) -> str:
+    """
+    Pad around the document block, for the query-distance ablation.
+
+    Pushes documents further from the query in the sequence to test whether the model depends on
+    positional proximity rather than content.
+
+    :param input_text: The assembled input (documents plus positioned text).
+    :param before_dummy: Repetitions to insert before the document block.
+    :param after_dummy: Repetitions to insert after it.
+    :param dummy_token: The string repeated.
+
+    :returns: The padded input, unchanged when both counts are zero.
+    """
+    if before_dummy == 0 and after_dummy == 0:
+        return input_text
+    parts = input_text.split("\n\n")
+    if before_dummy > 0:
+        parts.insert(0, (dummy_token * before_dummy).rstrip())
+    if after_dummy > 0:
+        parts.append((dummy_token * after_dummy).rstrip())
+    return "\n\n".join(parts)
+
+
+def build_questions_block(queries: Sequence[str]) -> str:
+    """
+    Render an example's own question(s).
+
+    :param queries: One or more questions. Multi-query tasks number them.
+
+    :returns: ``"Question: ..."`` for one, or numbered ``"Question N: ..."`` lines for several.
+    """
+    if len(queries) == 1:
+        return f"Question: {queries[0]}"
+    return "\n".join(f"Question {i + 1}: {q}" for i, q in enumerate(queries))
+
+
+def _position(context: str, positioned: str, query_position: str) -> str:
+    """
+    Place the positioned text relative to the document block.
+
+    :param context: The serialized documents.
+    :param positioned: The task query or question block.
+    :param query_position: One of :data:`QUERY_POSITIONS`.
+
+    :returns: The assembled input text.
+
+    :raises ValueError: On an unknown position.
+    """
+    if query_position == "before":
+        return f"{positioned}\n\n{context}"
+    if query_position == "both":
+        return f"{positioned}\n\n{context}\n\n{positioned}"
+    if query_position == "after":
+        return f"{context}\n\n{positioned}"
+    raise ValueError(f"query_position must be one of {QUERY_POSITIONS}, got {query_position!r}")
+
+
+def assemble_parts(
+    example: Example,
+    *,
+    task: str,
+    unified: bool,
+    header: str,
+    positioned: str,
+    query_position: str = "after",
+    use_titles: bool = True,
+    before_dummy: int = 0,
+    after_dummy: int = 0,
+) -> Tuple[str, str]:
+    """
+    Assemble the header and input text, without wrapping.
+
+    Kept separate from :func:`assemble` because some consumers need the two halves apart — the
+    axolotl conversion path wants an alpaca ``instruction``/``input`` pair rather than a single
+    string.
+
+    :param example: A unified-format example.
+    :param task: Task name, used to pick the document serializer.
+    :param unified: Whether this task uses the unified shape. A property of the task; pass
+        ``spec.unified``.
+    :param header: The ``### Instruction:`` body. For a unified task this is the generic string;
+        for a classic task it is the task instruction.
+    :param positioned: The text placed relative to the documents. For a unified task this is the
+        task query; for a classic task the question block.
+    :param query_position: One of :data:`QUERY_POSITIONS`.
+    :param use_titles: Include document titles where the serializer honours them.
+    :param before_dummy: Dummy repetitions before the documents.
+    :param after_dummy: Dummy repetitions after them.
+
+    :returns: ``(header, input_text)``.
+    """
+    del unified  # recorded by the caller's fingerprint; the shape is already baked into `header`
+    context = format_documents(example["documents"], task, use_titles=use_titles)
+    input_text = _position(context, positioned, query_position)
+    if before_dummy > 0 or after_dummy > 0:
+        input_text = insert_dummy_tokens(input_text, before_dummy, after_dummy)
+    return header, input_text
+
+
+def assemble(
+    example: Example,
+    *,
+    task: str,
+    unified: bool,
+    header: str,
+    positioned: str,
+    query_position: str = "after",
+    use_titles: bool = True,
+    before_dummy: int = 0,
+    after_dummy: int = 0,
+    use_alpaca: bool = True,
+) -> str:
+    """
+    Assemble the full prompt text for one example.
+
+    :param example: A unified-format example.
+    :param task: Task name.
+    :param unified: Whether this task uses the unified shape.
+    :param header: The instruction header.
+    :param positioned: The text placed relative to the documents.
+    :param query_position: One of :data:`QUERY_POSITIONS`.
+    :param use_titles: Include document titles where the serializer honours them.
+    :param before_dummy: Dummy repetitions before the documents.
+    :param after_dummy: Dummy repetitions after them.
+    :param use_alpaca: Wrap in the alpaca template. ``True`` for every trained model; ``False``
+        emits ``"{header}\\n\\n{input}\\n"``, which is the non-alpaca SFT path. Note the trailing
+        newline — it is part of the format.
+
+    :returns: The prompt, ready to tokenize.
+    """
+    header, input_text = assemble_parts(
+        example,
+        task=task,
+        unified=unified,
+        header=header,
+        positioned=positioned,
+        query_position=query_position,
+        use_titles=use_titles,
+        before_dummy=before_dummy,
+        after_dummy=after_dummy,
+    )
+    if use_alpaca:
+        return format_alpaca_prompt(header, input_text)
+    return f"{header}\n\n{input_text}\n"

--- a/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/format/documents.py
+++ b/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/format/documents.py
@@ -1,0 +1,235 @@
+"""
+Document serialization: how a list of documents becomes the context block of a prompt.
+
+Every task renders its corpus differently -- claims are numbered ``Claim 1:``, expressions
+``Expression 1:``, oolong and ruler are emitted verbatim with no wrapper at all -- but they all
+share one non-negotiable rule: **items are joined by a blank line.**
+
+That is not cosmetic. The chunked/landmark attention masks split the context on ``\\n\\n`` to
+decide chunk boundaries, so an item that contains a bare ``\\n`` where the format expects ``\\n\\n``
+lands in the wrong chunk, and one that contains an unexpected ``\\n\\n`` gets split across two.
+Both failures are invisible in the text and show up only as a degraded score, which is how they
+went undiagnosed the first time. The ``reorder`` serializer's ``\\n\\n`` -> ``\\n`` collapse below
+is a direct fix for the second case.
+
+Ported from ``corpus_reasoning/lib/data_format.py`` (``_format_doc`` / ``_format_documents``). The
+task dispatch was an ``if task == ...`` chain over disjoint names; it is a table here, which is the
+same mapping written down once. Output is byte-identical -- see ``ctc/tests/format/`` and the
+golden fixture it checks against.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Tuple
+
+from .prompts import (
+    CLAIM_TEMPLATE,
+    EXPRESSION_TEMPLATE,
+    NGRAM_TEMPLATE,
+    PASSAGE_TEMPLATE,
+    PASSAGE_TEMPLATE_GROUPING,
+    PASSAGE_TEMPLATE_ID,
+    PASSAGE_TEMPLATE_NO_TITLE,
+    PASSAGE_TEMPLATE_NO_TITLE_ID,
+    PASSAGE_TEMPLATE_REORDER,
+    STRING_TEMPLATE,
+    TEXTGROUPS_TEMPLATE,
+)
+
+__all__ = [
+    "format_doc",
+    "format_documents",
+    "shows_doc_ids",
+    "visible_doc_id_range",
+    "ITEM_SEPARATOR",
+    "TASKS_WITH_DOC_IDS",
+]
+
+#: Items are always joined by a blank line -- the chunk-boundary delimiter. See the module note.
+ITEM_SEPARATOR = "\n\n"
+
+#: Tasks whose default-serialized documents carry a visible ``[N]`` identifier, because the answer
+#: is a set of those identifiers. Every other task using the default serializer renders documents
+#: unnumbered, so a model cannot answer by position.
+TASKS_WITH_DOC_IDS = ("retrieval", "cot_retrieval", "outlier", "rerank")
+
+Document = Mapping[str, Any]
+
+
+def format_doc(doc: Document, use_titles: bool = True, doc_id: Optional[int] = None) -> str:
+    """
+    Render a single document with the passage template.
+
+    :param doc: A document mapping with a ``text`` key and an optional ``title``.
+    :param use_titles: Include the title when the document has one.
+    :param doc_id: 1-based identifier to prefix. ``None`` renders the document unnumbered.
+
+    :returns: The formatted document line.
+    """
+    title = doc.get("title")
+    text = doc["text"]
+    if doc_id is not None:
+        if use_titles and title:
+            return PASSAGE_TEMPLATE_ID.format(id=doc_id, title=title, text=text)
+        return PASSAGE_TEMPLATE_NO_TITLE_ID.format(id=doc_id, text=text)
+    if use_titles and title:
+        return PASSAGE_TEMPLATE.format(title=title, text=text)
+    return PASSAGE_TEMPLATE_NO_TITLE.format(text=text)
+
+
+def _numbered(template: str) -> Callable[[Sequence[Document]], List[str]]:
+    """Build a serializer that renders each item through a ``{id}``/``{text}`` template."""
+
+    def render(documents: Sequence[Document]) -> List[str]:
+        return [template.format(id=i + 1, text=doc["text"]) for i, doc in enumerate(documents)]
+
+    return render
+
+
+def _qdmatch(documents: Sequence[Document]) -> List[str]:
+    """Interleaved queries and documents under one shared 1-based index.
+
+    The order is decided by the generator (it encodes the separate-vs-shuffled layout), so this
+    only tags each item; it must not re-sort.
+    """
+    out = []
+    for i, item in enumerate(documents):
+        tag = "Query" if item.get("type") == "query" else "Document"
+        out.append(f"[{i + 1}] {tag}: {item['text']}")
+    return out
+
+
+def _xabsence(documents: Sequence[Document]) -> List[str]:
+    """Two corpora A and B, pre-ordered as an A block then a B block, one shared 1-based index."""
+    return [
+        f"[{i + 1}] {item.get('corpus', 'A')}: {item['text']}" for i, item in enumerate(documents)
+    ]
+
+
+def _absence(documents: Sequence[Document]) -> List[str]:
+    """Neutral numbered items -- claims, poem lines, numbers or diff lines by source domain."""
+    return [f"[{i + 1}] {doc['text']}" for i, doc in enumerate(documents)]
+
+
+def _reorder(documents: Sequence[Document]) -> List[str]:
+    """Passages with shuffled display IDs.
+
+    Gutenberg passages contain internal ``\\n\\n`` paragraph breaks. They are collapsed to ``\\n``
+    so each passage stays a single chunk; without this only a passage's first paragraph gets
+    wrapped and the remainder leaks into the unmasked region.
+    """
+    return [
+        PASSAGE_TEMPLATE_REORDER.format(id=i + 1, text=doc["text"].replace("\n\n", "\n"))
+        for i, doc in enumerate(documents)
+    ]
+
+
+def _grouping(documents: Sequence[Document]) -> List[str]:
+    return [
+        PASSAGE_TEMPLATE_GROUPING.format(id=i + 1, title=doc.get("title", ""), text=doc["text"])
+        for i, doc in enumerate(documents)
+    ]
+
+
+def _verbatim(documents: Sequence[Document]) -> List[str]:
+    """No per-document wrapper.
+
+    ``oolong`` arrives with the benchmark's own formatting already applied; ``summarization``
+    concatenates its sources; ``ruler`` needles must read as natural sentences, since a ``[N]``
+    prefix would let the model find them by shape instead of by content.
+    """
+    return [doc["text"] for doc in documents]
+
+
+#: task name -> item renderer. Tasks absent from this table use the default renderer, which numbers
+#: documents only for :data:`TASKS_WITH_DOC_IDS` and is the only serializer honouring ``use_titles``.
+_SERIALIZERS: Dict[str, Callable[[Sequence[Document]], List[str]]] = {
+    "qdmatch": _qdmatch,
+    "xabsence": _xabsence,
+    "contradiction": _numbered(CLAIM_TEMPLATE),
+    "redundancy": _numbered(CLAIM_TEMPLATE),
+    "cycle": _numbered(CLAIM_TEMPLATE),
+    "absence": _absence,
+    "matching_ngram": _numbered(NGRAM_TEMPLATE),
+    "mathmatch": _numbered(EXPRESSION_TEMPLATE),
+    "groups4": _numbered(EXPRESSION_TEMPLATE),
+    "textgroups": _numbered(TEXTGROUPS_TEMPLATE),
+    "strmatch": _numbered(STRING_TEMPLATE),
+    "reorder": _reorder,
+    "grouping": _grouping,
+    "grouping_labeled": _grouping,
+    "oolong": _verbatim,
+    "summarization": _verbatim,
+    "ruler": _verbatim,
+}
+
+
+#: Serializers that emit no identifier at all. Everything else numbers items from 1.
+_UNNUMBERED = ("oolong", "summarization", "ruler")
+
+
+def shows_doc_ids(task: str) -> bool:
+    """
+    :param task: Task name.
+
+    :returns: Whether this task's rendered context shows a per-item identifier. Only then is
+        :data:`~ctc.format.fingerprint.FormatFingerprint.doc_id_range` meaningful -- a task whose
+        items are unnumbered cannot suffer the digit-range failure, and recording a range for it
+        would invent a constraint.
+    """
+    if task in _UNNUMBERED:
+        return False
+    return task in _SERIALIZERS or task in TASKS_WITH_DOC_IDS
+
+
+def visible_doc_id_range(
+    examples: Sequence[Mapping[str, Any]], task: str
+) -> Optional[Tuple[int, int]]:
+    """
+    Measure the span of document identifiers a dataset actually shows the model.
+
+    This is the field behind the digit-range bug: training never rendered an id above 697, eval
+    rendered up to 1423, and the model's failure on ids it had never seen read as long-context
+    collapse. Measuring it from the data is the point -- the intended corpus size is a claim, and
+    the claim is what was wrong.
+
+    :param examples: Unified-format examples.
+    :param task: Task name.
+
+    :returns: ``(min, max)`` identifier, or ``None`` when this task renders items unnumbered or
+        the examples carry no documents.
+    """
+    if not shows_doc_ids(task):
+        return None
+    counts = [len(ex.get("documents") or ()) for ex in examples]
+    counts = [c for c in counts if c > 0]
+    if not counts:
+        return None
+    # Every serializer numbers from 1 through len(documents), so the span over a dataset is
+    # 1..max. Derived rather than assumed: if a serializer ever numbers differently, this is the
+    # one place to fix.
+    return (1, max(counts))
+
+
+def format_documents(documents: Sequence[Document], task: str, use_titles: bool = True) -> str:
+    """
+    Render a document list into the context block for ``task``.
+
+    :param documents: Document mappings, already in presentation order. This function never
+        reorders them -- position is meaningful for several tasks.
+    :param task: Task name. Unknown names fall back to the default passage serializer rather than
+        raising, matching the behaviour data generation has always had.
+    :param use_titles: Include titles. Only the default serializer consults this; the numbered
+        per-task templates render text alone.
+
+    :returns: The formatted context block, items joined by a blank line.
+    """
+    serializer = _SERIALIZERS.get(task)
+    if serializer is not None:
+        return ITEM_SEPARATOR.join(serializer(documents))
+
+    use_ids = task in TASKS_WITH_DOC_IDS
+    return ITEM_SEPARATOR.join(
+        format_doc(doc, use_titles=use_titles, doc_id=(i + 1) if use_ids else None)
+        for i, doc in enumerate(documents)
+    )

--- a/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/format/fingerprint.py
+++ b/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/format/fingerprint.py
@@ -1,0 +1,741 @@
+"""
+Format fingerprints: a hard train/eval compatibility check.
+
+A checkpoint is only meaningful against the exact prompt format it was trained on. Nothing enforces
+that today, so when the two drift the model still runs, still emits plausible text, and still gets a
+number -- one that reads as a modelling result. Several of the worst bugs in this project were
+exactly this, and each cost days:
+
+* **Chunk-layout drift.** Training wrapped documents one way, eval another; the mask therefore
+  isolated different spans than the model was trained under.
+* **Doc-id digit range.** Training never showed an id above 697; eval showed ids up to 1423. The
+  model had genuinely never seen a four-digit id, and the drop read as long-context collapse.
+* **Gold index base.** ``contradiction`` counts gold documents from 1, ``outlier``/``rerank``/``nq``
+  from 0. Grade one with the other's convention and every answer is off by one.
+* **Marker token ids.** Shards built against one marker id set, a checkpoint repaired against
+  another.
+
+The fix is to write a fingerprint next to the data at tokenize time and next to the checkpoint at
+train time, then **refuse to evaluate** on a mismatch. Refusing is the point: a warning in a log
+scrolls past, and these failures are invisible in the output.
+
+Two design choices worth knowing:
+
+1. **The record is structured, not a single hash.** A bare hash mismatch says "something differs"
+   and leaves you to bisect. :meth:`FormatFingerprint.compare` names the field.
+2. **Fields carry their own comparison rule.** Most must match exactly, but the digit-range bug is
+   not an equality failure -- it is a *containment* failure, where eval exceeds the range training
+   covered. See :data:`_RULES`.
+3. **Some fields are provenance and are never compared.** ``data_paths`` records which corpora fed
+   a task, so a checkpoint can answer "what was I trained on"; comparing it would fail two runs
+   over the same shards staged at different paths. See :data:`_PROVENANCE_FIELDS`.
+
+Usage::
+
+    # tokenize time, alongside the shards -- one task per shard directory
+    spec.fingerprint(query_position=..., tokenizer=...).write(shard_dir)
+
+    # train time, alongside every checkpoint -- a mix trains several tasks, so this is a SET.
+    # ctc.train.FormatFingerprintCallback does this automatically, collecting from the shard dirs.
+    FingerprintSet(formats).write(ckpt_dir)
+
+    # eval time -- raises before a single token is generated
+    check_or_explain_missing(spec.fingerprint(query_position=...), ckpt_dir)
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass, field, replace
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
+
+__all__ = [
+    "FormatFingerprint",
+    "FingerprintSet",
+    "Mismatch",
+    "FormatMismatchError",
+    "TaskNotTrainedError",
+    "FINGERPRINT_FILENAME",
+    "hash_prompt",
+    "collect_fingerprints",
+    "conflicting_formats",
+    "chunk_layout_for",
+]
+
+
+def chunk_layout_for(emit: str, chunk_by: str, doc_markers: bool = True) -> str:
+    """
+    The canonical ``chunk_layout`` name for a set of converter options.
+
+    One function so the converter that writes a shard's fingerprint and the evaluator that checks it
+    cannot drift into two spellings of the same layout -- which would read as a format mismatch on
+    data that matches perfectly.
+
+    **This names the token stream, not the attention mask.** The box markers are present in the
+    ``full`` arm too: "full" is a mask, not a token layout, and the full-vs-chunked comparison is
+    run over identically tokenized shards precisely so the mask is the only difference. So a
+    checkpoint trained on ``wrap_documents`` shards may legitimately be evaluated with ``--attn
+    full``, and the fingerprint must not object. What it does object to is evaluating it against a
+    prompt rendered *without* the markers, which is a different token stream and costs ~0.01 f1.
+
+    :param emit: ``"dense"`` (wrapped tokens only) or ``"landmark"`` (packed into landmark windows).
+    :param chunk_by: ``"document"`` (each ``documents[i]``) or ``"line"`` (each matching item line;
+        OOLONG only).
+    :param doc_markers: Whether the ``<|box_start|>``/``<|box_end|>`` boundary tokens are emitted.
+
+    :returns: One of ``none``, ``wrap_documents``, ``wrap_lines``, ``landmark_documents``,
+        ``landmark_lines``.
+
+    :raises ValueError: On an unknown ``emit`` or ``chunk_by``.
+    """
+    if emit not in ("dense", "landmark"):
+        raise ValueError(f"emit must be 'dense' or 'landmark', got {emit!r}")
+    if chunk_by not in ("document", "line"):
+        raise ValueError(f"chunk_by must be 'document' or 'line', got {chunk_by!r}")
+    if not doc_markers:
+        # No boundary tokens at all: the marker-free baseline. Whether the build *would* have
+        # chunked by document or by line is not observable in the stream, so it is not recorded --
+        # recording it would make two byte-identical shards compare as different formats.
+        return "none"
+    unit = "documents" if chunk_by == "document" else "lines"
+    return f"wrap_{unit}" if emit == "dense" else f"landmark_{unit}"
+
+
+#: Written into both the shard directory and the checkpoint directory.
+FINGERPRINT_FILENAME = "ctc_format_fingerprint.json"
+
+#: Bump when a change makes old fingerprints uncomparable rather than merely different. Comparing
+#: across schema versions is refused outright -- silently treating an absent field as "matches" is
+#: how a guard stops guarding.
+SCHEMA_VERSION = 1
+
+
+def hash_prompt(*parts: Optional[str]) -> str:
+    """
+    Hash the exact strings that will be shown to the model.
+
+    :param parts: Instruction and template strings, in a stable order. ``None`` entries are
+        recorded distinctly from ``""`` -- "no template" and "empty template" are different formats.
+
+    :returns: A short hex digest.
+    """
+    h = hashlib.sha256()
+    for p in parts:
+        h.update(b"\x00" if p is None else b"\x01")
+        if p is not None:
+            h.update(p.encode("utf-8"))
+    return h.hexdigest()[:16]
+
+
+@dataclass(frozen=True)
+class Mismatch:
+    """One field that failed its compatibility rule."""
+
+    field: str
+    train: Any
+    eval: Any
+    rule: str
+    why: str
+
+    def __str__(self) -> str:
+        return f"  {self.field}: train={self.train!r} eval={self.eval!r}\n      {self.why}"
+
+
+class FormatMismatchError(RuntimeError):
+    """Raised when an eval format is incompatible with the format a checkpoint was trained on."""
+
+    def __init__(self, mismatches: Sequence[Mismatch]):
+        self.mismatches = list(mismatches)
+        body = "\n".join(str(m) for m in self.mismatches)
+        super().__init__(
+            f"eval format is incompatible with the checkpoint's training format "
+            f"({len(self.mismatches)} field(s)):\n{body}\n\n"
+            "This is a hard error on purpose. Every one of these failures produces plausible "
+            "output and a plausible-looking score, so continuing would generate a number that "
+            "silently means nothing. Fix the eval config, or pass --ignore-format-fingerprint if "
+            "you have established the difference is benign."
+        )
+
+
+def _exact(name: str, train: Any, eval_: Any) -> Optional[str]:
+    if train == eval_:
+        return None
+    return f"must be identical; the checkpoint was trained under a different {name}"
+
+
+def _within(name: str, train: Any, eval_: Any) -> Optional[str]:
+    """Eval's numeric range must sit inside the range training covered."""
+    if train is None or eval_ is None:
+        return None
+    (tlo, thi), (elo, ehi) = tuple(train), tuple(eval_)
+    if elo >= tlo and ehi <= thi:
+        return None
+    return (
+        f"eval {name} falls outside the range seen in training; the model has never been "
+        f"shown values in this range, and the resulting drop reads as a capability limit"
+    )
+
+
+def _optional_exact(name: str, train: Any, eval_: Any) -> Optional[str]:
+    """Skip when either side did not record the field, otherwise require equality."""
+    if train is None or eval_ is None:
+        return None
+    return _exact(name, train, eval_)
+
+
+#: field -> (rule name, comparison). A field absent here is metadata and is not compared.
+_RULES = {
+    "task": ("exact", _exact),
+    "prompt_hash": ("exact", _exact),
+    "serializer": ("exact", _exact),
+    "item_separator": ("exact", _exact),
+    "gold_index_base": ("exact", _exact),
+    "prompt_shape": ("exact", _exact),
+    "query_position": ("exact", _exact),
+    "chunk_layout": ("exact", _exact),
+    "marker_token_ids": ("exact", _optional_exact),
+    "tokenizer": ("exact", _optional_exact),
+    "doc_id_range": ("within", _within),
+}
+
+#: Fields recorded for provenance and deliberately **not** compared. Two runs over byte-identical
+#: data staged at different paths -- weka, node-local ``/data``, an S3 mirror -- are compatible, and
+#: comparing paths would fail them all. It would also make the guard fire constantly for a reason
+#: nobody can act on, which is how a guard gets switched off. They are also what
+#: :meth:`FormatFingerprint.merged_with` accumulates rather than deduplicates.
+_PROVENANCE_FIELDS = ("data_paths", "notes")
+
+
+@dataclass(frozen=True)
+class FormatFingerprint:
+    """
+    Everything about a data format that a checkpoint is bound to.
+
+    :param task: Task name.
+    :param prompt_hash: Digest of the exact instruction and templates, from :func:`hash_prompt`.
+    :param serializer: Which document serializer rendered the context block.
+    :param item_separator: The delimiter between items -- the chunk boundary the masks split on.
+    :param gold_index_base: ``0`` or ``1``; differs per task and is an easy off-by-one.
+    :param prompt_shape: ``"unified"`` (generic alpaca header, task instruction positioned with the
+        documents) or ``"classic"`` (task instruction in the header, per-example query positioned).
+        Which one a task uses is a property of the task, not a knob -- see :class:`TaskSpec`.
+    :param query_position: ``"before"``, ``"after"`` or ``"both"``. Recorded because it is a real
+        knob that really varies (``both`` and ``before`` and ``after`` are all in use across runs)
+        and it changes the token stream substantially -- ``both`` repeats the entire query block on
+        the far side of the documents. Two checkpoints differing only here would otherwise share a
+        fingerprint, and the guard would pass on a format that genuinely differs.
+    :param chunk_layout: Chunk-wrapping scheme; see :func:`chunk_layout_for` for the vocabulary
+        and for why it describes the TOKEN STREAM rather than the attention mask.
+    :param doc_id_range: ``(min, max)`` document id actually present. Compared by containment.
+    :param marker_token_ids: Reserved marker ids, when the format uses them.
+    :param tokenizer: Tokenizer identifier.
+    :param data_paths: Which data this format was built from -- source corpora, shard directories,
+        or both. Several entries when a task is fed by a mix, which is why
+        :func:`collect_fingerprints` unions them rather than deduplicating whole records. Recorded,
+        never compared: the same shards on weka and on node-local ``/data`` are the same shards.
+    :param notes: Free-form provenance. Recorded, never compared.
+    """
+
+    task: str
+    prompt_hash: str
+    serializer: str
+    item_separator: str
+    gold_index_base: int
+    prompt_shape: str = "classic"
+    query_position: str = "after"
+    chunk_layout: str = "none"
+    doc_id_range: Optional[Tuple[int, int]] = None
+    marker_token_ids: Optional[Tuple[int, ...]] = None
+    tokenizer: Optional[str] = None
+    data_paths: Tuple[str, ...] = ()
+    notes: Dict[str, Any] = field(default_factory=dict)
+    schema_version: int = SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        if self.gold_index_base not in (0, 1):
+            raise ValueError(
+                f"gold_index_base must be 0 or 1, got {self.gold_index_base!r}. Tasks disagree "
+                "(contradiction is 1-based, outlier/rerank/nq are 0-based), which is exactly why "
+                "it is recorded."
+            )
+        if self.doc_id_range is not None:
+            lo, hi = self.doc_id_range
+            if lo > hi:
+                raise ValueError(f"doc_id_range {self.doc_id_range!r} is inverted")
+        if self.prompt_shape not in ("unified", "classic"):
+            raise ValueError(
+                f"prompt_shape must be 'unified' or 'classic', got {self.prompt_shape!r}"
+            )
+        if self.query_position not in ("before", "after", "both"):
+            raise ValueError(
+                f"query_position must be 'before', 'after' or 'both', got {self.query_position!r}"
+            )
+
+    # ── comparison ──────────────────────────────────────────────────────────────────────────────
+
+    def compare(self, trained: "FormatFingerprint") -> List[Mismatch]:
+        """
+        Compare this (eval-side) fingerprint against the one recorded at training time.
+
+        :param trained: The fingerprint written next to the checkpoint or its shards.
+
+        :returns: Every field that failed its rule; empty means compatible.
+
+        :raises ValueError: If the two use different schema versions, which cannot be compared
+            meaningfully.
+        """
+        if trained.schema_version != self.schema_version:
+            raise ValueError(
+                f"fingerprint schema {trained.schema_version} vs {self.schema_version}; "
+                "regenerate the training-side fingerprint rather than comparing across versions"
+            )
+        out = []
+        for name, (rule, fn) in _RULES.items():
+            why = fn(name, getattr(trained, name), getattr(self, name))
+            if why is not None:
+                out.append(
+                    Mismatch(
+                        field=name,
+                        train=getattr(trained, name),
+                        eval=getattr(self, name),
+                        rule=rule,
+                        why=why,
+                    )
+                )
+        return out
+
+    def same_format_as(self, other: "FormatFingerprint") -> bool:
+        """
+        :param other: Another fingerprint.
+
+        :returns: Whether the two describe the same format, ignoring provenance. Distinct from
+            ``==``: two shard directories built the same way from different corpora produce equal
+            formats and different :attr:`data_paths`, and collapsing them by ``==`` would lose one
+            of the paths.
+        """
+        return not self.compare(other)
+
+    def merged_with(self, other: "FormatFingerprint") -> "FormatFingerprint":
+        """
+        Fold another record of the same format into this one, accumulating provenance.
+
+        :param other: A fingerprint describing the same format.
+
+        :returns: This record with ``other``'s data paths appended (order preserved, duplicates
+            dropped) and its notes merged in.
+
+        :raises ValueError: If the two are not the same format. Merging different formats would
+            manufacture a record matching neither.
+        """
+        if not self.same_format_as(other):
+            raise ValueError(
+                "refusing to merge two different formats into one record; keep them as separate "
+                f"entries: {[m.field for m in self.compare(other)]}"
+            )
+        paths = list(self.data_paths) + [p for p in other.data_paths if p not in self.data_paths]
+        return replace(self, data_paths=tuple(paths), notes={**other.notes, **self.notes})
+
+    def with_data_paths(self, *paths: str) -> "FormatFingerprint":
+        """
+        :param paths: Paths to record, appended in order, duplicates dropped.
+
+        :returns: A copy carrying them.
+        """
+        new = list(self.data_paths) + [p for p in paths if p not in self.data_paths]
+        return replace(self, data_paths=tuple(new))
+
+    def require_compatible_with(self, trained: "FormatFingerprint") -> None:
+        """
+        Raise unless this eval format is compatible with ``trained``.
+
+        :param trained: The training-time fingerprint.
+
+        :raises FormatMismatchError: On any incompatible field.
+        """
+        mismatches = self.compare(trained)
+        if mismatches:
+            raise FormatMismatchError(mismatches)
+
+    # ── i/o ─────────────────────────────────────────────────────────────────────────────────────
+
+    def to_dict(self) -> Dict[str, Any]:
+        """:returns: A JSON-ready mapping."""
+        d = asdict(self)
+        for k in ("doc_id_range", "marker_token_ids", "data_paths"):
+            if d[k] is not None:
+                d[k] = list(d[k])
+        return d
+
+    @classmethod
+    def from_dict(cls, d: Mapping[str, Any]) -> "FormatFingerprint":
+        """
+        :param d: A mapping produced by :meth:`to_dict`.
+
+        :returns: The fingerprint.
+
+        :raises KeyError: If a required field is absent -- a truncated record must not read as a
+            match.
+        """
+        d = dict(d)
+        if d.get("doc_id_range") is not None:
+            d["doc_id_range"] = tuple(d["doc_id_range"])
+        if d.get("marker_token_ids") is not None:
+            d["marker_token_ids"] = tuple(d["marker_token_ids"])
+        # Tuple, not list: the record is frozen and hashable, and a list here would break equality
+        # against a freshly derived fingerprint.
+        d["data_paths"] = tuple(d.get("data_paths") or ())
+        known = {f for f in cls.__dataclass_fields__}
+        extra = set(d) - known
+        if extra:
+            # Forward compatibility: an older reader must not silently drop a field a newer writer
+            # considered load-bearing.
+            raise ValueError(
+                f"fingerprint has unknown field(s) {sorted(extra)}; this reader is too old to "
+                "validate it. Upgrade ctc rather than ignoring them."
+            )
+        return cls(**d)
+
+    def write(self, directory: Path) -> Path:
+        """
+        Write this single fingerprint into ``directory``, replacing anything already there.
+
+        A shard directory holds one task, so this is its natural writer. A *checkpoint* directory
+        usually holds several -- training mixes tasks -- so use :meth:`FingerprintSet.write` there,
+        or this will drop the others.
+
+        :param directory: Shard directory (at tokenize time).
+
+        :returns: The path written.
+        """
+        return FingerprintSet([self]).write(directory)
+
+    @classmethod
+    def read(cls, directory: Path) -> Optional["FormatFingerprint"]:
+        """
+        Read a single fingerprint from ``directory``.
+
+        :param directory: Shard directory.
+
+        :returns: The fingerprint, or ``None`` if the directory predates fingerprinting.
+
+        :raises ValueError: If the directory records more than one format. Picking one arbitrarily
+            would answer a question the caller did not ask -- use :meth:`FingerprintSet.read` and
+            :meth:`FingerprintSet.for_task`.
+        """
+        found = FingerprintSet.read(directory)
+        if found is None:
+            return None
+        if len(found.formats) != 1:
+            raise ValueError(
+                f"{Path(directory) / FINGERPRINT_FILENAME} records {len(found.formats)} formats "
+                f"({', '.join(found.tasks)}); read it as a FingerprintSet and select a task"
+            )
+        return found.formats[0]
+
+    def evolve(self, **changes: Any) -> "FormatFingerprint":
+        """
+        :param changes: Field overrides.
+
+        :returns: A copy with those fields replaced.
+        """
+        return replace(self, **changes)
+
+
+@dataclass(frozen=True)
+class FingerprintSet:
+    """
+    Every format a checkpoint was trained under.
+
+    A checkpoint is rarely bound to one format. The canonical SFT mix trains five tasks at once,
+    so its record has five entries, and eval asks a narrower question than "does this checkpoint
+    match" -- it asks "was *this task* trained, and in the format I am about to use".
+
+    Two entries may share a task name. That is not a mistake: a curriculum can legitimately train
+    one task under two layouts, and such a checkpoint is compatible with both. :meth:`for_task`
+    therefore returns a list, and :meth:`require_compatible` passes if *any* of them matches.
+
+    :param formats: The recorded formats, in a stable order.
+    """
+
+    formats: Tuple[FormatFingerprint, ...]
+
+    def __init__(self, formats: Sequence[FormatFingerprint]):
+        object.__setattr__(self, "formats", tuple(formats))
+        if not self.formats:
+            raise ValueError(
+                "a fingerprint set must record at least one format; writing an empty one would "
+                "make an unfingerprinted checkpoint look fingerprinted"
+            )
+
+    @property
+    def tasks(self) -> List[str]:
+        """:returns: The task names recorded, deduplicated, in first-seen order."""
+        seen: Dict[str, None] = {}
+        for fp in self.formats:
+            seen.setdefault(fp.task, None)
+        return list(seen)
+
+    def for_task(self, task: str) -> List[FormatFingerprint]:
+        """
+        :param task: Task name.
+
+        :returns: Every recorded format for that task; empty if it was not trained.
+        """
+        return [fp for fp in self.formats if fp.task == task]
+
+    def merge(self, other: "FingerprintSet") -> "FingerprintSet":
+        """
+        Combine two sets, folding same-format records together.
+
+        Deduplication is on *format*, not on the whole record, and matching records have their
+        provenance accumulated. That distinction is the mixed-corpus case: contradiction built from
+        PubMed and from FEVER yields two identical formats with different
+        :attr:`FormatFingerprint.data_paths`, and dropping the second as a duplicate would erase
+        half of what the model was trained on.
+
+        :param other: The set to fold in.
+
+        :returns: The union.
+        """
+        return FingerprintSet(_fold(list(self.formats), other.formats))
+
+    def require_compatible(self, eval_fp: FormatFingerprint) -> None:
+        """
+        Raise unless ``eval_fp`` matches one of the recorded formats for its task.
+
+        :param eval_fp: The format eval is about to use.
+
+        :raises FormatMismatchError: If the task was recorded but no entry matches. The reported
+            mismatches come from the *closest* entry, so a curriculum's several formats do not
+            produce several unrelated error lists.
+        :raises TaskNotTrainedError: If the task was never trained. This is a distinct failure:
+            nothing is mismatched, there is simply nothing to check against.
+        """
+        candidates = self.for_task(eval_fp.task)
+        if not candidates:
+            raise TaskNotTrainedError(eval_fp.task, self.tasks)
+        attempts = [eval_fp.compare(c) for c in candidates]
+        if any(not a for a in attempts):
+            return
+        raise FormatMismatchError(min(attempts, key=len))
+
+    # ── i/o ─────────────────────────────────────────────────────────────────────────────────────
+
+    def to_dict(self) -> Dict[str, Any]:
+        """:returns: A JSON-ready mapping."""
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "formats": [fp.to_dict() for fp in self.formats],
+        }
+
+    @classmethod
+    def from_dict(cls, d: Mapping[str, Any]) -> "FingerprintSet":
+        """
+        :param d: A mapping produced by :meth:`to_dict`.
+
+        :returns: The set.
+
+        :raises ValueError: If the record is not a fingerprint set.
+        """
+        if "formats" not in d:
+            raise ValueError(
+                "not a fingerprint set: no 'formats' key. A record written by ctc always has one, "
+                "even for a single task."
+            )
+        return cls([FormatFingerprint.from_dict(f) for f in d["formats"]])
+
+    def write(self, directory: Path) -> Path:
+        """
+        Write the set into ``directory``, replacing any existing record.
+
+        :param directory: Shard directory (tokenize time) or checkpoint directory (train time).
+
+        :returns: The path written.
+        """
+        directory = Path(directory)
+        directory.mkdir(parents=True, exist_ok=True)
+        path = directory / FINGERPRINT_FILENAME
+        path.write_text(json.dumps(self.to_dict(), indent=2, sort_keys=True) + "\n")
+        return path
+
+    @classmethod
+    def read(cls, directory: Path) -> Optional["FingerprintSet"]:
+        """
+        :param directory: Shard or checkpoint directory.
+
+        :returns: The recorded set, or ``None`` if the directory predates fingerprinting. Callers
+            must decide what to do with ``None`` explicitly -- see :func:`check_or_explain_missing`.
+        """
+        path = Path(directory) / FINGERPRINT_FILENAME
+        if not path.exists():
+            return None
+        return cls.from_dict(json.loads(path.read_text()))
+
+
+def _fold(
+    into: List[FormatFingerprint], incoming: Sequence[FormatFingerprint]
+) -> List[FormatFingerprint]:
+    """
+    Add records to a list, merging any that describe the same format.
+
+    :param into: Accumulator, mutated and returned.
+    :param incoming: Records to add.
+
+    :returns: ``into``.
+    """
+    for fp in incoming:
+        for i, existing in enumerate(into):
+            if existing.task == fp.task and existing.same_format_as(fp):
+                into[i] = existing.merged_with(fp)
+                break
+        else:
+            into.append(fp)
+    return into
+
+
+def collect_fingerprints(
+    directories: Sequence[Path],
+    *,
+    extra: Sequence[FormatFingerprint] = (),
+    allow_missing: bool = False,
+    record_source_paths: bool = True,
+) -> Tuple[FingerprintSet, List[str]]:
+    """
+    Gather the formats recorded across several shard directories.
+
+    Used by both the training callback and ``ctc-fingerprint collect``, which is the point: a
+    checkpoint stamped at train time and one stamped afterwards must record the same thing, and
+    two implementations of "collect" would eventually not.
+
+    **Mixing is the case this has to get right.** Different tasks fold in side by side, one entry
+    each. The *same* task from several directories -- contradiction from PubMed and from FEVER, or
+    one task spread over per-rung directories -- produces several records with an identical format,
+    which are merged into one entry whose :attr:`FormatFingerprint.data_paths` lists every source.
+    Deduplicating on the whole record instead would drop all but the first, leaving a checkpoint
+    that names one corpus out of five.
+
+    :param directories: Shard directories to read.
+    :param extra: Fingerprints to include that no directory records.
+    :param allow_missing: Tolerate a directory with no record. Off by default -- a partial record
+        is worse than none, because the eval guard then reports a trained task as untrained.
+    :param record_source_paths: Record each directory on the fingerprints read from it, so the
+        checkpoint says what it was trained on even when the shard writer recorded no path itself.
+
+    :returns: ``(set, skipped)`` where ``skipped`` names the directories that had no record. It is
+        non-empty only when ``allow_missing`` is set, and the caller must disclose it.
+
+    :raises FileNotFoundError: If a directory has no record and ``allow_missing`` is not set.
+    :raises ValueError: If nothing at all was found.
+    """
+    collected: List[FormatFingerprint] = list(extra)
+    missing: List[str] = []
+    for d in directories:
+        found = FingerprintSet.read(Path(d))
+        if found is None:
+            missing.append(str(d))
+            continue
+        source = str(Path(d).resolve())
+        _fold(
+            collected,
+            [fp.with_data_paths(source) if record_source_paths else fp for fp in found.formats],
+        )
+
+    if missing and not allow_missing:
+        raise FileNotFoundError(
+            f"no {FINGERPRINT_FILENAME} in {len(missing)} director(ies):\n  "
+            + "\n  ".join(missing)
+            + "\n\nFingerprint them first (ctc-fingerprint write --dir <shards> --task <name> …), "
+            "or allow them to be skipped. A partial record makes the eval guard report a trained "
+            "task as out-of-distribution."
+        )
+    if not collected:
+        raise ValueError(
+            "no formats found. Point this at the shard directories the run reads, or supply them "
+            "explicitly. Recording nothing while appearing to record something is the one outcome "
+            "this guard must not have."
+        )
+    return FingerprintSet(collected), missing
+
+
+def conflicting_formats(fingerprints: FingerprintSet) -> Dict[str, List[str]]:
+    """
+    Find tasks recorded under more than one format.
+
+    Legitimate for a curriculum that varies the layout deliberately, and
+    :meth:`FingerprintSet.require_compatible` accepts either. But it is also what accidental drift
+    between two shard builds looks like, and that case is otherwise invisible.
+
+    :param fingerprints: The set to inspect.
+
+    :returns: task -> the field names that differ, for each task with several formats.
+    """
+    by_task: Dict[str, List[FormatFingerprint]] = {}
+    for fp in fingerprints.formats:
+        by_task.setdefault(fp.task, []).append(fp)
+    return {
+        task: sorted({m.field for m in fps[0].compare(fps[1])})
+        for task, fps in by_task.items()
+        if len(fps) > 1
+    }
+
+
+class TaskNotTrainedError(RuntimeError):
+    """Raised when a checkpoint's fingerprint records no format for the task being graded."""
+
+    def __init__(self, task: str, trained: Sequence[str]):
+        self.task = task
+        self.trained = list(trained)
+        super().__init__(
+            f"this checkpoint records no training format for task {task!r}; it was trained on "
+            f"{', '.join(self.trained)}.\n"
+            "Either the task name is wrong, or this is a deliberate out-of-distribution eval. "
+            "The guard cannot verify an OOD eval -- there is no training format to compare "
+            "against -- so pass --ignore-format-fingerprint and the result will record that "
+            "compatibility was unverified."
+        )
+
+
+def check_or_explain_missing(
+    eval_fp: FormatFingerprint, ckpt_dir: Path, *, strict: bool = True
+) -> Optional[str]:
+    """
+    Enforce the fingerprint against a checkpoint directory.
+
+    :param eval_fp: The format eval is about to use.
+    :param ckpt_dir: Checkpoint directory to read the training-time fingerprint from.
+    :param strict: When ``True`` an *absent* fingerprint is also an error. Checkpoints trained
+        before fingerprinting existed have none, so batch-grading old runs needs ``strict=False``
+        -- but then the guard is off, and the caller should say so in the results file.
+
+    :returns: A warning string when the check could not be performed and ``strict`` is ``False``,
+        else ``None``.
+
+    :raises FormatMismatchError: On an incompatible fingerprint. Always raised, in both modes: an
+        actual mismatch is never merely a warning.
+    :raises FileNotFoundError: When the fingerprint is absent and ``strict`` is ``True``.
+    :raises TaskNotTrainedError: When the task was not trained and ``strict`` is ``True``.
+    """
+    trained = FingerprintSet.read(ckpt_dir)
+    if trained is None:
+        msg = (
+            f"no {FINGERPRINT_FILENAME} in {ckpt_dir}; train/eval format compatibility is "
+            "UNVERIFIED for this run"
+        )
+        if strict:
+            raise FileNotFoundError(
+                msg + ". Pass strict=False (or --ignore-format-fingerprint) to grade a checkpoint "
+                "that predates fingerprinting."
+            )
+        return msg
+    try:
+        trained.require_compatible(eval_fp)
+    except TaskNotTrainedError as e:
+        if strict:
+            raise
+        return (
+            f"{e.task!r} is not among this checkpoint's trained tasks ({', '.join(e.trained)}); "
+            "grading it as out-of-distribution, format compatibility UNVERIFIED"
+        )
+    return None

--- a/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/format/metrics.py
+++ b/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/format/metrics.py
@@ -1,0 +1,414 @@
+"""
+Scoring primitives: a parsed answer plus a gold answer -> a number.
+
+Two families, and they are not interchangeable:
+
+* **QA metrics** (:func:`exact_match`, :func:`substring_match`, :func:`token_f1`) compare answer
+  *text*, under HELMET-compatible normalization so our numbers are comparable with theirs.
+* **Retrieval metrics** (:func:`retrieval_f1` and friends) compare *sets of document ids*.
+
+Parsing lives in :mod:`ctc.format.parsing`, not here. That split matters: when a task scores near
+zero the first question is always "did it parse?", and keeping the two apart makes that answerable
+without re-running the model.
+
+.. note::
+   ``retrieval_f1`` is a **per-example** F1 over one example's id set, then averaged across the
+   eval set by :func:`aggregate`. It is not a corpus-level F1, and the two differ. When quoting a
+   number, also quote ``eval_size`` and its standard error -- at 488 examples the binomial SE is
+   about ±0.021 at f1≈0.70 and ±0.010 at f1≈0.95, which is larger than many differences that have
+   been reported as findings.
+
+Ported from ``corpus_reasoning/lib/metrics.py``.
+"""
+
+from __future__ import annotations
+
+import re
+import string
+from collections import Counter
+from itertools import combinations
+from typing import Callable, Dict, Iterable, List, Sequence, Set, Union
+
+__all__ = [
+    "normalize_answer",
+    "exact_match",
+    "substring_match",
+    "token_f1",
+    "max_over_answers",
+    "retrieval_exact_match",
+    "retrieval_recall",
+    "retrieval_precision",
+    "retrieval_f1",
+    "pair_metrics",
+    "cycle_metrics",
+    "set_metrics",
+    "pairwise_metrics",
+    "kendall_tau",
+    "clustering_extras",
+    "ordering_extras",
+    "aggregate",
+]
+
+
+def normalize_answer(s: str) -> str:
+    """
+    Lowercase, strip articles and punctuation, and collapse whitespace.
+
+    HELMET-compatible, deliberately -- changing it silently shifts every QA number and breaks
+    comparability with previously reported results.
+
+    :param s: Raw answer text.
+
+    :returns: The normalized form used by every QA metric here.
+    """
+    s = s.lower()
+    s = re.sub(r"\b(a|an|the)\b", " ", s)
+    s = "".join(ch for ch in s if ch not in string.punctuation)
+    return " ".join(s.split())
+
+
+def exact_match(pred: str, gold: str) -> bool:
+    """
+    :param pred: Predicted answer text.
+    :param gold: Gold answer text.
+
+    :returns: Whether the two match after normalization.
+    """
+    return normalize_answer(pred) == normalize_answer(gold)
+
+
+def substring_match(pred: str, gold: str) -> bool:
+    """
+    :param pred: Predicted answer text.
+    :param gold: Gold answer text.
+
+    :returns: Whether the normalized gold appears anywhere in the normalized prediction. Lenient by
+        design -- a rambling generation that contains the answer still counts.
+    """
+    return normalize_answer(gold) in normalize_answer(pred)
+
+
+def token_f1(pred: str, gold: str) -> float:
+    """
+    Standard SQuAD-style token-overlap F1.
+
+    :param pred: Predicted answer text.
+    :param gold: Gold answer text.
+
+    :returns: Harmonic mean of token precision and recall, ``0.0`` if they share no tokens.
+    """
+    pred_tokens = normalize_answer(pred).split()
+    gold_tokens = normalize_answer(gold).split()
+    # Counter intersection takes the minimum count of each shared token, so repeating a word does
+    # not earn credit more than once.
+    common = Counter(pred_tokens) & Counter(gold_tokens)
+    num_same = sum(common.values())
+    if num_same == 0:
+        return 0.0
+    precision = num_same / len(pred_tokens)
+    recall = num_same / len(gold_tokens)
+    return (2 * precision * recall) / (precision + recall)
+
+
+def max_over_answers(
+    metric_fn: Callable[[str, str], Union[bool, float]],
+    prediction: str,
+    answers: Union[str, Sequence],
+) -> Union[bool, float]:
+    """
+    Score against every acceptable gold answer and keep the best.
+
+    Many datasets list several valid answers (KILT supplies entity aliases), and SQuAD, HELMET and
+    KILT all score this way.
+
+    :param metric_fn: Any of the QA metrics above.
+    :param prediction: Predicted answer text.
+    :param answers: One answer, a list of answers, or a list-of-lists (some datasets add a wrapping
+        layer).
+
+    :returns: The best score across the gold answers.
+    """
+    if isinstance(answers, str):
+        answers = [answers]
+    elif answers and isinstance(answers[0], list):
+        answers = [a for sublist in answers for a in sublist]
+    return max(metric_fn(prediction, gt) for gt in answers)
+
+
+def retrieval_exact_match(predicted_ids: Set[int], gold_ids: Set[int]) -> bool:
+    """
+    :param predicted_ids: Ids the model named.
+    :param gold_ids: Gold ids.
+
+    :returns: Whether the sets are equal. All-or-nothing; use :func:`retrieval_f1` for partial credit.
+    """
+    return predicted_ids == gold_ids
+
+
+def retrieval_recall(predicted_ids: Set[int], gold_ids: Set[int]) -> float:
+    """
+    :param predicted_ids: Ids the model named.
+    :param gold_ids: Gold ids. An empty gold set scores ``1.0`` -- there was nothing to miss.
+
+    :returns: Fraction of gold documents retrieved.
+    """
+    if not gold_ids:
+        return 1.0
+    return len(predicted_ids & gold_ids) / len(gold_ids)
+
+
+def retrieval_precision(predicted_ids: Set[int], gold_ids: Set[int]) -> float:
+    """
+    :param predicted_ids: Ids the model named. Naming none scores ``0.0``, so abstaining is not a
+        way to score well.
+    :param gold_ids: Gold ids.
+
+    :returns: Fraction of named documents that are gold.
+    """
+    if not predicted_ids:
+        return 0.0
+    return len(predicted_ids & gold_ids) / len(predicted_ids)
+
+
+def retrieval_f1(predicted_ids: Set[int], gold_ids: Set[int]) -> float:
+    """
+    :param predicted_ids: Ids the model named.
+    :param gold_ids: Gold ids.
+
+    :returns: Harmonic mean of :func:`retrieval_precision` and :func:`retrieval_recall`, for this
+        one example. See the module note on per-example vs corpus-level F1.
+    """
+    p = retrieval_precision(predicted_ids, gold_ids)
+    r = retrieval_recall(predicted_ids, gold_ids)
+    if p + r == 0:
+        return 0.0
+    return (2 * p * r) / (p + r)
+
+
+def pair_metrics(
+    predicted: Sequence[Sequence[int]], gold: Sequence[Sequence[int]]
+) -> Dict[str, float]:
+    """
+    Set-level precision / recall / F1 / exact-match over pairs.
+
+    Shared by every pair task: contradiction, redundancy, mathmatch, matching_ngram, strmatch.
+
+    :param predicted: Parsed pairs. For unordered tasks these arrive already sorted from
+        :func:`~ctc.format.parsing.parse_pairs`; passing unsorted pairs would make ``[4, 1]`` miss
+        a gold ``[1, 4]``.
+    :param gold: Gold pairs, under the same ordering convention.
+
+    :returns: ``precision``, ``recall``, ``f1``, ``exact_match``. Predicting nothing when there is
+        nothing to find scores a perfect 1.0 -- correct, but it means a task whose examples mostly
+        have no pairs can be gamed by always answering ``[]``, so check the positive rate before
+        reading much into a high score.
+    """
+    pred_set = {tuple(p) for p in predicted}
+    gold_set = {tuple(p) for p in gold}
+    if not pred_set and not gold_set:
+        return {"precision": 1.0, "recall": 1.0, "f1": 1.0, "exact_match": 1.0}
+    tp = len(pred_set & gold_set)
+    p = tp / len(pred_set) if pred_set else 0.0
+    r = tp / len(gold_set) if gold_set else 0.0
+    f1 = (2 * p * r / (p + r)) if (p + r) > 0 else 0.0
+    return {"precision": p, "recall": r, "f1": f1, "exact_match": float(pred_set == gold_set)}
+
+
+def cycle_metrics(
+    predicted: Sequence[Sequence[int]], gold: Sequence[Sequence[int]]
+) -> Dict[str, float]:
+    """
+    Set-of-sets scoring for the cycle family: cycle, groups4, textgroups.
+
+    A predicted cycle counts as a true positive only if its id-set **exactly** equals a gold
+    cycle's. That is deliberately strict -- a cycle with one member wrong is not a cycle -- so a
+    softer ``claim_f1`` over the union of all cycle members is reported alongside it, giving partial
+    credit for finding most of a cycle's items.
+
+    Report both. Cycle-level F1 alone hides a model that is finding the right *items* but grouping
+    them wrongly, which is a different failure from not finding them at all.
+
+    :param predicted: Parsed cycles, each a sorted id list.
+    :param gold: Gold cycles.
+
+    :returns: ``precision``, ``recall``, ``f1``, ``exact_match`` (all cycle-level), and
+        ``claim_f1`` (item-level).
+    """
+    pred_set = {frozenset(c) for c in predicted}
+    gold_set = {frozenset(c) for c in gold}
+    if not pred_set and not gold_set:
+        return {
+            "precision": 1.0,
+            "recall": 1.0,
+            "f1": 1.0,
+            "exact_match": 1.0,
+            "claim_f1": 1.0,
+        }
+    tp = len(pred_set & gold_set)
+    p = tp / len(pred_set) if pred_set else 0.0
+    r = tp / len(gold_set) if gold_set else 0.0
+    f1 = (2 * p * r / (p + r)) if (p + r) > 0 else 0.0
+
+    pred_ids = {i for c in predicted for i in c}
+    gold_ids = {i for c in gold for i in c}
+    ctp = len(pred_ids & gold_ids)
+    cp = ctp / len(pred_ids) if pred_ids else 0.0
+    cr = ctp / len(gold_ids) if gold_ids else 0.0
+    claim_f1 = (2 * cp * cr / (cp + cr)) if (cp + cr) > 0 else 0.0
+    return {
+        "precision": p,
+        "recall": r,
+        "f1": f1,
+        "exact_match": float(pred_set == gold_set),
+        "claim_f1": claim_f1,
+    }
+
+
+def set_metrics(predicted: Set, gold: Set) -> Dict[str, float]:
+    """
+    Precision / recall / F1 / exact-match over two flat sets.
+
+    Used by the absence family, where the answer is a set of item ids (or of normalized text
+    snippets, for the Gutenberg variant -- the metric does not care which, as long as both sides
+    were normalized the same way).
+
+    :param predicted: What the model named.
+    :param gold: The gold set.
+
+    :returns: ``precision``, ``recall``, ``f1``, ``exact_match``. Two empty sets score a perfect
+        1.0, which is correct but means a task whose examples mostly have nothing missing can be
+        gamed by always answering empty -- check the positive rate before reading much into a high
+        score.
+    """
+    if not predicted and not gold:
+        return {"precision": 1.0, "recall": 1.0, "f1": 1.0, "exact_match": 1.0}
+    tp = len(predicted & gold)
+    p = tp / len(predicted) if predicted else 0.0
+    r = tp / len(gold) if gold else 0.0
+    f1 = 2 * p * r / (p + r) if (p + r) else 0.0
+    return {"precision": p, "recall": r, "f1": f1, "exact_match": float(predicted == gold)}
+
+
+def pairwise_metrics(pred_labels: Sequence[int], gold_labels: Sequence[int]) -> Dict[str, float]:
+    """
+    Pairwise clustering metrics for the grouping tasks.
+
+    Compares which *pairs* of documents were put together, rather than comparing cluster labels --
+    which is necessary because cluster identity is arbitrary: a model that finds exactly the right
+    grouping but numbers the clusters differently is completely correct.
+
+    Pure Python on purpose. The pre-migration scorer also reported ARI and NMI via sklearn, but the
+    headline metric is this one, and keeping it dependency-free is what lets :mod:`ctc.format` be
+    imported without sklearn. ARI/NMI live behind an optional extra.
+
+    :param pred_labels: Predicted cluster label per document.
+    :param gold_labels: Gold cluster label per document.
+
+    :returns: ``pairwise_precision``, ``pairwise_recall``, ``pairwise_f1``.
+
+    :raises ValueError: If the label arrays differ in length.
+    """
+    if len(pred_labels) != len(gold_labels):
+        raise ValueError(
+            f"label arrays differ in length ({len(pred_labels)} vs {len(gold_labels)}); "
+            "both must cover every document"
+        )
+    n = len(pred_labels)
+    pred_pairs = {(i, j) for i, j in combinations(range(n), 2) if pred_labels[i] == pred_labels[j]}
+    gold_pairs = {(i, j) for i, j in combinations(range(n), 2) if gold_labels[i] == gold_labels[j]}
+    tp = len(pred_pairs & gold_pairs)
+    p = tp / len(pred_pairs) if pred_pairs else 0.0
+    r = tp / len(gold_pairs) if gold_pairs else 0.0
+    f1 = 2 * p * r / (p + r) if (p + r) else 0.0
+    return {"pairwise_precision": p, "pairwise_recall": r, "pairwise_f1": f1}
+
+
+def kendall_tau(pred: Sequence[int], gold: Sequence[int]) -> float:
+    """
+    Kendall's tau between two orderings, for the reorder task.
+
+    Both arguments are permutations, so there are no ties and tau-b reduces to tau-a -- a plain
+    concordant-minus-discordant count over pairs. That equivalence is why this can be pure Python
+    instead of pulling in scipy, and it is pinned against ``scipy.stats.kendalltau`` in the golden
+    fixture rather than merely asserted here.
+
+    :param pred: The predicted ordering.
+    :param gold: The true ordering.
+
+    :returns: Tau in ``[-1, 1]``; ``1.0`` for identical orderings, ``-1.0`` for exact reversal, and
+        ``0.0`` for a sequence too short to have any pair.
+
+    :raises ValueError: If the two differ in length.
+    """
+    if len(pred) != len(gold):
+        raise ValueError(f"orderings differ in length ({len(pred)} vs {len(gold)})")
+    n = len(pred)
+    if n < 2:
+        return 0.0
+    concordant = discordant = 0
+    for i, j in combinations(range(n), 2):
+        a = (pred[i] - pred[j]) * (gold[i] - gold[j])
+        if a > 0:
+            concordant += 1
+        elif a < 0:
+            discordant += 1
+    total = n * (n - 1) / 2
+    return (concordant - discordant) / total
+
+
+def clustering_extras(pred_labels: Sequence[int], gold_labels: Sequence[int]) -> Dict[str, float]:
+    """
+    ARI and NMI for the grouping tasks, when scikit-learn is available.
+
+    Secondary to :func:`pairwise_metrics`, which is the headline number. Kept separate and lazily
+    imported so :mod:`ctc.format` stays importable on a bare install -- the data-generation side
+    depends on this module and has no reason to carry scikit-learn.
+
+    :param pred_labels: Predicted cluster label per document.
+    :param gold_labels: Gold cluster label per document.
+
+    :returns: ``{"ari": ..., "nmi": ...}``, or an empty dict when scikit-learn is absent. Empty
+        rather than zeros -- a missing metric must not be recorded as a score of zero.
+    """
+    try:
+        from sklearn.metrics import adjusted_rand_score, normalized_mutual_info_score
+    except ImportError:
+        return {}
+    return {
+        "ari": float(adjusted_rand_score(gold_labels, pred_labels)),
+        "nmi": float(normalized_mutual_info_score(gold_labels, pred_labels)),
+    }
+
+
+def ordering_extras(pred: Sequence[int], gold: Sequence[int]) -> Dict[str, float]:
+    """
+    Spearman's rho for the reorder task, when scipy is available.
+
+    :param pred: The predicted ordering.
+    :param gold: The true ordering.
+
+    :returns: ``{"spearman_rho": ...}``, or an empty dict when scipy is absent -- never a zero,
+        which would read as a real measurement.
+    """
+    try:
+        from scipy.stats import spearmanr
+    except ImportError:
+        return {}
+    if len(pred) < 2:
+        return {}
+    return {"spearman_rho": float(spearmanr(pred, gold).correlation)}
+
+
+def aggregate(results: List[Dict], keys: Iterable[str]) -> Dict[str, float]:
+    """
+    Average per-example metric values across an eval set.
+
+    :param results: Per-example result dicts.
+    :param keys: Metric names to average. Every result must carry every key -- a missing one raises
+        rather than being skipped, since silently averaging over a subset misreports ``eval_size``.
+
+    :returns: Mean value per key, or an empty dict when there are no results.
+    """
+    if not results:
+        return {}
+    return {k: sum(r[k] for r in results) / len(results) for k in keys}

--- a/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/format/parsing.py
+++ b/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/format/parsing.py
@@ -1,0 +1,477 @@
+"""
+Answer parsers: model generation -> the structured answer a scorer can grade.
+
+Parsing is where grading bugs live. A parser that is slightly too strict does not raise -- it
+returns ``None`` or an empty set, the scorer records a zero, and the run reads as "the model cannot
+do this task." Three such bugs reached published numbers in this project, and each fix is preserved
+below with the measurement that exposed it:
+
+* :func:`parse_doc_ids` -- required both brackets, so a checkpoint completing a primed ``[`` with
+  ``8]`` scored 0. niah collapsed to 0.16 while msmarco (which emits ``[15]``) scored 0.96.
+* :func:`parse_partition` -- a greedy ``\\{[\\s\\S]*\\}`` regex spanned first-brace to last-brace
+  across trailing ramble, failed to decode, and fell through to a digit scrape that lumped every id
+  into one cluster. Roughly halved pairwise F1.
+* :func:`parse_partition` again -- responses that begin mid-array because the opening brace landed
+  ahead of a truncated ``</think>``. Chunked grouping @2k measured 0.44 broken vs 0.82 recovered.
+
+The rule these share: **a near-zero score is a parser hypothesis until you have read the raw
+generations.** That is why ``ctc-eval`` dumps generations by default.
+
+Ported from ``corpus_reasoning/lib/eval_tasks.py`` and the ``parse_doc_ids`` in
+``corpus_reasoning/lib/metrics.py``.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import List, Optional, Set
+
+__all__ = [
+    "parse_doc_ids",
+    "parse_outlier_ids",
+    "parse_pairs",
+    "parse_qd_pairs",
+    "parse_cycles",
+    "parse_id_set",
+    "parse_snippet_list",
+    "normalize_snippet",
+    "ID_SET_ANCHORS",
+    "parse_partition",
+    "partition_to_labels",
+    "parse_permutation",
+]
+
+
+# ── Document ids ────────────────────────────────────────────────────────────────────────────────
+
+
+def parse_doc_ids(text: str) -> Set[int]:
+    """
+    Extract document ids from text like ``"[3], [7]"`` or ``"Document [3]"``.
+
+    The opening bracket is **optional**. Eval prompts prime the answer with a trailing ``[``, so
+    the model's generation is frequently the completion ``"8]"`` -- a closing bracket only. See the
+    module docstring for what requiring both brackets cost.
+
+    :param text: Raw model generation.
+
+    :returns: The set of ids mentioned. Empty if none parse.
+    """
+    return {int(m) for m in re.findall(r"\[?\s*(\d+)\s*\]", text)}
+
+
+# ── Outlier ─────────────────────────────────────────────────────────────────────────────────────
+
+
+def parse_outlier_ids(text: str, n_docs: int) -> Optional[List[int]]:
+    """
+    Extract 1-indexed outlier document ids, in the order the model listed them.
+
+    Unlike :func:`parse_doc_ids` this requires **both** brackets, and deliberately so: the outlier
+    target is a complete ``"Outliers: [1], [3]"`` line rather than a primed continuation, so a bare
+    ``[`` never appears at the start of a generation. Relaxing it here would instead start matching
+    the bare integers in the preceding reasoning sentence, which names the majority and outlier
+    attributes and often contains a star rating.
+
+    :param text: Raw model generation.
+    :param n_docs: Corpus size; ids outside ``1..n_docs`` are dropped as hallucinations.
+
+    :returns: Unique ids in first-mention order, or ``None`` if nothing valid parsed.
+    """
+    if not text:
+        return None
+    m = re.search(r"Outliers?\s*:\s*(.+)", text, flags=re.IGNORECASE)
+    scan = m.group(1) if m else text
+    ids = [int(x) for x in re.findall(r"\[(\d+)\]", scan)]
+    ids = [i for i in ids if 1 <= i <= n_docs]
+    if not ids:
+        return None
+    seen: Set[int] = set()
+    uniq: List[int] = []
+    for i in ids:
+        if i not in seen:
+            seen.add(i)
+            uniq.append(i)
+    return uniq
+
+
+# ── Pairs ───────────────────────────────────────────────────────────────────────────────────────
+#
+# Shared by every pair task -- contradiction, redundancy, mathmatch, matching_ngram, strmatch. One
+# definition on purpose: five copies of a parser this fiddly is how the copies drift apart.
+
+
+def parse_pairs(text: str) -> Optional[List[List[int]]]:
+    """
+    Extract unordered integer pairs, e.g. ``[[1, 4], [3, 7]]``.
+
+    Each pair is **sorted**, because "1 contradicts 4" and "4 contradicts 1" are the same claim.
+    Use :func:`parse_qd_pairs` where the two positions mean different things.
+
+    The prompt primes the answer with ``[[``, so a generation is usually the completion with the
+    opening brackets missing (``1, 37], [6, 60]]``). Requiring the leading ``[`` dropped the FIRST
+    pair of every such example: contradiction exact-match read ~0.60 while the model was emitting
+    the correct pairs and true EM was above 0.9. Bracket-reconstructed variants are therefore also
+    tried, keeping whichever parse yields the most pairs.
+
+    :param text: Raw model generation.
+
+    :returns: The pairs; ``[]`` for an explicitly empty answer; ``None`` when nothing parsed.
+        ``[]`` and ``None`` must not be conflated -- "the model said there are none" and "the model
+        produced nothing usable" score the same on this task but mean opposite things about it.
+    """
+    text = text.strip()
+    candidates = [text]
+    if text[:1].isdigit():
+        candidates.append("[[" + text)  # primed '[[' dropped, generation starts at a digit
+    elif text.startswith("[") and not text.startswith("[["):
+        candidates.append("[" + text)  # primed outer '[' dropped, starts at '[digit'
+
+    best: Optional[List[List[int]]] = None
+    for s in candidates:
+        for candidate in [s, re.search(r"\[\[[\s\S]*\]\]", s) or re.search(r"\[[\s\S]*\]", s)]:
+            if candidate is None:
+                continue
+            frag = candidate if isinstance(candidate, str) else candidate.group()
+            try:
+                parsed = json.loads(frag)
+            except (json.JSONDecodeError, ValueError, TypeError):
+                continue
+            if isinstance(parsed, list):
+                pairs = [
+                    sorted([int(p[0]), int(p[1])])
+                    for p in parsed
+                    if isinstance(p, list) and len(p) == 2
+                ]
+                if best is None or len(pairs) > len(best):
+                    best = pairs
+    if best:
+        return best
+
+    matches = re.findall(r"[\[\(]?\s*(\d+)\s*,\s*(\d+)\s*[\]\)]", text)
+    if matches:
+        return [sorted([int(a), int(b)]) for a, b in matches]
+    return [] if text in ("[]", "") else None
+
+
+def parse_qd_pairs(text: str) -> Optional[List[List[int]]]:
+    """
+    Extract **order-preserving** pairs, for ``qdmatch``.
+
+    Identical to :func:`parse_pairs` except that pairs are not sorted: a qdmatch pair is
+    ``(query_id, document_id)`` over one shared index, so swapping the two makes a different claim.
+    The regex fallback also requires a real opening bracket here, since without sorting there is no
+    way to recover from a mis-split.
+
+    :param text: Raw model generation.
+
+    :returns: The pairs in the order given, ``[]`` for an empty answer, or ``None`` on failure.
+    """
+    text = text.strip()
+    for candidate in [text, re.search(r"\[[\s\S]*\]", text)]:
+        if candidate is None:
+            continue
+        s = candidate if isinstance(candidate, str) else candidate.group()
+        try:
+            parsed = json.loads(s)
+            if isinstance(parsed, list):
+                return [
+                    [int(p[0]), int(p[1])] for p in parsed if isinstance(p, list) and len(p) == 2
+                ]
+        except (json.JSONDecodeError, ValueError, TypeError):
+            continue
+    matches = re.findall(r"[\[\(]\s*(\d+)\s*,\s*(\d+)\s*[\]\)]", text)
+    if matches:
+        return [[int(a), int(b)] for a, b in matches]
+    return [] if text in ("[]", "") else None
+
+
+# ── Id sets (absence family) ────────────────────────────────────────────────────────────────────
+
+#: Answer-line anchors for the absence family. The **last** occurrence wins, so a model that
+#: reasons aloud and revises itself is scored on its final answer rather than its first thought.
+ID_SET_ANCHORS = ("Missing:", "Unmatched:")
+
+
+def parse_id_set(text: str, n_docs: int) -> Optional[Set[int]]:
+    """
+    Extract a set of 1-indexed ids from an absence-style answer.
+
+    Unlike :func:`parse_pairs`, ids **are** range-filtered to ``1..n_docs``. The difference is
+    deliberate: this parser falls back to scraping bare integers when no bracketed ids are present,
+    and without the range check that fallback would pick up any number in the surrounding prose.
+
+    :param text: Raw model generation, e.g. ``"Missing: [3], [7]"``.
+    :param n_docs: Corpus size, bounding valid ids.
+
+    :returns: The ids; an empty set for an explicitly empty answer; ``None`` when nothing parsed.
+        Empty and ``None`` differ -- "nothing is missing" is a real answer and can be correct.
+    """
+    for anchor in ID_SET_ANCHORS:
+        if anchor in text:
+            text = text.rsplit(anchor, 1)[1]
+            break
+    ids = re.findall(r"\[(\d+)\]", text)
+    if not ids:
+        ids = re.findall(r"\b(\d+)\b", text)
+    out = {int(x) for x in ids if 1 <= int(x) <= n_docs}
+    return out if (ids or text.strip() in ("", "Missing:", "[]")) else None
+
+
+def normalize_snippet(s: str) -> str:
+    """
+    Normalize a first-four-words snippet for matching.
+
+    :param s: A snippet.
+
+    :returns: Lowercased, punctuation-stripped, whitespace-collapsed, truncated to four tokens --
+        so a model that quotes slightly more or less of a sentence still matches.
+    """
+    s = re.sub(r"\s+", " ", str(s)).strip().strip("\"'").lower()
+    s = re.sub(r"^[^\w]+|[^\w]+$", "", s)
+    return " ".join(s.split()[:4])
+
+
+def parse_snippet_list(text: str) -> Optional[List[str]]:
+    """
+    Extract the JSON list of snippets used by the Gutenberg text-diff absence variant.
+
+    The opening bracket is treated as optional, for the same reason as in :func:`parse_doc_ids`:
+    this task's target is a bare JSON array with no natural-language lead-in, and some checkpoints
+    -- notably under document-chunked attention -- drop the leading ``[`` (sometimes the whole
+    ``["``) and start directly at the first snippet. Requiring it scored every such response as a
+    parse failure: absence_gutenberg under chunked attention read ``parse_rate ~0.01`` while the
+    snippets it emitted were coherent and correct.
+
+    :param text: Raw model generation.
+
+    :returns: The snippets, or ``None`` when nothing parsed.
+    """
+    m = re.search(r"\[.*\]", text, re.DOTALL)
+    if m:
+        try:
+            arr = json.loads(m.group(0))
+            if isinstance(arr, list):
+                return [str(x) for x in arr]
+        except (json.JSONDecodeError, ValueError, TypeError):
+            pass
+        quoted = re.findall(r'"([^"]*)"', m.group(0))
+        if quoted:
+            return quoted
+
+    # No bracketed array at all: rebuild one and retry, rather than scoring coherent output as a
+    # parse failure.
+    if "]" in text and "[" not in text:
+        stripped = text.strip()
+        rebuilt = ("[" + stripped) if stripped.startswith('"') else ('["' + stripped)
+        m2 = re.search(r"\[.*\]", rebuilt, re.DOTALL)
+        if m2:
+            try:
+                arr = json.loads(m2.group(0))
+                if isinstance(arr, list):
+                    return [str(x) for x in arr]
+            except (json.JSONDecodeError, ValueError, TypeError):
+                pass
+            quoted = re.findall(r'"([^"]*)"', m2.group(0))
+            if quoted:
+                return quoted
+    return None
+
+
+# ── Cycles and groups ───────────────────────────────────────────────────────────────────────────
+#
+# Shared by cycle, groups4 and textgroups. The answer is a set of ID-*sets* of variable size, which
+# is what distinguishes it from the pair tasks -- there, every group has exactly two members.
+
+
+def parse_cycles(text: str) -> Optional[List[List[int]]]:
+    """
+    Extract a list of cycles/groups, each a list of item ids.
+
+    Accepts a JSON list of lists, a single flat list (read as one cycle), or bracketed integer
+    groups scraped from prose. Each cycle is normalized to a **sorted, de-duplicated** list, since
+    a cycle is a set: the order the model happened to walk it in carries no information, and
+    scoring compares sets.
+
+    Groups of fewer than two ids are dropped -- a single item cannot form a cycle, and admitting
+    them would let a model score by listing every id separately.
+
+    :param text: Raw model generation.
+
+    :returns: The cycles, ``[]`` for an explicitly empty answer, or ``None`` when nothing parsed.
+    """
+    text = text.strip()
+    for candidate in [text, re.search(r"\[[\s\S]*\]", text)]:
+        if candidate is None:
+            continue
+        s = candidate if isinstance(candidate, str) else candidate.group()
+        try:
+            parsed = json.loads(s)
+        except (json.JSONDecodeError, ValueError, TypeError):
+            continue
+        if isinstance(parsed, list):
+            if parsed and all(isinstance(x, int) for x in parsed):
+                return [sorted(set(parsed))]  # a single flat cycle
+            out = []
+            for c in parsed:
+                if isinstance(c, list) and len(c) >= 2:
+                    try:
+                        out.append(sorted({int(x) for x in c}))
+                    except (ValueError, TypeError):
+                        pass
+            return out
+
+    groups = re.findall(r"\[([\d,\s]+)\]", text)
+    if groups:
+        out = []
+        for g in groups:
+            ids = [int(x) for x in re.findall(r"\d+", g)]
+            if len(ids) >= 2:
+                out.append(sorted(set(ids)))
+        return out
+    return [] if text in ("[]", "") else None
+
+
+# ── Grouping ────────────────────────────────────────────────────────────────────────────────────
+
+
+def _first_groups_object(text: str) -> Optional[List[List[int]]]:
+    """
+    Return the clusters from the **first complete** ``{"groups": ...}`` object in ``text``.
+
+    Uses ``raw_decode``, which stops at the end of one object and therefore ignores any trailing
+    ramble. A regex spanning first-brace to last-brace does not, and the resulting decode failure
+    silently degraded to a digit scrape -- see the module docstring.
+
+    :param text: Text that may contain a grouping object.
+
+    :returns: One list of ids per group, or ``None`` if no such object decodes.
+    """
+    decoder = json.JSONDecoder()
+    for m in re.finditer(r"\{", text):
+        try:
+            obj, _ = decoder.raw_decode(text[m.start() :])
+        except (json.JSONDecodeError, ValueError):
+            continue
+        if isinstance(obj, dict) and "groups" in obj:
+            out = []
+            for g in obj["groups"]:
+                ids = g.get("doc_ids") if isinstance(g, dict) else g
+                if isinstance(ids, list):
+                    out.append([int(x) for x in ids])
+            if out:
+                return out
+    return None
+
+
+#: Prefixes re-attached to a response that begins mid-array. Longest first: the more specific
+#: primer must be tried before the shorter one, or a response missing only ``[{"doc_ids": [`` would
+#: decode against ``{"groups": [`` into the wrong shape.
+_GROUPING_PRIMERS = ('{"groups": [{"doc_ids": [', '{"groups": [')
+
+
+def parse_partition(text: str, n_docs: int) -> Optional[List[List[int]]]:
+    """
+    Extract a partition -- a list of clusters, each a list of 1-indexed document ids.
+
+    Tries, in order: the first complete JSON grouping object; the same after re-attaching a primer
+    for responses that begin mid-array; a bare list-of-lists; and finally a per-line digit scrape.
+    The scrape is a last resort and is usually wrong -- if it fires often, read the generations.
+
+    :param text: Raw model generation.
+    :param n_docs: Corpus size, used to bound ids in the digit-scrape fallback.
+
+    :returns: The clusters, or ``None`` if nothing parsed.
+    """
+    text = text.strip()
+    out = _first_groups_object(text)
+    if out is not None:
+        return out
+
+    # Primed-continuation recovery. Some checkpoints (notably the chunked -cmix models) place the
+    # opening `{"groups": [{"doc_ids": [` ahead of a late `</think>` that the generation truncator
+    # splits away, leaving a response that BEGINS mid-array, e.g. `2, 3, 4]}, {"doc_ids": [1, 6]}]}`.
+    # Dense responses carry the full object and never reach this branch.
+    if not text.startswith("{"):
+        for primer in _GROUPING_PRIMERS:
+            out = _first_groups_object(primer + text)
+            if out is not None:
+                return out
+
+    m = re.search(r"\[\s*\[[\s\S]*\]\s*\]", text)
+    if m:
+        try:
+            obj = json.loads(m.group())
+            if isinstance(obj, list) and all(isinstance(g, list) for g in obj):
+                return [[int(x) for x in g] for g in obj]
+        except (json.JSONDecodeError, ValueError, TypeError):
+            pass
+
+    groups = []
+    for line in text.splitlines():
+        ids = [int(x) for x in re.findall(r"\d+", line)]
+        ids = [i for i in ids if 1 <= i <= n_docs]
+        if ids:
+            groups.append(ids)
+    return groups or None
+
+
+def partition_to_labels(clusters: List[List[int]], n_docs: int) -> List[int]:
+    """
+    Convert 1-indexed clusters to a per-document label array, for clustering metrics.
+
+    A document claimed by two clusters keeps its first assignment, and any document the model left
+    out becomes its own singleton cluster -- so an under-specified answer is scored as
+    under-specified rather than crashing the metric.
+
+    :param clusters: Clusters of 1-indexed document ids.
+    :param n_docs: Corpus size; the length of the returned array.
+
+    :returns: A cluster label per document position.
+    """
+    labels = [-1] * n_docs
+    for cid, cluster in enumerate(clusters):
+        for d in cluster:
+            idx = d - 1
+            if 0 <= idx < n_docs and labels[idx] == -1:
+                labels[idx] = cid
+    next_label = max(labels) + 1 if any(label >= 0 for label in labels) else 0
+    for i in range(n_docs):
+        if labels[i] == -1:
+            labels[i] = next_label
+            next_label += 1
+    return labels
+
+
+# ── Reorder ─────────────────────────────────────────────────────────────────────────────────────
+
+
+def parse_permutation(text: str, n: int) -> Optional[List[int]]:
+    """
+    Extract a permutation of ``1..n``.
+
+    Prefers a JSON array; falls back to scanning every window of ``n`` consecutive integers in the
+    text. Both paths require an exact permutation, so a near-miss returns ``None`` rather than a
+    partially-credited answer -- reorder is graded on the whole ordering.
+
+    :param text: Raw model generation.
+    :param n: Expected permutation length.
+
+    :returns: The permutation, or ``None`` if none is present.
+    """
+    for m in re.finditer(r"\[[^\[\]]*\]", text):
+        try:
+            obj = json.loads(m.group())
+            if isinstance(obj, list) and all(isinstance(x, (int, float)) for x in obj):
+                perm = [int(x) for x in obj]
+                if len(perm) == n and sorted(perm) == list(range(1, n + 1)):
+                    return perm
+        except (json.JSONDecodeError, ValueError, TypeError):
+            continue
+    ints = [int(x) for x in re.findall(r"-?\d+", text)]
+    for start in range(len(ints) - n + 1):
+        cand = ints[start : start + n]
+        if len(cand) == n and sorted(cand) == list(range(1, n + 1)):
+            return cand
+    return None

--- a/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/format/prompts.py
+++ b/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/format/prompts.py
@@ -1,0 +1,467 @@
+"""
+Prompt templates and per-task instruction strings.
+
+**These strings are the training data.** Every shard we have tokenized was built by formatting
+examples through the constants below, so editing one does not "improve a prompt" -- it makes the
+next data build incompatible with every checkpoint trained before it, in a way that shows up as a
+quiet accuracy drop rather than an error. Add a new constant instead, and give it a new task name.
+
+Two axes of variation:
+
+1. Task type -- QA (answer the question) vs retrieval (identify relevant document IDs).
+2. Task scope -- single-doc (nq), multi-doc (hotpotqa), multi-query (multi-hotpotqa).
+
+Passage templates control how an individual document is rendered; the ``_ID`` variants prefix a
+numeric identifier for tasks whose answer is a set of document IDs.
+
+Ported verbatim from ``corpus_reasoning/lib/prompts.py``. Document *serialization* (which template
+applies to which task, and how documents are joined) lives in :mod:`ctc.format.documents`.
+"""
+
+
+# ── Passage templates ──
+# Used by all data generation and eval scripts to format individual documents.
+# The base template matches HELMET eval format exactly.
+# ── Unified-prompt instruction ──
+# When `unified_prompt=True` is passed to build_prompt, every task uses this
+# string as its alpaca "### Instruction:" header, and the task-specific ask
+# moves into the positioned "query" slot. This makes the pre-query prefix
+# textually identical across tasks (e.g. in qafter mode:
+# "<alpaca>{GENERIC_INSTRUCTION}\n\n### Input:\n<docs>\n\n") so a mixed-task
+# dataset shows the model the same structural prefill regardless of task type.
+GENERIC_INSTRUCTION = (
+    "You will be asked to do a long-context processing task for a context."
+)
+
+
+PASSAGE_TEMPLATE = "Document (Title: {title}): {text}"
+PASSAGE_TEMPLATE_NO_TITLE = "Document: {text}"
+PASSAGE_TEMPLATE_ID = "Document [{id}] (Title: {title}): {text}"
+PASSAGE_TEMPLATE_NO_TITLE_ID = "Document [{id}]: {text}"
+
+# ── QA task instructions ──
+# Single-query QA (used by NQ and HotpotQA): model outputs a short answer.
+QA_INSTRUCTION = (
+    "Use the given documents to write a concise and short answer to the question. "
+    "Write your answer in the following format:\nAnswer: [answer]"
+)
+
+# Multi-query QA (used by multi-HotpotQA): model outputs comma-separated answers.
+MULTI_QA_INSTRUCTION = (
+    "Use the given documents to answer each of the following questions. "
+    "Write a concise and short answer for each question, in order, as a comma-separated list.\n"
+    "Write your answer in the following format:\nAnswers: [answer1], [answer2], ..."
+)
+
+# ── Retrieval task instructions ──
+# Single-doc retrieval (NQ): model identifies one relevant document.
+RETRIEVAL_INSTRUCTION_SINGLE = (
+    "Use the given documents to identify which document is most relevant to "
+    "answering the question.\n"
+    "Write your answer in the following format:\nRelevant Document: [id]"
+)
+
+# Multi-doc retrieval (HotpotQA): model identifies multiple relevant documents.
+RETRIEVAL_INSTRUCTION_MULTI_DOC = (
+    "Use the given documents to identify which documents are relevant to "
+    "answering the question. List all relevant document IDs.\n"
+    "Write your answer in the following format:\nRelevant Documents: [id1], [id2]"
+)
+
+# CoT retrieval: single-doc (NQ) — reason about relevance, then output ID.
+COT_RETRIEVAL_INSTRUCTION_SINGLE = (
+    "Use the given documents to identify which document is most relevant to "
+    "answering the question. Think step by step about why the document is "
+    "relevant, then give your answer.\n"
+    "Write your answer in the following format:\n"
+    "[chain of thought reasoning]\n"
+    "Relevant Document: [id]"
+)
+
+# CoT retrieval: multi-doc (HotpotQA) — reason about relevance, then output IDs.
+COT_RETRIEVAL_INSTRUCTION_MULTI_DOC = (
+    "Use the given documents to identify which documents are relevant to "
+    "answering the question. Think step by step about why the documents are "
+    "relevant, then list all relevant document IDs.\n"
+    "Write your answer in the following format:\n"
+    "[chain of thought reasoning]\n"
+    "Relevant Documents: [id1], [id2]"
+)
+
+# Multi-query retrieval (multi-HotpotQA): per-query relevant document IDs.
+RETRIEVAL_INSTRUCTION_MULTI_QUERY = (
+    "Use the given documents to identify which documents are relevant to "
+    "answering each of the following questions. For each question, list the "
+    "relevant document IDs.\n"
+    "Write your answer in the following format:\n"
+    "Relevant Documents: Q1: [id1], [id2]; Q2: [id3], [id4]; ..."
+)
+
+# ── Re-ranking task (MS MARCO) ──
+# The model is given a query and a candidate pool, and must output the document
+# IDs ordered from most to least relevant. Scored by MRR@10. Reuses the numbered
+# retrieval document format.
+RERANK_INSTRUCTION = (
+    "Rank the documents by how relevant each is to the question, from most to "
+    "least relevant. Output the document IDs in ranked order.\n"
+    "Write your answer in the following format:\nRanking: [id1], [id2], [id3], ..."
+)
+
+
+def rerank_instruction(top_k=-1):
+    """Re-ranking instruction, optionally truncated to the top-K most relevant.
+
+    top_k <= 0 ranks the entire pool (the default, `RERANK_INSTRUCTION`).
+    top_k > 0 asks for only the K most relevant IDs in ranked order. (HELMET
+    itself requests the FULL ranking and scores NDCG@10 — see the exact-match
+    `rerank_helmet` task; this top-K knob is our own compact-output option.)"""
+    if top_k and top_k > 0:
+        return (
+            "Rank the documents by how relevant each is to the question. Output "
+            f"the IDs of the {top_k} most relevant documents, in ranked order "
+            "from most to least relevant.\n"
+            "Write your answer in the following format:\nRanking: [id1], [id2], ..."
+        )
+    return RERANK_INSTRUCTION
+
+
+# ── HELMET MS MARCO passage re-ranking (exact-match variant) ──
+# Verbatim from HELMET's data.py `load_msmarco_rerank` (INCLUDING the upstream
+# "relelvant" typo) so a model trained/evaluated on this format matches HELMET's
+# eval prompt token-for-token. The pool uses explicit per-doc IDs and the output
+# is a full permutation of those IDs joined by " > " (not our compact bracketed
+# form). Relevance is graded (0-3), gold order = label descending.
+HELMET_RERANK_USER_TEMPLATE = (
+    "You are provided with a list of documents, each indicated by their ID. "
+    "Rank each document based on their relevance to the question in descending "
+    "order from most relelvant to least relevant texts. Include all documents in "
+    "the rankings. Write your answer using the unique IDs, with the following "
+    "format:\nRanking: ID3 > ID1 > ID2\n\n{demos}{context}\n\nQuery: {question}"
+)
+HELMET_RERANK_SYSTEM_TEMPLATE = "Ranking:"
+
+
+def helmet_rerank_passage(doc_id, text, title=None):
+    """One candidate line in HELMET's rerank context block."""
+    if title is not None:
+        return f"[ID: {doc_id}] Document (Title: {title}): {text}"
+    return f"[ID: {doc_id}] Document: {text}"
+
+
+def helmet_rerank_prompt(context, question, demos=""):
+    """Full HELMET rerank prompt: filled user template + "\\n" + "Ranking:".
+
+    Matches HELMET's `prompt_template = user_template + "\\n" + system_template`,
+    so the prompt ends with "Ranking:" and the model/target continues with
+    " ID3 > ID1 > ...". `context` = passages joined by "\\n\\n"; `demos` = the
+    few-shot block (each demo already ends with "\\n\\n") or "" for zero-shot."""
+    user = HELMET_RERANK_USER_TEMPLATE.format(demos=demos, context=context,
+                                              question=question)
+    return user + "\n" + HELMET_RERANK_SYSTEM_TEMPLATE
+
+
+# ── Contradiction task instructions ──
+# Claims are formatted as numbered items; model identifies contradicting pairs.
+CONTRADICTION_INSTRUCTION = (
+    "Given the following corpus of numbered claims, identify all pairs of claims "
+    "that contradict each other. A pair of claims is contradictory if they cannot "
+    "both be true at the same time.\n\n"
+    "Output your answer as a JSON list of pairs, where each pair is a list of two "
+    "claim IDs. For example: [[1, 4], [3, 7]]\n"
+    "If there are no contradicting pairs, output: []"
+)
+
+CLAIM_TEMPLATE = "Claim {id}: {text}"
+
+# ── Query-document matching task (qdmatch — sparse N²-ified retrieval) ──
+# A numbered list mixing M queries and N documents (single shared index, each
+# line tagged Query:/Document:). Exactly k query-document pairs are relevant
+# (the document answers the query). Output the relevant [query_id, doc_id]
+# pairs — query number first, then the matching document number (ordered).
+QDMATCH_INSTRUCTION = (
+    "Below is a numbered list of items. Each item is labeled either 'Query:' "
+    "(a question) or 'Document:' (a passage). A few query-document pairs are "
+    "relevant: the document answers the query. Identify every relevant pair.\n\n"
+    "Output your answer as a JSON list of pairs, where each pair is "
+    "[query_id, document_id] — the query's number first, then the matching "
+    "document's number. For example: [[1, 8], [3, 4]]\n"
+    "If no pairs are relevant, output: []"
+)
+
+# ── Redundancy-detection task ──
+# Mirror of contradiction: find all pairs of claims that are REDUNDANT (state
+# the same fact / are paraphrases of each other). Reuses CLAIM_TEMPLATE and the
+# same JSON-pairs output schema, so the same parser and pair metrics apply.
+REDUNDANCY_INSTRUCTION = (
+    "Given the following corpus of numbered claims, identify all pairs of claims "
+    "that are redundant with each other. A pair of claims is redundant if they "
+    "state the same fact or finding (one is a paraphrase or restatement of the "
+    "other), even if worded differently.\n\n"
+    "Output your answer as a JSON list of pairs, where each pair is a list of two "
+    "claim IDs. For example: [[1, 4], [3, 7]]\n"
+    "If there are no redundant pairs, output: []"
+)
+
+# ── AbsenceBench task ──
+# The inverse of needle-in-a-haystack: the model is given the full numbered
+# original corpus, then a second version with some claims removed, and must
+# identify which numbered claims are MISSING. Reuses CLAIM_TEMPLATE; the second
+# (modified) version lives in the positioned query. Output is a set of IDs.
+ABSENCE_INSTRUCTION = (
+    "The numbered claims above are the original corpus. The text below is a "
+    "second version of that corpus with some claims removed. Identify which of "
+    "the numbered claims are MISSING from the second version (present above but "
+    "absent below).\n"
+    "Write your answer in the following format:\nMissing: [id1], [id2], ..."
+)
+
+# ── Gutenberg text-diff absence ──
+# Two versions of a prose passage (Version A = the full segment, Version B =
+# the same segment with some whole sentences deleted). The model reports the
+# first four words of every sentence that is in A but missing from B, as a JSON
+# list of strings in order of occurrence. No document IDs.
+ABSENCE_GUTENBERG_INSTRUCTION = (
+    "Above are two versions of the same passage. Version B is identical to "
+    "Version A except that some whole sentences have been removed. Identify "
+    "every sentence that appears in Version A but is MISSING from Version B. "
+    "For each missing sentence, write its first four words.\n"
+    "Write your answer as a JSON list of strings, in order of occurrence, for "
+    'example:\n["Bob was not happy", "Jane felt sad that"]'
+)
+
+# ── Cross-corpus absence (xabsence) ──
+# Two numbered corpora A and B. Almost every claim has a paraphrase in the OTHER
+# corpus; a few are unmatched (no paraphrase anywhere in the other corpus). Find
+# the unmatched ones. Output a set of IDs -> scored by the absence set-F1.
+XABSENCE_INSTRUCTION = (
+    "Below are two corpora of numbered claims, A and B. Almost every claim has a "
+    "paraphrase — a restatement of the same fact — somewhere in the OTHER corpus "
+    "(an A claim paraphrased in B, or a B claim paraphrased in A). A few claims "
+    "are UNMATCHED: they have no paraphrase anywhere in the other corpus. "
+    "Identify the unmatched claims.\n"
+    "Write your answer in the following format:\nUnmatched: [id1], [id2], ..."
+)
+
+# ── Cycle-comparison task ──
+# Claims assert a strict comparison (A ranks strictly above B). The model finds
+# every set of claims whose edges form a directed cycle (an impossible loop).
+# Reuses CLAIM_TEMPLATE. The per-example query states the task; this instruction
+# fixes the output format. Output is a JSON list of cycles (variable length).
+CYCLE_INSTRUCTION = (
+    "Output your answer as a JSON list of cycles, where each cycle is a list "
+    "of the claim IDs whose comparisons form the loop. For example: "
+    "[[3, 8, 12]]\n"
+    "If there are no cycles, output: []"
+)
+
+# ── Matching n-gram task ──
+# A list of N short n-grams; some pairs are character-identical. The model
+# identifies the matching pairs. Same output schema as contradiction.
+MATCHING_NGRAM_INSTRUCTION = (
+    "Given the following numbered list of short text snippets, identify all "
+    "pairs of snippets whose text is exactly identical to each other.\n\n"
+    "Output your answer as a JSON list of pairs, where each pair is a list of "
+    "two snippet IDs. For example: [[1, 4], [3, 7]]\n"
+    "If there are no matching pairs, output: []"
+)
+
+NGRAM_TEMPLATE = "Snippet {id}: {text}"
+
+# ── Mathmatch task ──
+# A list of N arithmetic expressions; some pairs of answers satisfy a closeness
+# criterion (e.g. |val(a)-val(b)| <= x). Model identifies those pairs. Same
+# output schema as contradiction; the per-example query specifies the criterion.
+MATHMATCH_INSTRUCTION = (
+    "Given the following numbered list of arithmetic expressions, identify all "
+    "pairs of expressions matching the criterion below.\n\n"
+    "Output your answer as a JSON list of pairs, where each pair is a list of "
+    "two expression IDs. For example: [[1, 4], [3, 7]]\n"
+    "If there are no matching pairs, output: []"
+)
+
+EXPRESSION_TEMPLATE = "Expression {id}: {text}"
+
+# ── Groups-of-4 task ──
+# A list of N arithmetic expressions; some groups of G satisfy a closeness
+# criterion (all answers within X of each other). Model identifies those groups.
+# Reuses EXPRESSION_TEMPLATE; per-example query states the criterion. Output is
+# a JSON list of groups (same shape as the cycle task, scored by the same
+# set-of-groups metric).
+GROUPS4_INSTRUCTION = (
+    "Given the following numbered list of arithmetic expressions, identify all "
+    "groups of expressions matching the criterion below.\n\n"
+    "Output your answer as a JSON list of groups, where each group is a list of "
+    "the matching expression IDs. For example: [[3, 8, 12, 19]]\n"
+    "If there are no matching groups, output: []"
+)
+
+# ── Strmatch task ──
+# A list of N short strings; some pairs satisfy a string-similarity criterion
+# (a shared contiguous run of words, or a shared word count). The model
+# identifies those pairs. Same output schema as contradiction/mathmatch; the
+# per-example query states the criterion.
+STRMATCH_INSTRUCTION = (
+    "Given the following numbered list of strings, identify all pairs of "
+    "strings matching the criterion below.\n\n"
+    "Output your answer as a JSON list of pairs, where each pair is a list of "
+    "two string IDs. For example: [[1, 4], [3, 7]]\n"
+    "If there are no matching pairs, output: []"
+)
+
+STRING_TEMPLATE = "String {id}: {text}"
+
+# ── Textgroups task ──
+# A list of N short natural-language passages. Each passage carries a *textual*
+# feature value (e.g. its noun count, or how many times a common word appears).
+# Some groups of G passages satisfy an aggregate criterion (their feature values
+# add up to a target T). The model identifies those groups. Same output schema
+# as the cycle/groups4 tasks (a JSON list of ID-groups, scored set-of-groups);
+# the per-example query states which feature and what target.
+TEXTGROUPS_INSTRUCTION = (
+    "Given the following numbered list of passages, identify all groups of "
+    "passages matching the criterion below.\n\n"
+    "Output your answer as a JSON list of groups, where each group is a list of "
+    "the matching passage IDs. For example: [[3, 8, 12]]\n"
+    "If there are no matching groups, output: []"
+)
+
+TEXTGROUPS_TEMPLATE = "Passage {id}: {text}"
+
+# ── Reorder task ──
+# Passages are shown with shuffled display IDs; model outputs a permutation
+# that restores the original document order as a JSON array of those IDs.
+PASSAGE_TEMPLATE_REORDER = "Passage [{id}]: {text}"
+
+REORDER_INSTRUCTION = (
+    "You are given a list of text passages presented in a random order. They "
+    "were originally consecutive segments of a single document. Output the "
+    "permutation that restores them to their original order, as a JSON array "
+    "of the passage IDs.\n"
+    "Write your answer in the following format:\n[id1, id2, id3, ...]"
+)
+
+# ── Grouping task ──
+PASSAGE_TEMPLATE_GROUPING = "Document [{id}](Title: {title}) {text}"
+
+GROUPING_INSTRUCTION = (
+    "You are given a list of scientific paper abstracts. Group them into the "
+    "requested number of categories based on what they are about. Output a "
+    'JSON object of the form {"groups": [{"doc_ids": [...]}, ...]} where each '
+    "group is a list of 1-indexed document IDs. Every document must appear in "
+    "exactly one group."
+)
+
+# Labeled variant: model also names each group (shared topic) before listing IDs.
+GROUPING_LABELED_INSTRUCTION = (
+    "You are given a list of scientific paper abstracts. Group them into the "
+    "requested number of categories based on what they are about. For each "
+    "group, give a short label describing the shared topic, then list the "
+    '1-indexed document IDs. Output a JSON object of the form '
+    '{"groups": [{"label": "<topic>", "doc_ids": [...]}, ...]}. Every '
+    "document must appear in exactly one group."
+)
+
+# ── Outlier task ──
+# Documents are product reviews; the majority share a common attribute (rating
+# or category) and a few are outliers. Model outputs the outlier IDs.
+OUTLIER_INSTRUCTION = (
+    "You are given a list of product reviews. Most share a common attribute "
+    "(star rating or product category); a few are outliers with a different "
+    "value. First state what the majority attribute is and what the outlier "
+    "attribute is, then list the 1-indexed document IDs of the outliers.\n"
+    "Write your answer in the following format:\n"
+    "[one sentence describing majority and outlier attributes]\n"
+    "Outliers: [id1], [id2], ..."
+)
+
+# ── Summarization task (HELMET: ∞Bench Sum, Multi-LexSum) ──
+SUMMARIZATION_INSTRUCTION = (
+    "Write a concise, faithful summary of the document(s) below. Cover the key "
+    "facts and findings; do not add information that is not in the document(s)."
+)
+
+# ── OOLONG task ──
+# Aggregate/distributional reasoning over many labeled items (Oolong,
+# arXiv:2511.02817). The per-example `question` already carries the full
+# instruction and answer-format spec, so the header is minimal and the raw
+# context block is shown verbatim (no per-document wrapper).
+OOLONG_INSTRUCTION = (
+    "Read the data below and answer the question. Compute the exact answer by "
+    "analyzing every item; do not guess or approximate."
+)
+
+# ── RULER tasks (native long-context synthetic benchmark) ──
+# Each subtask carries a self-contained answer-format spec so the tokens right
+# before "### Response:\n" fully describe the task. The per-example question
+# (which key/value/variable is asked about) lives in queries[0] and is appended
+# to the instruction by _build_task_query. The context is the haystack rendered
+# verbatim (needles read as natural sentences; no per-document [N] wrapper).
+RULER_INSTRUCTION_DEFAULT = (
+    "Some special magic numbers are hidden within the text above. Read the text "
+    "and answer the question below using only the information in the text.\n"
+    "Write your answer in the following format:\nAnswer: [answer]"
+)
+
+RULER_INSTRUCTIONS = {
+    "niah_single": (
+        "A special magic number is hidden within the text above. Find it and "
+        "answer the question below.\n"
+        "Write your answer in the following format:\nAnswer: [the magic number]"
+    ),
+    "niah_multikey": (
+        "Several special magic numbers, each tied to a different key, are hidden "
+        "within the text above. Find the one for the key in the question below.\n"
+        "Write your answer in the following format:\nAnswer: [the magic number]"
+    ),
+    "niah_multivalue": (
+        "Several special magic numbers for the same key are hidden within the "
+        "text above. Find ALL of them and answer the question below.\n"
+        "Write your answer in the following format:\n"
+        "Answer: [number1, number2, ...]"
+    ),
+    "niah_multiquery": (
+        "Special magic numbers for several keys are hidden within the text "
+        "above. Find the number for EACH key asked about in the question below.\n"
+        "Write your answer in the following format:\n"
+        "Answer: [number1, number2, ...]"
+    ),
+    "vt": (
+        "The text above contains chains of variable assignments. Variables can "
+        "be assigned a number directly or set equal to another variable. Trace "
+        "the assignments to answer the question below.\n"
+        "Write your answer as the list of all matching variable names in the "
+        "following format:\nAnswer: [VAR1, VAR2, ...]"
+    ),
+    "cwe": (
+        "Write your answer as a comma-separated list in the following format:\n"
+        "Answer: [word1, word2, ...]"
+    ),
+    "fwe": (
+        "Write your answer as a comma-separated list in the following format:\n"
+        "Answer: [word1, word2, ...]"
+    ),
+}
+
+
+# ── HELMET base-model eval templates (non-alpaca) ──
+# These are used when evaluating base models (no fine-tuning) with few-shot demos.
+# Trained models use the alpaca template from lib/io.py instead.
+DEMO_TEMPLATE = "{documents}\n\nQuestion: {question}\nAnswer: {answer}"
+
+HELMET_TEMPLATE = (
+    "Use the given documents to write a concise and short answer to the question. "
+    "Write your answer in the following format:\nAnswer: [answer]\n\n"
+    "{demos}{context}\n\nQuestion: {question}"
+)
+HELMET_TEMPLATE_QUERY_BEFORE = (
+    "Use the given documents to write a concise and short answer to the question. "
+    "Write your answer in the following format:\nAnswer: [answer]\n\n"
+    "{demos}Question: {question}\n\n{context}"
+)
+HELMET_TEMPLATE_QUERY_BOTH = (
+    "Use the given documents to write a concise and short answer to the question. "
+    "Write your answer in the following format:\nAnswer: [answer]\n\n"
+    "{demos}Question: {question}\n\n{context}\n\nQuestion: {question}"
+)
+
+

--- a/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/format/registry.py
+++ b/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/format/registry.py
@@ -1,0 +1,211 @@
+"""
+The task registry: the single place that says what a task *is*.
+
+Every task in the suite is described by exactly one :class:`TaskSpec`, and both halves of the
+pipeline read it — the generator that writes an example, and the grader that scores a model's
+answer. That shared reading is the point. Historically the prompt format, the answer parser, and the
+gold-index convention were re-stated independently in the data generator, the native evaluator, and
+the vLLM evaluator, and every one of the following bugs was one copy disagreeing with another:
+
+* ``parse_doc_ids`` required both brackets in one copy and not the other, so a checkpoint that
+  emitted the primed continuation ``8]`` scored 0.16 while one that emitted ``[15]`` scored 0.96 --
+  on the same underlying capability.
+* The grouping-JSON parser was fixed in one copy while the other kept falling through to a
+  digit-scrape that lumped every doc id into one cluster (0.44 vs 0.82 on chunked grouping @2k).
+* Gold indices are 1-based for contradiction and 0-based for outlier/rerank/nq, which lived only in
+  people's heads and produced an off-by-one that read as a modelling result.
+
+A task registered here cannot disagree with itself, because there is only one of it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+from .fingerprint import FormatFingerprint, hash_prompt
+
+__all__ = ["TaskSpec", "register", "get", "names", "clear"]
+
+
+@dataclass(frozen=True)
+class TaskSpec:
+    """
+    Everything the pipeline needs to know about one task.
+
+    Declared once, in ``ctc/tasks/<name>/spec.py``, and read by the generator that writes examples,
+    the grader that scores answers, and the fingerprint that checks the two agree. That last one is
+    why some fields here restate things the code already encodes: recording the *declared* format
+    lets :meth:`fingerprint` be derived rather than hand-maintained, so a spec and its fingerprint
+    cannot drift apart.
+
+    :param name: Registry key, e.g. ``"contradiction"``. Matches the ``--task`` CLI value.
+    :param gold_index_base: ``0`` or ``1`` -- whether this task's ``gold_doc_indices`` count the
+        first document as 0 or as 1. Contradiction is 1-based; outlier, rerank and nq are 0-based.
+        Getting this wrong shifts every gold id by one and looks exactly like a weak model.
+    :param build_prompt: ``(example, **opts) -> str``. Renders one example into a model prompt.
+    :param parse: ``(text, n_docs) -> parsed answer | None``. Extracts the answer from a generation.
+        Returns ``None`` when nothing parseable was produced, which callers must distinguish from a
+        parsed-but-wrong answer -- collapsing the two hides decoding regressions as accuracy drops.
+    :param score: ``(parsed, gold) -> dict[str, float]``. The metric(s) for this task.
+    :param instruction: The task's instruction string, verbatim. Hashed into the fingerprint, so
+        editing it correctly invalidates every checkpoint trained under the old wording.
+    :param instruction_variants: Additional instruction strings this task can use, when the choice
+        depends on the *example* rather than the task. retrieval picks among three (single-doc,
+        multi-doc, multi-query) by inspecting query and gold counts; qa and cot_retrieval pick
+        among two. All of them are hashed into the fingerprint, because a checkpoint is bound to
+        every wording it was trained under, not just the most common one -- hashing only
+        ``instruction`` would let a variant be edited without invalidating anything.
+    :param honors_query_position: Whether ``query_position`` actually changes this task's prompt.
+        False for ``grouping``, ``grouping_labeled`` and ``outlier``, which take a legacy path that
+        hardcodes documents-then-query and never consults the knob. Recorded because an **inert**
+        knob must not produce a false fingerprint mismatch: two runs differing only in a setting
+        that does nothing are compatible, and flagging them would teach people to ignore the guard.
+    :param serializer: Key into the table in :mod:`ctc.format.documents`, or ``"default"``.
+    :param unified: Whether this task uses the unified prompt shape -- a generic alpaca header with
+        the task instruction positioned alongside the documents. True for tasks with **no
+        per-example query**, where the instruction ("find every contradicting pair") *is* the whole
+        ask: 11 of the 20 canonical tasks. False for tasks that carry a real question per example
+        (retrieval, qa, oolong, grouping, outlier, rerank, summarization, cot_retrieval,
+        grouping_labeled), which keep the task instruction in the header and position the question.
+
+        In the pre-migration code this was a hardcoded ``force_unified`` set inside ``build_prompt``,
+        and a separate ``unified_prompt`` argument that could force it on for any task -- but that
+        argument was never once enabled, so the hardcoded set was the whole behaviour. Declaring it
+        per task makes the split visible and lets the fingerprint record it.
+    :param rungs: This task's own context-length ladder. There is no global set -- nq runs 2k-8k
+        while the xlong ladders reach 512k -- so ``--rungs all`` is only answerable per task.
+    :param primary_metric: Which key of ``score``'s output is *the* number for this task. Named
+        explicitly so a results table cannot quietly switch between f1 and exact_match.
+    :param max_new_tokens: Default decode budget. Too small truncates a correct answer into a parse
+        failure, which reads as a capability limit rather than as a config mistake.
+
+        The pre-migration tables disagreed here: ``eval_lc_native_docchunk``'s ``TASK_CFG`` gave
+        contradiction ``max_new=200`` while ``run_rung_eval``'s ``TASK_MAX_NEW`` gave 512, with the
+        driver passing its value explicitly -- so the budget in force depended on which entry point
+        you used. Declaring it once is the point of this field.
+    :param stop: Key into :data:`ctc.eval.stopping.STOP_PRESETS`, governing when generation ends and
+        what survives for the parser. A surprising share of this project's bad numbers came from
+        getting that wrong rather than from the model.
+    :param answer_is_set: True when the answer is an unordered set of ids (scored with set-F1)
+        rather than a ranked list or free text.
+    :param sources: Named source corpora this task can be built from, e.g.
+        ``("pubmed", "fever", "wiki")``. Empty for purely synthetic tasks.
+    :param description: One line, shown by ``ctc-eval --list-tasks``.
+    :param extra: Task-specific knobs that no other task shares. Kept out of the fields above so
+        the common contract stays small.
+    """
+
+    name: str
+    gold_index_base: int
+    build_prompt: Callable[..., str]
+    parse: Callable[..., object]
+    score: Callable[..., Dict[str, float]]
+    instruction: str = ""
+    instruction_variants: Tuple[str, ...] = ()
+    serializer: str = "default"
+    unified: bool = False
+    honors_query_position: bool = True
+    rungs: Tuple[str, ...] = ()
+    primary_metric: str = "f1"
+    max_new_tokens: int = 512
+    stop: str = "eos"
+    answer_is_set: bool = False
+    sources: Tuple[str, ...] = ()
+    description: str = ""
+    extra: Dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.gold_index_base not in (0, 1):
+            raise ValueError(
+                f"task {self.name!r}: gold_index_base must be 0 or 1, got {self.gold_index_base!r}"
+            )
+        if self.max_new_tokens <= 0:
+            raise ValueError(f"task {self.name!r}: max_new_tokens must be positive")
+
+    def fingerprint(self, **overrides: Any) -> FormatFingerprint:
+        """
+        Derive this task's format fingerprint.
+
+        Everything defining the format is already declared on the spec, so the fingerprint is
+        computed from it rather than written out a second time -- which is what stops the two from
+        disagreeing. The caller supplies only what the spec cannot know: the build options
+        (``query_position``), the tokenizer, the marker ids, the chunk layout, and the document-id
+        range actually present in the built data.
+
+        :param overrides: Fingerprint fields to set. ``query_position`` should always be passed --
+            it is a real build option that varies across runs, and its default here is only the
+            most common value, not a safe assumption.
+
+        :returns: The fingerprint to write beside the shards or the checkpoint.
+        """
+        from .documents import ITEM_SEPARATOR
+
+        base: Dict[str, Any] = dict(
+            task=self.name,
+            prompt_hash=hash_prompt(self.instruction, *self.instruction_variants, self.serializer),
+            serializer=self.serializer,
+            item_separator=ITEM_SEPARATOR,
+            gold_index_base=self.gold_index_base,
+            prompt_shape="unified" if self.unified else "classic",
+        )
+        if not self.honors_query_position:
+            # The knob does nothing for this task, so pin it: otherwise two compatible runs that
+            # merely passed different values would compare as incompatible.
+            base["query_position"] = "after"
+        base.update(overrides)
+        return FormatFingerprint(**base)
+
+
+_REGISTRY: Dict[str, TaskSpec] = {}
+
+
+def register(spec: TaskSpec) -> TaskSpec:
+    """
+    Add a task to the registry.
+
+    :param spec: The task description.
+
+    :returns: The same spec, so this can be used as a module-level statement.
+
+    :raises ValueError: If a task with this name is already registered. Silent replacement is
+        never what you want here -- it is how two definitions of one task start coexisting.
+    """
+    if spec.name in _REGISTRY:
+        raise ValueError(f"task {spec.name!r} is already registered")
+    _REGISTRY[spec.name] = spec
+    return spec
+
+
+def get(name: str) -> TaskSpec:
+    """
+    Look up a registered task.
+
+    :param name: The task name.
+
+    :returns: Its :class:`TaskSpec`.
+
+    :raises KeyError: If the task is not registered, listing what is.
+    """
+    try:
+        return _REGISTRY[name]
+    except KeyError:
+        known = ", ".join(names()) or "(none registered)"
+        raise KeyError(f"unknown task {name!r}; registered tasks: {known}") from None
+
+
+def names() -> List[str]:
+    """:returns: Sorted names of every registered task."""
+    return sorted(_REGISTRY)
+
+
+def clear(name: Optional[str] = None) -> None:
+    """
+    Drop one task, or all of them. For tests only.
+
+    :param name: Task to drop; ``None`` drops everything.
+    """
+    if name is None:
+        _REGISTRY.clear()
+    else:
+        _REGISTRY.pop(name, None)

--- a/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/format/rungs.py
+++ b/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/format/rungs.py
@@ -1,0 +1,84 @@
+"""
+Rung labels: the shared vocabulary for context-length ladder steps.
+
+A *rung* is a context-size budget (``"32k"`` = 32768 tokens), realised per task as however many
+documents fit that budget -- so the same rung means a different document count for every task, and
+that mapping lives in :data:`ctc.data.ladders.LADDERS`, not here.
+
+This module is deliberately tiny and deliberately shared. Data generation writes ``rung_<tokens>.jsonl``
+and evaluation selects it, so if the two disagreed about what ``"32k"`` means, eval would silently
+grade a file built for a different budget. There is no fixed set of legal rungs: tasks range from nq
+(currently 2k/4k/8k) to the xlong ladders (up to 512k), and a new one must not require a code change.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Iterable, List
+
+__all__ = ["parse_rung", "format_rung", "sort_rungs", "normalize"]
+
+_RUNG_RE = re.compile(r"^(\d+)\s*([kmKM]?)$")
+_SUFFIX = {"": 1, "k": 1024, "m": 1024 * 1024}
+
+
+def parse_rung(label: str) -> int:
+    """
+    Convert a rung label to a token count.
+
+    :param label: ``"2k"``, ``"512k"``, ``"1m"``, or a bare token count like ``"2048"``.
+        Binary units: ``"32k"`` is 32768, not 32000, matching the ``rung_<n>.jsonl`` filenames
+        the data pipeline writes.
+
+    :returns: The context budget in tokens.
+
+    :raises ValueError: If the label is not a recognised rung.
+    """
+    m = _RUNG_RE.match(label.strip())
+    if not m:
+        raise ValueError(
+            f"bad rung label {label!r}; expected forms like '2k', '128k', '1m', or '2048'"
+        )
+    digits, suffix = m.group(1), m.group(2).lower()
+    return int(digits) * _SUFFIX[suffix]
+
+
+def format_rung(tokens: int) -> str:
+    """
+    Convert a token count back to its canonical label.
+
+    :param tokens: Context budget in tokens.
+
+    :returns: ``"32k"`` for exact binary multiples, otherwise the bare count.
+    """
+    for suffix, size in (("m", _SUFFIX["m"]), ("k", _SUFFIX["k"])):
+        if tokens >= size and tokens % size == 0:
+            return f"{tokens // size}{suffix}"
+    return str(tokens)
+
+
+def normalize(label: str) -> str:
+    """
+    Round-trip a label through its token count, so ``"2048"`` and ``"2k"`` compare equal.
+
+    :param label: Any accepted rung label.
+
+    :returns: The canonical label.
+    """
+    return format_rung(parse_rung(label))
+
+
+def sort_rungs(labels: Iterable[str]) -> List[str]:
+    """
+    Sort rung labels by actual context length.
+
+    Lexical sort puts ``"128k"`` before ``"2k"``, which silently reorders every ladder plot.
+
+    :param labels: Rung labels in any order.
+
+    :returns: Canonical labels, ascending by token count, duplicates removed.
+    """
+    seen = {}
+    for label in labels:
+        seen[parse_rung(label)] = None
+    return [format_rung(tokens) for tokens in sorted(seen)]

--- a/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/__init__.py
+++ b/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/__init__.py
@@ -1,0 +1,98 @@
+"""
+One package per task. Adding a task means adding a directory here, and nothing else.
+
+Layout of a task package::
+
+    ctc/tasks/contradiction/
+        __init__.py     registers the spec -- the only file the loader touches
+        spec.py         the EVAL contract: instruction, parse, score, rungs, gold index base
+        generate.py     the DATA contract: source corpus -> task JSONL
+        sources/        one module per corpus, when a task has more than one
+
+``spec.py`` and ``generate.py`` are split because they answer to different masters and change for
+different reasons. A spec change reprices every existing result; a generator change only affects
+data built afterwards. Keeping them in one file made it easy to touch both while meaning to touch
+one, and the format fingerprint could not tell you which had moved.
+
+Anything shared by several tasks stays in :mod:`ctc.format` -- pair parsing alone is used by five
+tasks, and five copies of it is precisely how the copies drifted apart. A file under ``tasks/``
+should hold only what is true of that one task.
+
+Discovery is explicit: :data:`TASK_MODULES` lists what gets imported. Scanning the directory
+instead would mean a task silently disappearing from the suite because its module raised an
+ImportError, which is the sort of thing that gets noticed a week later when a results table has one
+fewer row than it should.
+"""
+
+from __future__ import annotations
+
+import importlib
+from typing import Dict, List
+
+from ..format import registry
+
+__all__ = ["TASK_MODULES", "load_all", "loaded", "import_errors"]
+
+#: Task packages to import, in registration order. Add a task by adding its name here.
+TASK_MODULES: tuple = (
+    "contradiction",
+    "redundancy",
+    "strmatch",
+    "mathmatch",
+    "cycle",
+    "groups4",
+    "textgroups",
+    "absence",
+    "xabsence",
+    "retrieval",
+    "qa",
+    "grouping_labeled",
+    "reorder",
+    "outlier",
+    "rerank",
+    "oolong",
+    "summarization",
+    "qdmatch",
+)
+
+_loaded: List[str] = []
+_errors: Dict[str, BaseException] = {}
+
+
+def load_all(*, strict: bool = True) -> List[str]:
+    """
+    Import every task package so their specs register themselves.
+
+    Idempotent: importing a task twice would hit the registry's duplicate guard, so already-loaded
+    modules are skipped.
+
+    :param strict: Raise if a task package fails to import. Default on, because a task that
+        silently vanishes from the registry produces a suite run with a missing row rather than an
+        error -- and a missing row is easy not to notice.
+
+    :returns: Names of the tasks now registered.
+
+    :raises ImportError: If ``strict`` and any task package failed to import.
+    """
+    for name in TASK_MODULES:
+        if name in _loaded:
+            continue
+        try:
+            importlib.import_module(f"{__name__}.{name}")
+        except BaseException as e:  # noqa: BLE001 -- recorded and re-raised below
+            _errors[name] = e
+            if strict:
+                raise ImportError(f"task package {name!r} failed to import: {e}") from e
+            continue
+        _loaded.append(name)
+    return registry.names()
+
+
+def loaded() -> List[str]:
+    """:returns: Task packages imported so far."""
+    return list(_loaded)
+
+
+def import_errors() -> Dict[str, BaseException]:
+    """:returns: Task packages that failed to import, when loaded with ``strict=False``."""
+    return dict(_errors)

--- a/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/_absence.py
+++ b/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/_absence.py
@@ -1,0 +1,122 @@
+"""
+Shared machinery for the absence family: absence and xabsence.
+
+Both ask *what is NOT here?* -- the inverse of needle-in-a-haystack. ``absence`` shows an original
+numbered corpus and a modified version, and asks which items were removed. ``xabsence`` shows two
+corpora and asks which claims have no paraphrase in the other. The answer is a flat set of ids in
+both cases, so they share a parser and a scorer.
+
+.. warning::
+   **Gold is 0-BASED here.** The pre-migration scorer does ``{int(g) + 1 for g in
+   gold_doc_indices}`` -- the stored indices are document positions, and it converts them to the
+   1-based ids the prompt actually renders. Contradiction and the whole pair family are 1-based, so
+   this is one of the places the convention genuinely flips. Getting it wrong shifts every id by
+   one and reads as a weak model rather than as a bug.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Dict, Optional, Sequence, Set
+
+from ..format import assemble, metrics, parsing
+from ..format.prompts import GENERIC_INSTRUCTION
+from ..format.registry import TaskSpec
+
+__all__ = ["parse", "score", "build_target", "make_absence_spec"]
+
+
+def parse(text: str, n_docs: int) -> Optional[Set[int]]:
+    """
+    Parse an absence answer.
+
+    :param text: Raw model generation, anchored on ``Missing:`` or ``Unmatched:``.
+    :param n_docs: Corpus size; ids outside ``1..n_docs`` are dropped.
+
+    :returns: The ids, an empty set for an explicit "nothing is missing", or ``None``.
+    """
+    return parsing.parse_id_set(text, n_docs)
+
+
+def score(parsed: Optional[Set[int]], gold: Sequence[int]) -> Dict[str, float]:
+    """
+    Score a predicted id set against gold.
+
+    :param parsed: Output of :func:`parse`. ``None`` scores zero; an empty set does not, since
+        "nothing is missing" is a real answer that can be right.
+    :param gold: Gold indices, **0-based** -- converted here to the 1-based ids the model sees.
+
+    :returns: ``precision``, ``recall``, ``f1``, ``exact_match``, ``parsed``.
+    """
+    gold_ids = {int(g) + 1 for g in gold}
+    if parsed is None:
+        return {"precision": 0.0, "recall": 0.0, "f1": 0.0, "exact_match": 0.0, "parsed": 0.0}
+    return {**metrics.set_metrics(set(parsed), gold_ids), "parsed": 1.0}
+
+
+def build_target(example: Dict, anchor: str) -> str:
+    """
+    :param example: A unified-format example with 0-based ``gold_doc_indices``.
+    :param anchor: ``"Missing"`` or ``"Unmatched"``, matching the task's instruction.
+
+    :returns: The answer line, with ids rendered 1-based and bracketed.
+    """
+    ids = sorted(int(g) + 1 for g in example["gold_doc_indices"])
+    return f"{anchor}: " + ", ".join(f"[{i}]" for i in ids)
+
+
+def make_absence_spec(
+    *,
+    name: str,
+    instruction: str,
+    serializer: str,
+    description: str,
+    rungs: tuple,
+    query_builder: Callable[[Dict], str],
+    max_new_tokens: int = 200,
+    stop: str = "newline",
+    sources: tuple = (),
+) -> TaskSpec:
+    """
+    Build the spec for one absence-family task.
+
+    :param name: Task name.
+    :param instruction: The instruction string, verbatim.
+    :param serializer: Document serializer key.
+    :param description: One line for ``--list-tasks``.
+    :param rungs: The task's ladder.
+    :param query_builder: ``(example) -> str``; the positioned ask.
+    :param max_new_tokens: Decode budget.
+    :param stop: Stop preset. ``newline`` is right here -- the answer is a single ``Missing: ...``
+        line, and unlike the pair tasks there is no bracket-pair terminator to key on.
+    :param sources: Source corpora.
+
+    :returns: The spec, not yet registered.
+    """
+
+    def build_prompt(example: Dict, **opts) -> str:
+        return assemble.assemble(
+            example,
+            task=name,
+            unified=True,
+            header=GENERIC_INSTRUCTION,
+            positioned=query_builder(example),
+            **opts,
+        )
+
+    return TaskSpec(
+        name=name,
+        description=description,
+        gold_index_base=0,
+        instruction=instruction,
+        serializer=serializer,
+        unified=True,
+        rungs=rungs,
+        build_prompt=build_prompt,
+        parse=parse,
+        score=score,
+        primary_metric="f1",
+        max_new_tokens=max_new_tokens,
+        stop=stop,
+        answer_is_set=False,  # a flat id set, not the bracketed-pair shape the "pairs" stop expects
+        sources=sources,
+    )

--- a/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/_cycles.py
+++ b/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/_cycles.py
@@ -1,0 +1,129 @@
+"""
+Shared machinery for the cycle family: cycle, groups4, textgroups.
+
+These three ask *which **groups** of items satisfy relation R?* -- as opposed to the pair family's
+*which pairs?*. The difference is not cosmetic: a group has variable size, so scoring compares sets
+of sets rather than sets of pairs, and a partially-correct group scores zero at the cycle level
+while still earning item-level credit. That is why these have their own scorer
+(:func:`ctc.format.metrics.cycle_metrics`) rather than reusing the pair one, and why
+``primary_metric`` is worth reading alongside ``claim_f1``.
+
+The pre-migration ``TASK_CFG`` routed all three to ``_eval_cycle``, so the grouping was already
+recognised; as with the pair family, it was implicit in a scorer lookup.
+
+Gold is 1-based here, matching the rendered item numbers.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Callable, Dict, Optional, Sequence
+
+from ..format import assemble, metrics, parsing
+from ..format.prompts import GENERIC_INSTRUCTION
+from ..format.registry import TaskSpec
+
+__all__ = ["parse", "score", "build_target", "make_cycle_spec"]
+
+
+def parse(text: str, n_docs: Optional[int] = None):
+    """
+    Parse a cycle/group answer.
+
+    :param text: Raw model generation.
+    :param n_docs: Corpus size. Unused -- ids are not range-filtered, so a hallucinated id costs
+        precision rather than silently disappearing.
+
+    :returns: Cycles as sorted id lists, ``[]`` for an explicit empty answer, or ``None``.
+    """
+    return parsing.parse_cycles(text)
+
+
+def score(parsed, gold: Sequence[Sequence[int]]) -> Dict[str, float]:
+    """
+    Score predicted groups against gold.
+
+    :param parsed: Output of :func:`parse`. ``None`` scores zero on every metric, including
+        ``claim_f1`` -- an unparseable generation found nothing, at any granularity.
+    :param gold: Gold groups, 1-based.
+
+    :returns: ``precision``, ``recall``, ``f1``, ``exact_match``, ``claim_f1``, ``parsed``.
+    """
+    if parsed is None:
+        return {
+            "precision": 0.0,
+            "recall": 0.0,
+            "f1": 0.0,
+            "exact_match": 0.0,
+            "claim_f1": 0.0,
+            "parsed": 0.0,
+        }
+    return {**metrics.cycle_metrics(parsed, gold), "parsed": 1.0}
+
+
+def build_target(example: Dict) -> str:
+    """
+    :param example: A unified-format example whose ``gold_doc_indices`` holds the groups directly,
+        as 1-based item ids.
+
+    :returns: The groups as JSON.
+    """
+    return json.dumps(example["gold_doc_indices"])
+
+
+def make_cycle_spec(
+    *,
+    name: str,
+    instruction: str,
+    serializer: str,
+    description: str,
+    rungs: tuple,
+    query_builder: Callable[[Dict], str],
+    max_new_tokens: int = 200,
+    stop: str = "newline",
+    sources: tuple = (),
+) -> TaskSpec:
+    """
+    Build the spec for one cycle-family task.
+
+    :param name: Task name.
+    :param instruction: The instruction string, verbatim.
+    :param serializer: Document serializer key.
+    :param description: One line for ``--list-tasks``.
+    :param rungs: The task's ladder.
+    :param query_builder: ``(example) -> str``. Separate per task because the ORDER differs --
+        cycle puts the example's question before its instruction, the other two after.
+    :param max_new_tokens: Decode budget.
+    :param stop: Stop preset.
+    :param sources: Source corpora.
+
+    :returns: The spec, not yet registered.
+    """
+
+    def build_prompt(example: Dict, **opts) -> str:
+        return assemble.assemble(
+            example,
+            task=name,
+            unified=True,
+            header=GENERIC_INSTRUCTION,
+            positioned=query_builder(example),
+            **opts,
+        )
+
+    return TaskSpec(
+        name=name,
+        description=description,
+        gold_index_base=1,
+        instruction=instruction,
+        serializer=serializer,
+        unified=True,
+        rungs=rungs,
+        build_prompt=build_prompt,
+        parse=parse,
+        score=score,
+        primary_metric="f1",
+        max_new_tokens=max_new_tokens,
+        stop=stop,
+        answer_is_set=True,
+        sources=sources,
+    )

--- a/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/_grouping.py
+++ b/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/_grouping.py
@@ -1,0 +1,182 @@
+"""
+Shared machinery for the grouping tasks: grouping and grouping_labeled.
+
+Partition a set of abstracts into K topical categories. Scored **pairwise** -- on which documents
+were put together -- rather than by comparing cluster labels, because cluster identity is
+arbitrary: a model that finds exactly the right partition but numbers the clusters differently is
+completely correct, and a label-wise comparison would score it near zero.
+
+``grouping_labeled`` additionally asks the model to name each group. The names are not scored; the
+task exists to test whether being asked to articulate the shared topic changes the partition.
+
+**Gold is 0-based** and converted to the 1-based ids the prompt renders.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Callable, Dict, List, Optional, Sequence
+
+from ..format import assemble, metrics, parsing
+from ..format.registry import TaskSpec
+
+__all__ = ["parse", "score", "build_labeled_target", "make_grouping_spec"]
+
+
+def parse(text: str, n_docs: int) -> Optional[List[List[int]]]:
+    """
+    :param text: Raw model generation.
+    :param n_docs: Corpus size, bounding the digit-scrape fallback.
+
+    :returns: Clusters of 1-indexed ids, or ``None``.
+    """
+    return parsing.parse_partition(text, n_docs)
+
+
+#: Zero score for an unparseable partition. Named so the shape cannot drift from what :func:`score`
+#: returns on the success path.
+_ZERO = {
+    "pairwise_precision": 0.0,
+    "pairwise_recall": 0.0,
+    "pairwise_f1": 0.0,
+    "k_exact": 0.0,
+    "coverage": 0.0,
+    "parsed": 0.0,
+}
+
+
+def score(
+    parsed: Optional[Sequence[Sequence[int]]],
+    gold: Sequence[Sequence[int]],
+    n_docs: Optional[int] = None,
+) -> Dict[str, float]:
+    """
+    Score a predicted partition.
+
+    :param parsed: Output of :func:`parse`. ``None`` returns zeros without touching ``gold``, so
+        the call is safe before any example is in hand.
+    :param gold: Gold clusters, 0-based.
+    :param n_docs: Corpus size. Defaults to the number of documents implied by ``gold``, which is
+        correct whenever the gold partition covers the corpus -- as it does for this task, where
+        every document belongs to exactly one group.
+
+    :returns: ``pairwise_precision``, ``pairwise_recall``, ``pairwise_f1``, ``k_exact``,
+        ``coverage``, ``parsed``, plus ``ari``/``nmi`` when scikit-learn is installed.
+    """
+    if parsed is None:
+        return dict(_ZERO)
+    if n_docs is None:
+        n_docs = sum(len(c) for c in gold)
+    n = n_docs
+    gold_clusters = [[int(i) + 1 for i in c] for c in gold]
+    gold_labels = parsing.partition_to_labels(gold_clusters, n)
+    pred_labels = parsing.partition_to_labels(list(parsed), n)
+    out = dict(metrics.pairwise_metrics(pred_labels, gold_labels))
+
+    # k_exact: did the model produce the requested number of groups? coverage: what fraction of
+    # documents it actually placed. A model can score well pairwise while quietly dropping
+    # documents, and coverage is what makes that visible.
+    out["k_exact"] = float(len(parsed) == len(gold))
+    placed = {d for c in parsed for d in c if 1 <= d <= n}
+    out["coverage"] = len(placed) / n if n else 0.0
+    out["parsed"] = 1.0
+    out.update(metrics.clustering_extras(pred_labels, gold_labels))
+    return out
+
+
+def build_labeled_target(example: Dict) -> str:
+    """
+    Build the ``grouping_labeled`` target.
+
+    :param example: A unified-format example. Group names come from ``cluster_labels`` -- note the
+        field name; a missing or short list yields empty labels rather than raising, matching the
+        pre-migration builder.
+
+    :returns: The JSON grouping object with a ``label`` per group, ids 1-based.
+    """
+    labels = example.get("cluster_labels") or []
+    groups = []
+    for i, cluster in enumerate(example["gold_doc_indices"]):
+        groups.append(
+            {
+                "label": labels[i] if i < len(labels) else "",
+                "doc_ids": [int(d) + 1 for d in cluster],
+            }
+        )
+    return json.dumps({"groups": groups})
+
+
+def make_grouping_spec(
+    *,
+    name: str,
+    instruction: str,
+    description: str,
+    rungs: tuple,
+    query_builder: Callable[[Dict], str],
+    sources: tuple = (),
+) -> TaskSpec:
+    """
+    Build the spec for one grouping task.
+
+    :param name: Task name.
+    :param instruction: The instruction string, verbatim.
+    :param description: One line for ``--list-tasks``.
+    :param rungs: The task's ladder.
+    :param query_builder: ``(example) -> str``; the positioned ask.
+    :param sources: Source corpora.
+
+    :returns: The spec, not yet registered.
+    """
+
+    def build_prompt(example: Dict, **opts) -> str:
+        """
+        :param example: A unified-format example.
+        :param opts: Assembly options. ``query_position`` is accepted and **ignored**, matching the
+            legacy path this reproduces.
+
+        :returns: The prompt.
+        """
+        # Discarded, not forwarded. The spec declares honors_query_position=False, and the
+        # fingerprint pins the field to "after" for such tasks so that two runs differing only in
+        # an inert knob still compare as compatible. Letting the knob through made it NOT inert:
+        # a --query-position before run produced a genuinely different prompt while writing a
+        # fingerprint that claimed "after", i.e. the guard would certify a format the checkpoint
+        # was never trained on. outlier and qdmatch already discarded it; this one did not.
+        opts.pop("query_position", None)
+        return assemble.assemble(
+            example,
+            task=name,
+            unified=False,
+            header=instruction,
+            positioned=query_builder(example),
+            query_position="after",
+            **opts,
+        )
+
+    return TaskSpec(
+        name=name,
+        description=description,
+        gold_index_base=0,
+        instruction=instruction,
+        serializer=name,
+        unified=False,
+        honors_query_position=False,  # legacy path hardcodes documents-then-query
+        rungs=rungs,
+        build_prompt=build_prompt,
+        parse=parse,
+        score=score,
+        primary_metric="pairwise_f1",
+        # A full partition of a large corpus is long, and EOS is genuinely emitted here, so any
+        # text stop would cut a valid multi-line answer short.
+        #
+        # 4096, not the pre-migration 2048. This answer grows with BOTH the rung and the concept
+        # level: at the 32k rung an L3 example asks for near-singleton clusters, so the target is
+        # roughly one labelled group per document. Measured over a build at n=175, the target's
+        # median is 1392 Qwen3 tokens but its **maximum is 2597** -- so at 2048 the finest examples
+        # of the longest rung are cut off, `parse_partition` returns a partition missing its tail,
+        # and coverage (with it pairwise F1) collapses for a reason that is not the model's.
+        max_new_tokens=4096,
+        stop="eos",
+        answer_is_set=False,
+        sources=sources,
+    )

--- a/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/_pairs.py
+++ b/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/_pairs.py
@@ -1,0 +1,146 @@
+"""
+Shared machinery for the pair tasks.
+
+Five tasks -- contradiction, redundancy, mathmatch, matching_ngram, strmatch -- ask the same
+structural question: *which pairs of items in this corpus stand in relation R?* They differ only in
+what R is (contradicting, redundant, arithmetically close, textually identical, string-similar) and
+in how each item is rendered. The answer format, the parser, the scorer and the gold convention are
+identical.
+
+The pre-migration code already recognised this -- ``TASK_CFG`` routes redundancy, strmatch and
+mathmatch to ``_eval_contradiction`` -- but the recognition was implicit, buried in a scorer lookup.
+Making it explicit here means the family cannot drift apart one member at a time, which is the exact
+failure that produced the duplicated-parser bugs recorded in :mod:`ctc.format.parsing`.
+
+Lives at ``tasks/`` root rather than in any one task's directory, because it belongs to none of
+them. Each task still gets its own package.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Callable, Dict, Optional, Sequence
+
+from ..format import assemble, metrics, parsing
+from ..format.prompts import GENERIC_INSTRUCTION
+from ..format.registry import TaskSpec
+
+__all__ = ["check_gold", "parse", "score", "make_pair_spec"]
+
+
+def check_gold(gold: Sequence[Sequence[int]]) -> None:
+    """
+    Assert the invariant the set comparison depends on.
+
+    :param gold: Gold pairs.
+
+    :raises ValueError: If a pair is not sorted low-high. Predicted pairs are sorted and scoring is
+        a set intersection, so such a pair could never match and would silently cost recall on
+        every example containing it.
+    """
+    for p in gold:
+        if len(p) == 2 and p[0] > p[1]:
+            raise ValueError(
+                f"gold pair {list(p)} is not sorted low-high; it could never be matched, and would "
+                "silently cost recall on every example that contains it"
+            )
+
+
+def parse(text: str, n_docs: Optional[int] = None):
+    """
+    Parse a pair answer.
+
+    :param text: Raw model generation.
+    :param n_docs: Corpus size. Unused -- pairs are deliberately not range-filtered, so a
+        hallucinated id costs precision rather than vanishing.
+
+    :returns: Sorted pairs, ``[]`` for an explicit empty answer, or ``None`` if nothing parsed.
+    """
+    return parsing.parse_pairs(text)
+
+
+def score(parsed, gold: Sequence[Sequence[int]]) -> Dict[str, float]:
+    """
+    Score predicted pairs against gold.
+
+    :param parsed: Output of :func:`parse`. ``None`` scores zero everywhere -- see the divergence
+        note in :mod:`ctc.tasks.contradiction.spec`.
+    :param gold: Gold pairs, 1-based, each sorted low-high.
+
+    :returns: ``precision``, ``recall``, ``f1``, ``exact_match``, ``parsed``.
+
+    :raises ValueError: If a gold pair is not sorted low-high.
+    """
+    check_gold(gold)
+    if parsed is None:
+        return {"precision": 0.0, "recall": 0.0, "f1": 0.0, "exact_match": 0.0, "parsed": 0.0}
+    return {**metrics.pair_metrics(parsed, gold), "parsed": 1.0}
+
+
+def build_target(example: Dict) -> str:
+    """
+    :param example: A unified-format example whose ``gold_doc_indices`` holds the pairs directly,
+        as 1-based item ids -- not document positions, despite sharing a field name with the
+        0-based tasks.
+
+    :returns: The pairs as JSON.
+    """
+    return json.dumps(example["gold_doc_indices"])
+
+
+def make_pair_spec(
+    *,
+    name: str,
+    instruction: str,
+    serializer: str,
+    description: str,
+    rungs: tuple,
+    query_builder: Callable[[Dict], str],
+    max_new_tokens: int = 200,
+    stop: str = "pairs",
+    sources: tuple = (),
+) -> TaskSpec:
+    """
+    Build the spec for one pair task.
+
+    :param name: Task name.
+    :param instruction: The task's instruction string, verbatim.
+    :param serializer: Document serializer key.
+    :param description: One line for ``--list-tasks``.
+    :param rungs: The task's ladder.
+    :param query_builder: ``(example) -> str``; the positioned ask. Separate per task because the
+        criterion tasks append the example's own criterion and the others do not.
+    :param max_new_tokens: Decode budget.
+    :param stop: Stop preset.
+    :param sources: Source corpora.
+
+    :returns: The spec, not yet registered.
+    """
+
+    def build_prompt(example: Dict, **opts) -> str:
+        return assemble.assemble(
+            example,
+            task=name,
+            unified=True,
+            header=GENERIC_INSTRUCTION,
+            positioned=query_builder(example),
+            **opts,
+        )
+
+    return TaskSpec(
+        name=name,
+        description=description,
+        gold_index_base=1,
+        instruction=instruction,
+        serializer=serializer,
+        unified=True,
+        rungs=rungs,
+        build_prompt=build_prompt,
+        parse=parse,
+        score=score,
+        primary_metric="f1",
+        max_new_tokens=max_new_tokens,
+        stop=stop,
+        answer_is_set=True,
+        sources=sources,
+    )

--- a/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/_retrieval.py
+++ b/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/_retrieval.py
@@ -1,0 +1,160 @@
+"""
+Shared machinery for the classic (non-unified) tasks: retrieval, cot_retrieval, qa.
+
+These are the tasks that carry a **real per-example question**, so the prompt takes the classic
+shape -- the task instruction in the alpaca header, the question positioned relative to the
+documents -- rather than the unified shape used by contradiction and its relatives.
+
+They also have an instruction that depends on the *example*, which nothing ported so far does:
+
+============  ====================================================================
+retrieval     single-gold, multi-gold, or multi-query -> three different strings
+cot_retrieval single-gold or multi-gold -> two
+qa            single-query or multi-query -> two
+============  ====================================================================
+
+Every variant is declared on the spec via ``instruction_variants`` and hashed into the format
+fingerprint. Hashing only the primary string would let a variant be reworded without invalidating
+any checkpoint, which is exactly the drift the fingerprint exists to catch.
+
+**Gold is 0-based here**, like the absence family and unlike the pair family -- the scorer converts
+with ``g + 1`` to reach the 1-based ids the prompt renders.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Sequence
+
+from ..format import assemble, metrics
+from ..format.prompts import (
+    COT_RETRIEVAL_INSTRUCTION_MULTI_DOC,
+    COT_RETRIEVAL_INSTRUCTION_SINGLE,
+    MULTI_QA_INSTRUCTION,
+    QA_INSTRUCTION,
+    RETRIEVAL_INSTRUCTION_MULTI_DOC,
+    RETRIEVAL_INSTRUCTION_MULTI_QUERY,
+    RETRIEVAL_INSTRUCTION_SINGLE,
+)
+
+__all__ = [
+    "is_multi_query",
+    "has_multi_gold",
+    "questions_block",
+    "retrieval_instruction",
+    "cot_retrieval_instruction",
+    "qa_instruction",
+    "flatten_gold",
+]
+
+
+def is_multi_query(example: Dict) -> bool:
+    """
+    :param example: A unified-format example.
+
+    :returns: Whether it carries more than one independent question.
+    """
+    return len(example["queries"]) > 1
+
+
+def has_multi_gold(example: Dict) -> bool:
+    """
+    :param example: A unified-format example.
+
+    :returns: Whether any query has more than one gold document. Selects between the single-doc and
+        multi-doc instruction wordings, so it changes the prompt, not just the scoring.
+    """
+    gold = example["gold_doc_indices"]
+    if not gold:
+        return False
+    if isinstance(gold[0], list):
+        return any(len(g) > 1 for g in gold)
+    return len(gold) > 1
+
+
+def questions_block(queries: Sequence[str]) -> str:
+    """
+    :param queries: The example's questions.
+
+    :returns: The positioned question text -- the classic shape's equivalent of the unified tasks'
+        task query.
+    """
+    return assemble.build_questions_block(queries)
+
+
+def retrieval_instruction(example: Dict) -> str:
+    """
+    :param example: A unified-format example.
+
+    :returns: Whichever of the three retrieval instructions this example calls for.
+    """
+    if is_multi_query(example):
+        return RETRIEVAL_INSTRUCTION_MULTI_QUERY
+    return (
+        RETRIEVAL_INSTRUCTION_MULTI_DOC if has_multi_gold(example) else RETRIEVAL_INSTRUCTION_SINGLE
+    )
+
+
+def cot_retrieval_instruction(example: Dict) -> str:
+    """
+    :param example: A unified-format example.
+
+    :returns: The single- or multi-doc CoT retrieval instruction. Multi-*query* is not supported by
+        this task, so it is not consulted.
+    """
+    return (
+        COT_RETRIEVAL_INSTRUCTION_MULTI_DOC
+        if has_multi_gold(example)
+        else COT_RETRIEVAL_INSTRUCTION_SINGLE
+    )
+
+
+def qa_instruction(example: Dict) -> str:
+    """
+    :param example: A unified-format example.
+
+    :returns: The single- or multi-query QA instruction.
+    """
+    return MULTI_QA_INSTRUCTION if is_multi_query(example) else QA_INSTRUCTION
+
+
+def flatten_gold(example: Dict) -> List[int]:
+    """
+    Flatten single-query gold indices.
+
+    :param example: A unified-format example. Single-query gold is stored either flat (``[0, 1]``)
+        or wrapped in one list (``[[0, 1]]``), depending on the generator.
+
+    :returns: The flat 0-based indices.
+    """
+    gold = example["gold_doc_indices"]
+    if gold and isinstance(gold[0], list):
+        return list(gold[0])
+    return list(gold)
+
+
+def score_ids(parsed, example: Dict) -> Dict[str, float]:
+    """
+    Score a predicted id set for a single-query retrieval example.
+
+    :param parsed: Ids the model named, or ``None``.
+    :param example: The example, whose ``gold_doc_indices`` are **0-based**.
+
+    :returns: ``exact_match``, ``recall``, ``precision``, ``f1``, ``parsed``.
+    """
+    gold_ids = {g + 1 for g in flatten_gold(example)}
+    if parsed is None:
+        return {
+            "exact_match": 0.0,
+            "recall": 0.0,
+            "precision": 0.0,
+            "f1": 0.0,
+            "parsed": 0.0,
+        }
+    pred = set(parsed)
+    return {
+        "exact_match": float(metrics.retrieval_exact_match(pred, gold_ids)),
+        "recall": metrics.retrieval_recall(pred, gold_ids),
+        "precision": metrics.retrieval_precision(pred, gold_ids),
+        "f1": metrics.retrieval_f1(pred, gold_ids),
+        "parsed": 1.0,
+    }

--- a/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/absence/__init__.py
+++ b/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/absence/__init__.py
@@ -1,0 +1,8 @@
+"""The ``absence`` task. Importing this package registers its spec."""
+
+from ...format import registry
+from .spec import SPEC
+
+registry.register(SPEC)
+
+__all__ = ["SPEC"]

--- a/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/absence/spec.py
+++ b/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/absence/spec.py
@@ -1,0 +1,109 @@
+"""
+The ``absence`` eval contract (AbsenceBench).
+
+The inverse of needle-in-a-haystack: the model sees a full numbered corpus, then a second version
+with some items removed, and reports which are missing. Items may be claims, poem lines, numbers or
+diff lines depending on the source domain, which is why the serializer renders them as neutral
+numbered items rather than as "claims".
+
+The second (modified) version is carried in ``queries[0]`` and is positioned *after* the
+instruction, because the instruction refers to it as "the text below".
+
+.. note::
+   **A second answer format exists.** The Gutenberg text-diff variant
+   (``meta.format == "textdiff"``) answers with the first four words of each removed sentence, as a
+   JSON list of strings, rather than with ids. The pre-migration scorer branched on that field at
+   the top of ``_eval_absence``. It is detected the same way here, and the snippet parser carries
+   its own primed-bracket fix -- absence_gutenberg under chunked attention read ``parse_rate ~0.01``
+   because the model dropped the leading ``[``, while the snippets it emitted were correct.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Optional, Sequence, Set, Union
+
+from ...format import metrics, parsing
+from ...format.prompts import ABSENCE_INSTRUCTION
+from .._absence import make_absence_spec
+from .._absence import parse as parse_ids
+
+__all__ = ["SPEC", "build_query", "build_target", "is_textdiff"]
+
+
+def is_textdiff(example: Dict) -> bool:
+    """
+    :param example: A unified-format example.
+
+    :returns: Whether this example uses the Gutenberg snippet answer format rather than ids.
+
+    Both metadata spellings are accepted, and that is not tidiness: the shipped pre-migration files
+    write bare ``meta`` while :func:`ctc.data.schema.make_example` normalises to ``_meta``, so
+    reading only one spelling makes this return ``False`` for every example built in this repo --
+    silently routing textdiff data to the id scorer.
+    """
+    meta = example.get("_meta") or example.get("meta") or {}
+    return meta.get("format") == "textdiff"
+
+
+def build_query(example: Dict) -> str:
+    """
+    :param example: A unified-format example whose ``queries[0]`` holds the modified corpus.
+
+    :returns: The instruction followed by the modified version -- the instruction says "the text
+        below", so the order is load-bearing.
+    """
+    return f"{ABSENCE_INSTRUCTION}\n\n{example['queries'][0]}"
+
+
+def parse(text: str, n_docs: int) -> Union[Set[int], Sequence[str], None]:
+    """
+    Parse an absence answer, in whichever of the two formats applies.
+
+    Both formats cannot be distinguished from the generation alone, so the id path is the default
+    and the snippet path is reached via :func:`score` when the example declares it.
+
+    :param text: Raw model generation.
+    :param n_docs: Corpus size.
+
+    :returns: Ids, snippets, or ``None``.
+    """
+    return parse_ids(text, n_docs)
+
+
+def build_target(example: Dict) -> str:
+    """
+    :param example: A unified-format example.
+
+    :returns: The ``Missing: [i], [j]`` answer line, with ids rendered 1-based.
+    """
+    from .._absence import build_target as _bt
+
+    return _bt(example, "Missing")
+
+
+def score_textdiff(parsed_snippets: Optional[Sequence[str]], gold_answers: Sequence[str]) -> Dict:
+    """
+    Score the Gutenberg snippet variant.
+
+    :param parsed_snippets: Output of :func:`ctc.format.parsing.parse_snippet_list`.
+    :param gold_answers: The example's ``answers``, i.e. the removed sentences' opening words.
+
+    :returns: Set metrics over normalized snippets, plus ``parsed``.
+    """
+    gold = {parsing.normalize_snippet(s) for s in gold_answers}
+    if parsed_snippets is None:
+        return {"precision": 0.0, "recall": 0.0, "f1": 0.0, "exact_match": 0.0, "parsed": 0.0}
+    pred = {n for s in parsed_snippets if (n := parsing.normalize_snippet(s))}
+    return {**metrics.set_metrics(pred, gold), "parsed": 1.0}
+
+
+SPEC = make_absence_spec(
+    name="absence",
+    description="Identify which numbered items were removed from a modified copy of the corpus.",
+    instruction=ABSENCE_INSTRUCTION,
+    serializer="absence",
+    rungs=("2k", "4k", "8k", "16k", "32k"),
+    query_builder=build_query,
+    max_new_tokens=200,
+    sources=("pubmed", "gutenberg", "poetry", "numbers"),
+)

--- a/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/contradiction/__init__.py
+++ b/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/contradiction/__init__.py
@@ -1,0 +1,14 @@
+"""
+The ``contradiction`` task.
+
+Importing this package registers the spec. Nothing else here has side effects, so the loader in
+:mod:`ctc.tasks` can import it cheaply to populate the registry without pulling in the generator's
+dependencies.
+"""
+
+from ...format import registry
+from .spec import SPEC
+
+registry.register(SPEC)
+
+__all__ = ["SPEC"]

--- a/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/contradiction/spec.py
+++ b/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/contradiction/spec.py
@@ -1,0 +1,199 @@
+"""
+The ``contradiction`` eval contract.
+
+Given a corpus of numbered claims, find every pair that cannot both be true. The answer is a set of
+unordered pairs, scored by set-F1 over those pairs.
+
+This is the suite's flagship N-squared task: the work is quadratic in corpus size, so it is the one
+where a model that can only attend locally is expected to fall off first. It is also the task with
+the largest history of grading bugs -- see :mod:`ctc.format.parsing` -- which is why the parse and
+score functions here are references to shared, golden-tested implementations rather than local
+copies.
+
+Two facts that have each cost real debugging time:
+
+* **Gold indices are 1-based here** and 0-based for outlier, rerank and nq. That lived in people's
+  heads until it produced an off-by-one that read as a modelling result.
+* **The rung label bounds corpus size, not prompt length.** These rung files fix the claim count
+  (see :data:`CLAIMS_PER_RUNG`) and let per-claim length vary, so measured prompts at the 4k rung
+  spanned 3,457-23,796 tokens. Sizing a decode budget from the label silently skipped 354/500
+  examples and scored them 0 -- in both arms, which read as "no dense-vs-chunked gap".
+
+.. warning::
+   **``stop="pairs"`` is a deliberate change from the pre-migration evaluator.** There,
+   contradiction ran under ``stop_rule="eos"``, whose ``should_stop`` returns ``False``
+   unconditionally -- so nothing but EOS or the budget ended generation. No-cot checkpoints
+   frequently never emit EOS, so they answered correctly and then rambled to the budget, and
+   whatever the parser made of the ramble is what got scored. Stopping at the closing ``]]``
+   terminates on the actual answer. This can move numbers relative to previously reported ones, in
+   either direction, and is worth a back-to-back comparison on a known checkpoint before it is
+   relied on.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Dict, List, Optional, Sequence
+
+from ...data.ladders import LADDERS
+from ...format import assemble, metrics, parsing
+from ...format.prompts import CONTRADICTION_INSTRUCTION, GENERIC_INSTRUCTION
+from ...format.registry import TaskSpec
+
+#: Corpus size per rung: claims, not tokens. See the module note on why this is not prompt length.
+#:
+#: These are the **re-calibrated** counts. The earlier ladder (77/167/346/705/1423) was fit against
+#: a filler pool that turned out to be 92-99.6% FEVER/wiki -- one-line Wikipedia trivia at ~22.8
+#: tokens per claim. Real PubMed claim sentences run ~43 tokens, so those counts overshoot every
+#: token label by roughly 1.8x against the corrected pubmed-only pool: n=77 measures 3,413 tokens
+#: rather than 2,048, and n=1423 measures 61,461 rather than 32,768. Refit over 25 examples per
+#: rung on full rendered prefills gives ``tokens = 170 + 42.8 * n_docs`` (r^2 ~ 1.00 across n in
+#: [77, 1423]), hence ``n = (target - 170) / 42.8``.
+#:
+#: The refit lands within a few documents of the ORIGINAL ladder (40/88/190/385/765), which was
+#: calibrated on real PubMed and was right all along -- the intermediate "fix" only looked
+#: necessary because the pool was contaminated.
+#:
+#: **Derived, not declared.** :data:`ctc.data.ladders.LADDERS` is what the builder actually reads,
+#: so a literal here would be a second copy of a number that has already been wrong once -- and the
+#: copy the tests pin, while the build used the other. Deriving makes drift impossible rather than
+#: merely detectable.
+CLAIMS_PER_RUNG: Dict[str, int] = dict(LADDERS["contradiction"])
+
+
+def parse(text: str, n_docs: Optional[int] = None) -> Optional[List[List[int]]]:
+    """
+    Parse a contradiction answer into sorted claim-id pairs.
+
+    :param text: Raw model generation.
+    :param n_docs: Corpus size. Unused -- pairs are not range-filtered, so a hallucinated id counts
+        against precision rather than vanishing. Silently dropping out-of-range ids would flatter a
+        model that invents them.
+
+    :returns: The pairs, ``[]`` for an explicit empty answer, or ``None`` when nothing parsed.
+    """
+    return parsing.parse_pairs(text)
+
+
+def _check_gold(gold: Sequence[Sequence[int]]) -> None:
+    """
+    Assert the invariant the set comparison depends on.
+
+    :param gold: Gold pairs.
+
+    :raises ValueError: If a pair is not sorted low-high, which would make it unmatchable.
+    """
+    for p in gold:
+        if len(p) == 2 and p[0] > p[1]:
+            raise ValueError(
+                f"gold pair {list(p)} is not sorted low-high. Predicted pairs are sorted, and "
+                "scoring is a set intersection, so this pair could never be matched and would "
+                "silently cost recall on every example that contains it."
+            )
+
+
+def score(
+    parsed: Optional[Sequence[Sequence[int]]], gold: Sequence[Sequence[int]]
+) -> Dict[str, float]:
+    """
+    Score predicted pairs against gold.
+
+    .. warning::
+       **This deliberately diverges from the pre-migration scorer.** ``_eval_contradiction`` mapped
+       an unparseable generation to ``[]`` and scored it normally, so on an example with *no* gold
+       pairs a garbage generation scored a perfect 1.0 on all four metrics. Contradiction data has
+       no empty-gold examples (checked: 0 of 3,153 across three unified files), so this never fired
+       there -- but the same scorer is shared by redundancy, strmatch and mathmatch, whose
+       instructions explicitly permit an empty answer. Here ``None`` scores zero instead. Numbers
+       from this scorer are therefore **not** guaranteed comparable with old ones on any task that
+       has empty-gold examples.
+
+    .. note::
+       Gold pairs must be sorted low-high, because :func:`parse` sorts predicted pairs and the
+       comparison is a set intersection -- a gold ``[4, 1]`` could never match a predicted
+       ``[1, 4]``. The generators satisfy this (checked: 0 unsorted of 3,153) but never asserted
+       it, so :func:`_check_gold` does.
+
+    :param parsed: Output of :func:`parse`. ``None`` (unparseable) scores zero on every metric --
+        it is not the same as ``[]``, which is a real answer and can be correct.
+    :param gold: Gold pairs, 1-based, each sorted low-high.
+
+    :returns: ``precision``, ``recall``, ``f1``, ``exact_match``, plus ``parsed`` as a 0/1 flag.
+        Track ``parsed``: a drop in it means a decoding or truncation problem, and without it that
+        is indistinguishable from the model getting worse.
+
+    :raises ValueError: If a gold pair is not sorted low-high.
+    """
+    _check_gold(gold)
+    if parsed is None:
+        return {"precision": 0.0, "recall": 0.0, "f1": 0.0, "exact_match": 0.0, "parsed": 0.0}
+    return {**metrics.pair_metrics(parsed, gold), "parsed": 1.0}
+
+
+def build_query(example: Dict) -> str:
+    """
+    The positioned ask.
+
+    Contradiction has no per-example question, so the instruction *is* the ask and the example's
+    ``queries`` field is unused. That is exactly why the task is ``unified``.
+
+    :param example: A unified-format example.
+
+    :returns: The text placed before/after/both relative to the claims.
+    """
+    return CONTRADICTION_INSTRUCTION
+
+
+def build_target(example: Dict) -> str:
+    """
+    The training target: the gold pairs as JSON.
+
+    :param example: A unified-format example. ``gold_doc_indices`` holds the pairs directly, as
+        ``[[a, b], ...]`` of **1-based** claim ids -- not document positions, despite the field
+        name it shares with the 0-based tasks.
+
+    :returns: A JSON list of pairs, e.g. ``"[[1, 4], [3, 7]]"``.
+    """
+    return json.dumps(example["gold_doc_indices"])
+
+
+def build_prompt(example: Dict, **opts) -> str:
+    """
+    Render one contradiction example into a prompt.
+
+    :param example: A unified-format example with ``documents`` (the claims).
+    :param opts: Assembly options -- ``query_position``, ``use_alpaca``, ``use_titles``,
+        ``before_dummy``, ``after_dummy``. See :func:`ctc.format.assemble.assemble`.
+
+    :returns: The prompt string.
+    """
+    return assemble.assemble(
+        example,
+        task=SPEC.name,
+        unified=SPEC.unified,
+        header=GENERIC_INSTRUCTION,
+        positioned=build_query(example),
+        **opts,
+    )
+
+
+SPEC = TaskSpec(
+    name="contradiction",
+    description="Find every pair of claims that cannot both be true (N^2 over the corpus).",
+    gold_index_base=1,
+    instruction=CONTRADICTION_INSTRUCTION,
+    serializer="contradiction",
+    # No per-example query -- "find every contradicting pair" IS the ask, so the instruction takes
+    # the positioned slot and the alpaca header is the generic one.
+    unified=True,
+    rungs=("2k", "4k", "8k", "16k", "32k"),
+    build_prompt=build_prompt,
+    parse=parse,
+    score=score,
+    primary_metric="f1",
+    max_new_tokens=512,
+    stop="pairs",
+    answer_is_set=True,
+    sources=("pubmed", "fever", "wiki"),
+    extra={"claims_per_rung": CLAIMS_PER_RUNG},
+)

--- a/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/cycle/__init__.py
+++ b/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/cycle/__init__.py
@@ -1,0 +1,8 @@
+"""The ``cycle`` task. Importing this package registers its spec."""
+
+from ...format import registry
+from .spec import SPEC
+
+registry.register(SPEC)
+
+__all__ = ["SPEC"]

--- a/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/cycle/spec.py
+++ b/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/cycle/spec.py
@@ -1,0 +1,45 @@
+"""
+The ``cycle`` eval contract.
+
+Claims assert strict comparisons ("A ranks strictly above B"). Find every set of claims whose edges
+form a directed cycle -- an impossible loop. Cycles are variable-length, which is what puts this in
+the cycle family rather than the pair family.
+
+.. note::
+   **The query comes BEFORE the instruction here**, uniquely among the group tasks (ruler is the
+   only other task that does this). The per-example question states the comparison domain, and the
+   instruction then fixes the output format. groups4 and textgroups put theirs the other way round.
+   In the pre-migration code this was one line in a 17-branch chain and easy to miss; as a per-task
+   function it is visible, and the golden fixture holds it in place.
+"""
+
+from __future__ import annotations
+
+from typing import Dict
+
+from ...format.prompts import CYCLE_INSTRUCTION
+from .._cycles import build_target, make_cycle_spec  # noqa: F401 (build_target re-exported)
+
+__all__ = ["SPEC", "build_query", "build_target"]
+
+
+def build_query(example: Dict) -> str:
+    """
+    :param example: A unified-format example whose ``queries[0]`` states the task.
+
+    :returns: The example's question followed by the format instruction -- in that order. Reversing
+        it changes every shard this task has ever produced.
+    """
+    return f"{example['queries'][0]}\n\n{CYCLE_INSTRUCTION}"
+
+
+SPEC = make_cycle_spec(
+    name="cycle",
+    description="Find every set of comparison claims forming a directed cycle.",
+    instruction=CYCLE_INSTRUCTION,
+    serializer="cycle",
+    rungs=("2k", "4k", "8k", "16k", "32k"),
+    query_builder=build_query,
+    max_new_tokens=200,
+    stop="pairs",
+)

--- a/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/grouping_labeled/__init__.py
+++ b/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/grouping_labeled/__init__.py
@@ -1,0 +1,8 @@
+"""The ``grouping_labeled`` task. Importing this package registers its spec."""
+
+from ...format import registry
+from .spec import SPEC
+
+registry.register(SPEC)
+
+__all__ = ["SPEC"]

--- a/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/grouping_labeled/spec.py
+++ b/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/grouping_labeled/spec.py
@@ -1,0 +1,54 @@
+"""
+The ``grouping_labeled`` eval contract.
+
+:mod:`ctc.tasks.grouping` plus a short name for each group. **The names are not scored** -- the
+partition is, by exactly the same pairwise metric. The task exists to test whether being asked to
+articulate the shared topic changes the partition the model produces, so its number is only
+meaningful next to plain ``grouping``.
+
+
+.. note::
+   **This task takes a legacy prompt path.** The documents are followed by the *raw* query string
+   -- no ``Question:`` prefix -- with the instruction in the alpaca header. The path also
+   **ignores ``query_position`` entirely**: it hardcodes documents-then-query. That is why the spec
+   sets ``honors_query_position=False``, which stops the fingerprint reporting a false mismatch
+   over a knob that does nothing here.
+"""
+
+from __future__ import annotations
+
+from typing import Dict
+
+from ...format.prompts import GROUPING_LABELED_INSTRUCTION
+from .._grouping import build_labeled_target, make_grouping_spec
+
+__all__ = ["SPEC", "build_query", "build_target"]
+
+
+def build_query(example: Dict) -> str:
+    """
+    :param example: A unified-format example whose ``queries[0]`` states the requested K.
+
+    :returns: The raw query string -- no "Question:" prefix, and no instruction, which
+        already sits in the header.
+    """
+    return example["queries"][0]
+
+
+def build_target(example: Dict) -> str:
+    """
+    :param example: A unified-format example, optionally carrying ``cluster_labels``.
+
+    :returns: The JSON grouping object with a ``label`` per group.
+    """
+    return build_labeled_target(example)
+
+
+SPEC = make_grouping_spec(
+    name="grouping_labeled",
+    description="Partition abstracts into K categories, naming each group.",
+    instruction=GROUPING_LABELED_INSTRUCTION,
+    rungs=("2k", "4k", "8k", "16k", "32k"),
+    query_builder=build_query,
+    sources=("arxiv", "openalex"),
+)

--- a/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/groups4/__init__.py
+++ b/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/groups4/__init__.py
@@ -1,0 +1,8 @@
+"""The ``groups4`` task. Importing this package registers its spec."""
+
+from ...format import registry
+from .spec import SPEC
+
+registry.register(SPEC)
+
+__all__ = ["SPEC"]

--- a/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/groups4/spec.py
+++ b/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/groups4/spec.py
@@ -1,0 +1,45 @@
+"""
+The ``groups4`` eval contract.
+
+A list of arithmetic expressions; find every group of G whose values satisfy a closeness criterion
+(all within X of each other). The criterion is per-example and lives in ``queries[0]``.
+
+Scored by the shared cycle-family metric rather than the pair metric, because groups are
+variable-length -- see :mod:`ctc.tasks._cycles`.
+
+.. warning::
+   **groups4 collapsed in Stage-3 2k validation** while 26 of 27 other full-attention tasks passed.
+   A near-zero score here is a known prior, not necessarily a new regression, so check
+   ``parse_rate`` and read generations before drawing a conclusion from it.
+"""
+
+from __future__ import annotations
+
+from typing import Dict
+
+from ...format.prompts import GROUPS4_INSTRUCTION
+from .._cycles import build_target, make_cycle_spec  # noqa: F401 (build_target re-exported)
+
+__all__ = ["SPEC", "build_query", "build_target"]
+
+
+def build_query(example: Dict) -> str:
+    """
+    :param example: A unified-format example whose ``queries[0]`` states this example's criterion.
+
+    :returns: The instruction followed by the criterion -- the opposite order from
+        :mod:`ctc.tasks.cycle`.
+    """
+    return f"{GROUPS4_INSTRUCTION}\n\n{example['queries'][0]}"
+
+
+SPEC = make_cycle_spec(
+    name="groups4",
+    description="Find every group of arithmetic expressions meeting a closeness criterion.",
+    instruction=GROUPS4_INSTRUCTION,
+    serializer="groups4",
+    rungs=("2k", "4k", "8k", "16k", "32k"),
+    query_builder=build_query,
+    max_new_tokens=200,
+    stop="pairs",
+)

--- a/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/mathmatch/__init__.py
+++ b/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/mathmatch/__init__.py
@@ -1,0 +1,8 @@
+"""The ``mathmatch`` task. Importing this package registers its spec."""
+
+from ...format import registry
+from .spec import SPEC
+
+registry.register(SPEC)
+
+__all__ = ["SPEC"]

--- a/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/mathmatch/spec.py
+++ b/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/mathmatch/spec.py
@@ -1,0 +1,38 @@
+"""
+The ``mathmatch`` eval contract.
+
+A list of arithmetic expressions; find every pair whose values satisfy a closeness criterion (e.g.
+``|val(a) - val(b)| <= x``). Synthetic, with the criterion carried per example in ``queries[0]``.
+
+Structurally identical to :mod:`ctc.tasks.strmatch` -- instruction then criterion, shared pair
+machinery -- and differs only in what the items are and which template renders them.
+"""
+
+from __future__ import annotations
+
+from typing import Dict
+
+from ...format.prompts import MATHMATCH_INSTRUCTION
+from .._pairs import build_target, make_pair_spec  # noqa: F401 (build_target re-exported)
+
+__all__ = ["SPEC", "build_query", "build_target"]
+
+
+def build_query(example: Dict) -> str:
+    """
+    :param example: A unified-format example whose ``queries[0]`` states this example's criterion.
+
+    :returns: The instruction followed by the criterion.
+    """
+    return f"{MATHMATCH_INSTRUCTION}\n\n{example['queries'][0]}"
+
+
+SPEC = make_pair_spec(
+    name="mathmatch",
+    description="Find every pair of arithmetic expressions whose values meet a criterion.",
+    instruction=MATHMATCH_INSTRUCTION,
+    serializer="mathmatch",
+    rungs=("2k", "4k", "8k", "16k", "32k"),
+    query_builder=build_query,
+    max_new_tokens=200,
+)

--- a/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/oolong/__init__.py
+++ b/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/oolong/__init__.py
@@ -1,0 +1,8 @@
+"""The ``oolong`` task. Importing this package registers its spec."""
+
+from ...format import registry
+from .spec import SPEC
+
+registry.register(SPEC)
+
+__all__ = ["SPEC"]

--- a/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/oolong/spec.py
+++ b/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/oolong/spec.py
@@ -1,0 +1,175 @@
+"""
+The ``oolong`` eval contract (Oolong, arXiv:2511.02817).
+
+Aggregate reasoning over many labelled items: "how many are labelled X?", "which user posted
+most?", "what is the date range?". The answer depends on *every* item, so it cannot be produced by
+retrieving one span.
+
+Three answer types, three scoring rules, chosen per example from ``_meta.answer_type``:
+
+============  =========================================================================
+NUMERIC       partial credit ``0.75 ** |gold - pred|`` -- being off by one beats being
+              off by ten, which a strict exact-match would hide
+list          set-overlap F1 over the semicolon/comma-split answer
+everything     exact match after normalization
+============  =========================================================================
+
+Two task-specific quirks:
+
+* The per-example ``question`` already carries the full instruction and answer-format spec, so the
+  header is minimal and the context block is rendered verbatim with no per-document wrapper.
+* Stopping keys on the templated ``answer:`` line rather than the first newline, because the
+  preamble is legitimately multi-line -- see the ``oolong`` stop preset.
+
+.. warning::
+   **Rebuild any oolong shard built before 2026-07-26.** The ``--item-regex`` leak (a bare ``'||'``
+   matched every line) affected shards built before that date.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Dict, Optional
+
+from ...format import assemble
+from ...format.prompts import OOLONG_INSTRUCTION
+from ...format.registry import TaskSpec
+from .._retrieval import questions_block
+
+__all__ = ["SPEC", "build_query", "build_target", "parse", "score", "normalize"]
+
+
+def normalize(s: str) -> str:
+    """
+    :param s: An answer fragment.
+
+    :returns: Lowercased with brackets and quotes stripped -- the comparison form for the
+        exact-match and set-overlap paths.
+    """
+    return re.sub(r"[\[\]'\"]", "", str(s)).strip().lower()
+
+
+def build_query(example: Dict) -> str:
+    """
+    :param example: A unified-format example whose ``queries[0]`` carries the full question and its
+        answer-format spec.
+
+    :returns: The positioned question.
+    """
+    return questions_block(example["queries"])
+
+
+def build_prompt(example: Dict, **opts) -> str:
+    """
+    :param example: A unified-format example.
+    :param opts: Assembly options.
+
+    :returns: The prompt, in the classic shape.
+    """
+    return assemble.assemble(
+        example,
+        task="oolong",
+        unified=False,
+        header=OOLONG_INSTRUCTION,
+        positioned=build_query(example),
+        **opts,
+    )
+
+
+def build_target(example: Dict) -> str:
+    """
+    :param example: A unified-format example.
+
+    :returns: The answer text.
+    """
+    return str(example["answers"][0])
+
+
+def parse(text: str, n_docs: Optional[int] = None) -> Optional[str]:
+    """
+    :param text: Raw model generation.
+    :param n_docs: Unused.
+
+    :returns: The text after the templated ``answer:`` marker when present, else the whole
+        generation; ``None`` when empty.
+    """
+    if not text.strip():
+        return None
+    lowered = text.lower()
+    if "answer:" in lowered:
+        at = lowered.rindex("answer:") + len("answer:")
+        return text[at:].strip()
+    return text.strip()
+
+
+def score(parsed: Optional[str], gold, answer_type: str = "") -> Dict[str, float]:
+    """
+    Score by the answer type this example declares.
+
+    :param parsed: Output of :func:`parse`.
+    :param gold: The gold answer(s), or the example carrying ``_meta.gold_list``/``answers``.
+    :param answer_type: From ``_meta.answer_type``; ``"NUMERIC"`` selects partial credit. Ignored
+        when ``gold`` is an example, which carries its own.
+
+    :returns: ``score`` (the primary; partial credit for numerics) and ``exact_match``, plus
+        ``parsed``.
+    """
+    if isinstance(gold, dict):
+        meta = gold.get("_meta") or {}
+        answer_type = meta.get("answer_type", answer_type)
+        gold_list = meta.get("gold_list") or [gold["answers"][0]]
+    else:
+        gold_list = list(gold) if not isinstance(gold, str) else [gold]
+
+    if parsed is None:
+        return {"score": 0.0, "exact_match": 0.0, "parsed": 0.0}
+
+    if "NUMERIC" in (answer_type or ""):
+        nums = re.findall(r"-?\d+\.?\d*", parsed)
+        try:
+            err = abs(float(gold_list[0]) - float(nums[-1]))
+            # Geometric decay, not a threshold: off-by-one must score better than off-by-ten, and
+            # a hard exact-match would report both as total failure.
+            return {"score": 0.75**err, "exact_match": float(err == 0), "parsed": 1.0}
+        except (ValueError, IndexError):
+            return {"score": 0.0, "exact_match": 0.0, "parsed": 1.0}
+
+    if len(gold_list) > 1:
+        pset = {normalize(x) for x in re.split(r"[;,]", parsed)}
+        gset = {normalize(x) for x in gold_list}
+        tp = len(pset & gset)
+        p = tp / len(pset) if pset else 0.0
+        r = tp / len(gset) if gset else 0.0
+        f1 = 2 * p * r / (p + r) if (p + r) else 0.0
+        return {"score": f1, "exact_match": float(pset == gset), "parsed": 1.0}
+
+    em = float(normalize(parsed) == normalize(gold_list[0]))
+    return {"score": em, "exact_match": em, "parsed": 1.0}
+
+
+SPEC = TaskSpec(
+    name="oolong",
+    description="Aggregate reasoning over many labelled items (partial credit).",
+    gold_index_base=0,
+    instruction=OOLONG_INSTRUCTION,
+    serializer="oolong",
+    unified=False,
+    rungs=("2k", "4k", "8k", "16k", "32k"),
+    build_prompt=build_prompt,
+    parse=parse,
+    score=score,
+    primary_metric="score",
+    max_new_tokens=256,
+    stop="oolong",
+    answer_is_set=False,
+    sources=("oolong",),
+    # The one task in the suite whose chunks are not documents. An oolong example is a single
+    # context block of labelled lines, so document chunking would wrap the whole context in one
+    # marker pair -- the training converter chunks by line, and eval must match or the model is
+    # graded against a token stream it never saw.
+    #
+    # `item_regex` is the ESCAPED pattern, matching a literal `||` separator. A bare `'||'` is a
+    # regex alternation of two empty strings, so it matches every line -- that is the leak that
+    # wrapped oolong preambles as chunks in shards built before 2026-07-26.
+    extra={"chunk_by": "line", "item_regex": r"\|\|"},
+)

--- a/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/outlier/__init__.py
+++ b/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/outlier/__init__.py
@@ -1,0 +1,8 @@
+"""The ``outlier`` task. Importing this package registers its spec."""
+
+from ...format import registry
+from .spec import SPEC
+
+registry.register(SPEC)
+
+__all__ = ["SPEC"]

--- a/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/outlier/spec.py
+++ b/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/outlier/spec.py
@@ -1,0 +1,114 @@
+"""
+The ``outlier`` eval contract.
+
+The corpus is a set of items (product reviews, Wikipedia passages) that mostly share an attribute
+-- a star rating, a product category -- and a few differ. Name the odd ones out.
+
+.. note::
+   **Legacy prompt path**, shared with ``grouping_labeled``: the documents are followed by the
+   *raw* query string (no ``Question:`` prefix), with the instruction in the alpaca header. The
+   path ignores ``query_position`` entirely, so the spec sets ``honors_query_position=False`` and
+   the fingerprint pins the value rather than reporting a mismatch over an inert knob.
+
+.. note::
+   **Gold is 0-based**, converted to the 1-based ids the prompt renders.
+
+The answer line is ``Outliers: [i], [j]``, preceded by one sentence naming the majority and
+minority attributes. That sentence is *not* scored -- only the ids -- but it is why
+:func:`~ctc.format.parsing.parse_outlier_ids` insists on bracketed ids: relaxing it the way
+``parse_doc_ids`` is relaxed would start matching the star rating in that very sentence.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+from ...format import assemble, metrics, parsing
+from ...format.prompts import OUTLIER_INSTRUCTION
+from ...format.registry import TaskSpec
+
+__all__ = ["SPEC", "build_query", "build_target", "parse", "score"]
+
+
+def build_query(example: Dict) -> str:
+    """
+    :param example: A unified-format example.
+
+    :returns: The raw query string -- no ``Question:`` prefix, and no instruction, which already
+        sits in the header.
+    """
+    return example["queries"][0]
+
+
+def build_prompt(example: Dict, **opts) -> str:
+    """
+    :param example: A unified-format example.
+    :param opts: Assembly options. ``query_position`` is accepted and ignored, matching the legacy
+        path.
+
+    :returns: The prompt.
+    """
+    opts.pop("query_position", None)
+    return assemble.assemble(
+        example,
+        task="outlier",
+        unified=False,
+        header=OUTLIER_INSTRUCTION,
+        positioned=build_query(example),
+        query_position="after",
+        **opts,
+    )
+
+
+def build_target(example: Dict) -> str:
+    """
+    :param example: A unified-format example with 0-based ``gold_doc_indices``.
+
+    :returns: The ``Outliers: [i], [j]`` answer line, ids 1-based and ascending.
+    """
+    ids = ", ".join(f"[{g + 1}]" for g in sorted(example["gold_doc_indices"]))
+    return f"Outliers: {ids}"
+
+
+def parse(text: str, n_docs: int) -> Optional[List[int]]:
+    """
+    :param text: Raw model generation.
+    :param n_docs: Corpus size; ids outside ``1..n_docs`` are dropped as hallucinations.
+
+    :returns: Ids in first-mention order, or ``None``.
+    """
+    return parsing.parse_outlier_ids(text, n_docs)
+
+
+def score(parsed: Optional[List[int]], gold) -> Dict[str, float]:
+    """
+    :param parsed: Output of :func:`parse`.
+    :param gold: 0-based gold indices, or the example carrying them.
+
+    :returns: ``precision``, ``recall``, ``f1``, ``exact_match``, ``parsed``.
+    """
+    indices = gold["gold_doc_indices"] if isinstance(gold, dict) else gold
+    gold_ids = {int(g) + 1 for g in indices}
+    if parsed is None:
+        return {"precision": 0.0, "recall": 0.0, "f1": 0.0, "exact_match": 0.0, "parsed": 0.0}
+    return {**metrics.set_metrics(set(parsed), gold_ids), "parsed": 1.0}
+
+
+SPEC = TaskSpec(
+    name="outlier",
+    description="Name the items whose attribute differs from the majority.",
+    gold_index_base=0,
+    instruction=OUTLIER_INSTRUCTION,
+    serializer="default",  # numbered, via TASKS_WITH_DOC_IDS
+    unified=False,
+    honors_query_position=False,  # legacy path hardcodes documents-then-query
+    rungs=("2k", "4k", "8k", "16k", "32k"),
+    build_prompt=build_prompt,
+    parse=parse,
+    score=score,
+    primary_metric="f1",
+    max_new_tokens=256,
+    stop="newline",
+    answer_is_set=False,
+    sources=("amazon", "wiki"),
+)

--- a/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/qa/__init__.py
+++ b/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/qa/__init__.py
@@ -1,0 +1,8 @@
+"""The ``qa`` task. Importing this package registers its spec."""
+
+from ...format import registry
+from .spec import SPEC
+
+registry.register(SPEC)
+
+__all__ = ["SPEC"]

--- a/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/qa/spec.py
+++ b/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/qa/spec.py
@@ -1,0 +1,151 @@
+"""
+The ``qa`` eval contract.
+
+Answer the question from the documents, in free text. The only ported task whose answer is prose
+rather than a structure, which is why it is the only one scored by text overlap.
+
+Scoring is deliberately **lenient**: the pre-migration ``compute_qa_metrics`` takes the maximum
+over several extraction strategies -- the raw generation, the text after an ``Answer:`` prefix, the
+text after ``</think>``, and that text's own ``Answer:`` line. A model that produces the right
+answer in any of those positions gets credit. That is a defensible choice for free-text QA, but it
+means a qa number is not comparable with the structured tasks' set-F1, and that ``exact_match``
+here is far more forgiving than exact_match elsewhere in the suite.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional, Sequence
+
+from ...format import assemble, metrics
+from ...format.prompts import MULTI_QA_INSTRUCTION, QA_INSTRUCTION
+from ...format.registry import TaskSpec
+from .._retrieval import qa_instruction, questions_block
+
+__all__ = ["SPEC", "build_query", "build_target", "parse", "score", "extraction_candidates"]
+
+
+def build_query(example: Dict) -> str:
+    """
+    :param example: A unified-format example.
+
+    :returns: The positioned question(s).
+    """
+    return questions_block(example["queries"])
+
+
+def build_prompt(example: Dict, **opts) -> str:
+    """
+    :param example: A unified-format example.
+    :param opts: Assembly options.
+
+    :returns: The prompt, in the classic shape.
+    """
+    return assemble.assemble(
+        example,
+        task="qa",
+        unified=False,
+        header=qa_instruction(example),
+        positioned=build_query(example),
+        **opts,
+    )
+
+
+def build_target(example: Dict) -> str:
+    """
+    :param example: A unified-format example.
+
+    :returns: The bare answer text, **without** an ``Answer:`` prefix.
+
+        The instruction asks for ``Answer: [answer]``, so a prefix would look right -- but the
+        trained target is the bare answer, and the prompt's ``### Response:\\n`` is where the model
+        begins. Adding the prefix would shift every qa target by two tokens against every existing
+        checkpoint. (cot_retrieval, confusingly, *does* prefix its target. The two are inconsistent
+        in the pre-migration data and the port preserves that rather than tidying it.)
+    """
+    answers = example["answers"]
+    if len(answers) > 1:
+        return ", ".join(str(a) for a in answers)
+    return str(answers[0])
+
+
+def extraction_candidates(text: str) -> List[str]:
+    """
+    Every span a QA answer might occupy.
+
+    :param text: Raw model generation.
+
+    :returns: The candidate spans, most-raw first. Scoring takes the best of these, which is what
+        makes qa lenient -- see the module docstring.
+    """
+    out = [text]
+    after_think = text.split("</think>", 1)[1] if "</think>" in text else None
+    if after_think is not None:
+        out.append(after_think)
+        first_line = after_think.strip().split("\n")[0].strip()
+        if first_line:
+            out.append(first_line)
+    for span in list(out):
+        if "Answer:" in span:
+            out.append(span.split("Answer:", 1)[1].strip().split("\n")[0].strip())
+    return [s for s in out if s.strip()]
+
+
+def parse(text: str, n_docs: Optional[int] = None) -> Optional[str]:
+    """
+    :param text: Raw model generation.
+    :param n_docs: Unused.
+
+    :returns: The generation itself. QA does not parse into a structure -- extraction happens
+        inside :func:`score`, which needs the gold answers to pick the best span.
+    """
+    return text if text.strip() else None
+
+
+def score(parsed: Optional[str], gold: Sequence[str]) -> Dict[str, float]:
+    """
+    :param parsed: Output of :func:`parse`.
+    :param gold: Acceptable answers; many datasets supply several aliases.
+
+    :returns: ``exact_match``, ``substring_exact_match``, ``f1``, ``parsed``.
+    """
+    if parsed is None:
+        return {
+            "exact_match": 0.0,
+            "substring_exact_match": 0.0,
+            "f1": 0.0,
+            "parsed": 0.0,
+        }
+    answers = list(gold) if not isinstance(gold, str) else [gold]
+    best = {"exact_match": 0.0, "substring_exact_match": 0.0, "f1": 0.0}
+    for span in extraction_candidates(parsed):
+        best["exact_match"] = max(
+            best["exact_match"], float(metrics.max_over_answers(metrics.exact_match, span, answers))
+        )
+        best["substring_exact_match"] = max(
+            best["substring_exact_match"],
+            float(metrics.max_over_answers(metrics.substring_match, span, answers)),
+        )
+        best["f1"] = max(
+            best["f1"], float(metrics.max_over_answers(metrics.token_f1, span, answers))
+        )
+    return {**best, "parsed": 1.0}
+
+
+SPEC = TaskSpec(
+    name="qa",
+    description="Answer the question from the documents, in free text.",
+    gold_index_base=0,
+    instruction=QA_INSTRUCTION,
+    instruction_variants=(MULTI_QA_INSTRUCTION,),
+    serializer="default",  # unnumbered: qa is not in TASKS_WITH_DOC_IDS
+    unified=False,
+    rungs=("2k", "4k", "8k", "16k", "32k"),
+    build_prompt=build_prompt,
+    parse=parse,
+    score=score,
+    primary_metric="f1",
+    max_new_tokens=64,
+    stop="newline",
+    answer_is_set=False,
+    sources=("nq", "hotpotqa", "helmet_qa"),
+)

--- a/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/qdmatch/__init__.py
+++ b/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/qdmatch/__init__.py
@@ -1,0 +1,8 @@
+"""The ``qdmatch`` task. Importing this package registers its spec."""
+
+from ...format import registry
+from .spec import SPEC
+
+registry.register(SPEC)
+
+__all__ = ["SPEC"]

--- a/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/qdmatch/spec.py
+++ b/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/qdmatch/spec.py
@@ -1,0 +1,120 @@
+"""
+The ``qdmatch`` eval contract.
+
+A single numbered list mixing M queries and N documents, each line tagged ``Query:`` or
+``Document:``. A few query-document pairs are relevant. Name them.
+
+The N-squared retrieval task: because queries and documents share one index, finding the answer
+means comparing across the whole list rather than scanning for one target.
+
+Two things differ from the other pair tasks and both matter:
+
+* **Pairs are ORDERED.** A qdmatch pair is ``(query_id, document_id)``; swapping the two makes a
+  different claim, so :func:`~ctc.format.parsing.parse_qd_pairs` does not sort. Feeding these to
+  the contradiction parser -- which sorts -- would silently turn wrong answers into right ones.
+* **Gold lives in ``gold_pairs``**, not ``gold_doc_indices``, and is already 1-based and ordered.
+  Reading the usual field would find the wrong data or none at all.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Dict, List, Optional
+
+from ...format import assemble, metrics, parsing
+from ...format.prompts import GENERIC_INSTRUCTION, QDMATCH_INSTRUCTION
+from ...format.registry import TaskSpec
+
+__all__ = ["SPEC", "build_query", "build_target", "parse", "score"]
+
+
+def build_query(example: Dict) -> str:
+    """
+    :param example: A unified-format example. ``queries`` is unused -- the queries are already
+        interleaved into the rendered list, so the instruction is the whole ask.
+
+    :returns: The positioned ask.
+    """
+    return QDMATCH_INSTRUCTION
+
+
+def build_prompt(example: Dict, **opts) -> str:
+    """
+    :param example: A unified-format example.
+    :param opts: Assembly options. ``query_position`` is accepted and **overridden** -- see below.
+
+    :returns: The prompt, with the instruction repeated before AND after the item list.
+    """
+    # qdmatch hardcodes query_position="both", ignoring the caller. The item list is long and
+    # interleaves queries with documents, so the instruction is repeated immediately before the
+    # response to remind the model of the task and output format. Honouring a caller's "after"
+    # here would silently produce a prompt no qdmatch checkpoint was trained on.
+    opts.pop("query_position", None)
+    return assemble.assemble(
+        example,
+        task="qdmatch",
+        unified=True,
+        header=GENERIC_INSTRUCTION,
+        positioned=build_query(example),
+        query_position="both",
+        **opts,
+    )
+
+
+def build_target(example: Dict) -> str:
+    """
+    :param example: A unified-format example carrying ``gold_pairs`` (1-based, ordered).
+
+    :returns: The pairs as JSON, order preserved.
+    """
+    return json.dumps(example.get("gold_pairs", []))
+
+
+def parse(text: str, n_docs: Optional[int] = None) -> Optional[List[List[int]]]:
+    """
+    :param text: Raw model generation.
+    :param n_docs: Unused.
+
+    :returns: Ordered pairs, ``[]`` for an explicit empty answer, or ``None``.
+    """
+    return parsing.parse_qd_pairs(text)
+
+
+def score(parsed, gold) -> Dict[str, float]:
+    """
+    :param parsed: Output of :func:`parse`.
+    :param gold: ``gold_pairs``, or the example carrying them. **Not** ``gold_doc_indices``.
+
+    :returns: ``precision``, ``recall``, ``f1``, ``exact_match``, ``parsed``.
+    """
+    pairs = gold.get("gold_pairs", []) if isinstance(gold, dict) else gold
+    if parsed is None:
+        return {"precision": 0.0, "recall": 0.0, "f1": 0.0, "exact_match": 0.0, "parsed": 0.0}
+    # pair_metrics keys on tuple(p), so order is preserved -- exactly what this task needs.
+    return {**metrics.pair_metrics(parsed, pairs), "parsed": 1.0}
+
+
+SPEC = TaskSpec(
+    name="qdmatch",
+    description="Name every relevant (query, document) pair in one interleaved list.",
+    gold_index_base=1,
+    instruction=QDMATCH_INSTRUCTION,
+    serializer="qdmatch",
+    unified=True,
+    honors_query_position=False,  # hardcoded to "both"
+    rungs=("2k", "4k", "8k", "16k", "32k"),
+    build_prompt=build_prompt,
+    parse=parse,
+    score=score,
+    primary_metric="f1",
+    max_new_tokens=200,
+    stop="pairs",
+    answer_is_set=True,
+    # ObliQ is NOT a qdmatch corpus. It was dropped from this task's roster on 2026-07-19
+    # (``BUILD_MATRIX.md`` rows 21a/21c) and re-entered the suite as a standalone in-context
+    # *retrieval* row built by a different generator, with the shipped `qdmatch_*obliq*` pilot
+    # JSONL explicitly marked do-not-use. Listing it here was the only in-repo statement of which
+    # corpora this task builds from, and it said the opposite of the roster.
+    sources=("nq", "hotpotqa"),
+    extra={"gold_field": "gold_pairs"},
+)

--- a/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/redundancy/__init__.py
+++ b/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/redundancy/__init__.py
@@ -1,0 +1,8 @@
+"""The ``redundancy`` task. Importing this package registers its spec."""
+
+from ...format import registry
+from .spec import SPEC
+
+registry.register(SPEC)
+
+__all__ = ["SPEC"]

--- a/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/redundancy/spec.py
+++ b/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/redundancy/spec.py
@@ -1,0 +1,46 @@
+"""
+The ``redundancy`` eval contract.
+
+The mirror image of contradiction: find every pair of claims stating the *same* fact, one a
+paraphrase or restatement of the other. Same corpus shape, same answer format, same scorer, so it
+shares :mod:`ctc.tasks._pairs` with the rest of the family.
+
+Unlike contradiction, this task has always stopped at the end of its answer line rather than
+decoding to the budget -- which is why it never showed contradiction's rambling behaviour, and part
+of the evidence that contradiction's ``stop="eos"`` was an oversight rather than a decision.
+
+.. note::
+   The only redundancy eval file found during the port has **244 examples**, below the 500
+   threshold. Numbers off it must be quoted with their size and error bar inline.
+"""
+
+from __future__ import annotations
+
+from typing import Dict
+
+from ...format.prompts import REDUNDANCY_INSTRUCTION
+from .._pairs import build_target, make_pair_spec  # noqa: F401 (build_target re-exported)
+
+__all__ = ["SPEC", "build_query", "build_target"]
+
+
+def build_query(example: Dict) -> str:
+    """
+    :param example: A unified-format example. Its ``queries`` field is unused -- the instruction is
+        the whole ask, which is why the task is unified.
+
+    :returns: The positioned ask.
+    """
+    return REDUNDANCY_INSTRUCTION
+
+
+SPEC = make_pair_spec(
+    name="redundancy",
+    description="Find every pair of claims that state the same fact (N^2 over the corpus).",
+    instruction=REDUNDANCY_INSTRUCTION,
+    serializer="redundancy",
+    rungs=("2k", "4k", "8k", "16k", "32k"),
+    query_builder=build_query,
+    max_new_tokens=200,
+    sources=("pubmed",),
+)

--- a/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/reorder/__init__.py
+++ b/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/reorder/__init__.py
@@ -1,0 +1,8 @@
+"""The ``reorder`` task. Importing this package registers its spec."""
+
+from ...format import registry
+from .spec import SPEC
+
+registry.register(SPEC)
+
+__all__ = ["SPEC"]

--- a/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/reorder/spec.py
+++ b/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/reorder/spec.py
@@ -1,0 +1,139 @@
+"""
+The ``reorder`` eval contract.
+
+Passages from one document are shown in random order under shuffled display ids; the model outputs
+the permutation restoring the original order. Scored by Kendall's tau, so a nearly-right ordering
+scores nearly right -- unlike the set tasks, where a near-miss scores zero.
+
+Two things specific to this task:
+
+* **The target comes from ``gold_order``**, a list of 1-indexed display ids already in source
+  order. It is *not* derived from ``gold_doc_indices`` the way every other task's target is.
+* **The serializer collapses each passage's internal blank lines to single newlines.** Gutenberg
+  passages contain their own paragraph breaks, and without that collapse a passage would be split
+  across two chunks under the chunked mask, leaking its tail into the unmasked region.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Dict, List, Optional
+
+from ...format import assemble, metrics, parsing
+from ...format.prompts import REORDER_INSTRUCTION
+from ...format.registry import TaskSpec
+
+__all__ = ["SPEC", "build_query", "build_target", "parse", "score"]
+
+
+def build_query(example: Dict) -> str:
+    """
+    :param example: A unified-format example. ``queries`` is unused -- restoring the order is the
+        whole ask, which is why this task is unified.
+
+    :returns: The positioned ask.
+    """
+    return REORDER_INSTRUCTION
+
+
+def build_prompt(example: Dict, **opts) -> str:
+    """
+    :param example: A unified-format example.
+    :param opts: Assembly options.
+
+    :returns: The prompt.
+    """
+    from ...format.prompts import GENERIC_INSTRUCTION
+
+    return assemble.assemble(
+        example,
+        task="reorder",
+        unified=True,
+        header=GENERIC_INSTRUCTION,
+        positioned=build_query(example),
+        **opts,
+    )
+
+
+def build_target(example: Dict) -> str:
+    """
+    :param example: A unified-format example carrying ``gold_order``.
+
+    :returns: The permutation as a JSON array.
+    """
+    return json.dumps(example["gold_order"])
+
+
+def parse(text: str, n_docs: Optional[int] = None) -> Optional[List[int]]:
+    """
+    :param text: Raw model generation.
+    :param n_docs: Expected permutation length. Required here -- a permutation can only be
+        recognised against a known length.
+
+    :returns: The permutation, or ``None`` if the output is not an exact permutation of ``1..n``.
+    """
+    if n_docs is None:
+        return None
+    return parsing.parse_permutation(text, n_docs)
+
+
+def score(parsed: Optional[List[int]], gold_order: List[int]) -> Dict[str, float]:
+    """
+    :param parsed: Output of :func:`parse`.
+    :param gold_order: The true ordering, 1-indexed.
+
+    :returns: ``kendall_tau``, ``pmr`` (perfect match rate), ``position_accuracy``, ``parsed``,
+        plus ``spearman_rho`` when scipy is installed.
+
+        Note ``kendall_tau`` ranges over ``[-1, 1]``, not ``[0, 1]`` like every other primary
+        metric in the suite: a systematically reversed ordering scores ``-1``, and 0 means no
+        better than chance. Averaging it alongside F1 scores without saying so would be misleading.
+    """
+    if parsed is None:
+        return {
+            "kendall_tau": 0.0,
+            "pmr": 0.0,
+            "position_accuracy": 0.0,
+            "parsed": 0.0,
+        }
+    n = len(gold_order)
+    correct = sum(1 for a, b in zip(parsed, gold_order) if a == b)
+    out = {
+        "kendall_tau": metrics.kendall_tau(parsed, gold_order),
+        "pmr": float(list(parsed) == list(gold_order)),
+        "position_accuracy": correct / n if n else 0.0,
+        "parsed": 1.0,
+    }
+    out.update(metrics.ordering_extras(parsed, gold_order))
+    return out
+
+
+SPEC = TaskSpec(
+    name="reorder",
+    description="Restore the original order of shuffled passages (Kendall tau).",
+    gold_index_base=1,  # gold_order carries 1-indexed display ids directly
+    instruction=REORDER_INSTRUCTION,
+    serializer="reorder",
+    unified=True,
+    rungs=("2k", "4k", "8k", "16k", "32k"),
+    build_prompt=build_prompt,
+    parse=parse,
+    score=score,
+    primary_metric="kendall_tau",
+    # 2048, not the pre-migration 1024. Reorder is the one task whose ANSWER grows with the rung:
+    # the target is a permutation of n ids, measured at ~4.5 Qwen3 tokens each, so the 32k rung's
+    # target has a median length of 1057 tokens and does not fit in 1024. `parse_permutation`
+    # requires an EXACT permutation of 1..n, so a truncated answer parses as None and scores
+    # kendall_tau 0.0 -- for every example at that rung, reading as a long-context collapse rather
+    # than as a decode budget. Sized against the measured 32k target; `grouping_labeled`, the other
+    # task whose answer is a long list, already sets 2048 for the same reason.
+    max_new_tokens=2048,
+    stop="eos",
+    answer_is_set=False,
+    sources=("gutenberg",),
+    # Declared, not defaulted. Without this the shared build/audit layer reads
+    # `gold_doc_indices` -- which a reorder example does not have at all -- so `validate` rejects
+    # every row for a missing gold field, and `gold_fingerprint` collapses every example onto one
+    # digest, which would make the train/eval contamination guard report leakage everywhere.
+    extra={"gold_field": "gold_order"},
+)

--- a/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/rerank/__init__.py
+++ b/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/rerank/__init__.py
@@ -1,0 +1,8 @@
+"""The ``rerank`` task. Importing this package registers its spec."""
+
+from ...format import registry
+from .spec import SPEC
+
+registry.register(SPEC)
+
+__all__ = ["SPEC"]

--- a/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/rerank/spec.py
+++ b/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/rerank/spec.py
@@ -1,0 +1,157 @@
+"""
+The ``rerank`` eval contract (MS MARCO passage re-ranking).
+
+Given a query and a candidate pool, order the documents from most to least relevant.
+
+.. warning::
+   **The old binary rerank format is DISABLED, and that is deliberate.** Data without per-document
+   cross-encoder scores (``ce_scores``) yields a degenerate gold-first target and MRR-only metrics,
+   so the pre-migration evaluator raises rather than scoring it -- "so stale numbers can't be read
+   by accident". That guard is preserved here. Regenerate with
+   ``generate_msmarco_trainhn_data.py`` for CE-graded data, which scores NDCG@10 and Kendall tau.
+
+Scoring reflects **ordering quality**, not merely whether a gold document reached the top-k. MRR@10
+alone would give full credit to a ranking that puts one gold first and then scrambles everything
+after it, which for a re-ranking task is most of the answer.
+
+**Gold is 0-based**, converted to the 1-based ids the prompt renders.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+from ...format import assemble
+from ...format.prompts import RERANK_INSTRUCTION, rerank_instruction
+from ...format.registry import TaskSpec
+from .._retrieval import questions_block
+
+__all__ = ["SPEC", "build_query", "build_target", "parse", "score", "require_ce_scores"]
+
+#: NDCG cutoff, and the length of the ranked prefix that is scored.
+TOP_K = 10
+
+
+def require_ce_scores(example: Dict) -> None:
+    """
+    Refuse to score data that predates cross-encoder grading.
+
+    :param example: A unified-format example.
+
+    :raises NotImplementedError: When ``ce_scores`` is absent or all-``None``. The old format
+        produces a degenerate gold-first target whose MRR-only numbers are not comparable with
+        anything current, and silently scoring it is how a stale number gets read as a live one.
+    """
+    ce = example.get("ce_scores")
+    if not (ce and any(s is not None for s in ce)):
+        raise NotImplementedError(
+            "DEPRECATED binary rerank data: no `ce_scores`. The old gold-first / MRR-only format "
+            "is disabled so stale numbers cannot be read by accident. Regenerate with "
+            "generate_msmarco_trainhn_data.py (CE-graded -> NDCG@10 + Kendall tau)."
+        )
+
+
+def build_query(example: Dict) -> str:
+    """
+    :param example: A unified-format example.
+
+    :returns: The positioned question.
+    """
+    return questions_block(example["queries"])
+
+
+def build_prompt(example: Dict, **opts) -> str:
+    """
+    :param example: A unified-format example.
+    :param opts: Assembly options.
+
+    :returns: The prompt, in the classic shape.
+    """
+    return assemble.assemble(
+        example,
+        task="rerank",
+        unified=False,
+        header=RERANK_INSTRUCTION,
+        positioned=build_query(example),
+        **opts,
+    )
+
+
+def build_target(example: Dict) -> str:
+    """
+    :param example: A unified-format example with 0-based ``gold_doc_indices``.
+
+    :returns: The ``Ranking: [i], [j], ...`` answer line, ids 1-based.
+    """
+    ids = ", ".join(f"[{g + 1}]" for g in example["gold_doc_indices"])
+    return f"Ranking: {ids}"
+
+
+def parse(text: str, n_docs: Optional[int] = None) -> Optional[List[int]]:
+    """
+    Extract the ranked id list, **order preserved and duplicates dropped**.
+
+    :param text: Raw model generation.
+    :param n_docs: Corpus size; ids outside ``1..n_docs`` are dropped.
+
+    :returns: The ranking, or ``None`` if nothing parsed.
+
+    .. note::
+       :func:`~ctc.format.parsing.parse_doc_ids` returns a *set* and is therefore wrong here --
+       a ranking is an ordering, and set semantics would discard the entire answer.
+    """
+    import re
+
+    ids = [int(x) for x in re.findall(r"\[?\s*(\d+)\s*\]", text)]
+    if n_docs is not None:
+        ids = [i for i in ids if 1 <= i <= n_docs]
+    seen, out = set(), []
+    for i in ids:
+        if i not in seen:
+            seen.add(i)
+            out.append(i)
+    return out or None
+
+
+def score(parsed: Optional[List[int]], gold, k: int = TOP_K) -> Dict[str, float]:
+    """
+    :param parsed: Output of :func:`parse`.
+    :param gold: 0-based gold indices, or the example carrying them.
+    :param k: Cutoff for MRR and recall.
+
+    :returns: ``mrr@10``, ``recall@10``, ``parsed``.
+    """
+    indices = gold["gold_doc_indices"] if isinstance(gold, dict) else gold
+    gold_ids = {int(g) + 1 for g in indices}
+    if not parsed:
+        return {f"mrr@{k}": 0.0, f"recall@{k}": 0.0, "parsed": 0.0}
+
+    prefix = parsed[:k]
+    rr = 0.0
+    for rank, doc in enumerate(prefix, start=1):
+        if doc in gold_ids:
+            rr = 1.0 / rank
+            break
+    recall = len(set(prefix) & gold_ids) / len(gold_ids) if gold_ids else 0.0
+    return {f"mrr@{k}": rr, f"recall@{k}": recall, "parsed": 1.0}
+
+
+SPEC = TaskSpec(
+    name="rerank",
+    description="Order candidate documents by relevance to the query (MRR@10).",
+    gold_index_base=0,
+    instruction=RERANK_INSTRUCTION,
+    instruction_variants=(rerank_instruction(TOP_K),),
+    serializer="default",  # numbered, via TASKS_WITH_DOC_IDS
+    unified=False,
+    rungs=("2k", "4k", "8k", "16k", "32k"),
+    build_prompt=build_prompt,
+    parse=parse,
+    score=score,
+    primary_metric="mrr@10",
+    max_new_tokens=512,
+    stop="newline",
+    answer_is_set=False,
+    sources=("msmarco",),
+    extra={"top_k": TOP_K, "requires_ce_scores": True},
+)

--- a/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/rerank/spec.py
+++ b/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/rerank/spec.py
@@ -85,6 +85,22 @@ def _ce_top_k(example: Dict, k: int) -> List[int]:
     return [i + 1 for i in ranked[:k]]
 
 
+def _ce_pos_ref(example: Dict, k: int) -> List[int]:
+    """The graded reference set: document ids (1-based) with ``CE > 0``, capped at the ``k``
+    highest so the metric ceiling stays exactly 1.0 for a ``k``-slot answer.
+
+    Measured on the token-accurate ladder (100 examples/rung, 2k and 32k): median 3 docs/example
+    have CE > 0, p90 5, and there is essentially nothing in (-5, 0] -- relevance is bimodal. That
+    is why the reference is the CE-POSITIVE set and not the CE-top-10: ranks 4-10 of the top-10
+    are ordering noise among ~-11 CE docs that no model could reproduce, which put a ~0.5 luck
+    ceiling on the top-10-recall variant this metric replaces (2026-08-14, measured before the
+    first repriced number was ever produced)."""
+    ce = example.get("ce_scores") or []
+    pos = sorted((i for i, v in enumerate(ce) if v is not None and v > 0),
+                 key=lambda i: ce[i], reverse=True)
+    return [i + 1 for i in pos[:k]]
+
+
 def build_target(example: Dict) -> str:
     """
     :param example: A unified-format example.
@@ -131,13 +147,14 @@ def score(parsed: Optional[List[int]], gold, k: int = TOP_K) -> Dict[str, float]
         indices from a legacy caller.
     :param k: Cutoff for every @k metric.
 
-    :returns: ``ce_top10_recall`` (primary -- fraction of the CE-top-10 documents present in the
-        model's first 10 ids), plus ``mrr@10``/``recall@10`` against the single qrel gold, and
-        ``parsed``. The qrel metrics saturate near 0.98 even for weak arms -- finding ONE known
-        document is easy -- which is why they were demoted (prasann, 2026-08-14): the task is
-        meant to measure tracking the whole top-10.
+    :returns: ``ce_pos_recall`` (primary -- fraction of the CE-positive documents, median 3 /
+        p90 5 per example, present in the model's first 10 ids), plus ``mrr@10``/``recall@10``
+        against the single qrel gold, and ``parsed``. The qrel metrics saturate near 0.98 even
+        for weak arms -- finding ONE known document is easy -- which is why they were demoted
+        (prasann, 2026-08-14): the task is meant to measure tracking every genuinely relevant
+        document.
 
-    ``ce_top10_recall`` is always present (the registry contract requires the primary metric in
+    ``ce_pos_recall`` is always present (the registry contract requires the primary metric in
     every score() output); ``ce_ref_available`` says whether a CE reference set actually existed,
     so a legacy caller that passes bare indices produces a diagnosable 0/0 rather than a silent
     zero that reads as a model collapse.
@@ -145,9 +162,9 @@ def score(parsed: Optional[List[int]], gold, k: int = TOP_K) -> Dict[str, float]
     example = gold if isinstance(gold, dict) else None
     indices = example["gold_doc_indices"] if example else gold
     gold_ids = {int(g) + 1 for g in indices}
-    ce_ref = set(_ce_top_k(example, k)) if example else set()
+    ce_ref = set(_ce_pos_ref(example, k)) if example else set()
 
-    out: Dict[str, float] = {f"mrr@{k}": 0.0, f"recall@{k}": 0.0, "ce_top10_recall": 0.0,
+    out: Dict[str, float] = {f"mrr@{k}": 0.0, f"recall@{k}": 0.0, "ce_pos_recall": 0.0,
                              "ce_ref_available": 1.0 if ce_ref else 0.0, "parsed": 0.0}
     if not parsed:
         return out
@@ -159,14 +176,14 @@ def score(parsed: Optional[List[int]], gold, k: int = TOP_K) -> Dict[str, float]
             break
     out[f"recall@{k}"] = len(set(prefix) & gold_ids) / len(gold_ids) if gold_ids else 0.0
     if ce_ref:
-        out["ce_top10_recall"] = len(set(prefix) & ce_ref) / len(ce_ref)
+        out["ce_pos_recall"] = len(set(prefix) & ce_ref) / len(ce_ref)
     out["parsed"] = 1.0
     return out
 
 
 SPEC = TaskSpec(
     name="rerank",
-    description="Order candidate documents by relevance; graded on CE-top-10 recall.",
+    description="Order candidate documents by relevance; graded on CE-positive recall.",
     gold_index_base=0,
     instruction=RERANK_INSTRUCTION,
     instruction_variants=(rerank_instruction(TOP_K),),
@@ -176,7 +193,7 @@ SPEC = TaskSpec(
     build_prompt=build_prompt,
     parse=parse,
     score=score,
-    primary_metric="ce_top10_recall",
+    primary_metric="ce_pos_recall",
     max_new_tokens=512,
     stop="newline",
     answer_is_set=False,

--- a/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/rerank/spec.py
+++ b/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/rerank/spec.py
@@ -77,14 +77,25 @@ def build_prompt(example: Dict, **opts) -> str:
     )
 
 
+def _ce_top_k(example: Dict, k: int) -> List[int]:
+    """The ``k`` highest-CE document ids (1-based), CE=None (pooled-foreign docs) excluded."""
+    ce = example.get("ce_scores") or []
+    ranked = sorted((i for i, v in enumerate(ce) if v is not None),
+                    key=lambda i: ce[i], reverse=True)
+    return [i + 1 for i in ranked[:k]]
+
+
 def build_target(example: Dict) -> str:
     """
-    :param example: A unified-format example with 0-based ``gold_doc_indices``.
+    :param example: A unified-format example.
 
-    :returns: The ``Ranking: [i], [j], ...`` answer line, ids 1-based.
+    :returns: The ``Ranking: [i], [j], ...`` answer line, 1-based -- the CE-ordered top-10 when
+        ``ce_scores`` are present, which is both the SFT training target
+        (``_rerank_reference_order``) and the answer :func:`score` grades for; the bare qrel gold
+        otherwise.
     """
-    ids = ", ".join(f"[{g + 1}]" for g in example["gold_doc_indices"])
-    return f"Ranking: {ids}"
+    ids = _ce_top_k(example, TOP_K) or [g + 1 for g in example["gold_doc_indices"]]
+    return "Ranking: " + ", ".join(f"[{i}]" for i in ids)
 
 
 def parse(text: str, n_docs: Optional[int] = None) -> Optional[List[int]]:
@@ -116,29 +127,46 @@ def parse(text: str, n_docs: Optional[int] = None) -> Optional[List[int]]:
 def score(parsed: Optional[List[int]], gold, k: int = TOP_K) -> Dict[str, float]:
     """
     :param parsed: Output of :func:`parse`.
-    :param gold: 0-based gold indices, or the example carrying them.
-    :param k: Cutoff for MRR and recall.
+    :param gold: The EXAMPLE (via ``extra["score_takes_example"]``), or bare 0-based gold
+        indices from a legacy caller.
+    :param k: Cutoff for every @k metric.
 
-    :returns: ``mrr@10``, ``recall@10``, ``parsed``.
+    :returns: ``ce_top10_recall`` (primary -- fraction of the CE-top-10 documents present in the
+        model's first 10 ids), plus ``mrr@10``/``recall@10`` against the single qrel gold, and
+        ``parsed``. The qrel metrics saturate near 0.98 even for weak arms -- finding ONE known
+        document is easy -- which is why they were demoted (prasann, 2026-08-14): the task is
+        meant to measure tracking the whole top-10.
+
+    ``ce_top10_recall`` is always present (the registry contract requires the primary metric in
+    every score() output); ``ce_ref_available`` says whether a CE reference set actually existed,
+    so a legacy caller that passes bare indices produces a diagnosable 0/0 rather than a silent
+    zero that reads as a model collapse.
     """
-    indices = gold["gold_doc_indices"] if isinstance(gold, dict) else gold
+    example = gold if isinstance(gold, dict) else None
+    indices = example["gold_doc_indices"] if example else gold
     gold_ids = {int(g) + 1 for g in indices}
+    ce_ref = set(_ce_top_k(example, k)) if example else set()
+
+    out: Dict[str, float] = {f"mrr@{k}": 0.0, f"recall@{k}": 0.0, "ce_top10_recall": 0.0,
+                             "ce_ref_available": 1.0 if ce_ref else 0.0, "parsed": 0.0}
     if not parsed:
-        return {f"mrr@{k}": 0.0, f"recall@{k}": 0.0, "parsed": 0.0}
+        return out
 
     prefix = parsed[:k]
-    rr = 0.0
     for rank, doc in enumerate(prefix, start=1):
         if doc in gold_ids:
-            rr = 1.0 / rank
+            out[f"mrr@{k}"] = 1.0 / rank
             break
-    recall = len(set(prefix) & gold_ids) / len(gold_ids) if gold_ids else 0.0
-    return {f"mrr@{k}": rr, f"recall@{k}": recall, "parsed": 1.0}
+    out[f"recall@{k}"] = len(set(prefix) & gold_ids) / len(gold_ids) if gold_ids else 0.0
+    if ce_ref:
+        out["ce_top10_recall"] = len(set(prefix) & ce_ref) / len(ce_ref)
+    out["parsed"] = 1.0
+    return out
 
 
 SPEC = TaskSpec(
     name="rerank",
-    description="Order candidate documents by relevance to the query (MRR@10).",
+    description="Order candidate documents by relevance; graded on CE-top-10 recall.",
     gold_index_base=0,
     instruction=RERANK_INSTRUCTION,
     instruction_variants=(rerank_instruction(TOP_K),),
@@ -148,10 +176,10 @@ SPEC = TaskSpec(
     build_prompt=build_prompt,
     parse=parse,
     score=score,
-    primary_metric="mrr@10",
+    primary_metric="ce_top10_recall",
     max_new_tokens=512,
     stop="newline",
     answer_is_set=False,
     sources=("msmarco",),
-    extra={"top_k": TOP_K, "requires_ce_scores": True},
+    extra={"top_k": TOP_K, "requires_ce_scores": True, "score_takes_example": True},
 )

--- a/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/retrieval/__init__.py
+++ b/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/retrieval/__init__.py
@@ -1,0 +1,8 @@
+"""The ``retrieval`` task. Importing this package registers its spec."""
+
+from ...format import registry
+from .spec import SPEC
+
+registry.register(SPEC)
+
+__all__ = ["SPEC"]

--- a/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/retrieval/spec.py
+++ b/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/retrieval/spec.py
@@ -1,0 +1,131 @@
+"""
+The ``retrieval`` eval contract.
+
+Given a corpus and a question, name the document ids that answer it. The canonical target for six
+different suite entries -- ``nq``, ``hotpotqa``, ``niah_contradiction``, ``beir_scifact``,
+``beir_fiqa`` and ``msmarco`` all alias to this one task. They are *sources*, not separate tasks,
+which is what :attr:`~ctc.format.registry.TaskSpec.sources` records.
+
+The first classic-shape task in the port: the instruction lives in the alpaca header and the
+question is positioned, rather than the instruction itself being positioned.
+
+.. note::
+   **The instruction depends on the example.** Single-gold, multi-gold and multi-query select three
+   different wordings, so the same task produces three prompt shapes. All three are declared in
+   ``instruction_variants`` and hashed into the fingerprint.
+
+.. note::
+   **Gold is 0-based**, converted to the 1-based ids the prompt renders. Same as the absence
+   family, opposite to contradiction and the pair family.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Optional, Set
+
+from ...format import assemble, parsing
+from ...format.prompts import (
+    RETRIEVAL_INSTRUCTION_MULTI_DOC,
+    RETRIEVAL_INSTRUCTION_MULTI_QUERY,
+    RETRIEVAL_INSTRUCTION_SINGLE,
+)
+from ...format.registry import TaskSpec
+from .._retrieval import (
+    flatten_gold,
+    is_multi_query,
+    questions_block,
+    retrieval_instruction,
+    score_ids,
+)
+
+__all__ = ["SPEC", "build_query", "build_target", "parse", "score"]
+
+
+def build_query(example: Dict) -> str:
+    """
+    :param example: A unified-format example.
+
+    :returns: The positioned text -- here the example's own question(s), since the instruction sits
+        in the header.
+    """
+    return questions_block(example["queries"])
+
+
+def build_prompt(example: Dict, **opts) -> str:
+    """
+    :param example: A unified-format example.
+    :param opts: Assembly options.
+
+    :returns: The prompt, in the classic shape.
+    """
+    return assemble.assemble(
+        example,
+        task="retrieval",
+        unified=False,
+        header=retrieval_instruction(example),
+        positioned=build_query(example),
+        **opts,
+    )
+
+
+def build_target(example: Dict) -> str:
+    """
+    :param example: A unified-format example with 0-based ``gold_doc_indices``.
+
+    :returns: The bracketed 1-based ids; multi-query examples are grouped ``Q1: ...; Q2: ...``.
+    """
+    gold = example["gold_doc_indices"]
+    if is_multi_query(example):
+        parts = []
+        for i, per_query in enumerate(gold):
+            ids = ", ".join(f"[{g + 1}]" for g in per_query)
+            parts.append(f"Q{i + 1}: {ids}")
+        return "; ".join(parts)
+    return ", ".join(f"[{g + 1}]" for g in sorted(flatten_gold(example)))
+
+
+def parse(text: str, n_docs: Optional[int] = None) -> Optional[Set[int]]:
+    """
+    :param text: Raw model generation.
+    :param n_docs: Corpus size. Unused -- ids are not range-filtered here.
+
+    :returns: The named ids, or ``None`` if none parsed. An empty set is never returned as a
+        distinct answer: naming nothing is a failure to retrieve, not an assertion.
+    """
+    ids = parsing.parse_doc_ids(text)
+    return ids if ids else None
+
+
+def score(parsed, example_or_gold) -> Dict[str, float]:
+    """
+    :param parsed: Output of :func:`parse`.
+    :param example_or_gold: The example, or its raw 0-based gold indices.
+
+    :returns: ``exact_match``, ``recall``, ``precision``, ``f1``, ``parsed``.
+    """
+    example = (
+        example_or_gold
+        if isinstance(example_or_gold, dict)
+        else {"gold_doc_indices": example_or_gold, "queries": [""]}
+    )
+    return score_ids(parsed, example)
+
+
+SPEC = TaskSpec(
+    name="retrieval",
+    description="Name the document ids relevant to the question.",
+    gold_index_base=0,
+    instruction=RETRIEVAL_INSTRUCTION_SINGLE,
+    instruction_variants=(RETRIEVAL_INSTRUCTION_MULTI_DOC, RETRIEVAL_INSTRUCTION_MULTI_QUERY),
+    serializer="default",  # numbered, via TASKS_WITH_DOC_IDS
+    unified=False,
+    rungs=("2k", "4k", "8k", "16k", "32k"),
+    build_prompt=build_prompt,
+    parse=parse,
+    score=score,
+    primary_metric="f1",
+    max_new_tokens=64,
+    stop="newline",
+    answer_is_set=True,
+    sources=("nq", "hotpotqa", "niah_contradiction", "beir_scifact", "beir_fiqa", "msmarco"),
+)

--- a/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/strmatch/__init__.py
+++ b/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/strmatch/__init__.py
@@ -1,0 +1,8 @@
+"""The ``strmatch`` task. Importing this package registers its spec."""
+
+from ...format import registry
+from .spec import SPEC
+
+registry.register(SPEC)
+
+__all__ = ["SPEC"]

--- a/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/strmatch/spec.py
+++ b/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/strmatch/spec.py
@@ -1,0 +1,41 @@
+"""
+The ``strmatch`` eval contract.
+
+A list of short strings; find every pair satisfying a string-similarity criterion -- a shared
+contiguous run of words, or a matching word count. Synthetic, so the criterion varies per example
+and is carried in ``queries[0]`` rather than being fixed by the instruction.
+
+That per-example criterion is the one structural difference from :mod:`ctc.tasks.redundancy`: the
+positioned ask is the instruction *followed by* the example's criterion. Everything else -- answer
+format, parser, scorer, gold convention -- is the shared pair-family machinery.
+"""
+
+from __future__ import annotations
+
+from typing import Dict
+
+from ...format.prompts import STRMATCH_INSTRUCTION
+from .._pairs import build_target, make_pair_spec  # noqa: F401 (build_target re-exported)
+
+__all__ = ["SPEC", "build_query", "build_target"]
+
+
+def build_query(example: Dict) -> str:
+    """
+    :param example: A unified-format example whose ``queries[0]`` states this example's criterion.
+
+    :returns: The instruction followed by the criterion, in that order -- the order is part of the
+        format the shards were built with.
+    """
+    return f"{STRMATCH_INSTRUCTION}\n\n{example['queries'][0]}"
+
+
+SPEC = make_pair_spec(
+    name="strmatch",
+    description="Find every pair of strings matching a per-example similarity criterion.",
+    instruction=STRMATCH_INSTRUCTION,
+    serializer="strmatch",
+    rungs=("2k", "4k", "8k", "16k", "32k"),
+    query_builder=build_query,
+    max_new_tokens=200,
+)

--- a/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/summarization/__init__.py
+++ b/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/summarization/__init__.py
@@ -1,0 +1,8 @@
+"""The ``summarization`` task. Importing this package registers its spec."""
+
+from ...format import registry
+from .spec import SPEC
+
+registry.register(SPEC)
+
+__all__ = ["SPEC"]

--- a/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/summarization/spec.py
+++ b/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/summarization/spec.py
@@ -1,0 +1,151 @@
+"""
+The ``summarization`` eval contract (HELMET: ∞Bench Sum, Multi-LexSum, GovReport).
+
+Write a faithful summary of the documents. Graded by ROUGE.
+
+.. warning::
+   **ROUGE requires ``pip install 'ctc[rouge]'``, and its absence is an ERROR here, not a
+   fallback.** The pre-migration scorer caught the ImportError and silently wrote token-F1 under
+   the keys ``rouge1_f``/``rougeL_f``. It did exactly that for the whole ``helmet_summ`` column of
+   the CTC grid -- ``rouge_score`` was installed on sneetches but its dependency ``absl-py`` was
+   not -- so every published "ROUGE" number there was really token-F1. The tell is
+   ``rouge1_f == rougeL_f`` to full precision, which ROUGE-1 and ROUGE-L never are.
+
+   Refusing to score is the correct behaviour: a metric that quietly becomes a different metric is
+   worse than one that fails. :func:`score` therefore raises unless ``rouge_score`` imports, and
+   ``score_token_f1`` exists as an explicit, differently-named opt-in for anyone who genuinely
+   wants the cheap approximation.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Optional, Sequence
+
+from ...format import assemble, metrics
+from ...format.prompts import SUMMARIZATION_INSTRUCTION
+from ...format.registry import TaskSpec
+from .._retrieval import questions_block
+
+__all__ = ["SPEC", "build_query", "build_target", "parse", "score", "score_token_f1"]
+
+
+def build_query(example: Dict) -> str:
+    """
+    :param example: A unified-format example.
+
+    :returns: The positioned question(s).
+    """
+    return questions_block(example["queries"])
+
+
+def build_prompt(example: Dict, **opts) -> str:
+    """
+    :param example: A unified-format example.
+    :param opts: Assembly options.
+
+    :returns: The prompt, in the classic shape.
+    """
+    return assemble.assemble(
+        example,
+        task="summarization",
+        unified=False,
+        header=SUMMARIZATION_INSTRUCTION,
+        positioned=build_query(example),
+        **opts,
+    )
+
+
+def build_target(example: Dict) -> str:
+    """
+    :param example: A unified-format example.
+
+    :returns: The reference summary.
+    """
+    return str(example["answers"][0])
+
+
+def parse(text: str, n_docs: Optional[int] = None) -> Optional[str]:
+    """
+    :param text: Raw model generation.
+    :param n_docs: Unused.
+
+    :returns: The generation, or ``None`` when it is empty. Summaries are free text; there is
+        nothing to parse into.
+    """
+    return text if text.strip() else None
+
+
+def score(parsed: Optional[str], gold: Sequence[str]) -> Dict[str, float]:
+    """
+    ROUGE against the reference summary.
+
+    :param parsed: Output of :func:`parse`.
+    :param gold: Reference summary/summaries.
+
+    :returns: ``rouge1_f``, ``rougeL_f``, ``parsed``.
+
+    :raises ImportError: If ``rouge_score`` is unavailable. Deliberate -- see the module warning.
+        Silently substituting token-F1 under the ROUGE key is what corrupted the published
+        helmet_summ column.
+    """
+    # Checked BEFORE the import: an unparseable generation scores zero regardless of which
+    # library is installed, and requiring rouge to say so would make a missing dependency look
+    # like a scoring failure.
+    if parsed is None:
+        return {"rouge1_f": 0.0, "rougeL_f": 0.0, "parsed": 0.0}
+
+    try:
+        from rouge_score import rouge_scorer
+    except ImportError as e:
+        raise ImportError(
+            f"summarization needs rouge_score ({e}). Install with: pip install 'ctc[rouge]'. "
+            "This is deliberately NOT falling back to token_f1: the pre-migration scorer did, "
+            "under the SAME metric keys, and silently relabelled the entire helmet_summ column. "
+            "If you genuinely want the approximation, call score_token_f1 explicitly."
+        ) from None
+
+    refs = list(gold) if not isinstance(gold, str) else [gold]
+    scorer = rouge_scorer.RougeScorer(["rouge1", "rougeL"], use_stemmer=True)
+    best = {"rouge1_f": 0.0, "rougeL_f": 0.0}
+    for ref in refs:
+        s = scorer.score(str(ref), parsed)
+        best["rouge1_f"] = max(best["rouge1_f"], s["rouge1"].fmeasure)
+        best["rougeL_f"] = max(best["rougeL_f"], s["rougeL"].fmeasure)
+    return {**best, "parsed": 1.0}
+
+
+def score_token_f1(parsed: Optional[str], gold: Sequence[str]) -> Dict[str, float]:
+    """
+    Token-F1 approximation, under **distinct keys** so it can never be mistaken for ROUGE.
+
+    :param parsed: Output of :func:`parse`.
+    :param gold: Reference summary/summaries.
+
+    :returns: ``token_f1``, ``parsed``. Note the key: this is the whole point of the function.
+    """
+    if parsed is None:
+        return {"token_f1": 0.0, "parsed": 0.0}
+    refs = list(gold) if not isinstance(gold, str) else [gold]
+    return {
+        "token_f1": float(metrics.max_over_answers(metrics.token_f1, parsed, refs)),
+        "parsed": 1.0,
+    }
+
+
+SPEC = TaskSpec(
+    name="summarization",
+    description="Write a faithful summary of the documents (ROUGE).",
+    gold_index_base=0,
+    instruction=SUMMARIZATION_INSTRUCTION,
+    serializer="summarization",
+    unified=False,
+    rungs=("2k", "4k", "8k", "16k", "32k"),
+    build_prompt=build_prompt,
+    parse=parse,
+    score=score,
+    primary_metric="rouge1_f",
+    max_new_tokens=1024,
+    stop="eos",
+    answer_is_set=False,
+    sources=("helmet_summ", "govreport", "multi_lexsum", "infbench_sum"),
+)

--- a/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/textgroups/__init__.py
+++ b/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/textgroups/__init__.py
@@ -1,0 +1,8 @@
+"""The ``textgroups`` task. Importing this package registers its spec."""
+
+from ...format import registry
+from .spec import SPEC
+
+registry.register(SPEC)
+
+__all__ = ["SPEC"]

--- a/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/textgroups/spec.py
+++ b/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/textgroups/spec.py
@@ -1,0 +1,42 @@
+"""
+The ``textgroups`` eval contract.
+
+The natural-language counterpart to :mod:`ctc.tasks.groups4`. Each passage carries a *textual*
+feature value -- its noun count, or how often a common word appears -- and the model finds groups
+whose feature values meet an aggregate target. The criterion, including which feature is meant, is
+per-example and lives in ``queries[0]``.
+
+Structurally identical to groups4: instruction then criterion, shared cycle-family scoring. It
+differs in that the feature must be *read out of prose* rather than computed from an expression,
+which is the point of having both.
+"""
+
+from __future__ import annotations
+
+from typing import Dict
+
+from ...format.prompts import TEXTGROUPS_INSTRUCTION
+from .._cycles import build_target, make_cycle_spec  # noqa: F401 (build_target re-exported)
+
+__all__ = ["SPEC", "build_query", "build_target"]
+
+
+def build_query(example: Dict) -> str:
+    """
+    :param example: A unified-format example whose ``queries[0]`` names the feature and target.
+
+    :returns: The instruction followed by the criterion.
+    """
+    return f"{TEXTGROUPS_INSTRUCTION}\n\n{example['queries'][0]}"
+
+
+SPEC = make_cycle_spec(
+    name="textgroups",
+    description="Find every group of passages whose textual feature values meet a target.",
+    instruction=TEXTGROUPS_INSTRUCTION,
+    serializer="textgroups",
+    rungs=("2k", "4k", "8k", "16k", "32k"),
+    query_builder=build_query,
+    max_new_tokens=200,
+    stop="pairs",
+)

--- a/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/xabsence/__init__.py
+++ b/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/xabsence/__init__.py
@@ -1,0 +1,8 @@
+"""The ``xabsence`` task. Importing this package registers its spec."""
+
+from ...format import registry
+from .spec import SPEC
+
+registry.register(SPEC)
+
+__all__ = ["SPEC"]

--- a/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/xabsence/spec.py
+++ b/src/olmo_eval/evals/tasks/ctc_suite/_vendor/ctc/tasks/xabsence/spec.py
@@ -1,0 +1,59 @@
+"""
+The ``xabsence`` eval contract (cross-corpus absence).
+
+Two numbered corpora, A and B, under one shared index. Almost every claim has a paraphrase in the
+*other* corpus; a few are unmatched. Find the unmatched ones.
+
+Harder than :mod:`ctc.tasks.absence` in a specific way: absence compares an item against its own
+copy, so the match is near-exact, whereas here the match is a paraphrase and must be recognised
+semantically across the corpus boundary. That is why it is grouped with the N-squared tasks despite
+producing the same flat id-set answer.
+
+The answer anchors on ``Unmatched:`` rather than ``Missing:``; the shared parser accepts both.
+
+.. note::
+   Pre-2026-07-26 xabsence shards may be affected by the oolong ``--item-regex`` leak (a bare
+   ``'||'`` matched every line). Check the build date of any shard before trusting a number.
+"""
+
+from __future__ import annotations
+
+from typing import Dict
+
+from ...format.prompts import XABSENCE_INSTRUCTION
+from .._absence import make_absence_spec
+
+__all__ = ["SPEC", "build_query", "build_target"]
+
+
+def build_query(example: Dict) -> str:
+    """
+    :param example: A unified-format example. ``queries`` is unused -- both corpora are already in
+        the rendered context, so the instruction is the whole ask.
+
+    :returns: The positioned ask.
+    """
+    return XABSENCE_INSTRUCTION
+
+
+def build_target(example: Dict) -> str:
+    """
+    :param example: A unified-format example with 0-based ``gold_doc_indices``.
+
+    :returns: The ``Unmatched: [i], [j]`` answer line, with ids rendered 1-based.
+    """
+    from .._absence import build_target as _bt
+
+    return _bt(example, "Unmatched")
+
+
+SPEC = make_absence_spec(
+    name="xabsence",
+    description="Find claims with no paraphrase in the other corpus (cross-corpus absence).",
+    instruction=XABSENCE_INSTRUCTION,
+    serializer="xabsence",
+    rungs=("2k", "4k", "8k", "16k", "32k"),
+    query_builder=build_query,
+    max_new_tokens=200,
+    sources=("pubmed", "abstracts"),
+)

--- a/tests/evals/tasks/test_ctc_suite.py
+++ b/tests/evals/tasks/test_ctc_suite.py
@@ -1,0 +1,127 @@
+"""CTC suite: registration, formatting, and scoring round-trips on synthetic examples.
+
+No network and no dataset downloads: examples are written to tmp_path as JSONL and loaded through
+``CTC_SUITE_DATA_ROOT``, the suite's local-tree escape hatch.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from olmo_eval.common.types import LMOutput
+from olmo_eval.evals.tasks.common.registry import get_task, list_tasks, list_variants
+from olmo_eval.evals.tasks.ctc_suite import ROSTER, RUNG_TOKENS
+
+
+def test_all_22_rows_register() -> None:
+    names = {n for n in list_tasks() if n.startswith("ctc_")}
+    assert names == set(ROSTER)
+    assert len(names) == 22
+
+
+def test_every_row_has_its_rung_variants() -> None:
+    for name, row in ROSTER.items():
+        variants = set(list_variants(name).get(name, []))
+        assert set(row.rungs) <= variants, f"{name}: missing rung variants"
+
+
+def test_sub500_rungs_are_flagged() -> None:
+    for name, row in ROSTER.items():
+        for rung in ("r256k", "r512k", "r1m"):
+            if rung in row.rungs:
+                assert row.eval_size.get(rung, 500) < 500, (
+                    f"{name}:{rung} must carry an eval_size flag -- xlong rungs are subsampled"
+                )
+
+
+def _write_ladder(tmp_path, subset: str, rung_tokens: int, example: dict) -> None:
+    d = tmp_path / subset
+    d.mkdir(parents=True, exist_ok=True)
+    (d / f"rung_{rung_tokens}.jsonl").write_text(json.dumps(example) + "\n")
+
+
+#: Minimal but structurally faithful examples for three representative families.
+RETRIEVAL_EXAMPLE = {
+    "source": "nq",
+    "queries": ["who wrote the paper"],
+    "answers": ["ada"],
+    "documents": [{"text": f"filler document number {i}"} for i in range(4)]
+    + [{"text": "the paper was written by ada"}],
+    "gold_doc_indices": [4],  # 0-based; the prompt shows documents 1-based
+    "hard_neg_indices": [0],
+}
+
+PAIR_EXAMPLE = {
+    "source": "contradiction",
+    "queries": [],
+    "answers": [],
+    "documents": [
+        {"text": "the sky is blue"},
+        {"text": "water boils at 100C"},
+        {"text": "the sky is not blue"},
+    ],
+    "gold_doc_indices": [[1, 3]],  # 1-based pairs for the pair family
+}
+
+QDMATCH_EXAMPLE = {
+    "source": "qdmatch_nq",
+    "queries": [],
+    "answers": [],
+    "num_queries": 2,
+    "num_docs": 2,
+    "num_relevant": 1,
+    "layout": "separate",
+    "documents": [
+        {"type": "query", "text": "capital of france?"},
+        {"type": "query", "text": "tallest mountain?"},
+        {"type": "document", "text": "paris is the capital of france"},
+        {"type": "document", "text": "unrelated filler text"},
+    ],
+    "gold_pairs": [[1, 3]],  # 1-based, ordered (query, document)
+    "gold_doc_indices": [],
+}
+
+
+@pytest.mark.parametrize(
+    ("task_name", "example", "gold_text", "wrong_text"),
+    [
+        ("ctc_nq", RETRIEVAL_EXAMPLE, "[5]", "[2]"),
+        ("ctc_contradiction", PAIR_EXAMPLE, "[[1, 3]]", "[[1, 2]]"),
+        ("ctc_qdmatch_nq", QDMATCH_EXAMPLE, "[[1, 3]]", "[[2, 3]]"),
+    ],
+)
+def test_round_trip(tmp_path, monkeypatch, task_name, example, gold_text, wrong_text) -> None:
+    row = ROSTER[task_name]
+    rung = row.rungs[0]
+    tokens = row.rung_alias.get(rung, RUNG_TOKENS[rung])
+    _write_ladder(tmp_path, row.subset, tokens, example)
+    monkeypatch.setenv("CTC_SUITE_DATA_ROOT", str(tmp_path))
+
+    task = get_task(f"{task_name}:{rung}")
+    instances = list(task.instances)
+    assert len(instances) == 1
+    request = task.format_request(instances[0])
+    # every document's text must appear in the rendered prompt
+    for doc in example["documents"]:
+        assert doc["text"] in request.prompt
+
+    scorer = task.config.metrics[0].scorer()
+    assert scorer.score(instances[0], LMOutput(text=gold_text)) == 1.0
+    assert scorer.score(instances[0], LMOutput(text=wrong_text)) < 1.0
+    assert scorer.score(instances[0], LMOutput(text="no ids at all")) == 0.0
+
+
+def test_gold_index_base_is_the_graders(tmp_path, monkeypatch) -> None:
+    """The 0-vs-1-based split is per-family and has produced silent zero-scores before:
+    retrieval gold is stored 0-based and shifted by the grader; pair gold is stored 1-based."""
+    row = ROSTER["ctc_nq"]
+    _write_ladder(tmp_path, row.subset, RUNG_TOKENS[row.rungs[0]], RETRIEVAL_EXAMPLE)
+    monkeypatch.setenv("CTC_SUITE_DATA_ROOT", str(tmp_path))
+    task = get_task(f"ctc_nq:{row.rungs[0]}")
+    inst = list(task.instances)[0]
+    scorer = task.config.metrics[0].scorer()
+    # answering with the raw stored index (0-based "4") instead of the prompt's 1-based "5"
+    # must NOT get credit
+    assert scorer.score(inst, LMOutput(text="[4]")) == 0.0


### PR DESCRIPTION
## Description

Added 22 tasks from the CTC-Suite (coming out publically soon) in case OLMO long context folks (Yashas, Jackson, ...) would be interested in using it.

## Type of Change

New tasks in suite.

## Testing

No extensive testing