### PR TITLE
Include HELMET's RULER recall tasks in the helmet recall suites

### DIFF
--- a/src/olmo_eval/evals/suites/helmet.py
+++ b/src/olmo_eval/evals/suites/helmet.py
@@ -10,10 +10,10 @@ Three deliberate differences from `suites/ruler.py`:
 1. `helmet_all__*` aggregates the *category* suites rather than flat-averaging
    every task, matching how the HELMET paper reports an overall number. A flat
    average would let a category's task count set its weight -- ICL contributes
-   five tasks and recall one, so recall would be worth a sixth of ICL.
+   five tasks and rerank one, so rerank would be worth a fifth of ICL.
 
 2. `helmet_all__*` is only registered where more than one category exists at
-   that length. Above 128k only `json_kv` extends, so a combined suite there
+   that length. Above 128k only recall extends, so a combined suite there
    would be a rename of `helmet_recall__*` whose composition silently differs
    from the same suite at shorter lengths -- exactly the thing that turns a
    length sweep into a misleading trend line. Use `helmet_recall__*` for the
@@ -24,24 +24,42 @@ Three deliberate differences from `suites/ruler.py`:
    the execution-oriented split in `suites/science.py`, `helmet_all__*` is the
    umbrella that includes them and `helmet_nojudge__*` is the subset that runs
    without one.
+
+HELMET's recall category is `json_kv` plus three RULER synthetic tasks
+(`niah_mk_2`, `niah_mk_3`, `niah_mv`). Those three are implemented in the
+`ruler_plus` task family, which covers the same 4k-2m sweep, so the recall
+suites pull them in by their `ruler_plus_*` names rather than duplicating
+them under a `helmet_` prefix.
 """
 
 from olmo_eval.data.helmet_tasks import CONTEXT_SIZES, HELMET_TASKS
+from olmo_eval.data.ruler_plus_tasks import RULER_PLUS_TASKS
 from olmo_eval.evals.suites.registry import AggregationStrategy, Suite, register
 
 # Task categories (tags), in the order HELMET reports them
 CATEGORIES = ["recall", "rag", "rerank", "longqa", "summ", "icl", "cite"]
 
+# RULER tasks HELMET includes in its recall category, taken from the
+# extended-context ruler_plus family; none of them use an LLM judge
+_RULER_RECALL_TASKS = ("niah_mk_2", "niah_mk_3", "niah_mv")
+
 
 def _tasks_for(category: str, size: int, judged: bool | None = None) -> list[str]:
     """Task names in a category at a size, optionally filtered by judge use."""
-    return [
+    tasks = [
         f"helmet_{name}"
         for name, config in HELMET_TASKS.items()
         if config["tag"] == category
         and name.endswith(f"__{size}")
         and (judged is None or bool(config.get("judged")) == judged)
     ]
+    if category == "recall" and judged is not True:
+        tasks += [
+            f"ruler_plus_{task}__{size}"
+            for task in _RULER_RECALL_TASKS
+            if f"{task}__{size}" in RULER_PLUS_TASKS
+        ]
+    return tasks
 
 
 for size in CONTEXT_SIZES:

--- a/tests/evals/tasks/test_helmet.py
+++ b/tests/evals/tasks/test_helmet.py
@@ -406,8 +406,15 @@ def test_helmet_suite_structure():
     import olmo_eval.evals.suites.helmet  # noqa: F401 - triggers registration
     from olmo_eval.evals.suites.registry import get_suite
 
-    assert len(get_suite("helmet_all__4096").expanded_tasks) == 20
+    assert len(get_suite("helmet_all__4096").expanded_tasks) == 23
     assert len(get_suite("helmet_cite__4096").expanded_tasks) == 4
+    # recall follows HELMET: json_kv plus three RULER synthetics (from ruler_plus)
+    assert set(get_suite("helmet_recall__4096").expanded_tasks) == {
+        "helmet_json_kv__4096",
+        "ruler_plus_niah_mk_2__4096",
+        "ruler_plus_niah_mk_3__4096",
+        "ruler_plus_niah_mv__4096",
+    }
     # nojudge excludes exactly the three judged tasks
     all_tasks = set(get_suite("helmet_all__4096").expanded_tasks)
     nojudge = set(get_suite("helmet_nojudge__4096").expanded_tasks)
@@ -419,4 +426,4 @@ def test_helmet_suite_structure():
     # above 128k only recall extends; a combined suite there would mislead
     with pytest.raises(KeyError):
         get_suite("helmet_all__2097152")
-    assert len(get_suite("helmet_recall__2097152").expanded_tasks) == 1
+    assert len(get_suite("helmet_recall__2097152").expanded_tasks) == 4


### PR DESCRIPTION
Upstream HELMET's recall category is json_kv plus three RULER synthetic tasks (niah_mk_2, niah_mk_3, niah_mv). Pull those into helmet_recall__* by their ruler_plus_* names, since the ruler_plus family covers the same 4k-2m context sweep.
