### PR TITLE
Exclude Torch companion packages and nvidia-cutlass-dsl from CUDA constraints

### DIFF
--- a/src/olmo_eval/launch/beaker/launcher.py
+++ b/src/olmo_eval/launch/beaker/launcher.py
@@ -892,7 +892,11 @@ class BeakerLauncher:
         # an otherwise compatible vLLM impossible to resolve.
         constraints = "/tmp/cuda-constraints.txt"
         steps.append(
-            f"uv pip freeze -q | grep -E '^(torch|nvidia-)' "
+            # Match torch itself, but not companion packages such as
+            # torchvision or torchaudio. Provider releases pin those companions
+            # alongside their Torch generation and must be allowed to replace
+            # the versions inherited from the base image.
+            f"uv pip freeze -q | grep -E '^(torch(==| @ )|nvidia-)' "
             f"| grep -vE '^nvidia-cutlass-dsl' > {constraints}"
         )
 

--- a/src/olmo_eval/launch/beaker/launcher.py
+++ b/src/olmo_eval/launch/beaker/launcher.py
@@ -886,9 +886,15 @@ class BeakerLauncher:
         if runtime_torch_version:
             steps.append(build_install_command(runtime_torch_spec(), force_reinstall=True))
 
-        # Generate constraints from pre-installed CUDA packages to prevent uv from changing them
+        # Generate constraints from pre-installed CUDA packages to prevent uv from changing them.
+        # CUTLASS DSL is the exception: vLLM pins this package independently of
+        # Torch's CUDA package set, so constraining an image's older build makes
+        # an otherwise compatible vLLM impossible to resolve.
         constraints = "/tmp/cuda-constraints.txt"
-        steps.append(f"uv pip freeze -q | grep -E '^(torch|nvidia-)' > {constraints}")
+        steps.append(
+            f"uv pip freeze -q | grep -E '^(torch|nvidia-)' "
+            f"| grep -vE '^nvidia-cutlass-dsl' > {constraints}"
+        )
 
         # Install vLLM in isolated venv when requested (for server mode)
         if use_isolated_vllm_venv:

--- a/tests/launch/test_beaker.py
+++ b/tests/launch/test_beaker.py
@@ -561,6 +561,28 @@ class TestBuildCommandWithTaskPackages:
         task_pos = install_cmd.find("uv pip install 'task-dep==1.0'")
         assert provider_pos < task_pos
 
+    def test_cuda_constraints_exclude_torch_companions_and_cutlass(self):
+        """Only Torch itself and the CUDA packages are pinned to the base image.
+
+        Provider releases pin torchvision/torchaudio alongside their Torch
+        generation, and vLLM pins CUTLASS DSL independently of Torch's CUDA
+        package set, so neither may be frozen to the image's build.
+        """
+        from olmo_eval.launch import BeakerLauncher
+
+        launcher = BeakerLauncher()
+        install_cmd = launcher._build_install_cmd(
+            extras=[],
+            env_exports=None,
+            provider_packages=["vllm==0.14.0"],
+        )
+
+        assert (
+            "uv pip freeze -q | grep -E '^(torch(==| @ )|nvidia-)' "
+            "| grep -vE '^nvidia-cutlass-dsl' > /tmp/cuda-constraints.txt"
+        ) in install_cmd
+        assert "grep -E '^(torch|nvidia-)' > /tmp/cuda-constraints.txt" not in install_cmd
+
     def test_no_task_packages_if_none(self):
         """Test that no extra install steps if task_packages is None."""
         from olmo_eval.launch import BeakerLauncher


### PR DESCRIPTION
`/tmp/cuda-constraints.txt` froze everything matching `^(torch|nvidia-)`, which also catches `torchvision`/`torchaudio` and `nvidia-cutlass-dsl` — pinning them to the base image and breaking any provider release that swaps torch at runtime (OLMoE3/KDA plugin stack: `failed to remove .../torchgen`). Now only `torch` itself (`torch==` / `torch @ `) and `nvidia-*` are constrained.

The first two commits are @akshitab's, cherry-picked from #303, which targets `jacksonp/ladder` and so cannot reach `main`; `launcher.py` here is byte-identical to it. The third adds a regression test that fails against the old pattern.

Validated on the OLMoE3-KDA MoE: Beaker `01M0R4PSF4QZCJQ4T8NH7DH4A4` — torch 2.10.0+cu128 swap completed, plugin registered, no `torchgen` failure. That run predates the cherry-pick rework, which left the emitted install command byte-identical.
