### PR TITLE
Add the unsampled sa_co_gold_point_mp variant

### DIFF
--- a/src/olmo_eval/evals/suites/molmo2.py
+++ b/src/olmo_eval/evals/suites/molmo2.py
@@ -58,6 +58,9 @@ MOLMO2_POINTING_MP_TASKS = (
     "sa_co_gold_point_4k_mp",
 )
 
+# `sa_co_gold_point_mp` (the unsampled 166,766-example gold set) is registered but kept out
+# of the suite: it is ~6x the 4k variant and measures the same thing.
+
 make_suite(
     "molmo2_pointing_mp",
     MOLMO2_POINTING_MP_TASKS,

--- a/src/olmo_eval/evals/tasks/sa_co_gold.py
+++ b/src/olmo_eval/evals/tasks/sa_co_gold.py
@@ -180,13 +180,12 @@ def _load_gold_examples(sample: int | None) -> list[dict]:
     return examples
 
 
-@register("sa_co_gold_point_4k_mp")
-class SaCoGoldPoint4kMpTask(ModelPromptPointingTask):
-    """``sa_co_gold_point_4k_mp:test`` — 4096 examples per subset over the full gold test set.
+class SaCoGoldPointMpBase(ModelPromptPointingTask):
+    """The gold test set scored as pointing, with mm_olmo's ``_mp`` prompt.
 
     Unlike the prepared subsets this carries no per-example weight (so the primaries are
     plain means) and is dominated by absent phrases, which is what ``is_absent_acc`` and
-    ``is_present_acc`` measure.
+    ``is_present_acc`` measure. Subclasses set how many examples to draw per subset.
     """
 
     sampling_params = SamplingParams(temperature=0.0, max_tokens=2048)
@@ -194,8 +193,8 @@ class SaCoGoldPoint4kMpTask(ModelPromptPointingTask):
     primary_metric = _POINT_METRICS[2]  # f1
     split = Split.TEST
 
-    #: mm_olmo's ``sample`` for this variant, applied per subset.
-    sample_per_subset = 4096
+    #: mm_olmo's ``sample``, applied per subset; ``None`` keeps every example.
+    sample_per_subset: int | None = None
 
     def _build_instances(self) -> Iterator[Instance]:
         for idx, ex in enumerate(_load_gold_examples(self.sample_per_subset)):
@@ -215,3 +214,17 @@ class SaCoGoldPoint4kMpTask(ModelPromptPointingTask):
                     "label": ex["text_input"],
                 },
             )
+
+
+@register("sa_co_gold_point_4k_mp")
+class SaCoGoldPoint4kMpTask(SaCoGoldPointMpBase):
+    """``sa_co_gold_point_4k_mp:test`` — 4096 examples per subset (28,672 in total)."""
+
+    sample_per_subset = 4096
+
+
+@register("sa_co_gold_point_mp")
+class SaCoGoldPointMpTask(SaCoGoldPointMpBase):
+    """``sa_co_gold_point_mp:test`` — every example in the gold test set, unsampled."""
+
+    sample_per_subset = None


### PR DESCRIPTION
## Description

mm_olmo defines the SA-Co gold pointing set in two sizes, and only the sampled one existed here:

```python
"sa_co_gold_point_4k_mp" → SACoGold(segmentation=False, sample=4096, prompt_kind="model")
"sa_co_gold_point_mp"    → SACoGold(segmentation=False, sample=None, prompt_kind="model")
```

This adds the unsampled variant. The shared loading, prompt handling and metrics move onto a
`SaCoGoldPointMpBase`, so the two tasks differ only in how many examples they draw per subset.

| task | examples |
| --- | --- |
| `sa_co_gold_point_4k_mp` | 28,672 (4096 × 7 subsets) |
| `sa_co_gold_point_mp` | **166,766** (every example) |

Both counts verified against mm_olmo's own loader.

`sa_co_gold_point_mp` is registered but deliberately **left out of the `molmo2_pointing_mp` suite**:
at ~6× the 4k variant it measures the same thing at much greater cost, so running it should be an
explicit choice. At the ~1 item/s these evals sustain it is roughly two days per checkpoint.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Testing

- [x] Unit tests pass locally — 2054 passed, 9 skipped
- [x] Lint + format clean; `ty` back to its one pre-existing diagnostic in `providers/olmo_core.py:219`
- [x] Instance counts verified: 28,672 and 166,766, matching mm_olmo
- [x] `sa_co_gold_point_4k_mp` unchanged by the refactor (same count, same prompts)

No new tests: this adds a task variant over an existing, already-tested loader and metric set.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published