### PR TITLE
Fix ladder dataset resolution and vLLM runtime installs

### DIFF
--- a/src/olmo_eval/evals/tasks/csqa.py
+++ b/src/olmo_eval/evals/tasks/csqa.py
@@ -23,7 +23,7 @@ from olmo_eval.evals.tasks.constants.csqa import CSQA_FIXED_FEWSHOT
 
 @register("csqa")
 class CommonsenseQA(Task):
-    data_source = DataSource(path="commonsense_qa", split="validation")
+    data_source = DataSource(path="tau/commonsense_qa", split="validation")
     split = Split.VALIDATION
     metrics = (LogprobMCAccuracyMetric(),)
     num_fewshot = 0
@@ -157,7 +157,7 @@ register_variant(
     "olmo3base",
     num_fewshot=5,
     fewshot_source="olmes_csqa_fixed",
-    data_source=DataSource(path="commonsense_qa", split="validation"),
+    data_source=DataSource(path="tau/commonsense_qa", split="validation"),
     metrics=(LogprobUncondMCAccuracyMetric(),),
 )
 register_variant(
@@ -166,14 +166,14 @@ register_variant(
     formatter=MultipleChoiceFormatter(),
     num_fewshot=5,
     fewshot_source="olmes_csqa_fixed",
-    data_source=DataSource(path="commonsense_qa", split="validation+train"),
+    data_source=DataSource(path="tau/commonsense_qa", split="validation+train"),
     limit=10000,
     seed=1234,
 )
 register_variant(
     "csqa",
     "xlarge",
-    data_source=DataSource(path="commonsense_qa", split="validation+train"),
+    data_source=DataSource(path="tau/commonsense_qa", split="validation+train"),
     num_fewshot=5,
     limit=10000,
     seed=1234,

--- a/src/olmo_eval/evals/tasks/gsm8k.py
+++ b/src/olmo_eval/evals/tasks/gsm8k.py
@@ -32,7 +32,7 @@ def _clean_short_answer(text: str) -> str:
 
 @register("gsm8k")
 class GSM8K(Task):
-    data_source = DataSource(path="gsm8k", subset="main")
+    data_source = DataSource(path="openai/gsm8k", subset="main")
     metrics = (AccuracyMetric(scorer=ExactMatchScorer),)
     num_fewshot = 8
     sampling_params = SamplingParams(

--- a/src/olmo_eval/evals/tasks/humaneval.py
+++ b/src/olmo_eval/evals/tasks/humaneval.py
@@ -28,7 +28,7 @@ class CodeExecutionScorer3s(CodeExecutionScorer):
 class HumanEval(Task):
     """HumanEval code generation task."""
 
-    data_source = DataSource(path="openai_humaneval")
+    data_source = DataSource(path="openai/openai_humaneval")
     sampling_params = SamplingParams(
         max_tokens=1024,
         temperature=0.0,

--- a/src/olmo_eval/evals/tasks/piqa.py
+++ b/src/olmo_eval/evals/tasks/piqa.py
@@ -18,7 +18,9 @@ from olmo_eval.evals.tasks.constants.piqa import PIQA_FIXED_FEWSHOT
 
 @register("piqa")
 class PiQA(Task):
-    data_source = DataSource(path="piqa", split="validation", revision="refs/convert/parquet")
+    data_source = DataSource(
+        path="ybisk/piqa", split="validation", revision="refs/convert/parquet"
+    )
     split = Split.VALIDATION
     metrics = (LogprobPerTokenMCAccuracyMetric(),)
     num_fewshot = 0

--- a/src/olmo_eval/evals/tasks/socialiqa.py
+++ b/src/olmo_eval/evals/tasks/socialiqa.py
@@ -21,7 +21,7 @@ from olmo_eval.evals.tasks.constants.socialiqa import SOCIALIQA_FIXED_FEWSHOT
 @register("socialiqa")
 class SocialIQA(Task):
     data_source = DataSource(
-        path="social_i_qa", split="validation", revision="refs/convert/parquet"
+        path="allenai/social_i_qa", split="validation", revision="refs/convert/parquet"
     )
     split = Split.VALIDATION
     metrics = (LogprobPerCharMCAccuracyMetric(),)
@@ -158,7 +158,7 @@ register_variant(
     "mc_olmo3base",
     formatter=MultipleChoiceFormatter(),
     data_source=DataSource(
-        path="social_i_qa", split="train+validation", revision="refs/convert/parquet"
+        path="allenai/social_i_qa", split="train+validation", revision="refs/convert/parquet"
     ),
     num_fewshot=5,
     limit=10000,
@@ -168,7 +168,7 @@ register_variant(
     "socialiqa",
     "xlarge",
     data_source=DataSource(
-        path="social_i_qa", split="train+validation", revision="refs/convert/parquet"
+        path="allenai/social_i_qa", split="train+validation", revision="refs/convert/parquet"
     ),
     num_fewshot=5,
     limit=10000,

--- a/src/olmo_eval/evals/tasks/winogrande.py
+++ b/src/olmo_eval/evals/tasks/winogrande.py
@@ -64,7 +64,9 @@ def _format_mc(sentence: str, options: tuple[str, ...], answer: str | None = Non
 
 @register("winogrande")
 class Winogrande(Task):
-    data_source = DataSource(path="winogrande", subset="winogrande_xl", split="validation")
+    data_source = DataSource(
+        path="allenai/winogrande", subset="winogrande_xl", split="validation"
+    )
     split = Split.VALIDATION
     metrics = (LogprobMCAccuracyMetric(),)
     num_fewshot = 0

--- a/src/olmo_eval/launch/beaker/launcher.py
+++ b/src/olmo_eval/launch/beaker/launcher.py
@@ -894,7 +894,11 @@ class BeakerLauncher:
         # an otherwise compatible vLLM impossible to resolve.
         constraints = "/tmp/cuda-constraints.txt"
         steps.append(
-            f"uv pip freeze -q | grep -E '^(torch|nvidia-)' "
+            # Match torch itself, but not companion packages such as
+            # torchvision or torchaudio. Provider releases pin those companions
+            # alongside their Torch generation and must be allowed to replace
+            # the versions inherited from the base image.
+            f"uv pip freeze -q | grep -E '^(torch(==| @ )|nvidia-)' "
             f"| grep -vE '^nvidia-cutlass-dsl' > {constraints}"
         )
 

--- a/src/olmo_eval/launch/beaker/launcher.py
+++ b/src/olmo_eval/launch/beaker/launcher.py
@@ -872,7 +872,9 @@ class BeakerLauncher:
 
             _, flags = parse_install_spec(package)
             extra_flags: list[str] = []
-            if "--index-url" not in flags and "--extra-index-url" not in flags:
+            if "--index-url" not in flags:
+                extra_flags.extend(["--index-url", "https://pypi.org/simple"])
+            if "--extra-index-url" not in flags:
                 extra_flags.extend(["--extra-index-url", runtime_torch_index_url])
             if "--index-strategy" not in flags:
                 extra_flags.extend(["--index-strategy", "unsafe-best-match"])

--- a/src/olmo_eval/launch/beaker/launcher.py
+++ b/src/olmo_eval/launch/beaker/launcher.py
@@ -886,9 +886,15 @@ class BeakerLauncher:
         if runtime_torch_version:
             steps.append(build_install_command(runtime_torch_spec(), force_reinstall=True))
 
-        # Generate constraints from pre-installed CUDA packages to prevent uv from changing them
+        # Generate constraints from pre-installed CUDA packages to prevent uv from changing them.
+        # CUTLASS DSL is the exception: vLLM pins this package independently of
+        # Torch's CUDA package set, so constraining an image's older build makes
+        # an otherwise compatible vLLM impossible to resolve.
         constraints = "/tmp/cuda-constraints.txt"
-        steps.append(f"uv pip freeze -q | grep -E '^(torch|nvidia-)' > {constraints}")
+        steps.append(
+            f"uv pip freeze -q | grep -E '^(torch|nvidia-)' "
+            f"| grep -vE '^nvidia-cutlass-dsl' > {constraints}"
+        )
 
         # Install vLLM in isolated venv when requested (for server mode)
         if use_isolated_vllm_venv:

--- a/tests/launch/test_beaker.py
+++ b/tests/launch/test_beaker.py
@@ -580,6 +580,8 @@ class TestBuildCommandWithTaskPackages:
             "--extra-index-url https://download.pytorch.org/whl/cu130 "
             "--index-strategy unsafe-best-match"
         ) in install_cmd
+        assert "grep -E '^(torch(==| @ )|nvidia-)'" in install_cmd
+        assert "grep -E '^(torch|nvidia-)'" not in install_cmd
 
     def test_no_task_packages_if_none(self):
         """Test that no extra install steps if task_packages is None."""

--- a/tests/launch/test_beaker.py
+++ b/tests/launch/test_beaker.py
@@ -561,6 +561,26 @@ class TestBuildCommandWithTaskPackages:
         task_pos = install_cmd.find("uv pip install 'task-dep==1.0'")
         assert provider_pos < task_pos
 
+    def test_runtime_torch_index_is_extra_to_pypi_for_provider_builds(self):
+        """Provider build dependencies should resolve from PyPI, not the Torch index."""
+        from olmo_eval.launch import BeakerLauncher
+
+        launcher = BeakerLauncher()
+        install_cmd = launcher._build_install_cmd(
+            extras=[],
+            env_exports={
+                "OLMO_EVAL_RUNTIME_TORCH_VERSION": "2.11.0",
+                "OLMO_EVAL_RUNTIME_TORCH_INDEX_URL": "https://download.pytorch.org/whl/cu130",
+            },
+            provider_packages=["git+https://github.com/user/plugin@main"],
+        )
+
+        assert (
+            "--index-url https://pypi.org/simple "
+            "--extra-index-url https://download.pytorch.org/whl/cu130 "
+            "--index-strategy unsafe-best-match"
+        ) in install_cmd
+
     def test_no_task_packages_if_none(self):
         """Test that no extra install steps if task_packages is None."""
         from olmo_eval.launch import BeakerLauncher


### PR DESCRIPTION
## Summary

- use fully qualified Hugging Face IDs for GSM8K, CommonsenseQA, HumanEval, PIQA, SocialIQA, and WinoGrande
- use PyPI as the primary provider-package index and the runtime PyTorch CUDA index as an extra index
- allow vLLM to resolve its required CUTLASS DSL, torchvision, and torchaudio versions instead of constraining those to the base image

These changes make fresh, uncached ladder eval launches reliable and support the CUDA 13 / vLLM 0.26 runtime stack.

## Validation

- ============================= test session starts ==============================
platform darwin -- Python 3.14.6, pytest-9.0.3, pluggy-1.6.0
rootdir: /Users/akshitab/local/code/scaling-ladders/olmo-eval
configfile: pyproject.toml
plugins: anyio-4.9.0, cov-7.1.0
collected 102 items

tests/launch/test_beaker.py ............................................ [ 43%]
..........................................................               [100%]

============================= 102 passed in 1.36s ============================== (102 passed)
- Ruff on all changed Python files
- 