### PR TITLE
Add PopQA task

### DIFF
--- a/src/olmo_eval/evals/tasks/constants/popqa.py
+++ b/src/olmo_eval/evals/tasks/constants/popqa.py
@@ -1,0 +1,32 @@
+"""Fixed few-shot examples for PopQA.
+
+One example per PopQA question template, drawn from the standard fixed
+few-shot source so prompts match the reference implementation.
+"""
+
+# fmt: off
+POPQA_FIXED_FEWSHOT = [
+    {"question": "What is Thomas Widdrington's occupation?", "answer": "politician"},
+    {"question": "In what city was Glover Morrill Allen born?", "answer": "Walpole"},
+    {"question": "What genre is The Arab?", "answer": "adventure film"},
+    {
+        "question": "Who is the father of Qasim ibn Muhammad ibn Abi Bakr?",
+        "answer": "Muhammad ibn Abi Bakr",
+    },
+    {"question": "In what country is Cora?", "answer": "United States of America"},
+    {"question": "Who was the producer of Genre?", "answer": "Don Hertzfeldt"},
+    {"question": "Who was the director of Up in the Air?", "answer": "Howard Bretherton"},
+    {"question": "What is Lima the capital of?", "answer": "Peru"},
+    {"question": "Who was the screenwriter for Trivandrum Lodge?", "answer": "Anoop Menon"},
+    {"question": "Who was the composer of 1983?", "answer": "Gopi Sundar"},
+    {"question": "What color is chalk?", "answer": "white"},
+    {
+        "question": "What is the religion of Spring Arbor University?",
+        "answer": "Free Methodist Church",
+    },
+    {"question": "What sport does Harry Clay play?", "answer": "association football"},
+    {"question": "Who is the author of B²FH paper?", "answer": "William Alfred Fowler"},
+    {"question": "Who is the mother of Terry Fox?", "answer": "Betty Fox"},
+    {"question": "What is the capital of Kingdom of Italy?", "answer": "Florence"},
+]
+# fmt: on

--- a/src/olmo_eval/evals/tasks/popqa.py
+++ b/src/olmo_eval/evals/tasks/popqa.py
@@ -39,13 +39,19 @@ class PopQAContainsScorer(Scorer):
 
     A response is correct if any accepted alias appears in it verbatim,
     lowercased, or capitalized — the matching rule used by the reference
-    implementation.
+    implementation. With ``first_line`` set, only text up to the first
+    newline is searched: models that ramble past their answer invent
+    follow-up Q/A pairs full of plausible entity names, and whole-output
+    containment credits those accidental hits.
     """
 
     name: str = "popqa_contains"
+    first_line: bool = False
 
     def score(self, instance: Instance, output: LMOutput) -> float:
         response = output.text or ""
+        if self.first_line:
+            response = response.split("\n")[0]
         aliases = instance.metadata.get("aliases") or []
         if not aliases and instance.gold_answer:
             aliases = [instance.gold_answer]
@@ -56,11 +62,24 @@ class PopQAContainsScorer(Scorer):
         return 0.0
 
 
+_FIRST_LINE = PopQAContainsScorer(name="popqa_contains_first_line", first_line=True)
+_CONTAINMENT = PopQAContainsScorer()
+
+# First-line containment is the primary metric: it is robust to ramble-rate
+# differences between models, where whole-output containment awards verbose
+# models free credit. Whole-output containment is what the reference
+# implementation computes, so it stays reported for cross-harness and
+# historical comparison.
+_FIRST_LINE_ACCURACY = AccuracyMetric(name="exact_match_first_line", scorer=_FIRST_LINE)
+_CONTAINMENT_ACCURACY = AccuracyMetric(name="exact_match_containment", scorer=_CONTAINMENT)
+
+
 @register("popqa")
 class PopQA(Task):
     data_source = DataSource(path="akariasai/PopQA", split="test")
     split = Split.TEST
-    metrics = (AccuracyMetric(scorer=PopQAContainsScorer),)
+    metrics = (_FIRST_LINE_ACCURACY, _CONTAINMENT_ACCURACY)
+    primary_metric = _FIRST_LINE_ACCURACY
     num_fewshot = 15
     sampling_params = SamplingParams(
         max_tokens=15,

--- a/src/olmo_eval/evals/tasks/popqa.py
+++ b/src/olmo_eval/evals/tasks/popqa.py
@@ -118,13 +118,14 @@ class PopQA(Task):
 
 
 # Chat variant for instruct and reasoning models. Drops stop sequences and
-# raises the token budget so chain-of-thought reasoning is not truncated.
+# lifts the token cap (None = generate to the model's context limit) so
+# chain-of-thought reasoning is not truncated on any context size.
 register_variant(
     "popqa",
     "chat",
     formatter=ChatFormatter(),
     sampling_params=SamplingParams(
-        max_tokens=131072,
+        max_tokens=None,
         temperature=0.6,
         top_p=0.95,
     ),

--- a/src/olmo_eval/evals/tasks/popqa.py
+++ b/src/olmo_eval/evals/tasks/popqa.py
@@ -1,0 +1,131 @@
+"""PopQA: open-domain QA over entities spanning a wide popularity range.
+
+PopQA (https://arxiv.org/abs/2212.10511) probes factual recall with
+template-generated questions from Wikidata triples, weighted toward
+long-tail entities. A response is correct if any accepted alias of the
+answer appears in it.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from dataclasses import dataclass
+from typing import Any
+
+from olmo_eval.common.formatters import ChatFormatter
+from olmo_eval.common.metrics import AccuracyMetric
+from olmo_eval.common.scorers.base import Scorer
+from olmo_eval.common.types import (
+    Instance,
+    LMOutput,
+    LMRequest,
+    RequestType,
+    SamplingParams,
+    Split,
+)
+from olmo_eval.data import DataSource
+from olmo_eval.evals.tasks.common import Task, register, register_variant
+from olmo_eval.evals.tasks.constants.popqa import POPQA_FIXED_FEWSHOT
+
+
+def _format_query(question: str) -> str:
+    return f"Q: {question} A:"
+
+
+@dataclass(frozen=True, slots=True)
+class PopQAContainsScorer(Scorer):
+    """Alias containment scorer for PopQA.
+
+    A response is correct if any accepted alias appears in it verbatim,
+    lowercased, or capitalized — the matching rule used by the reference
+    implementation.
+    """
+
+    name: str = "popqa_contains"
+
+    def score(self, instance: Instance, output: LMOutput) -> float:
+        response = output.text or ""
+        aliases = instance.metadata.get("aliases") or []
+        if not aliases and instance.gold_answer:
+            aliases = [instance.gold_answer]
+        for alias in aliases:
+            alias = str(alias)
+            if alias in response or alias.lower() in response or alias.capitalize() in response:
+                return 1.0
+        return 0.0
+
+
+@register("popqa")
+class PopQA(Task):
+    data_source = DataSource(path="akariasai/PopQA", split="test")
+    split = Split.TEST
+    metrics = (AccuracyMetric(scorer=PopQAContainsScorer),)
+    num_fewshot = 15
+    sampling_params = SamplingParams(
+        max_tokens=15,
+        temperature=0.0,
+        do_sample=False,
+        stop_sequences=("\n\n",),
+    )
+
+    @property
+    def instances(self) -> Iterator[Instance]:
+        yield from self._load_instances_cached()
+
+    def process_doc(self, doc: dict[str, Any], index: int = 0) -> Instance | None:
+        question = str(doc.get("question", ""))
+        if not question:
+            return None
+        aliases = json.loads(doc["possible_answers"])
+
+        return Instance(
+            question=_format_query(question),
+            gold_answer=str(doc["obj"]),
+            metadata={
+                "id": doc.get("id", index),
+                "template_id": doc.get("prop_id"),
+                "subject_popularity": doc.get("s_pop"),
+                "aliases": aliases,
+            },
+        )
+
+    def _build_fewshot(self) -> list[Instance]:
+        instances = [
+            Instance(
+                question=_format_query(str(doc["question"])),
+                gold_answer=str(doc["answer"]),
+                metadata={"id": f"popqa_fixed_{index}"},
+            )
+            for index, doc in enumerate(POPQA_FIXED_FEWSHOT)
+        ]
+        if self.config.num_fewshot and self.config.num_fewshot < len(instances):
+            instances = instances[: self.config.num_fewshot]
+        return instances
+
+    def format_request(self, instance: Instance) -> LMRequest:
+        parts = [f"{ex.question} {ex.gold_answer}" for ex in self.get_fewshot()]
+        parts.append(instance.question)
+        prompt = "\n\n".join(parts)
+        # Few-shot examples stay in a single user message under chat format,
+        # matching the reference implementation.
+        if self.request_type == RequestType.CHAT:
+            return LMRequest(
+                request_type=RequestType.CHAT,
+                messages=({"role": "user", "content": prompt},),
+            )
+        return LMRequest(request_type=RequestType.COMPLETION, prompt=prompt)
+
+
+# Chat variant for instruct and reasoning models. Drops stop sequences and
+# raises the token budget so chain-of-thought reasoning is not truncated.
+register_variant(
+    "popqa",
+    "chat",
+    formatter=ChatFormatter(),
+    sampling_params=SamplingParams(
+        max_tokens=131072,
+        temperature=0.6,
+        top_p=0.95,
+    ),
+)

--- a/src/olmo_eval/evals/tasks/popqa.py
+++ b/src/olmo_eval/evals/tasks/popqa.py
@@ -91,6 +91,9 @@ class PopQA(Task):
         )
 
     def _build_fewshot(self) -> list[Instance]:
+        num_fewshot = self.config.num_fewshot or 0
+        if num_fewshot <= 0:
+            return []
         instances = [
             Instance(
                 question=_format_query(str(doc["question"])),
@@ -99,9 +102,7 @@ class PopQA(Task):
             )
             for index, doc in enumerate(POPQA_FIXED_FEWSHOT)
         ]
-        if self.config.num_fewshot and self.config.num_fewshot < len(instances):
-            instances = instances[: self.config.num_fewshot]
-        return instances
+        return instances[:num_fewshot]
 
     def format_request(self, instance: Instance) -> LMRequest:
         parts = [f"{ex.question} {ex.gold_answer}" for ex in self.get_fewshot()]

--- a/tests/evals/tasks/test_popqa.py
+++ b/tests/evals/tasks/test_popqa.py
@@ -25,6 +25,17 @@ class TestPopQATask(unittest.TestCase):
         self.assertEqual(task.config.sampling_params.max_tokens, 15)
         self.assertEqual(task.config.sampling_params.stop_sequences, ("\n\n",))
 
+    def test_metrics(self) -> None:
+        """First-line containment is primary; whole-output containment stays."""
+        task = get_task("popqa")
+        self.assertEqual(
+            {metric.name for metric in task.config.metrics},
+            {"exact_match_first_line", "exact_match_containment"},
+        )
+        primary = task.config.get_primary_metric()
+        assert primary is not None
+        self.assertEqual(primary.name, "exact_match_first_line")
+
     def test_chat_variant(self) -> None:
         task = get_task("popqa:chat")
         self.assertEqual(task.request_type, RequestType.CHAT)
@@ -89,10 +100,21 @@ class TestPopQATask(unittest.TestCase):
 class TestPopQAContainsScorer(unittest.TestCase):
     def setUp(self) -> None:
         self.scorer = PopQAContainsScorer()
+        self.first_line = PopQAContainsScorer(name="popqa_contains_first_line", first_line=True)
         self.instance = _make_instance(["United States of America", "USA"])
 
     def _score(self, text: str) -> float:
         return self.scorer.score(self.instance, LMOutput(text=text))
+
+    def test_first_line_ignores_rambled_hits(self) -> None:
+        """An alias appearing only in invented follow-up Q/A must not count."""
+        rambled = "France\n\nQ: Where is NASA? A: USA\n\nQ: Who wrote it?"
+        self.assertEqual(self.scorer.score(self.instance, LMOutput(text=rambled)), 1.0)
+        self.assertEqual(self.first_line.score(self.instance, LMOutput(text=rambled)), 0.0)
+
+    def test_first_line_accepts_answer_on_first_line(self) -> None:
+        text = "The USA, of course.\nSome elaboration follows."
+        self.assertEqual(self.first_line.score(self.instance, LMOutput(text=text)), 1.0)
 
     def test_verbatim_match(self) -> None:
         self.assertEqual(self._score(" United States of America"), 1.0)

--- a/tests/evals/tasks/test_popqa.py
+++ b/tests/evals/tasks/test_popqa.py
@@ -59,6 +59,24 @@ class TestPopQATask(unittest.TestCase):
         self.assertIn(" A: ", examples[0])
         self.assertTrue(request.prompt.endswith("Q: What is X? A:"))
 
+    def _task_with_fewshot(self, num_fewshot: int):
+        """``get_task`` hands back a shared config, so restore it afterwards."""
+        task = get_task("popqa")
+        original = task.config.num_fewshot
+        self.addCleanup(setattr, task.config, "num_fewshot", original)
+        task.config.num_fewshot = num_fewshot
+        return task
+
+    def test_zero_shot_override_drops_all_examples(self) -> None:
+        """A zero-shot override must not fall back to the full fixed set."""
+        task = self._task_with_fewshot(0)
+        self.assertEqual(task._build_fewshot(), [])
+        request = task.format_request(_make_instance(["answer"]))
+        self.assertEqual(request.prompt, "Q: What is X? A:")
+
+    def test_fewshot_truncates_to_requested_count(self) -> None:
+        self.assertEqual(len(self._task_with_fewshot(3)._build_fewshot()), 3)
+
     def test_chat_fewshot_in_single_message(self) -> None:
         task = get_task("popqa:chat")
         request = task.format_request(_make_instance(["answer"]))

--- a/tests/evals/tasks/test_popqa.py
+++ b/tests/evals/tasks/test_popqa.py
@@ -1,0 +1,97 @@
+"""Tests for the PopQA task."""
+
+from __future__ import annotations
+
+import unittest
+
+from olmo_eval.common.types import Instance, LMOutput, RequestType
+from olmo_eval.evals.tasks.common import get_task
+from olmo_eval.evals.tasks.popqa import PopQAContainsScorer
+
+
+def _make_instance(aliases: list[str]) -> Instance:
+    return Instance(
+        question="Q: What is X? A:",
+        gold_answer=aliases[0],
+        metadata={"id": "test", "aliases": aliases},
+    )
+
+
+class TestPopQATask(unittest.TestCase):
+    def test_registered(self) -> None:
+        task = get_task("popqa")
+        self.assertEqual(task.request_type, RequestType.COMPLETION)
+        self.assertEqual(task.config.num_fewshot, 15)
+        self.assertEqual(task.config.sampling_params.max_tokens, 15)
+        self.assertEqual(task.config.sampling_params.stop_sequences, ("\n\n",))
+
+    def test_chat_variant(self) -> None:
+        task = get_task("popqa:chat")
+        self.assertEqual(task.request_type, RequestType.CHAT)
+        self.assertIsNone(task.config.sampling_params.stop_sequences)
+        self.assertEqual(task.config.sampling_params.temperature, 0.6)
+
+    def test_process_doc(self) -> None:
+        task = get_task("popqa")
+        doc = {
+            "id": 1,
+            "prop_id": 22,
+            "question": "What is George Rankin's occupation?",
+            "obj": "politician",
+            "possible_answers": '["politician", "political leader"]',
+            "s_pop": 100,
+        }
+        instance = task.process_doc(doc, index=0)
+        assert instance is not None
+        self.assertEqual(instance.question, "Q: What is George Rankin's occupation? A:")
+        self.assertEqual(instance.gold_answer, "politician")
+        self.assertEqual(instance.metadata["aliases"], ["politician", "political leader"])
+        self.assertEqual(instance.metadata["subject_popularity"], 100)
+
+    def test_fewshot_prompt_format(self) -> None:
+        task = get_task("popqa")
+        instance = _make_instance(["answer"])
+        request = task.format_request(instance)
+        self.assertEqual(request.request_type, RequestType.COMPLETION)
+        examples = request.prompt.split("\n\n")
+        self.assertEqual(len(examples), 16)  # 15 shots + the question
+        self.assertTrue(examples[0].startswith("Q: "))
+        self.assertIn(" A: ", examples[0])
+        self.assertTrue(request.prompt.endswith("Q: What is X? A:"))
+
+    def test_chat_fewshot_in_single_message(self) -> None:
+        task = get_task("popqa:chat")
+        request = task.format_request(_make_instance(["answer"]))
+        self.assertEqual(request.request_type, RequestType.CHAT)
+        self.assertEqual(len(request.messages), 1)
+        self.assertEqual(request.messages[0]["role"], "user")
+        self.assertEqual(len(request.messages[0]["content"].split("\n\n")), 16)
+
+
+class TestPopQAContainsScorer(unittest.TestCase):
+    def setUp(self) -> None:
+        self.scorer = PopQAContainsScorer()
+        self.instance = _make_instance(["United States of America", "USA"])
+
+    def _score(self, text: str) -> float:
+        return self.scorer.score(self.instance, LMOutput(text=text))
+
+    def test_verbatim_match(self) -> None:
+        self.assertEqual(self._score(" United States of America"), 1.0)
+
+    def test_any_alias_matches(self) -> None:
+        self.assertEqual(self._score("I believe it is the USA."), 1.0)
+
+    def test_lowercase_alias_in_response(self) -> None:
+        # Response is checked against the lowered alias too.
+        self.assertEqual(self._score("the united states of america"), 1.0)
+
+    def test_miss(self) -> None:
+        self.assertEqual(self._score("Canada"), 0.0)
+
+    def test_empty_response(self) -> None:
+        self.assertEqual(self._score(""), 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Ports PopQA from oe-eval. Default `popqa` = completion regime (15-shot, greedy, 15 tokens, `\n\n` stop, mirrors oe-eval `popqa`); `popqa:chat` = post-training regime (few-shot in a single user message, temp 0.6 / top-p 0.95, uncapped tokens, mirrors `popqa::olmo3:adapt` and `popqa::hamish_zs_reasoning_deepseek`).

## Scoring — deliberate divergence from oe-eval

Two metrics, alias containment (verbatim / lowercased / capitalized) both:

- **`exact_match_first_line` (primary)** — searches only up to the first newline.
- **`exact_match_containment`** — whole output; this is what oe-eval computes. Anyone comparing against historical Olmo 3 popqa numbers must use this one.

The primary intentionally diverges because whole-output containment awards free credit proportional to a model's ramble rate: models that continue past their answer invent follow-up Q/A pairs full of plausible entity names, and any accidental alias hit counts. Measured identically on both harnesses' stored predictions for Olmo-3-7B-Instruct (22.8% ramble rate, n=14,267):

| answer region | oe-eval | olmo-eval |
|---|---|---|
| whole output (containment) | 0.1876 | 0.1845 |
| before first invented `Q:` | 0.1748 | 0.1721 |
| **first line only** | **0.1640** | **0.1623** |

~12.5% of containment credits on this model are spurious. The effect is a per-model level shift (saturates within ~230 tokens, so budget/caps don't matter) that ranks verbose models above equally knowledgeable concise ones — and concision is an explicit Olmo 3.5 SFT goal, so a successful SFT would look like a popqa regression under containment. Terse models are unaffected (dense/hybrid SFT audits: ~0 spurious hits; first-line ≈ containment), so the between-model gap-replication result (z>3) carries over.

First-line is the mildly conservative boundary (a genuine two-line answer scores as a miss); before-first-`Q:` is the mildly generous one. They bracket the truth ~1pt apart.

## Verification

- **Parity scope:** the 4-model cross-harness cells and the 14,267/14,267 paired scorer result in the comments certify the *containment* metric — that's oe-eval's metric, and it stays reported. The first-line metric has no oe-eval counterpart; its cross-harness sanity check is the table above (gap +0.0017, tighter than containment's +0.0031).
- Shipped scorers reproduce the audit exactly on oe-eval's stored predictions: 0.1876 containment, 0.1640 first-line.
- Prompts byte-identical in both regimes vs oe-eval's own code; golds/aliases identical.
- 15 unit tests; ruff/ty clean; full suite 1972 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LMFjgUqHjQA3aCeB4QmEHZ
