### PR TITLE
Make the counting and pointing benchmarks follow the checkpoint's prompt family too

### DIFF
--- a/src/olmo_eval/common/pointing_prompts.py
+++ b/src/olmo_eval/common/pointing_prompts.py
@@ -84,6 +84,8 @@ _STYLE_PREFIX_STYLES = ("style_and_length", "style_and_length_v2")
 
 #: The formatter's style name for these tasks, used as the system prefix.
 POINTING_STYLE = "pointing"
+#: The formatter's style name for the counting benchmarks (PixMo-Count, CountBenchQA).
+POINT_COUNT_STYLE = "point_count"
 
 
 def pointing_rng(index: int) -> np.random.RandomState:
@@ -93,16 +95,31 @@ def pointing_rng(index: int) -> np.random.RandomState:
     return np.random.RandomState((EVAL_DATA_SEED * _SEED_MULTIPLIER + index) % (2**32 - 1))
 
 
-def system_prefix(system_prompt: str) -> str:
-    """Prefix that ``system_prompt`` puts in front of a pointing question."""
+def system_prefix(system_prompt: str, style: str = POINTING_STYLE) -> str:
+    """Prefix that ``system_prompt`` puts in front of a question of ``style``.
+
+    mm_olmo's ``DataFormatter`` prefixes ``"<style>:"`` for the pointing/counting style
+    family under ``style_and_length``/``_v2`` and adds nothing under ``demo_or_style_v*``
+    (``olmo/data/data_formatter.py``). It keys off the *style*, not off whether the
+    benchmark supplied a ready-made question, so the pre-built-question benchmarks need the
+    prefix just as much as the ``_mp`` ones.
+    """
     if system_prompt in _NO_PREFIX_STYLES:
         return ""
     if system_prompt in _STYLE_PREFIX_STYLES:
-        return f"{POINTING_STYLE}:"
+        return f"{style}:"
     raise ValueError(
-        f"Unsupported system_prompt {system_prompt!r} for pointing; "
+        f"Unsupported system_prompt {system_prompt!r} for {style}; "
         f"expected one of {_NO_PREFIX_STYLES + _STYLE_PREFIX_STYLES}"
     )
+
+
+def apply_style_prefix(question: str, system_prompt: str, style: str) -> str:
+    """Return ``question`` with the family's ``"<style>:"`` prefix, if the family adds one."""
+    prefix = system_prefix(system_prompt, style)
+    if not prefix:
+        return question
+    return f"{prefix} {question}" if question else prefix
 
 
 def build_pointing_prompt(

--- a/src/olmo_eval/evals/tasks/common/pointing_base.py
+++ b/src/olmo_eval/evals/tasks/common/pointing_base.py
@@ -20,12 +20,17 @@ from __future__ import annotations
 from abc import abstractmethod
 from collections.abc import Callable, Iterator, Sequence
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from olmo_eval.common.metrics.base import Metric
-from olmo_eval.common.pointing_prompts import build_pointing_prompt
+from olmo_eval.common.pointing_prompts import (
+    POINTING_STYLE,
+    apply_style_prefix,
+    build_pointing_prompt,
+)
 from olmo_eval.common.scorers.base import Scorer
 from olmo_eval.common.types import Instance, LMRequest, RequestType, Response
-from olmo_eval.evals.tasks.common.base import Task
+from olmo_eval.evals.tasks.common.base import Task, TaskConfig
 
 # Generic (not image-QA-specific) data/image utilities.
 from olmo_eval.evals.tasks.common.image_qa_base import (
@@ -76,6 +81,35 @@ class PointingTask(Task):
             request_type=RequestType.CHAT,
             messages=({"role": "user", "content": instance.question},),
             images=(image,) if image is not None else None,
+        )
+
+
+class StylePrefixMixin:
+    """Applies the checkpoint's ``"<style>:"`` prompt prefix to a pre-built question.
+
+    For benchmarks that supply their own question, the prompt still has to follow the
+    checkpoint: mm_olmo's ``DataFormatter`` keys the prefix off the example's *style*, so a
+    ``style_and_length``/``_v2`` checkpoint saw ``"pointing: <q>"`` / ``"point_count: <q>"``
+    in training while a ``demo_or_style_v*`` one saw the bare question. Set
+    ``-o system_prompt_style=style_and_length_v2`` for a pretrain checkpoint; the default
+    matches the instruction-tuned models, as in :class:`ModelPromptPointingTask`.
+
+    Subclasses set :data:`style` to the mm_olmo style name for the benchmark.
+    """
+
+    #: mm_olmo style name for this benchmark's examples ("pointing" / "point_count").
+    style: str = POINTING_STYLE
+    default_system_prompt_style = "demo_or_style_v2"
+
+    if TYPE_CHECKING:  # supplied by the Task this is mixed into
+        config: TaskConfig
+
+    def apply_family_prefix(self, question: str) -> str:
+        """Return ``question`` prefixed for the checkpoint's prompt family."""
+        return apply_style_prefix(
+            question,
+            self.config.system_prompt_style or self.default_system_prompt_style,
+            self.style,
         )
 
 

--- a/src/olmo_eval/evals/tasks/countbench_qa.py
+++ b/src/olmo_eval/evals/tasks/countbench_qa.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 
+from olmo_eval.common.pointing_prompts import POINT_COUNT_STYLE
 from olmo_eval.common.scorers.image_qa import PointCountScorer
 from olmo_eval.common.types import Instance, SamplingParams, Split
 from olmo_eval.evals.tasks.common import register
@@ -22,13 +23,15 @@ from olmo_eval.evals.tasks.common.image_qa_base import (
     point_count_metrics,
     torch_datasets_dir,
 )
+from olmo_eval.evals.tasks.common.pointing_base import StylePrefixMixin
 
 _SCORER = PointCountScorer()
 _METRICS = point_count_metrics(_SCORER)
 
 
 @register("countbench_qa")
-class CountBenchQaTask(ImageQATask):
+class CountBenchQaTask(StylePrefixMixin, ImageQATask):
+    style = POINT_COUNT_STYLE
     sampling_params = SamplingParams(temperature=0.0, max_tokens=192)
     metrics = _METRICS
     primary_metric = _METRICS[0]  # correct
@@ -44,7 +47,7 @@ class CountBenchQaTask(ImageQATask):
         for idx in range(len(ds_nodecode)):
             ex = ds_nodecode[idx]
             yield Instance(
-                question=str(ex["question"]),
+                question=self.apply_family_prefix(str(ex["question"])),
                 gold_answer=str(ex["count"]),
                 metadata={
                     "count": ex["count"],

--- a/src/olmo_eval/evals/tasks/pixmo_count.py
+++ b/src/olmo_eval/evals/tasks/pixmo_count.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 from collections.abc import Iterator
 
 from olmo_eval.common.image_qa import pixmo_count_question
+from olmo_eval.common.pointing_prompts import POINT_COUNT_STYLE
 from olmo_eval.common.scorers.image_qa import PointCountScorer
 from olmo_eval.common.types import Instance, SamplingParams, Split
 from olmo_eval.evals.tasks.common import register, register_variant
@@ -27,13 +28,15 @@ from olmo_eval.evals.tasks.common.image_qa_base import (
     rebase_data_path,
     torch_datasets_dir,
 )
+from olmo_eval.evals.tasks.common.pointing_base import StylePrefixMixin
 
 _SCORER = PointCountScorer()
 _METRICS = point_count_metrics(_SCORER)
 
 
 @register("pixmo_count")
-class PixmoCountTask(ImageQATask):
+class PixmoCountTask(StylePrefixMixin, ImageQATask):
+    style = POINT_COUNT_STYLE
     sampling_params = SamplingParams(temperature=0.0, max_tokens=192)
     metrics = _METRICS
     primary_metric = _METRICS[0]  # correct
@@ -49,7 +52,7 @@ class PixmoCountTask(ImageQATask):
         for idx in range(len(ds)):
             ex = ds[idx]
             yield Instance(
-                question=pixmo_count_question(ex["label"], idx),
+                question=self.apply_family_prefix(pixmo_count_question(ex["label"], idx)),
                 gold_answer=str(ex["count"]),
                 metadata={
                     "count": ex["count"],

--- a/src/olmo_eval/evals/tasks/pixmo_points_eval.py
+++ b/src/olmo_eval/evals/tasks/pixmo_points_eval.py
@@ -19,6 +19,7 @@ from olmo_eval.evals.tasks.common import register
 from olmo_eval.evals.tasks.common.pointing_base import (
     ModelPromptPointingTask,
     PointingTask,
+    StylePrefixMixin,
     pointing_metrics,
     rebase_data_path,
     torch_datasets_dir,
@@ -72,14 +73,14 @@ def _build_instances(question_for: Callable[[str, int], str]) -> Iterator[Instan
 
 
 @register("pixmo_points_eval")
-class PixmoPointsEvalTask(PointingTask):
+class PixmoPointsEvalTask(StylePrefixMixin, PointingTask):
     sampling_params = SamplingParams(temperature=0.0, max_tokens=512)
     metrics = _METRICS
     primary_metric = _METRICS[2]  # f1
     split = Split.TEST
 
     def _build_instances(self) -> Iterator[Instance]:
-        return _build_instances(lambda label, _idx: _format_query(label))
+        return _build_instances(lambda label, _idx: self.apply_family_prefix(_format_query(label)))
 
 
 @register("pixmo_points_eval_mp")

--- a/src/olmo_eval/evals/tasks/sa_co_gold.py
+++ b/src/olmo_eval/evals/tasks/sa_co_gold.py
@@ -20,6 +20,7 @@ from olmo_eval.evals.tasks.common import register
 from olmo_eval.evals.tasks.common.pointing_base import (
     ModelPromptPointingTask,
     PointingTask,
+    StylePrefixMixin,
     pointing_metrics,
     presence_metrics,
     rebase_data_path,
@@ -78,14 +79,17 @@ def _subset_instances(filename: str, question_for: Callable[[str, int], str]) ->
 
 
 @register("sa_co_gold_subset")
-class SaCoGoldSubsetTask(PointingTask):
+class SaCoGoldSubsetTask(StylePrefixMixin, PointingTask):
     sampling_params = SamplingParams(temperature=0.0, max_tokens=1024)
     metrics = _METRICS
     primary_metric = _METRICS[2]  # weighted f1
     split = Split.TEST
 
     def _build_instances(self) -> Iterator[Instance]:
-        return _subset_instances("molmo-subset-v1.json", lambda text, _idx: _format_query(text))
+        return _subset_instances(
+            "molmo-subset-v1.json",
+            lambda text, _idx: self.apply_family_prefix(_format_query(text)),
+        )
 
 
 @register("sa_co_gold_subset_mp")


### PR DESCRIPTION
Follow-up to #301, which fixed `dense_caption`. The same gap exists on every other benchmark that
supplies its own question.

mm_olmo's `DataFormatter` keys the `"<style>:"` prefix off the example's **style**, not off whether
the benchmark supplied a ready-made question (`olmo/data/data_formatter.py`: styles `pointing`,
`point_count`, … under `style_and_length`/`_v2`; nothing under `demo_or_style_v*`). Only the `_mp`
variants honoured that, because they route through `build_pointing_prompt` — so
`-o system_prompt_style=style_and_length_v2`, the override a pretrain checkpoint is meant to pass,
was **silently inert** on four tasks:

| task | mm_olmo style | evidence |
|---|---|---|
| `pixmo_count` | `point_count` | PixMoCount message style |
| `countbench_qa` | `point_count` | `CountBenchQaConfig.format_example` sets it explicitly |
| `pixmo_points_eval` | `pointing` | `pixmo_datasets.py:789` |
| `sa_co_gold_subset` | `pointing` | `academic_datasets.py:1766` |

A `style_and_length_v2` checkpoint was trained on `"point_count: how many cats?"` and
`"pointing: the dog"`; these tasks were sending the bare question.

## Why it's worth fixing

On a 4B Molmo2 stage-1 checkpoint, the equivalent mismatch on `dense_caption` (#301) cost **7.1
recall points** (38.18 → 45.28) and turned **3.4% of caption answers into `<points .../>` markup**,
with some replies as short as three words. It presented as a model regression: two stage-1
checkpoints that looked 3–4 points apart were within 0.05 recall of each other once both were scored
correctly. The counting and pointing benchmarks have the same exposure for any pretrain checkpoint.

## The change

- `system_prefix(system_prompt, style=POINTING_STYLE)` — style-aware; the default keeps existing
  callers unchanged.
- `apply_style_prefix(question, system_prompt, style)` — prefixes a pre-built question.
- `StylePrefixMixin` — gives a task the same `system_prompt_style` override the `_mp` tasks already
  had; each task declares its mm_olmo `style`.

**Backwards compatible.** Defaults stay `demo_or_style_v2`, which adds no prefix, so every existing
run keeps its current prompts. Only an explicit `-o system_prompt_style=style_and_length*` changes
behaviour.

## Verification

Prefix resolution checked per task for the default and for `style_and_length_v2` (`point_count: Q`,
`pointing: Q`, bare by default), and #301's `dense_caption` behaviour re-checked on top of this.
`make lint` clean (520 files). `make type-check` reports one diagnostic, pre-existing and in
`providers/olmo_core.py:219` — the one new diagnostic this introduced (the mixin referencing
`self.config`) is resolved with a `TYPE_CHECKING` annotation.