### PR TITLE
Fail fast when inference providers terminate

### DIFF
--- a/src/olmo_eval/common/progress.py
+++ b/src/olmo_eval/common/progress.py
@@ -94,7 +94,7 @@ class ProgressLogger:
         """Format progress without rounding an incomplete run to 100%."""
         if self.total <= 0 or self.count >= self.total:
             return "100%"
-        return f"{self.count / self.total * 100:.2f}%"
+        return f"{min(self.count / self.total * 100, 99.99):.2f}%"
 
     def close(self) -> None:
         """Log final progress summary."""

--- a/src/olmo_eval/common/progress.py
+++ b/src/olmo_eval/common/progress.py
@@ -84,12 +84,17 @@ class ProgressLogger:
         """Log current progress."""
         elapsed = now - self.start_time
         rate = self.count / elapsed if elapsed > 0 else 0.0
-        pct = (self.count / self.total * 100) if self.total > 0 else 0.0
 
         self.logger.info(
             f"{self._format_desc()} {self.count:>6}/{self.total} "
-            f"({pct:>3.0f}%) at {rate:.1f} items/sec"
+            f"({self._format_percentage():>6}) at {rate:.1f} items/sec"
         )
+
+    def _format_percentage(self) -> str:
+        """Format progress without rounding an incomplete run to 100%."""
+        if self.total <= 0 or self.count >= self.total:
+            return "100%"
+        return f"{self.count / self.total * 100:.2f}%"
 
     def close(self) -> None:
         """Log final progress summary."""
@@ -98,7 +103,7 @@ class ProgressLogger:
 
         self.logger.info(
             f"{self._format_desc()} {self.count:>6}/{self.total} "
-            f"(100%) in {elapsed:.1f}s ({rate:.1f} items/sec)"
+            f"({self._format_percentage()}) in {elapsed:.1f}s ({rate:.1f} items/sec)"
         )
 
     def __enter__(self) -> ProgressLogger:

--- a/src/olmo_eval/inference/dispatch.py
+++ b/src/olmo_eval/inference/dispatch.py
@@ -73,52 +73,47 @@ class ContinuousBatchDispatcher[T, R]:
         # Track in-flight tasks: task -> (index, item, attempt)
         in_flight: dict[asyncio.Task, tuple[int, T, int]] = {}
 
-        try:
-            while pending_idx < len(pending) or in_flight:
-                # Top up in-flight set to target
-                while len(in_flight) < self.max_in_flight and pending_idx < len(pending):
-                    idx, item, attempt = pending[pending_idx]
-                    pending_idx += 1
+        while pending_idx < len(pending) or in_flight:
+            # Top up in-flight set to target
+            while len(in_flight) < self.max_in_flight and pending_idx < len(pending):
+                idx, item, attempt = pending[pending_idx]
+                pending_idx += 1
 
-                    task = asyncio.create_task(self._safe_process(item))
-                    in_flight[task] = (idx, item, attempt)
+                task = asyncio.create_task(self._safe_process(item))
+                in_flight[task] = (idx, item, attempt)
 
-                if not in_flight:
-                    break
+            if not in_flight:
+                break
 
-                # Wait for any one to complete
-                done, _ = await asyncio.wait(in_flight.keys(), return_when=asyncio.FIRST_COMPLETED)
+            # Wait for any one to complete
+            done, _ = await asyncio.wait(in_flight.keys(), return_when=asyncio.FIRST_COMPLETED)
 
-                for task in done:
-                    idx, item, attempt = in_flight.pop(task)
+            for task in done:
+                idx, item, attempt = in_flight.pop(task)
+                try:
                     result, error = task.result()
+                except TerminalProviderError:
+                    for sibling in in_flight:
+                        sibling.cancel()
+                    await asyncio.gather(*in_flight, return_exceptions=True)
+                    raise
 
-                    if error is not None and attempt < self.max_retries:
-                        # Retry: add back to pending
-                        pending.append((idx, item, attempt + 1))
-                        self._stats.retried += 1
-                    else:
-                        # Record result
-                        results[idx] = result
-                        self._stats.completed += 1
-                        if error is not None:
-                            self._stats.failed += 1
+                if error is not None and attempt < self.max_retries:
+                    # Retry: add back to pending
+                    pending.append((idx, item, attempt + 1))
+                    self._stats.retried += 1
+                else:
+                    # Record result
+                    results[idx] = result
+                    self._stats.completed += 1
+                    if error is not None:
+                        self._stats.failed += 1
 
-                        # Callbacks
-                        if self.on_result is not None:
-                            self.on_result(idx, result, error)
-                        if self.on_progress is not None:
-                            self.on_progress(self._stats.completed, total)
-        finally:
-            # A terminal provider failure (or caller cancellation) must not leave
-            # sibling requests running in the background. Retrieve every outcome
-            # as well, so no task exception is lost or reported as unhandled.
-            remaining = tuple(in_flight)
-            for task in remaining:
-                if not task.done():
-                    task.cancel()
-            if remaining:
-                await asyncio.gather(*remaining, return_exceptions=True)
+                    # Callbacks
+                    if self.on_result is not None:
+                        self.on_result(idx, result, error)
+                    if self.on_progress is not None:
+                        self.on_progress(self._stats.completed, total)
 
         return results
 
@@ -128,8 +123,6 @@ class ContinuousBatchDispatcher[T, R]:
             result = await self.process_fn(item)
             return (result, None)
         except TerminalProviderError:
-            # A dead provider cannot safely process retries or additional work.
-            # Propagate to the inference worker so it emits WORKER_FATAL and exits.
             raise
         except Exception as e:
             logger.warning("dispatch: process_fn raised %s: %s", type(e).__name__, e)

--- a/src/olmo_eval/inference/dispatch.py
+++ b/src/olmo_eval/inference/dispatch.py
@@ -73,41 +73,52 @@ class ContinuousBatchDispatcher[T, R]:
         # Track in-flight tasks: task -> (index, item, attempt)
         in_flight: dict[asyncio.Task, tuple[int, T, int]] = {}
 
-        while pending_idx < len(pending) or in_flight:
-            # Top up in-flight set to target
-            while len(in_flight) < self.max_in_flight and pending_idx < len(pending):
-                idx, item, attempt = pending[pending_idx]
-                pending_idx += 1
+        try:
+            while pending_idx < len(pending) or in_flight:
+                # Top up in-flight set to target
+                while len(in_flight) < self.max_in_flight and pending_idx < len(pending):
+                    idx, item, attempt = pending[pending_idx]
+                    pending_idx += 1
 
-                task = asyncio.create_task(self._safe_process(item))
-                in_flight[task] = (idx, item, attempt)
+                    task = asyncio.create_task(self._safe_process(item))
+                    in_flight[task] = (idx, item, attempt)
 
-            if not in_flight:
-                break
+                if not in_flight:
+                    break
 
-            # Wait for any one to complete
-            done, _ = await asyncio.wait(in_flight.keys(), return_when=asyncio.FIRST_COMPLETED)
+                # Wait for any one to complete
+                done, _ = await asyncio.wait(in_flight.keys(), return_when=asyncio.FIRST_COMPLETED)
 
-            for task in done:
-                idx, item, attempt = in_flight.pop(task)
-                result, error = task.result()
+                for task in done:
+                    idx, item, attempt = in_flight.pop(task)
+                    result, error = task.result()
 
-                if error is not None and attempt < self.max_retries:
-                    # Retry: add back to pending
-                    pending.append((idx, item, attempt + 1))
-                    self._stats.retried += 1
-                else:
-                    # Record result
-                    results[idx] = result
-                    self._stats.completed += 1
-                    if error is not None:
-                        self._stats.failed += 1
+                    if error is not None and attempt < self.max_retries:
+                        # Retry: add back to pending
+                        pending.append((idx, item, attempt + 1))
+                        self._stats.retried += 1
+                    else:
+                        # Record result
+                        results[idx] = result
+                        self._stats.completed += 1
+                        if error is not None:
+                            self._stats.failed += 1
 
-                    # Callbacks
-                    if self.on_result is not None:
-                        self.on_result(idx, result, error)
-                    if self.on_progress is not None:
-                        self.on_progress(self._stats.completed, total)
+                        # Callbacks
+                        if self.on_result is not None:
+                            self.on_result(idx, result, error)
+                        if self.on_progress is not None:
+                            self.on_progress(self._stats.completed, total)
+        finally:
+            # A terminal provider failure (or caller cancellation) must not leave
+            # sibling requests running in the background. Retrieve every outcome
+            # as well, so no task exception is lost or reported as unhandled.
+            remaining = tuple(in_flight)
+            for task in remaining:
+                if not task.done():
+                    task.cancel()
+            if remaining:
+                await asyncio.gather(*remaining, return_exceptions=True)
 
         return results
 

--- a/src/olmo_eval/inference/dispatch.py
+++ b/src/olmo_eval/inference/dispatch.py
@@ -7,6 +7,8 @@ import logging
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 
+from olmo_eval.inference.errors import TerminalProviderError
+
 logger = logging.getLogger(__name__)
 
 
@@ -114,6 +116,10 @@ class ContinuousBatchDispatcher[T, R]:
         try:
             result = await self.process_fn(item)
             return (result, None)
+        except TerminalProviderError:
+            # A dead provider cannot safely process retries or additional work.
+            # Propagate to the inference worker so it emits WORKER_FATAL and exits.
+            raise
         except Exception as e:
             logger.warning("dispatch: process_fn raised %s: %s", type(e).__name__, e)
             return (None, e)

--- a/src/olmo_eval/inference/errors.py
+++ b/src/olmo_eval/inference/errors.py
@@ -6,28 +6,9 @@ from __future__ import annotations
 class TerminalProviderError(RuntimeError):
     """A provider failure after which its worker cannot serve more requests."""
 
-    def __init__(
-        self,
-        provider: str,
-        cause_type: str,
-        detail: str = "",
-    ) -> None:
-        self.provider = provider
-        self.cause_type = cause_type
-        self.detail = detail
 
-        message = f"{provider} provider became unavailable ({cause_type})"
-        if detail:
-            message = f"{message}: {detail}"
-        super().__init__(message)
-
-
-# Keep optional provider imports out of this module. Classification by fully
-# qualified name lets CPU-only installations recognize terminal failures
-# without importing CUDA-only packages such as vLLM.
-_TERMINAL_PROVIDER_ERRORS = {
-    ("vllm.v1.engine.exceptions", "EngineDeadError"): "vLLM",
-}
+# Avoid importing optional GPU-only provider packages just to classify errors.
+_TERMINAL_PROVIDER_ERRORS = {"vllm.v1.engine.exceptions.EngineDeadError"}
 
 
 def classify_terminal_provider_error(exc: BaseException) -> TerminalProviderError | None:
@@ -42,13 +23,9 @@ def classify_terminal_provider_error(exc: BaseException) -> TerminalProviderErro
             return current
 
         error_type = type(current)
-        provider = _TERMINAL_PROVIDER_ERRORS.get((error_type.__module__, error_type.__qualname__))
-        if provider is not None:
-            return TerminalProviderError(
-                provider=provider,
-                cause_type=error_type.__qualname__,
-                detail=str(current).strip(),
-            )
+        error_name = f"{error_type.__module__}.{error_type.__qualname__}"
+        if error_name in _TERMINAL_PROVIDER_ERRORS:
+            return TerminalProviderError(f"{error_name}: {current}")
 
         current = current.__cause__ or current.__context__
 

--- a/src/olmo_eval/inference/errors.py
+++ b/src/olmo_eval/inference/errors.py
@@ -1,0 +1,58 @@
+"""Inference provider error classification."""
+
+from __future__ import annotations
+
+
+class TerminalProviderError(RuntimeError):
+    """A provider failure after which its worker cannot serve more requests."""
+
+    def __init__(
+        self,
+        provider: str,
+        cause_type: str,
+        detail: str = "",
+    ) -> None:
+        self.provider = provider
+        self.cause_type = cause_type
+        self.detail = detail
+
+        message = f"{provider} provider became unavailable ({cause_type})"
+        if detail:
+            message = f"{message}: {detail}"
+        super().__init__(message)
+
+
+# Keep optional provider imports out of this module. Classification by fully
+# qualified name lets CPU-only installations recognize terminal failures
+# without importing CUDA-only packages such as vLLM.
+_TERMINAL_PROVIDER_ERRORS = {
+    ("vllm.v1.engine.exceptions", "EngineDeadError"): "vLLM",
+}
+
+
+def classify_terminal_provider_error(exc: BaseException) -> TerminalProviderError | None:
+    """Return a terminal provider error found in an exception chain, if any."""
+    current: BaseException | None = exc
+    seen: set[int] = set()
+
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+
+        if isinstance(current, TerminalProviderError):
+            return current
+
+        error_type = type(current)
+        provider = _TERMINAL_PROVIDER_ERRORS.get((error_type.__module__, error_type.__qualname__))
+        if provider is not None:
+            return TerminalProviderError(
+                provider=provider,
+                cause_type=error_type.__qualname__,
+                detail=str(current).strip(),
+            )
+
+        current = current.__cause__ or current.__context__
+
+    return None
+
+
+__all__ = ["TerminalProviderError", "classify_terminal_provider_error"]

--- a/src/olmo_eval/runners/asynq/batching/streaming.py
+++ b/src/olmo_eval/runners/asynq/batching/streaming.py
@@ -43,6 +43,7 @@ class StreamingStrategy(BatchingStrategy):
         concurrency = max_concurrency or 64
         semaphore = asyncio.Semaphore(concurrency)
         in_flight: set[asyncio.Task[None]] = set()
+        failure: BaseException | None = None
 
         worker_instances = math.ceil(total_instances / num_workers)
         progress = ProgressLogger(
@@ -62,27 +63,13 @@ class StreamingStrategy(BatchingStrategy):
                 progress.update(1)
                 report_progress(progress.count, progress.total)
 
-        def raise_completed_task_errors() -> None:
-            """Remove completed tasks and propagate the first failure.
-
-            Retrieve every completed task's outcome before raising so concurrent
-            failures cannot turn into unhandled task exceptions.
-            """
-            done = {task for task in in_flight if task.done()}
-            in_flight.difference_update(done)
-
-            first_error: BaseException | None = None
-            for task in done:
-                if task.cancelled():
-                    continue
-                try:
-                    task.result()
-                except BaseException as error:
-                    if first_error is None:
-                        first_error = error
-
-            if first_error is not None:
-                raise first_error
+        def task_done(task: asyncio.Task[None]) -> None:
+            nonlocal failure
+            in_flight.discard(task)
+            if not task.cancelled():
+                error = task.exception()
+                if failure is None:
+                    failure = error
 
         async def get_item() -> QueueItem | None:
             """Get next item from queue asynchronously."""
@@ -91,7 +78,8 @@ class StreamingStrategy(BatchingStrategy):
                 try:
                     return await loop.run_in_executor(None, lambda: item_queue.get(timeout=0.1))
                 except queue.Empty:
-                    raise_completed_task_errors()
+                    if failure is not None:
+                        raise failure from None
                     if not in_flight:
                         try:
                             return await loop.run_in_executor(
@@ -103,27 +91,28 @@ class StreamingStrategy(BatchingStrategy):
 
         try:
             while True:
-                raise_completed_task_errors()
+                if failure is not None:
+                    raise failure
                 item = await get_item()
-                raise_completed_task_errors()
+                if failure is not None:
+                    raise failure
 
                 if item is None:
                     break
 
-                in_flight.add(asyncio.create_task(process_single(item)))
+                task = asyncio.create_task(process_single(item))
+                in_flight.add(task)
+                task.add_done_callback(task_done)
 
             if in_flight:
                 await asyncio.gather(*in_flight)
+            if failure is not None:
+                raise failure
         finally:
-            # Stop and drain all sibling requests when any streamed request is
-            # terminal. Keeping the tasks tracked until their outcomes are
-            # retrieved prevents fast failures from disappearing.
-            remaining = tuple(in_flight)
-            for task in remaining:
-                if not task.done():
-                    task.cancel()
-            if remaining:
-                await asyncio.gather(*remaining, return_exceptions=True)
+            for task in in_flight:
+                task.cancel()
+            if in_flight:
+                await asyncio.gather(*in_flight, return_exceptions=True)
 
             progress.close()
             report_progress(progress.count, progress.total, force=True)

--- a/src/olmo_eval/runners/asynq/batching/streaming.py
+++ b/src/olmo_eval/runners/asynq/batching/streaming.py
@@ -42,7 +42,7 @@ class StreamingStrategy(BatchingStrategy):
 
         concurrency = max_concurrency or 64
         semaphore = asyncio.Semaphore(concurrency)
-        in_flight: set[asyncio.Task] = set()
+        in_flight: set[asyncio.Task[None]] = set()
 
         worker_instances = math.ceil(total_instances / num_workers)
         progress = ProgressLogger(
@@ -62,6 +62,28 @@ class StreamingStrategy(BatchingStrategy):
                 progress.update(1)
                 report_progress(progress.count, progress.total)
 
+        def raise_completed_task_errors() -> None:
+            """Remove completed tasks and propagate the first failure.
+
+            Retrieve every completed task's outcome before raising so concurrent
+            failures cannot turn into unhandled task exceptions.
+            """
+            done = {task for task in in_flight if task.done()}
+            in_flight.difference_update(done)
+
+            first_error: BaseException | None = None
+            for task in done:
+                if task.cancelled():
+                    continue
+                try:
+                    task.result()
+                except BaseException as error:
+                    if first_error is None:
+                        first_error = error
+
+            if first_error is not None:
+                raise first_error
+
         async def get_item() -> QueueItem | None:
             """Get next item from queue asynchronously."""
             loop = asyncio.get_event_loop()
@@ -69,6 +91,7 @@ class StreamingStrategy(BatchingStrategy):
                 try:
                     return await loop.run_in_executor(None, lambda: item_queue.get(timeout=0.1))
                 except queue.Empty:
+                    raise_completed_task_errors()
                     if not in_flight:
                         try:
                             return await loop.run_in_executor(
@@ -78,18 +101,29 @@ class StreamingStrategy(BatchingStrategy):
                             return None
                     await asyncio.sleep(0.01)
 
-        while True:
-            item = await get_item()
+        try:
+            while True:
+                raise_completed_task_errors()
+                item = await get_item()
+                raise_completed_task_errors()
 
-            if item is None:
-                break
+                if item is None:
+                    break
 
-            task = asyncio.create_task(process_single(item))
-            in_flight.add(task)
-            task.add_done_callback(in_flight.discard)
+                in_flight.add(asyncio.create_task(process_single(item)))
 
-        if in_flight:
-            await asyncio.gather(*in_flight)
+            if in_flight:
+                await asyncio.gather(*in_flight)
+        finally:
+            # Stop and drain all sibling requests when any streamed request is
+            # terminal. Keeping the tasks tracked until their outcomes are
+            # retrieved prevents fast failures from disappearing.
+            remaining = tuple(in_flight)
+            for task in remaining:
+                if not task.done():
+                    task.cancel()
+            if remaining:
+                await asyncio.gather(*remaining, return_exceptions=True)
 
-        progress.close()
-        report_progress(progress.count, progress.total, force=True)
+            progress.close()
+            report_progress(progress.count, progress.total, force=True)

--- a/src/olmo_eval/runners/asynq/monitoring.py
+++ b/src/olmo_eval/runners/asynq/monitoring.py
@@ -72,18 +72,9 @@ def check_workers_alive(
     except queue.Empty:
         pass  # Queue empty, continue
 
-    # A single failed worker can strand its in-flight instances even while the
-    # remaining workers exit successfully, so do not wait for every worker to die.
-    failed_workers = [
-        (index, worker.exitcode)
-        for index, worker in enumerate(workers)
-        if not worker.is_alive() and worker.exitcode not in (None, 0)
-    ]
-    if failed_workers:
-        failures = ", ".join(
-            f"worker {index} exited with code {code}" for index, code in failed_workers
-        )
-        raise RuntimeError(f"Inference worker failed unexpectedly: {failures}")
+    for index, worker in enumerate(workers):
+        if worker.exitcode not in (None, 0):
+            raise RuntimeError(f"Inference worker {index} exited with code {worker.exitcode}")
 
 
 def wait_for_workers_ready(

--- a/src/olmo_eval/runners/asynq/monitoring.py
+++ b/src/olmo_eval/runners/asynq/monitoring.py
@@ -48,7 +48,7 @@ def check_workers_alive(
         timeout: How long to wait for queue items
 
     Raises:
-        RuntimeError: If all workers are dead or a fatal error is found
+        RuntimeError: If a worker exits unsuccessfully or a fatal error is found
     """
     # Check for fatal errors in queue (non-blocking)
     try:
@@ -72,13 +72,18 @@ def check_workers_alive(
     except queue.Empty:
         pass  # Queue empty, continue
 
-    # Check if all workers are dead
-    alive_count = sum(1 for w in workers if w.is_alive())
-    if alive_count == 0:
-        # All workers dead - check exit codes
-        exit_codes = [w.exitcode for w in workers]
-        if any(code != 0 and code is not None for code in exit_codes):
-            raise RuntimeError(f"All workers died unexpectedly. Exit codes: {exit_codes}")
+    # A single failed worker can strand its in-flight instances even while the
+    # remaining workers exit successfully, so do not wait for every worker to die.
+    failed_workers = [
+        (index, worker.exitcode)
+        for index, worker in enumerate(workers)
+        if not worker.is_alive() and worker.exitcode not in (None, 0)
+    ]
+    if failed_workers:
+        failures = ", ".join(
+            f"worker {index} exited with code {code}" for index, code in failed_workers
+        )
+        raise RuntimeError(f"Inference worker failed unexpectedly: {failures}")
 
 
 def wait_for_workers_ready(

--- a/src/olmo_eval/runners/asynq/processing.py
+++ b/src/olmo_eval/runners/asynq/processing.py
@@ -323,13 +323,16 @@ async def process_items(
             def on_progress(done: int, total: int) -> None:
                 progress.update(1)
 
-            await dispatch_concurrent(
-                chat_items,
-                process,
-                max_in_flight=max_concurrency or len(chat_items),
-                on_progress=on_progress,
-            )
-            progress.close()
+            try:
+                await dispatch_concurrent(
+                    chat_items,
+                    process,
+                    max_in_flight=max_concurrency or len(chat_items),
+                    on_progress=on_progress,
+                )
+            finally:
+                # Preserve the actual completed count on terminal failure.
+                progress.close()
         else:
             await dispatch_concurrent(
                 chat_items,

--- a/src/olmo_eval/runners/asynq/processing.py
+++ b/src/olmo_eval/runners/asynq/processing.py
@@ -7,6 +7,7 @@ import multiprocessing as mp
 from typing import TYPE_CHECKING
 
 from olmo_eval.common.logging import get_logger
+from olmo_eval.inference.errors import classify_terminal_provider_error
 from olmo_eval.inference.metrics.core.stats import compute_batch_hash
 from olmo_eval.runners.asynq.types import QueueItem, ResultItem
 
@@ -137,6 +138,15 @@ async def process_chat_request(
     except Exception as e:
         import traceback
 
+        terminal_error = classify_terminal_provider_error(e)
+        if terminal_error is not None:
+            log.critical(
+                "Terminal provider error on CHAT instance %s: %s",
+                item.instance_idx,
+                terminal_error,
+            )
+            raise terminal_error from e
+
         error_detail = _format_error_detail(e)
         full_tb = traceback.format_exc()
         log.error(f"Error on CHAT instance {item.instance_idx}: {error_detail}\n{full_tb}")
@@ -218,6 +228,15 @@ async def process_batch(
         harness.flush_metrics(batch_hash)
 
     except Exception as e:
+        terminal_error = classify_terminal_provider_error(e)
+        if terminal_error is not None:
+            log.critical(
+                "Terminal provider error for batch of %s item(s): %s",
+                len(items),
+                terminal_error,
+            )
+            raise terminal_error from e
+
         # Batch failed - report error for all items
         error_detail = _format_error_detail(e)
         log.error(f"Batch error ({len(items)} items): {error_detail}")

--- a/src/olmo_eval/runners/asynq/processing.py
+++ b/src/olmo_eval/runners/asynq/processing.py
@@ -140,11 +140,6 @@ async def process_chat_request(
 
         terminal_error = classify_terminal_provider_error(e)
         if terminal_error is not None:
-            log.critical(
-                "Terminal provider error on CHAT instance %s: %s",
-                item.instance_idx,
-                terminal_error,
-            )
             raise terminal_error from e
 
         error_detail = _format_error_detail(e)
@@ -230,11 +225,6 @@ async def process_batch(
     except Exception as e:
         terminal_error = classify_terminal_provider_error(e)
         if terminal_error is not None:
-            log.critical(
-                "Terminal provider error for batch of %s item(s): %s",
-                len(items),
-                terminal_error,
-            )
             raise terminal_error from e
 
         # Batch failed - report error for all items
@@ -331,7 +321,6 @@ async def process_items(
                     on_progress=on_progress,
                 )
             finally:
-                # Preserve the actual completed count on terminal failure.
                 progress.close()
         else:
             await dispatch_concurrent(

--- a/src/olmo_eval/runners/asynq/results.py
+++ b/src/olmo_eval/runners/asynq/results.py
@@ -31,6 +31,48 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 
+InstanceKey = tuple[str, str, int]
+
+
+def _build_pending_instance_keys(trackers: dict[str, TaskTracker]) -> set[InstanceKey]:
+    """Build the exact set of inference results expected from workers."""
+    return {
+        (tracker.model_name, spec, instance_idx)
+        for spec, tracker in trackers.items()
+        for instance_idx in range(tracker.total_instances)
+    }
+
+
+def _consume_pending_instance(pending_instances: set[InstanceKey], result_item: ResultItem) -> None:
+    """Mark a result received, rejecting duplicate or unexpected identities."""
+    key = (result_item.model_name, result_item.task_id, result_item.instance_idx)
+    if key not in pending_instances:
+        raise RuntimeError(
+            "Received duplicate or unexpected inference result for "
+            f"{result_item.task_id}[{result_item.instance_idx}]"
+        )
+    pending_instances.remove(key)
+
+
+def _format_pending_instances(pending_instances: set[InstanceKey], limit: int = 10) -> str:
+    """Format a bounded, deterministic preview of unresolved instances."""
+    ordered = sorted(pending_instances)
+    preview = ", ".join(
+        f"{model_name}:{spec}[{instance_idx}]" for model_name, spec, instance_idx in ordered[:limit]
+    )
+    if len(ordered) > limit:
+        preview = f"{preview}, ... and {len(ordered) - limit} more"
+    return preview
+
+
+def _format_worker_failure(error: object, pending_instances: set[InstanceKey]) -> str:
+    """Combine a fatal worker error with exact unresolved-instance accounting."""
+    pending_preview = _format_pending_instances(pending_instances)
+    return (
+        f"Worker process crashed with {len(pending_instances)} inference result(s) "
+        f"pending ({pending_preview}): {error}"
+    )
+
 
 def _format_scoring_error(exc: Exception, *, phase: str) -> dict[str, str]:
     """Build a JSON-serializable scoring error payload."""
@@ -205,12 +247,18 @@ async def process_results(
             tasks_complete += 1
             _report_task_completion(model_name, task_result)
 
-    pending_instances = total_instances
+    pending_instances = _build_pending_instance_keys(trackers)
+    if len(pending_instances) != total_instances:
+        raise RuntimeError(
+            "Inference accounting mismatch before processing: "
+            f"runner expected {total_instances} instance(s), "
+            f"task trackers describe {len(pending_instances)}"
+        )
     last_health_check = time.time()
     health_check_interval = 5.0
 
     # Collect instance results and score each inline
-    while pending_instances > 0:
+    while pending_instances:
         _reap_done_tasks()
 
         try:
@@ -219,17 +267,25 @@ async def process_results(
             )
         except queue.Empty:
             if time.time() - last_health_check > health_check_interval:
-                check_workers_alive(workers, result_queue)
+                try:
+                    check_workers_alive(workers, result_queue)
+                except RuntimeError as e:
+                    fatal_message = _format_worker_failure(e, pending_instances)
+                    logger.error(f"FATAL: {fatal_message}")
+                    scoring_progress.close()
+                    raise RuntimeError(fatal_message) from e
                 last_health_check = time.time()
             continue
 
         # Check for fatal worker crash
         if result_item.task_id == WORKER_FATAL:
-            logger.error(f"FATAL: Worker crashed! {result_item.error}")
-            raise RuntimeError(f"Worker process crashed: {result_item.error}")
+            fatal_message = _format_worker_failure(result_item.error, pending_instances)
+            logger.error(f"FATAL: {fatal_message}")
+            scoring_progress.close()
+            raise RuntimeError(fatal_message)
 
+        _consume_pending_instance(pending_instances, result_item)
         tracker = trackers[result_item.task_id]
-        pending_instances -= 1
 
         if tracker.error:
             continue

--- a/src/olmo_eval/runners/asynq/results.py
+++ b/src/olmo_eval/runners/asynq/results.py
@@ -54,23 +54,17 @@ def _consume_pending_instance(pending_instances: set[InstanceKey], result_item: 
     pending_instances.remove(key)
 
 
-def _format_pending_instances(pending_instances: set[InstanceKey], limit: int = 10) -> str:
-    """Format a bounded, deterministic preview of unresolved instances."""
+def _format_worker_failure(error: object, pending_instances: set[InstanceKey]) -> str:
+    """Combine a fatal worker error with unresolved-instance accounting."""
     ordered = sorted(pending_instances)
     preview = ", ".join(
-        f"{model_name}:{spec}[{instance_idx}]" for model_name, spec, instance_idx in ordered[:limit]
+        f"{model_name}:{spec}[{instance_idx}]" for model_name, spec, instance_idx in ordered[:10]
     )
-    if len(ordered) > limit:
-        preview = f"{preview}, ... and {len(ordered) - limit} more"
-    return preview
-
-
-def _format_worker_failure(error: object, pending_instances: set[InstanceKey]) -> str:
-    """Combine a fatal worker error with exact unresolved-instance accounting."""
-    pending_preview = _format_pending_instances(pending_instances)
+    if len(ordered) > 10:
+        preview += f", ... and {len(ordered) - 10} more"
     return (
         f"Worker process crashed with {len(pending_instances)} inference result(s) "
-        f"pending ({pending_preview}): {error}"
+        f"pending ({preview}): {error}"
     )
 
 

--- a/tests/common/test_progress.py
+++ b/tests/common/test_progress.py
@@ -10,22 +10,11 @@ from olmo_eval.common.progress import ProgressLogger
 
 def test_incomplete_progress_never_rounds_to_one_hundred_percent() -> None:
     logger = Mock(spec=logging.Logger)
-    progress = ProgressLogger(total=1000, logger=logger, log_interval=0)
+    progress = ProgressLogger(total=1_000_000, logger=logger, log_interval=0)
 
-    progress.update(999)
-    assert "99.90%" in logger.info.call_args.args[0]
-    assert "100%" not in logger.info.call_args.args[0]
+    progress.update(999_999)
+    assert "99.99%" in logger.info.call_args.args[0]
 
     progress.close()
-    assert "99.90%" in logger.info.call_args.args[0]
+    assert "99.99%" in logger.info.call_args.args[0]
     assert "100%" not in logger.info.call_args.args[0]
-
-
-def test_complete_progress_reports_one_hundred_percent() -> None:
-    logger = Mock(spec=logging.Logger)
-    progress = ProgressLogger(total=2, logger=logger, log_interval=0)
-
-    progress.update(2)
-    progress.close()
-
-    assert "100%" in logger.info.call_args.args[0]

--- a/tests/common/test_progress.py
+++ b/tests/common/test_progress.py
@@ -1,0 +1,31 @@
+"""Tests for non-TTY progress reporting."""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import Mock
+
+from olmo_eval.common.progress import ProgressLogger
+
+
+def test_incomplete_progress_never_rounds_to_one_hundred_percent() -> None:
+    logger = Mock(spec=logging.Logger)
+    progress = ProgressLogger(total=1000, logger=logger, log_interval=0)
+
+    progress.update(999)
+    assert "99.90%" in logger.info.call_args.args[0]
+    assert "100%" not in logger.info.call_args.args[0]
+
+    progress.close()
+    assert "99.90%" in logger.info.call_args.args[0]
+    assert "100%" not in logger.info.call_args.args[0]
+
+
+def test_complete_progress_reports_one_hundred_percent() -> None:
+    logger = Mock(spec=logging.Logger)
+    progress = ProgressLogger(total=2, logger=logger, log_interval=0)
+
+    progress.update(2)
+    progress.close()
+
+    assert "100%" in logger.info.call_args.args[0]

--- a/tests/inference/test_terminal_errors.py
+++ b/tests/inference/test_terminal_errors.py
@@ -51,3 +51,28 @@ def test_dispatch_propagates_terminal_provider_error() -> None:
 
     with pytest.raises(TerminalProviderError, match="engine died"):
         asyncio.run(dispatch_concurrent([1], process, max_retries=3))
+
+
+def test_dispatch_cancels_siblings_after_terminal_provider_error() -> None:
+    async def run() -> None:
+        sibling_started = asyncio.Event()
+        sibling_cancelled = asyncio.Event()
+
+        async def process(item: int) -> None:
+            if item == 0:
+                await sibling_started.wait()
+                raise TerminalProviderError("vLLM", "EngineDeadError", "engine died")
+
+            sibling_started.set()
+            try:
+                await asyncio.Future()
+            except asyncio.CancelledError:
+                sibling_cancelled.set()
+                raise
+
+        with pytest.raises(TerminalProviderError, match="engine died"):
+            await dispatch_concurrent([0, 1], process, max_in_flight=2)
+
+        assert sibling_cancelled.is_set()
+
+    asyncio.run(run())

--- a/tests/inference/test_terminal_errors.py
+++ b/tests/inference/test_terminal_errors.py
@@ -1,0 +1,53 @@
+"""Tests for terminal inference-provider error handling."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from olmo_eval.inference.dispatch import dispatch_concurrent
+from olmo_eval.inference.errors import (
+    TerminalProviderError,
+    classify_terminal_provider_error,
+)
+
+
+def _engine_dead_error(message: str = "engine died") -> Exception:
+    error_type = type(
+        "EngineDeadError",
+        (Exception,),
+        {"__module__": "vllm.v1.engine.exceptions"},
+    )
+    return error_type(message)
+
+
+def test_classifies_vllm_engine_death_as_terminal() -> None:
+    classified = classify_terminal_provider_error(_engine_dead_error())
+
+    assert classified is not None
+    assert classified.provider == "vLLM"
+    assert classified.cause_type == "EngineDeadError"
+    assert "engine died" in str(classified)
+
+
+def test_classifies_terminal_error_through_exception_chain() -> None:
+    wrapped = RuntimeError("provider call failed")
+    wrapped.__cause__ = _engine_dead_error()
+
+    classified = classify_terminal_provider_error(wrapped)
+
+    assert classified is not None
+    assert classified.cause_type == "EngineDeadError"
+
+
+def test_does_not_classify_recoverable_provider_error() -> None:
+    assert classify_terminal_provider_error(RuntimeError("request failed")) is None
+
+
+def test_dispatch_propagates_terminal_provider_error() -> None:
+    async def process(_item: int) -> int:
+        raise TerminalProviderError("vLLM", "EngineDeadError", "engine died")
+
+    with pytest.raises(TerminalProviderError, match="engine died"):
+        asyncio.run(dispatch_concurrent([1], process, max_retries=3))

--- a/tests/inference/test_terminal_errors.py
+++ b/tests/inference/test_terminal_errors.py
@@ -22,38 +22,18 @@ def _engine_dead_error(message: str = "engine died") -> Exception:
     return error_type(message)
 
 
-def test_classifies_vllm_engine_death_as_terminal() -> None:
-    classified = classify_terminal_provider_error(_engine_dead_error())
-
-    assert classified is not None
-    assert classified.provider == "vLLM"
-    assert classified.cause_type == "EngineDeadError"
-    assert "engine died" in str(classified)
-
-
-def test_classifies_terminal_error_through_exception_chain() -> None:
+def test_classifies_only_vllm_engine_death_as_terminal() -> None:
     wrapped = RuntimeError("provider call failed")
     wrapped.__cause__ = _engine_dead_error()
 
-    classified = classify_terminal_provider_error(wrapped)
-
-    assert classified is not None
-    assert classified.cause_type == "EngineDeadError"
-
-
-def test_does_not_classify_recoverable_provider_error() -> None:
+    for error in (_engine_dead_error(), wrapped):
+        classified = classify_terminal_provider_error(error)
+        assert classified is not None
+        assert "EngineDeadError" in str(classified)
     assert classify_terminal_provider_error(RuntimeError("request failed")) is None
 
 
-def test_dispatch_propagates_terminal_provider_error() -> None:
-    async def process(_item: int) -> int:
-        raise TerminalProviderError("vLLM", "EngineDeadError", "engine died")
-
-    with pytest.raises(TerminalProviderError, match="engine died"):
-        asyncio.run(dispatch_concurrent([1], process, max_retries=3))
-
-
-def test_dispatch_cancels_siblings_after_terminal_provider_error() -> None:
+def test_dispatch_propagates_terminal_error_and_cancels_siblings() -> None:
     async def run() -> None:
         sibling_started = asyncio.Event()
         sibling_cancelled = asyncio.Event()
@@ -61,7 +41,7 @@ def test_dispatch_cancels_siblings_after_terminal_provider_error() -> None:
         async def process(item: int) -> None:
             if item == 0:
                 await sibling_started.wait()
-                raise TerminalProviderError("vLLM", "EngineDeadError", "engine died")
+                raise TerminalProviderError("engine died")
 
             sibling_started.set()
             try:
@@ -71,7 +51,7 @@ def test_dispatch_cancels_siblings_after_terminal_provider_error() -> None:
                 raise
 
         with pytest.raises(TerminalProviderError, match="engine died"):
-            await dispatch_concurrent([0, 1], process, max_in_flight=2)
+            await dispatch_concurrent([0, 1], process, max_in_flight=2, max_retries=3)
 
         assert sibling_cancelled.is_set()
 

--- a/tests/runners/test_async_failure_safety.py
+++ b/tests/runners/test_async_failure_safety.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import asyncio
 import logging
 import queue
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
@@ -16,9 +18,9 @@ from olmo_eval.runners.asynq.processing import process_batch, process_chat_reque
 from olmo_eval.runners.asynq.results import (
     _build_pending_instance_keys,
     _consume_pending_instance,
-    process_results,
+    _format_worker_failure,
 )
-from olmo_eval.runners.asynq.types import WORKER_FATAL, QueueItem, ResultItem, TaskTracker
+from olmo_eval.runners.asynq.types import QueueItem, ResultItem, TaskTracker
 
 
 def _engine_dead_error() -> Exception:
@@ -43,126 +45,72 @@ def _queue_item(instance_idx: int) -> QueueItem:
     )
 
 
-class _Provider:
-    def __init__(self, error: Exception) -> None:
-        self.error = error
-
-    def describe_request(self, _request: LMRequest, _params: object) -> None:
-        return None
-
-    async def agenerate(self, _requests: list[LMRequest], _params: object) -> None:
-        raise self.error
-
-
-class _Harness:
-    def __init__(self, error: Exception) -> None:
-        self.provider = _Provider(error)
-
-    def _apply_config(self, request: LMRequest) -> LMRequest:
-        return request
-
-    def flush_metrics(self, _batch_hash: str) -> None:
-        raise AssertionError("metrics should not flush after a failed provider call")
+def _harness(error: Exception) -> SimpleNamespace:
+    provider = SimpleNamespace(
+        describe_request=Mock(return_value=None),
+        agenerate=AsyncMock(side_effect=error),
+    )
+    return SimpleNamespace(
+        provider=provider,
+        _apply_config=lambda request: request,
+        flush_metrics=Mock(),
+        run=AsyncMock(side_effect=error),
+    )
 
 
-class _ChatHarness(_Harness):
-    async def run(self, *_args: object, **_kwargs: object) -> None:
-        raise self.provider.error
-
-
-def test_terminal_batch_error_propagates_without_instance_failures() -> None:
-    result_queue: queue.Queue[ResultItem] = queue.Queue()
-
-    with pytest.raises(TerminalProviderError, match="EngineDeadError"):
-        asyncio.run(
-            process_batch(
-                [_queue_item(0), _queue_item(1)],
-                _Harness(_engine_dead_error()),  # type: ignore[arg-type]
-                result_queue,  # type: ignore[arg-type]
-            )
-        )
-
-    assert result_queue.empty()
-
-
-def test_terminal_chat_error_propagates_without_instance_failure() -> None:
-    result_queue: queue.Queue[ResultItem] = queue.Queue()
-
-    with pytest.raises(TerminalProviderError, match="EngineDeadError"):
-        asyncio.run(
-            process_chat_request(
+def test_terminal_processing_paths_propagate_without_instance_failures() -> None:
+    for chat in (False, True):
+        result_queue: queue.Queue[ResultItem] = queue.Queue()
+        harness = _harness(_engine_dead_error())
+        if chat:
+            request = process_chat_request(
                 _queue_item(0),
-                _ChatHarness(_engine_dead_error()),  # type: ignore[arg-type]
+                harness,
                 result_queue,  # type: ignore[arg-type]
             )
-        )
+        else:
+            request = process_batch(
+                [_queue_item(0)],
+                harness,
+                result_queue,  # type: ignore[arg-type]
+            )
 
-    assert result_queue.empty()
+        with pytest.raises(TerminalProviderError, match="EngineDeadError"):
+            asyncio.run(request)
+        assert result_queue.empty()
 
 
-def test_streaming_strategy_propagates_fast_failure_and_cancels_sibling(
+def test_streaming_strategy_propagates_fast_failure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     class _Reporter:
         def progress_callback(self, _label: str):
             return lambda *_args, **_kwargs: None
 
+    async def fail(*_args: object, **_kwargs: object) -> None:
+        raise TerminalProviderError("engine died")
+
     async def run() -> None:
-        sibling_started = asyncio.Event()
-        sibling_cancelled = asyncio.Event()
-
-        async def fail_or_wait(items: list[QueueItem], *_args: object, **_kwargs: object) -> None:
-            if items[0].instance_idx == 0:
-                await sibling_started.wait()
-                raise TerminalProviderError("vLLM", "EngineDeadError", "engine died")
-
-            sibling_started.set()
-            try:
-                await asyncio.Future()
-            except asyncio.CancelledError:
-                sibling_cancelled.set()
-                raise
-
-        monkeypatch.setattr("olmo_eval.runners.asynq.processing.process_items", fail_or_wait)
+        monkeypatch.setattr("olmo_eval.runners.asynq.processing.process_items", fail)
         item_queue: queue.Queue[QueueItem | None] = queue.Queue()
         result_queue: queue.Queue[ResultItem] = queue.Queue()
         item_queue.put(_queue_item(0))
-        item_queue.put(_queue_item(1))
 
         with pytest.raises(TerminalProviderError, match="engine died"):
             await StreamingStrategy(BatchConfig.streaming()).run(
                 item_queue=item_queue,  # type: ignore[arg-type]
                 harness=object(),  # type: ignore[arg-type]
                 result_queue=result_queue,  # type: ignore[arg-type]
-                max_concurrency=2,
+                max_concurrency=1,
                 worker_logger=logging.getLogger(__name__),
-                total_instances=2,
+                total_instances=1,
             )
-
-        assert sibling_cancelled.is_set()
-        assert result_queue.empty()
 
     monkeypatch.setattr("olmo_eval.common.beaker_status.BeakerStatusReporter", _Reporter)
     asyncio.run(run())
 
 
-def test_recoverable_batch_error_still_reports_each_instance() -> None:
-    result_queue: queue.Queue[ResultItem] = queue.Queue()
-
-    asyncio.run(
-        process_batch(
-            [_queue_item(0), _queue_item(1)],
-            _Harness(RuntimeError("request failed")),  # type: ignore[arg-type]
-            result_queue,  # type: ignore[arg-type]
-        )
-    )
-
-    results = [result_queue.get_nowait(), result_queue.get_nowait()]
-    assert [result.instance_idx for result in results] == [0, 1]
-    assert all(result.error and "request failed" in result.error for result in results)
-
-
-def test_pending_instance_tracking_rejects_duplicates() -> None:
+def test_pending_identities_reject_duplicates_and_appear_in_fatal_error() -> None:
     trackers = {
         "task": TaskTracker(
             model_name="model",
@@ -172,6 +120,11 @@ def test_pending_instance_tracking_rejects_duplicates() -> None:
         )
     }
     pending = _build_pending_instance_keys(trackers)
+    message = _format_worker_failure("terminal failure", pending)
+    assert "2 inference result(s) pending" in message
+    assert "model:task[0]" in message
+    assert "model:task[1]" in message
+
     result = ResultItem(
         model_name="model",
         task_id="task",
@@ -188,63 +141,8 @@ def test_pending_instance_tracking_rejects_duplicates() -> None:
         _consume_pending_instance(pending, result)
 
 
-def test_worker_fatal_reports_exact_pending_instance_identities() -> None:
-    result_queue: queue.Queue[ResultItem] = queue.Queue()
-    result_queue.put(
-        ResultItem(
-            model_name="model",
-            task_id=WORKER_FATAL,
-            instance_idx=-1,
-            instance=None,
-            request=None,
-            outputs=[],
-            error="terminal provider failure",
-        )
-    )
-    trackers = {
-        "task": TaskTracker(
-            model_name="model",
-            spec="task",
-            task=None,
-            total_instances=2,
-        )
-    }
-
-    with pytest.raises(RuntimeError) as exc_info:
-        asyncio.run(
-            process_results(
-                trackers=trackers,
-                result_queue=result_queue,  # type: ignore[arg-type]
-                workers=[],
-                scoring_context=None,  # type: ignore[arg-type]
-                scoring_concurrency=1,
-                total_tasks=1,
-                total_instances=2,
-                model_name="model",
-                save_predictions=False,
-                write_predictions_fn=lambda *_args: None,
-                save_requests=False,
-                write_requests_fn=lambda *_args: None,
-            )
-        )
-
-    message = str(exc_info.value)
-    assert "2 inference result(s) pending" in message
-    assert "model:task[0]" in message
-    assert "model:task[1]" in message
-
-
-class _Process:
-    def __init__(self, *, alive: bool, exitcode: int | None) -> None:
-        self._alive = alive
-        self.exitcode = exitcode
-
-    def is_alive(self) -> bool:
-        return self._alive
-
-
 def test_single_failed_worker_is_fatal_while_other_workers_are_alive() -> None:
-    workers = [_Process(alive=False, exitcode=1), _Process(alive=True, exitcode=None)]
+    workers = [SimpleNamespace(exitcode=1), SimpleNamespace(exitcode=None)]
 
     with pytest.raises(RuntimeError, match="worker 0 exited with code 1"):
         check_workers_alive(

--- a/tests/runners/test_async_failure_safety.py
+++ b/tests/runners/test_async_failure_safety.py
@@ -1,0 +1,205 @@
+"""Regression tests for fatal async inference failures."""
+
+from __future__ import annotations
+
+import asyncio
+import queue
+
+import pytest
+
+from olmo_eval.common.types import Instance, LMRequest, RequestType
+from olmo_eval.inference.errors import TerminalProviderError
+from olmo_eval.runners.asynq.monitoring import check_workers_alive
+from olmo_eval.runners.asynq.processing import process_batch, process_chat_request
+from olmo_eval.runners.asynq.results import (
+    _build_pending_instance_keys,
+    _consume_pending_instance,
+    process_results,
+)
+from olmo_eval.runners.asynq.types import WORKER_FATAL, QueueItem, ResultItem, TaskTracker
+
+
+def _engine_dead_error() -> Exception:
+    error_type = type(
+        "EngineDeadError",
+        (Exception,),
+        {"__module__": "vllm.v1.engine.exceptions"},
+    )
+    return error_type("EngineCore encountered an issue")
+
+
+def _queue_item(instance_idx: int) -> QueueItem:
+    return QueueItem(
+        model_name="model",
+        task_id="task",
+        instance_idx=instance_idx,
+        instance=Instance(question=f"question {instance_idx}", gold_answer="answer"),
+        request=LMRequest(
+            request_type=RequestType.COMPLETION,
+            prompt=f"question {instance_idx}",
+        ),
+    )
+
+
+class _Provider:
+    def __init__(self, error: Exception) -> None:
+        self.error = error
+
+    def describe_request(self, _request: LMRequest, _params: object) -> None:
+        return None
+
+    async def agenerate(self, _requests: list[LMRequest], _params: object) -> None:
+        raise self.error
+
+
+class _Harness:
+    def __init__(self, error: Exception) -> None:
+        self.provider = _Provider(error)
+
+    def _apply_config(self, request: LMRequest) -> LMRequest:
+        return request
+
+    def flush_metrics(self, _batch_hash: str) -> None:
+        raise AssertionError("metrics should not flush after a failed provider call")
+
+
+class _ChatHarness(_Harness):
+    async def run(self, *_args: object, **_kwargs: object) -> None:
+        raise self.provider.error
+
+
+def test_terminal_batch_error_propagates_without_instance_failures() -> None:
+    result_queue: queue.Queue[ResultItem] = queue.Queue()
+
+    with pytest.raises(TerminalProviderError, match="EngineDeadError"):
+        asyncio.run(
+            process_batch(
+                [_queue_item(0), _queue_item(1)],
+                _Harness(_engine_dead_error()),  # type: ignore[arg-type]
+                result_queue,  # type: ignore[arg-type]
+            )
+        )
+
+    assert result_queue.empty()
+
+
+def test_terminal_chat_error_propagates_without_instance_failure() -> None:
+    result_queue: queue.Queue[ResultItem] = queue.Queue()
+
+    with pytest.raises(TerminalProviderError, match="EngineDeadError"):
+        asyncio.run(
+            process_chat_request(
+                _queue_item(0),
+                _ChatHarness(_engine_dead_error()),  # type: ignore[arg-type]
+                result_queue,  # type: ignore[arg-type]
+            )
+        )
+
+    assert result_queue.empty()
+
+
+def test_recoverable_batch_error_still_reports_each_instance() -> None:
+    result_queue: queue.Queue[ResultItem] = queue.Queue()
+
+    asyncio.run(
+        process_batch(
+            [_queue_item(0), _queue_item(1)],
+            _Harness(RuntimeError("request failed")),  # type: ignore[arg-type]
+            result_queue,  # type: ignore[arg-type]
+        )
+    )
+
+    results = [result_queue.get_nowait(), result_queue.get_nowait()]
+    assert [result.instance_idx for result in results] == [0, 1]
+    assert all(result.error and "request failed" in result.error for result in results)
+
+
+def test_pending_instance_tracking_rejects_duplicates() -> None:
+    trackers = {
+        "task": TaskTracker(
+            model_name="model",
+            spec="task",
+            task=None,
+            total_instances=2,
+        )
+    }
+    pending = _build_pending_instance_keys(trackers)
+    result = ResultItem(
+        model_name="model",
+        task_id="task",
+        instance_idx=0,
+        instance=None,
+        request=None,
+        outputs=[],
+    )
+
+    _consume_pending_instance(pending, result)
+
+    assert pending == {("model", "task", 1)}
+    with pytest.raises(RuntimeError, match="duplicate or unexpected"):
+        _consume_pending_instance(pending, result)
+
+
+def test_worker_fatal_reports_exact_pending_instance_identities() -> None:
+    result_queue: queue.Queue[ResultItem] = queue.Queue()
+    result_queue.put(
+        ResultItem(
+            model_name="model",
+            task_id=WORKER_FATAL,
+            instance_idx=-1,
+            instance=None,
+            request=None,
+            outputs=[],
+            error="terminal provider failure",
+        )
+    )
+    trackers = {
+        "task": TaskTracker(
+            model_name="model",
+            spec="task",
+            task=None,
+            total_instances=2,
+        )
+    }
+
+    with pytest.raises(RuntimeError) as exc_info:
+        asyncio.run(
+            process_results(
+                trackers=trackers,
+                result_queue=result_queue,  # type: ignore[arg-type]
+                workers=[],
+                scoring_context=None,  # type: ignore[arg-type]
+                scoring_concurrency=1,
+                total_tasks=1,
+                total_instances=2,
+                model_name="model",
+                save_predictions=False,
+                write_predictions_fn=lambda *_args: None,
+                save_requests=False,
+                write_requests_fn=lambda *_args: None,
+            )
+        )
+
+    message = str(exc_info.value)
+    assert "2 inference result(s) pending" in message
+    assert "model:task[0]" in message
+    assert "model:task[1]" in message
+
+
+class _Process:
+    def __init__(self, *, alive: bool, exitcode: int | None) -> None:
+        self._alive = alive
+        self.exitcode = exitcode
+
+    def is_alive(self) -> bool:
+        return self._alive
+
+
+def test_single_failed_worker_is_fatal_while_other_workers_are_alive() -> None:
+    workers = [_Process(alive=False, exitcode=1), _Process(alive=True, exitcode=None)]
+
+    with pytest.raises(RuntimeError, match="worker 0 exited with code 1"):
+        check_workers_alive(
+            workers,  # type: ignore[arg-type]
+            queue.Queue(),  # type: ignore[arg-type]
+        )

--- a/tests/runners/test_async_failure_safety.py
+++ b/tests/runners/test_async_failure_safety.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import queue
 
 import pytest
 
 from olmo_eval.common.types import Instance, LMRequest, RequestType
 from olmo_eval.inference.errors import TerminalProviderError
+from olmo_eval.runners.asynq.batching import BatchConfig, StreamingStrategy
 from olmo_eval.runners.asynq.monitoring import check_workers_alive
 from olmo_eval.runners.asynq.processing import process_batch, process_chat_request
 from olmo_eval.runners.asynq.results import (
@@ -96,6 +98,52 @@ def test_terminal_chat_error_propagates_without_instance_failure() -> None:
         )
 
     assert result_queue.empty()
+
+
+def test_streaming_strategy_propagates_fast_failure_and_cancels_sibling(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _Reporter:
+        def progress_callback(self, _label: str):
+            return lambda *_args, **_kwargs: None
+
+    async def run() -> None:
+        sibling_started = asyncio.Event()
+        sibling_cancelled = asyncio.Event()
+
+        async def fail_or_wait(items: list[QueueItem], *_args: object, **_kwargs: object) -> None:
+            if items[0].instance_idx == 0:
+                await sibling_started.wait()
+                raise TerminalProviderError("vLLM", "EngineDeadError", "engine died")
+
+            sibling_started.set()
+            try:
+                await asyncio.Future()
+            except asyncio.CancelledError:
+                sibling_cancelled.set()
+                raise
+
+        monkeypatch.setattr("olmo_eval.runners.asynq.processing.process_items", fail_or_wait)
+        item_queue: queue.Queue[QueueItem | None] = queue.Queue()
+        result_queue: queue.Queue[ResultItem] = queue.Queue()
+        item_queue.put(_queue_item(0))
+        item_queue.put(_queue_item(1))
+
+        with pytest.raises(TerminalProviderError, match="engine died"):
+            await StreamingStrategy(BatchConfig.streaming()).run(
+                item_queue=item_queue,  # type: ignore[arg-type]
+                harness=object(),  # type: ignore[arg-type]
+                result_queue=result_queue,  # type: ignore[arg-type]
+                max_concurrency=2,
+                worker_logger=logging.getLogger(__name__),
+                total_instances=2,
+            )
+
+        assert sibling_cancelled.is_set()
+        assert result_queue.empty()
+
+    monkeypatch.setattr("olmo_eval.common.beaker_status.BeakerStatusReporter", _Reporter)
+    asyncio.run(run())
 
 
 def test_recoverable_batch_error_still_reports_each_instance() -> None:


### PR DESCRIPTION
## Description

Fail fast when an inference provider becomes permanently unavailable instead of converting every later request into an ordinary instance failure or waiting forever for missing results.

This is the safety slice motivated by the long-context run where three vLLM EngineCore processes died and the surrounding workers either drained the shared queue with `EngineDeadError` failures or left unresolved results behind.

Changes:

- classify vLLM `EngineDeadError` as a terminal provider error without importing optional CUDA-only dependencies
- propagate terminal errors through batched, CHAT, concurrent-dispatch, and streaming paths so the worker emits `WORKER_FATAL` and exits nonzero
- retrieve streaming task failures before discarding completed tasks, preventing fast exceptions from being silently lost
- cancel and drain sibling inference tasks after a terminal error or caller cancellation
- treat any single nonzero inference-worker exit as fatal, even while other workers remain alive
- track expected results by `(model, task, instance)` identity instead of only an integer count
- reject duplicate or unexpected inference results
- include exact unresolved identities in fatal run errors
- close progress reporting at the actual completed count and display incomplete percentages precisely so 99.9% cannot render as 100%

The existing CLI converts the propagated runner exception into exit code 1.

Out of scope for this PR:

- worker leases, retries, or requeue/recovery
- heartbeat and provider-call timeouts
- vLLM prompt-logprob memory tuning
- artifact and metrics redesign

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Testing

- [x] Unit tests pass locally
- [x] Integration tests pass
- [x] New tests added for new functionality

`make verify` passed locally:

- Ruff formatting and lint
- `ty check src/ alembic/`
- 1,991 tests passed, 26 skipped
- Docker-backed PostgreSQL and LocalStack integration tests

Seven focused regressions cover terminal classification, concurrent fail-fast cancellation, batched and CHAT propagation, the streaming failure race, pending identity and duplicate handling, single-worker nonzero exits, and incomplete progress formatting.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
