### PR TITLE
Make caption, counting and pointing benchmarks follow the checkpoint's prompt family

### DIFF
--- a/src/olmo_eval/evals/tasks/dense_caption.py
+++ b/src/olmo_eval/evals/tasks/dense_caption.py
@@ -190,9 +190,38 @@ class DenseCaptionEval(Task):
     #: Image decoding builds the instances; the GPT judge needs an OpenAI client.
     #: A missing scorer dependency scores every instance zero rather than failing.
     dependencies = ["pillow", "openai"]
-    # None => reproduce mm_olmo's per-example seeded `long_caption` template (the released
-    # Molmo2-4B behavior). Set to a fixed string on a subclass to force one prompt.
+    # None => decide from the checkpoint's prompt family (see `_question`). Set to a fixed
+    # string on a subclass to force one prompt regardless of family.
     caption_prompt: str | None = None
+    #: Prompt family assumed when the run does not say. Matches the instruction-tuned
+    #: checkpoints, mirroring `ModelPromptPointingTask`'s defaults.
+    default_system_prompt_style = "demo_or_style_v2"
+    #: mm_olmo `DataFormatter.default_inference_len`; the length bucket used at inference by
+    #: the `style_and_length*` families.
+    default_inference_len = 65
+
+    def _question(self, idx: int) -> str:
+        """The caption prompt for example ``idx``, following the checkpoint's family.
+
+        The prompt has to follow the checkpoint rather than the task, exactly as for the
+        `_mp` pointing tasks: a captioner-family checkpoint (mm_olmo `train_captioner.py`,
+        `system_prompt="style_and_length_v2"`, which includes OLMo-core's
+        `Molmo2-Stage1.py` runs with `style_length_conditioning=True`) was trained with a
+        `"<style> <bucket>:"` prefix on every caption, and mm_olmo re-applies it at
+        inference via `default_inference_len` (`olmo/data/data_formatter.py`). Handing such
+        a checkpoint a natural-language instruction instead measures it out of distribution:
+        on a 4B stage-1 run it cost 7.1 recall points (38.18 -> 45.28) and made 3.4% of
+        answers come back as `<points .../>` markup rather than prose.
+
+        So `-o system_prompt_style=style_and_length_v2` selects the captioner prompt here,
+        the same override that selects it for the pointing tasks.
+        """
+        if self.caption_prompt is not None:
+            return self.caption_prompt
+        style = self.config.system_prompt_style or self.default_system_prompt_style
+        if style in ("style_and_length", "style_and_length_v2"):
+            return f"long_caption {self.default_inference_len}:"
+        return dense_caption_question(idx)
 
     @property
     def instances(self) -> Iterator[Instance]:
@@ -241,11 +270,7 @@ class DenseCaptionEval(Task):
                     mturk_data = json.load(f2)
                 mturk_statements: str = mturk_data["canonical_statements"]
 
-                question = (
-                    self.caption_prompt
-                    if self.caption_prompt is not None
-                    else dense_caption_question(idx)
-                )
+                question = self._question(idx)
                 yield Instance(
                     question=question,
                     gold_answer=None,


### PR DESCRIPTION
mm_olmo's `DataFormatter` prefixes `"<style>:"` based on the example's **style** — `long_caption`,
`pointing`, `point_count`, … — under the `style_and_length`/`_v2` families, and adds nothing under
`demo_or_style_v*` (`olmo/data/data_formatter.py`). It keys off the style, **not** off whether the
benchmark supplied a ready-made question.

olmo-eval honoured that only for the `_mp` pointing variants, which route through
`build_pointing_prompt`. Every other family-sensitive benchmark sent the bare question, so
`-o system_prompt_style=style_and_length_v2` — the override a pretrain checkpoint is supposed to
pass — was **silently inert** on them:

| task | mm_olmo style | source of truth |
|---|---|---|
| `dense_caption` | `long_caption` | `default_inference_len` at inference |
| `pixmo_count` | `point_count` | PixMoCount message style |
| `countbench_qa` | `point_count` | `CountBenchQaConfig.format_example` sets it |
| `pixmo_points_eval` | `pointing` | `pixmo_datasets.py:789` |
| `sa_co_gold_subset` | `pointing` | `academic_datasets.py:1766` |

## Why it matters

Measured on a 4B Molmo2 stage-1 checkpoint (`style_and_length_v2`; every caption trained behind a
`"<style> <bucket>:"` prefix), `dense_caption` both ways:

| | bare question | family declared |
|---|---|---|
| **recall** | 38.18 | **45.28** |
| consistency | 69.68 | 70.69 |
| recall_at_10 | 77.20 | 86.73 |
| num_statements | 19.80 | 21.66 |
| **avg** | 53.93 | **57.98** |
| `<points .../>` answers | 93 (3.4%) | **0** |
| answers < 30 words | 60 | **0** |
| words | med 143, **min 3** | med 164, **min 105** |

**7.1 recall points**, and it reads as a model regression rather than a harness setting — which is
exactly how it was reported. Given a prompt it never saw in training, the model sometimes answered a
caption request with pointing markup, or with three words. Two stage-1 checkpoints that looked 3–4
points apart turned out to be within 0.05 recall of each other once both were scored correctly.

The counting and pointing tasks have the same exposure for any pretrain checkpoint.

## The change

- `system_prefix(system_prompt, style=POINTING_STYLE)` — now style-aware; existing callers unchanged.
- `apply_style_prefix(question, system_prompt, style)` — prefixes a pre-built question.
- `StylePrefixMixin` — gives a task the same `system_prompt_style` override the `_mp` tasks have;
  each task declares its mm_olmo `style`.
- `dense_caption` honours `system_prompt_style` directly, selecting
  `"long_caption {default_inference_len}:"`.

**Backwards compatible.** Defaults stay `demo_or_style_v2` (no prefix), so every existing run keeps
its current prompts; only an explicit `-o system_prompt_style=style_and_length*` changes behaviour.
`dense_caption_captioner` still force-sets its prompt via `caption_prompt`, which takes precedence.

## Verification

Prefix resolution checked per task for the default and for `style_and_length_v2` (`point_count: Q`,
`pointing: Q`, bare by default); `dense_caption` checked for no-override, `demo_or_style_v2`,
`style_and_length`, `style_and_length_v2`, and the `dense_caption_captioner` subclass. `make lint`
clean (520 files). `make type-check` reports one diagnostic, pre-existing and in
`providers/olmo_core.py:219`, untouched here.