### PR TITLE
Fix judge-task crash at results aggregation (judge_fn not JSON serializable)

### DIFF
--- a/src/olmo_eval/common/scorers/llm_judge.py
+++ b/src/olmo_eval/common/scorers/llm_judge.py
@@ -236,6 +236,23 @@ class LLMJudgeScorer(ContextScorer):
         if self.provider_name is not None:
             object.__setattr__(self, "judge_fn", None)
 
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize for task hashing and results storage.
+
+        Overrides the base to keep `judge_fn` out of the dict: it is a live
+        closure, which json.dumps rejects -- a judge-fn-configured scorer
+        otherwise crashes results aggregation *after* every instance has been
+        scored (and paid for). Its repr also embeds a memory address, so even
+        a serializable form would make task hashes differ run to run. A stable
+        marker records whether a judge_fn was configured; there is no
+        deserialization path that would need the function back.
+        """
+        from dataclasses import asdict
+
+        data = {"type": self.__class__.__name__, **asdict(self)}
+        data["judge_fn"] = "<configured>" if self.judge_fn is not None else None
+        return data
+
     @abstractmethod
     def format_judge_prompt(self, instance: Instance, output: LMOutput) -> str:
         """Format the prompt to send to the judge model.

--- a/tests/evals/tasks/test_helmet.py
+++ b/tests/evals/tasks/test_helmet.py
@@ -420,3 +420,41 @@ def test_helmet_suite_structure():
     with pytest.raises(KeyError):
         get_suite("helmet_all__2097152")
     assert len(get_suite("helmet_recall__2097152").expanded_tasks) == 1
+
+
+# ---------------------------------------------------------------------------
+# config serialization (regression: judge_fn closure crashed results
+# aggregation after all instances were already scored)
+
+
+def test_every_helmet_task_config_is_json_serializable():
+    """`compute_task_hash` json.dumps's each task's config at aggregation time.
+
+    The judged tasks' scorers carry a `judge_fn` closure, which leaked into
+    the serialized config via dataclasses.asdict and crashed a full demo run
+    at 100% scored. Instantiating a task touches no data, so this sweeps all
+    registered helmet tasks cheaply.
+    """
+    from olmo_eval.evals.tasks.common.registry import get_task
+
+    for task_name in HELMET_TASKS:
+        task = get_task(f"helmet_{task_name}", {"limit": 1, "seed": 42})
+        config = task.config.to_dict()
+        serialized = json.dumps(config, sort_keys=True)
+        assert serialized == json.dumps(config, sort_keys=True)
+
+
+def test_judge_scorer_to_dict_is_stable_and_serializable():
+    from olmo_eval.common.scorers.helmet_judge import (
+        HelmetLongQAJudgeScorer,
+        HelmetSummJudgeScorer,
+    )
+
+    for scorer in (HelmetLongQAJudgeScorer(), HelmetSummJudgeScorer(is_book=True)):
+        data = scorer.to_dict()
+        # a live closure must never appear in the serialized form
+        assert data["judge_fn"] == "<configured>"
+        assert json.dumps(data, sort_keys=True)
+    # two independent constructions carry distinct closures but must
+    # serialize identically, or task hashes would differ run to run
+    assert HelmetLongQAJudgeScorer().to_dict() == HelmetLongQAJudgeScorer().to_dict()


### PR DESCRIPTION
Fixes the crash from the HELMET demo run: the judged tasks (narrativeqa, infbench_sum_eng, multi_lexsum) scored all 1800 instances successfully, then died in `_aggregate_results` with `Object of type function is not JSON serializable` — losing the run after every judge call had been paid for.

**Cause**: `TaskConfig.to_dict()` → `Metric.to_dict()` → `Scorer.to_dict()`, whose `dataclasses.asdict` includes `judge_fn`, the live async closure built by `build_openai_judge_fn`. `compute_task_hash` then `json.dumps`'s that dict. Class-valued scorers serialize as `__name__` (why the non-judge tasks were fine), and the wildguard judge dodges it because `provider_name` nulls `judge_fn` in `__post_init__` — the HELMET judges are the first judge-fn-configured scorers to reach aggregation. `SimpleQAJudgeScorer` had the same latent bug.

**Fix**: a `to_dict` override on `LLMJudgeScorer` replacing the closure with a stable `"<configured>"` marker. Also more correct for hashing — a function repr embeds a memory address, so even a serializable form would have made task hashes differ run to run. No deserialization path needs the function back (no `from_dict` exists in scorers/metrics).

**Tests**: reproduced the crash through the real config path before fixing; added a regression sweep asserting every registered helmet task's config round-trips through `json.dumps` (task instantiation touches no data, so it's cheap), plus stability of judge-scorer serialization across independent constructions.

The judged demo run will need re-running once this lands — the aggregation crash happened before `_finalize_and_save`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)