### PR TITLE
DeepScholar-Bench as a first-class task on the shared paper-search agent scaffold

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,6 +158,9 @@ vllm = [
 [tool.ruff]
 line-length = 100
 target-version = "py312"
+# Verbatim vendored copy of the pinned DeepScholar-Bench scorer; it is a
+# fixture precisely because it is not ours to restyle.
+extend-exclude = ["tests/evals/tasks/fixtures/deepscholar_c95413b"]
 
 [tool.ruff.lint]
 select = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,6 +178,8 @@ select = [
 # Verbatim prompt templates from asta-bench reference implementation
 "src/olmo_eval/evals/tasks/astabench_sqa.py" = ["E501"]
 "src/olmo_eval/common/scorers/citation.py" = ["E501"]
+# Verbatim bilingual prompt templates from DeepResearch Bench
+"src/olmo_eval/evals/tasks/deepresearch_bench.py" = ["E501"]
 # Verbatim prompt templates and gold snippets from scicode-bench reference implementation
 "src/olmo_eval/evals/external/benchmarks/scicode/prompts.py" = ["E501"]
 # Embedded fewshot data with long string literals

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -180,6 +180,9 @@ select = [
 "src/olmo_eval/common/scorers/citation.py" = ["E501"]
 # Verbatim bilingual prompt templates from DeepResearch Bench
 "src/olmo_eval/evals/tasks/deepresearch_bench.py" = ["E501"]
+# Verbatim prompt template from DeepScholar-Bench, and its golden copy
+"src/olmo_eval/evals/tasks/deepscholar_bench.py" = ["E501"]
+"tests/evals/tasks/test_deepscholar_bench.py" = ["E501"]
 # Verbatim prompt templates and gold snippets from scicode-bench reference implementation
 "src/olmo_eval/evals/external/benchmarks/scicode/prompts.py" = ["E501"]
 # Embedded fewshot data with long string literals

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,9 +158,10 @@ vllm = [
 [tool.ruff]
 line-length = 100
 target-version = "py312"
-# Verbatim vendored copy of the pinned DeepScholar-Bench scorer; it is a
-# fixture precisely because it is not ours to restyle.
-extend-exclude = ["tests/evals/tasks/fixtures/deepscholar_c95413b"]
+# Verbatim vendored copies of the pinned DeepScholar-Bench scorer and of
+# lit-agents' export-contract validators; they are fixtures precisely
+# because they are not ours to restyle.
+extend-exclude = ["tests/evals/tasks/fixtures"]
 
 [tool.ruff.lint]
 select = [

--- a/scripts/internal/build_deepresearch_bench_dataset.py
+++ b/scripts/internal/build_deepresearch_bench_dataset.py
@@ -1,0 +1,247 @@
+"""Offline builder for the DeepResearch Bench dataset mirror.
+
+Downloads the official query, criteria, and cleaned-reference JSONL files at a
+pinned upstream commit (or reads them from ``--source-dir``), joins them by task
+ID, writes local JSONL configs, and can push them to the HF Hub. This script is
+intentionally not imported or run by tests.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger("build_deepresearch_bench_dataset")
+
+DEEPRESEARCH_BENCH_REPO = "allenai/deepresearch-bench"
+UPSTREAM_COMMIT = "469cce54ea7f6a63c163d3d9fec879cf289ec484"
+UPSTREAM_RAW_ROOT = (
+    f"https://raw.githubusercontent.com/Ayanami0730/deep_research_bench/{UPSTREAM_COMMIT}"
+)
+EXPECTED_IDS = set(range(1, 101))
+
+SOURCE_FILES = {
+    "queries": Path("data/prompt_data/query.jsonl"),
+    "criteria": Path("data/criteria_data/criteria.jsonl"),
+    "references": Path("data/test_data/cleaned_data/reference.jsonl"),
+}
+
+
+def load_jsonl_lines(lines: Iterable[str], *, source: str) -> list[dict[str, Any]]:
+    """Parse JSONL records and report the source and line on malformed input."""
+    rows: list[dict[str, Any]] = []
+    for line_number, line in enumerate(lines, start=1):
+        if not line.strip():
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Invalid JSON in {source} at line {line_number}: {exc}") from exc
+        if not isinstance(row, dict):
+            raise TypeError(f"Expected an object in {source} at line {line_number}")
+        rows.append(row)
+    return rows
+
+
+def load_jsonl_path(path: Path) -> list[dict[str, Any]]:
+    with path.open(encoding="utf-8") as handle:
+        return load_jsonl_lines(handle, source=str(path))
+
+
+def download_jsonl(relative_path: Path) -> list[dict[str, Any]]:
+    """Download one official file from the immutable upstream revision."""
+    url = f"{UPSTREAM_RAW_ROOT}/{relative_path.as_posix()}"
+    logger.info("Downloading %s", url)
+    request = Request(url, headers={"User-Agent": "olmo-eval-deepresearch-builder"})
+    try:
+        with urlopen(request, timeout=120) as response:
+            text = response.read().decode("utf-8")
+    except (HTTPError, URLError) as exc:
+        raise RuntimeError(f"Could not download DeepResearch Bench data from {url}: {exc}") from exc
+    return load_jsonl_lines(text.splitlines(), source=url)
+
+
+def load_official_files(
+    source_dir: Path | None,
+) -> dict[str, list[dict[str, Any]]]:
+    """Load all three official inputs from disk or the pinned raw URLs."""
+    if source_dir is None:
+        return {name: download_jsonl(path) for name, path in SOURCE_FILES.items()}
+
+    missing = [
+        source_dir / path for path in SOURCE_FILES.values() if not (source_dir / path).is_file()
+    ]
+    if missing:
+        missing_text = "\n".join(f"- {path}" for path in missing)
+        raise FileNotFoundError(
+            "DeepResearch Bench source files are missing:\n"
+            f"{missing_text}\nOmit --source-dir to fetch the pinned official files instead."
+        )
+    return {
+        name: load_jsonl_path(source_dir / relative_path)
+        for name, relative_path in SOURCE_FILES.items()
+    }
+
+
+def index_by_id(
+    rows: list[dict[str, Any]],
+    *,
+    source_name: str,
+) -> dict[int, dict[str, Any]]:
+    """Validate the official integer IDs and reject duplicates or omissions."""
+    indexed: dict[int, dict[str, Any]] = {}
+    for row_number, row in enumerate(rows, start=1):
+        identifier = row.get("id")
+        if not isinstance(identifier, int):
+            raise TypeError(f"{source_name} row {row_number} has non-integer id {identifier!r}")
+        if identifier in indexed:
+            raise ValueError(f"Duplicate id {identifier} in {source_name}")
+        indexed[identifier] = row
+
+    actual_ids = set(indexed)
+    if actual_ids != EXPECTED_IDS:
+        missing = sorted(EXPECTED_IDS - actual_ids)
+        unexpected = sorted(actual_ids - EXPECTED_IDS)
+        raise ValueError(
+            f"{source_name} must contain exactly IDs 1..100; "
+            f"missing={missing}, unexpected={unexpected}"
+        )
+    return indexed
+
+
+def _require_string(row: dict[str, Any], key: str, *, source: str, identifier: int) -> str:
+    value = row.get(key)
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{source} id {identifier} has invalid {key!r}")
+    return value
+
+
+def build_rows(inputs: dict[str, list[dict[str, Any]]]) -> list[dict[str, Any]]:
+    """Join official inputs by ID while preserving all benchmark text verbatim."""
+    queries = index_by_id(inputs["queries"], source_name="query.jsonl")
+    criteria = index_by_id(inputs["criteria"], source_name="criteria.jsonl")
+    references = index_by_id(inputs["references"], source_name="reference.jsonl")
+
+    output: list[dict[str, Any]] = []
+    for identifier in sorted(EXPECTED_IDS):
+        query = queries[identifier]
+        criterion_row = criteria[identifier]
+        reference = references[identifier]
+
+        prompt = _require_string(query, "prompt", source="query.jsonl", identifier=identifier)
+        criterion_prompt = _require_string(
+            criterion_row, "prompt", source="criteria.jsonl", identifier=identifier
+        )
+        reference_prompt = _require_string(
+            reference, "prompt", source="reference.jsonl", identifier=identifier
+        )
+        if criterion_prompt != prompt:
+            logger.warning("Prompt mismatch between query and criteria for id %d", identifier)
+        if reference_prompt != prompt:
+            logger.warning("Prompt mismatch between query and reference for id %d", identifier)
+
+        language = query.get("language")
+        if language not in {"en", "zh"}:
+            raise ValueError(f"query.jsonl id {identifier} has invalid language {language!r}")
+        topic = _require_string(query, "topic", source="query.jsonl", identifier=identifier)
+
+        dimension_weight = criterion_row.get("dimension_weight")
+        criterions = criterion_row.get("criterions")
+        if not isinstance(dimension_weight, dict) or not isinstance(criterions, dict):
+            raise TypeError(
+                f"criteria.jsonl id {identifier} must contain mapping-valued "
+                "dimension_weight and criterions"
+            )
+
+        article = _require_string(
+            reference, "article", source="reference.jsonl", identifier=identifier
+        )
+        output.append(
+            {
+                "id": identifier,
+                "language": language,
+                "topic": topic,
+                "prompt": prompt,
+                "criteria": {
+                    "dimension_weight": dimension_weight,
+                    "criterions": criterions,
+                },
+                "reference_article": article,
+            }
+        )
+
+    language_counts = {
+        language: sum(row["language"] == language for row in output) for language in ("en", "zh")
+    }
+    if language_counts != {"en": 50, "zh": 50}:
+        raise ValueError(f"Expected 50 English and 50 Chinese rows, got {language_counts}")
+    return output
+
+
+def dataset_configs(rows: list[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
+    """Return the full dataset and its two language-specific subsets."""
+    return {
+        "default": rows,
+        "en": [row for row in rows if row["language"] == "en"],
+        "zh": [row for row in rows if row["language"] == "zh"],
+    }
+
+
+def write_local(rows: list[dict[str, Any]], output_dir: Path) -> list[Path]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    paths: list[Path] = []
+    for config_name, config_rows in dataset_configs(rows).items():
+        path = output_dir / f"{config_name}.jsonl"
+        with path.open("w", encoding="utf-8") as handle:
+            for row in config_rows:
+                handle.write(json.dumps(row, ensure_ascii=False) + "\n")
+        logger.info("Wrote %d rows to %s", len(config_rows), path)
+        paths.append(path)
+    return paths
+
+
+def push_to_hub(rows: list[dict[str, Any]], *, repo_id: str) -> None:
+    try:
+        from datasets import Dataset, DatasetDict
+    except ImportError as exc:
+        raise RuntimeError("Pushing DeepResearch Bench requires `datasets`.") from exc
+
+    for config_name, config_rows in dataset_configs(rows).items():
+        dataset = DatasetDict({"test": Dataset.from_list(config_rows)})
+        dataset.push_to_hub(repo_id, config_name=config_name)
+        logger.info("Pushed %s/test with %d rows to %s", config_name, len(config_rows), repo_id)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--source-dir",
+        type=Path,
+        help=(
+            "Read an official repository checkout instead of downloading files "
+            f"at pinned commit {UPSTREAM_COMMIT}."
+        ),
+    )
+    parser.add_argument("--repo-id", default=DEEPRESEARCH_BENCH_REPO)
+    parser.add_argument("--output-dir", type=Path, default=Path("deepresearch_bench_dataset"))
+    parser.add_argument("--push", action="store_true", help="Push all configs to the HF Hub.")
+    args = parser.parse_args()
+
+    inputs = load_official_files(args.source_dir)
+    rows = build_rows(inputs)
+    write_local(rows, args.output_dir)
+    if args.push:
+        push_to_hub(rows, repo_id=args.repo_id)
+    else:
+        logger.info("Skipping Hub push. Use --push to upload.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/olmo_eval/cli/beaker/launch.py
+++ b/src/olmo_eval/cli/beaker/launch.py
@@ -573,6 +573,8 @@ def launch(
             if sandbox.required_secrets:
                 all_required_secrets.update(sandbox.required_secrets)
 
+    all_required_secrets = _unsatisfied_required_secrets(all_required_secrets, secret_env_overrides)
+
     # Ensure secrets
     common_secrets, store_secrets, task_secrets = _ensure_secrets(
         launcher, dry_run, launch_config, all_required_secrets
@@ -743,6 +745,12 @@ def _get_task_configs(
         task_configs[task_spec] = task_cfg
 
     return task_configs
+
+
+def _unsatisfied_required_secrets(
+    required_secrets: set[str], secret_env_overrides: dict[str, str]
+) -> set[str]:
+    return required_secrets - set(secret_env_overrides.values())
 
 
 def _ensure_secrets(

--- a/src/olmo_eval/cli/run/__init__.py
+++ b/src/olmo_eval/cli/run/__init__.py
@@ -8,6 +8,8 @@ Configuration parsing, storage setup, and runner creation are delegated to:
 - options.py: Option decorators for logical grouping
 """
 
+from typing import Any
+
 import click
 
 from olmo_eval.cli.run.options import (
@@ -25,6 +27,21 @@ from olmo_eval.cli.utils import (
     process_ordered_args,
     reconstruct_ordered_args,
 )
+
+
+def _scored_nothing(results: Any) -> bool:
+    """Whether a completed run scored zero instances across every task.
+
+    ``aggregate_results`` omits ``num_instances`` entirely for a task that
+    errored, and sets it to 0 when every instance of a task failed, so a missing
+    key and a zero mean the same thing here. Returns False for anything
+    unexpected: this gates the exit code, and guessing wrong would fail runs
+    that actually produced data.
+    """
+    tasks = results.get("tasks") if isinstance(results, dict) else None
+    if not isinstance(tasks, dict) or not tasks:
+        return False
+    return all(isinstance(task, dict) and not task.get("num_instances") for task in tasks.values())
 
 
 @click.command()
@@ -233,8 +250,21 @@ def run(
         runner.print_config()
     else:
         try:
-            runner.run()
+            results = runner.run()
         except Exception as e:
             console.print(f"\n[bold red]Evaluation failed:[/bold red] {e}")
             console.print_exception()
             raise SystemExit(1) from None
+
+        # A run that scored nothing is a failure, however calmly it ended. The
+        # per-instance handlers turn every error into a failed instance rather
+        # than an exception, so an inference server that dies mid-run leaves the
+        # process exiting 0 with an empty metrics file, and Beaker reports the
+        # job SUCCEEDED. Results are already written and uploaded by this point,
+        # so exiting non-zero here costs no artifacts.
+        if _scored_nothing(results):
+            console.print(
+                "\n[bold red]Evaluation produced no scored instances.[/bold red] "
+                "Every task failed; see the errors above and in metrics.json."
+            )
+            raise SystemExit(1)

--- a/src/olmo_eval/common/beaker_status.py
+++ b/src/olmo_eval/common/beaker_status.py
@@ -37,12 +37,20 @@ class BeakerStatusReporter:
         self._git_suffix = _git_suffix()
         self._workload: BeakerWorkload | None = None
         self._last_update: float = float("-inf")
+        # Being inside a Beaker job and having a Beaker client configured are
+        # different conditions: a workstation with `beaker` set up passes
+        # Beaker.from_env() and then dies on the missing workload id. The
+        # workload id is the fact that decides, so it is checked first.
+        workload_id = os.environ.get("BEAKER_WORKLOAD_ID")
+        if workload_id is None:
+            self._client = None
+            return
         try:
             self._client: Beaker | None = Beaker.from_env()
         except BeakerConfigurationError:
             self._client = None
             return
-        self._workload = self._client.workload.get(os.environ["BEAKER_WORKLOAD_ID"])
+        self._workload = self._client.workload.get(workload_id)
 
     def update(self, message: str, force: bool = False) -> None:
         """Push a status message to the Beaker workload description.

--- a/src/olmo_eval/common/constants/infrastructure.py
+++ b/src/olmo_eval/common/constants/infrastructure.py
@@ -195,6 +195,7 @@ BACKEND_OPTIONAL_GROUPS: dict[str, str | None] = {
     "olmo_core": "olmo_core",
     "litellm": "litellm",
     "mock": None,
+    "python": "vllm",
 }
 """Mapping of backend types to their pyproject.toml optional dependency group names.
 

--- a/src/olmo_eval/common/types/literals.py
+++ b/src/olmo_eval/common/types/literals.py
@@ -13,9 +13,10 @@ class ProviderKind(StrEnum):
     OLMO_CORE = "olmo_core"
     MOCK = "mock"
     LITELLM = "litellm"
+    PYTHON = "python"
 
 
-ProviderLiteral = Literal["vllm", "vllm_server", "hf", "olmo_core", "mock", "litellm"]
+ProviderLiteral = Literal["vllm", "vllm_server", "hf", "olmo_core", "mock", "litellm", "python"]
 DtypeLiteral = Literal["auto", "float16", "bfloat16", "float32"]
 PriorityLiteral = Literal["low", "normal", "high", "urgent"]
 LoadFormatLiteral = Literal[

--- a/src/olmo_eval/evals/tasks/common/base.py
+++ b/src/olmo_eval/evals/tasks/common/base.py
@@ -172,6 +172,12 @@ class TaskConfig:
     #: beaker launcher mounts each as the user-scoped secret ``{user}_{NAME}``.
     required_secrets: tuple[str, ...] = ()
 
+    #: Tool names the configured harness actually exposes to the agent, empty when
+    #: it exposes none. The runner fills this in from the harness config so a task
+    #: whose prompt names tools can describe what is really callable instead of a
+    #: hardcoded list.
+    harness_tool_names: tuple[str, ...] = ()
+
     def __post_init__(self) -> None:
         """Validate scheduler-only sandbox allocation hints."""
         if isinstance(self.output_score_aggregation, str):

--- a/src/olmo_eval/evals/tasks/deepresearch_bench.py
+++ b/src/olmo_eval/evals/tasks/deepresearch_bench.py
@@ -7,18 +7,17 @@ ported verbatim/faithfully from the benchmark repository.
 
 This integration deliberately deviates from the official implementation in
 six ways: (1) FACT scrapes with olmo-eval's crawl4ai-backed browsing logic
-instead of Jina Reader; (2) generated articles receive only deterministic
-``<think>`` stripping instead of the optional LLM ArticleCleaner, equivalent
-to evaluating with official cleaning skipped; (3) both judge models can be
-overridden with ``OLMO_EVAL_JUDGE``; and (4) the appended report-generation
-instruction is ours because the official benchmark leaves each deep-research
-system's generation prompting unspecified; (5) ``clean_urls`` is applied to
-every article rather than conditionally by source model, and text-fragment
-URLs are also normalized while grouping, merging citations to fragments of
-the same page; and (6) judge failures use three attempts with ``2**n``
-backoff, while the official RACE runner uses ten attempts with ``1.5**n``
-backoff. After final RACE judge/parse failure, an instance receives zero RACE
-scores and remains in every mean.
+instead of Jina Reader; (2) generated articles receive deterministic ``<think>``
+stripping and tool/channel-scaffold marker removal instead of the optional LLM
+ArticleCleaner; (3) both judge models can be overridden with
+``OLMO_EVAL_JUDGE``; and (4) the appended report-generation instruction is ours
+because the official benchmark leaves each deep-research system's generation
+prompting unspecified; (5) ``clean_urls`` is applied to every article rather
+than conditionally by source model, and text-fragment URLs are also normalized
+while grouping, merging citations to fragments of the same page; and (6) judge
+failures use three attempts with ``2**n`` backoff, while the official RACE
+runner uses ten attempts with ``1.5**n`` backoff. After final RACE judge/parse
+failure, an instance receives zero RACE scores and remains in every mean.
 """
 
 from __future__ import annotations
@@ -69,13 +68,17 @@ DEEPRESEARCH_GENERATION_INSTRUCTIONS = {
     "en": (
         "Write a comprehensive research report in English. Research the task using the "
         "available web-search and webpage-browsing tools before writing. Place an inline "
-        "Markdown citation in the exact form `[source title](url)` immediately after every "
-        "factual claim it supports. Synthesize the sources into a clear, detailed report."
+        "Markdown citation in the exact form `[<the source's actual "
+        "title>](<the source's actual URL>)` immediately after every factual claim it "
+        "supports. Replace both placeholders with the real page title and URL; never output "
+        "either placeholder itself. Synthesize the sources "
+        "into a clear, detailed report."
     ),
     "zh": (
         "请用中文撰写一份全面的研究报告。写作前请使用可用的网页搜索和网页浏览工具调研任务。"
-        "每项事实性主张后都应紧跟一个格式严格为 `[来源标题](url)` 的行内 Markdown 引用。"
-        "请综合各项来源，形成清晰、详尽的报告。"
+        "每项事实性主张后都应紧跟一个格式严格为 `[<来源的真实标题>]"
+        "(<来源的真实链接>)` 的行内 Markdown 引用。请将两个占位符替换为真实网页标题和链接，"
+        "绝不要原样输出任何一个占位符。请综合各项来源，形成清晰、详尽的报告。"
     ),
 }
 
@@ -700,7 +703,7 @@ def clean_urls(input_text: str) -> str:
 
 def clean_citation_url(url: str) -> str:
     """Apply the official ``#:~:text=`` URL cleanup to a raw URL."""
-    return url.split("#:~:text=", maxsplit=1)[0]
+    return url.strip().strip("<>").split("#:~:text=", maxsplit=1)[0]
 
 
 def remove_urls(input_text: str) -> str:
@@ -941,11 +944,128 @@ DEEPRESEARCH_METRICS = (
 
 
 def strip_think_block(text: str) -> str:
-    """Strip a leading reasoning block using the ResearchQA helper pattern."""
+    """Strip a reasoning prefix using the intentionally lossy ResearchQA pattern.
+
+    Only text after the first ``</think>`` is retained, so a mid-report closing tag
+    discards the report prefix as well. This pre-existing behavior matches ResearchQA.
+    """
     think_end = text.find("</think>")
     if think_end >= 0:
         text = text[think_end + len("</think>") :]
     return text.strip()
+
+
+_SCAFFOLD_IDENTIFIER = r"[A-Za-z_][\w.:-]*"
+_SCAFFOLD_QUOTED_VALUE = r"""(?:"[^"<>\r\n]*"|'[^'<>\r\n]*')"""
+_SCAFFOLD_VALUE = rf"(?:{_SCAFFOLD_IDENTIFIER}|{_SCAFFOLD_QUOTED_VALUE})"
+_SCAFFOLD_OPEN_WITH_ATTRIBUTES_RE = re.compile(
+    rf"<(?:tool_call|tool_response|function|parameter)(?:"
+    rf"[ \t]*=[ \t]*{_SCAFFOLD_VALUE}|"
+    rf"(?:[ \t]+{_SCAFFOLD_IDENTIFIER}[ \t]*=[ \t]*{_SCAFFOLD_VALUE})+"
+    rf")[ \t]*>",
+    flags=re.IGNORECASE,
+)
+_SCAFFOLD_TAG_RE = re.compile(
+    r"</?(?:tool_call|tool_response)[ \t]*>|</(?:function|parameter)[ \t]*>",
+    flags=re.IGNORECASE,
+)
+_SPECIAL_TOKEN_PATTERN = r"<(?:\|[A-Za-z_][\w.:-]*\|?|[A-Za-z_][\w.:-]*\|)>"
+_SPECIAL_TOKEN_RE = re.compile(_SPECIAL_TOKEN_PATTERN, flags=re.IGNORECASE)
+_CHANNEL_HEADER_RE = re.compile(
+    rf"<\|channel\|?>[ \t]*(?P<channel>analysis|commentary|final|thought|tool)"
+    rf"[ \t\r\n]*(?={_SPECIAL_TOKEN_PATTERN})",
+    flags=re.IGNORECASE,
+)
+_ASSISTANT_TURN_PREFIX_RE = re.compile(
+    r"(?:<\|start\|>|<start\|>)[ \t]*assistant\b", flags=re.IGNORECASE
+)
+_MARKDOWN_CODE_SPAN_RE = re.compile(r"```[\s\S]*?```|`[^`\n]*`")
+_PAIRED_BARE_SCAFFOLD_TAGS = ("function", "parameter")
+_BARE_SCAFFOLD_OPEN_RES = {
+    tag: re.compile(rf"<{tag}[ \t]*>", flags=re.IGNORECASE) for tag in _PAIRED_BARE_SCAFFOLD_TAGS
+}
+_BARE_SCAFFOLD_CLOSE_RES = {
+    tag: re.compile(rf"</{tag}[ \t]*>", flags=re.IGNORECASE) for tag in _PAIRED_BARE_SCAFFOLD_TAGS
+}
+_REASONING_CHANNELS = frozenset({"analysis", "commentary", "thought"})
+
+
+def _partition_markdown_code(text: str) -> list[tuple[bool, str]]:
+    """Return ``(is_code, text)`` parts without modifying protected Markdown code."""
+    parts: list[tuple[bool, str]] = []
+    cursor = 0
+    for match in _MARKDOWN_CODE_SPAN_RE.finditer(text):
+        if cursor < match.start():
+            parts.append((False, text[cursor : match.start()]))
+        parts.append((True, match.group()))
+        cursor = match.end()
+    if cursor < len(text):
+        parts.append((False, text[cursor:]))
+    return parts
+
+
+def _retain_final_channel(parts: Sequence[tuple[bool, str]]) -> list[tuple[bool, str]]:
+    """Keep pre-header and final prose when reasoning and final channels coexist."""
+    channel_names = {
+        match.group("channel").lower()
+        for is_code, part in parts
+        if not is_code
+        for match in _CHANNEL_HEADER_RE.finditer(part)
+    }
+    if "final" not in channel_names or channel_names.isdisjoint(_REASONING_CHANNELS):
+        return list(parts)
+
+    retained: list[tuple[bool, str]] = []
+    active_channel: str | None = None
+    for is_code, part in parts:
+        if is_code:
+            retained.append((True, part))
+            continue
+
+        cursor = 0
+        retained_chunks: list[str] = []
+        for match in _CHANNEL_HEADER_RE.finditer(part):
+            if active_channel in (None, "final"):
+                retained_chunks.append(part[cursor : match.start()])
+            active_channel = match.group("channel").lower()
+            cursor = match.end()
+        if active_channel in (None, "final"):
+            retained_chunks.append(part[cursor:])
+        retained.append((False, "".join(retained_chunks)))
+    return retained
+
+
+def _clean_report_segment(text: str, paired_bare_tags: frozenset[str]) -> str:
+    """Remove scaffold tokens from a non-code Markdown segment in linear passes."""
+    text = _ASSISTANT_TURN_PREFIX_RE.sub(" ", text)
+    text = _CHANNEL_HEADER_RE.sub(" ", text)
+    text = _SPECIAL_TOKEN_RE.sub(" ", text)
+    for tag in paired_bare_tags:
+        text = _BARE_SCAFFOLD_OPEN_RES[tag].sub("", text)
+    text = _SCAFFOLD_OPEN_WITH_ATTRIBUTES_RE.sub("", text)
+    return _SCAFFOLD_TAG_RE.sub("", text)
+
+
+def _clean_generated_report(text: str) -> str:
+    """Strip reasoning and tool-call scaffold while preserving report prose and code.
+
+    Explicit analysis/commentary/thought content is dropped only when an explicit final
+    channel is also present; ordinary report content before the first channel header and
+    final-channel content are retained. This intentionally limited parser infers
+    boundaries from channel headers rather than assigning semantics to every possible
+    special token; protected Markdown code spans are always retained verbatim.
+    """
+    text = strip_think_block(text)
+    parts = _retain_final_channel(_partition_markdown_code(text))
+    paired_bare_tags = frozenset(
+        tag
+        for tag, close_re in _BARE_SCAFFOLD_CLOSE_RES.items()
+        if any(not is_code and close_re.search(part) for is_code, part in parts)
+    )
+    return "".join(
+        part if is_code else _clean_report_segment(part, paired_bare_tags)
+        for is_code, part in parts
+    ).strip()
 
 
 def _validated_criteria(doc: Mapping[str, Any]) -> dict[str, Any] | None:
@@ -1025,7 +1145,7 @@ class DeepResearchBench(Task):
         )
 
     def extract_answer(self, output: LMOutput) -> str:
-        return strip_think_block(output.text)
+        return _clean_generated_report(output.text)
 
     async def score_responses(
         self,

--- a/src/olmo_eval/evals/tasks/deepresearch_bench.py
+++ b/src/olmo_eval/evals/tasks/deepresearch_bench.py
@@ -844,6 +844,17 @@ def _build_judge_fn(default_spec: str, scorer_name: str, default_effort: str) ->
     )
 
 
+def _fact_scoring_disabled() -> bool:
+    """Whether FACT scoring is switched off for this run.
+
+    FACT crawls every cited URL and judges each extracted statement, so it dominates the cost of
+    scoring this benchmark. RACE alone is often what is wanted, and there was previously no way
+    to ask for it.
+    """
+    value = os.environ.get("DEEPRESEARCH_SKIP_FACT", "")
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
 def build_deepresearch_race_judge_fn() -> JudgeFn:
     """Build the RACE judge with medium effort unless a spec suffix overrides it."""
     return _build_judge_fn(DEEPRESEARCH_RACE_DEFAULT_JUDGE_SPEC, "DeepResearchBenchRACE", "medium")
@@ -1159,6 +1170,7 @@ class DeepResearchBench(Task):
         fact_judge = build_deepresearch_fact_judge_fn()
 
         race_failures = 0
+        fact_skipped = 0
         fact_failures = 0
         for response in responses:
             output = response.outputs[0] if response.outputs else None
@@ -1174,20 +1186,29 @@ class DeepResearchBench(Task):
                 race_scores, race_details, race_failed = await self._score_race(
                     response.instance, answer, race_judge
                 )
-                try:
-                    fact_scores, fact_details = await self._score_fact(
-                        response.instance, answer, fact_judge
-                    )
-                    fact_failed = False
-                except Exception as exc:
-                    logger.warning(
-                        "DeepResearch Bench FACT scoring failed for id %r: %s",
-                        response.instance.metadata.get("id"),
-                        exc,
-                    )
+                if _fact_scoring_disabled():
+                    # Skipped, not zero. Leaving silent zeros here would be indistinguishable
+                    # from "ran and scored nothing", which is exactly the confusion that made an
+                    # earlier all-zero metrics column unreadable.
                     fact_scores = self._zero_fact_scores()
-                    fact_details = []
-                    fact_failed = True
+                    fact_details = [{"fact_scoring": "skipped"}]
+                    fact_failed = False
+                    fact_skipped += 1
+                else:
+                    try:
+                        fact_scores, fact_details = await self._score_fact(
+                            response.instance, answer, fact_judge
+                        )
+                        fact_failed = False
+                    except Exception as exc:
+                        logger.warning(
+                            "DeepResearch Bench FACT scoring failed for id %r: %s",
+                            response.instance.metadata.get("id"),
+                            exc,
+                        )
+                        fact_scores = self._zero_fact_scores()
+                        fact_details = []
+                        fact_failed = True
             else:
                 race_scores = self._zero_race_scores()
                 race_details = None
@@ -1207,6 +1228,14 @@ class DeepResearchBench(Task):
                 output.metadata["deepresearch_fact"] = fact_details
                 for metric_name, score in response.scores.items():
                     output.metadata[f"score:{metric_name}"] = score
+
+        if fact_skipped:
+            logger.warning(
+                "DeepResearch Bench FACT scoring skipped for %d instance(s) because "
+                "DEEPRESEARCH_SKIP_FACT is set; every fact_* metric below is a placeholder "
+                "and must not be read as a score of zero.",
+                fact_skipped,
+            )
 
         if race_failures:
             logger.warning(

--- a/src/olmo_eval/evals/tasks/deepresearch_bench.py
+++ b/src/olmo_eval/evals/tasks/deepresearch_bench.py
@@ -832,7 +832,7 @@ async def fetch_crawl4ai_page(url: str) -> str:
     return text
 
 
-def _build_judge_fn(default_spec: str, scorer_name: str) -> JudgeFn:
+def _build_judge_fn(default_spec: str, scorer_name: str, default_effort: str) -> JudgeFn:
     spec = os.getenv("OLMO_EVAL_JUDGE", default_spec)
     model, separator, effort = spec.partition(":")
     return build_openai_judge_fn(
@@ -840,18 +840,18 @@ def _build_judge_fn(default_spec: str, scorer_name: str) -> JudgeFn:
         temperature=0.0,
         max_tokens=DEEPRESEARCH_JUDGE_MAX_TOKENS,
         scorer_name=scorer_name,
-        reasoning_effort=(effort if separator else None),
+        reasoning_effort=(effort if separator else default_effort),
     )
 
 
 def build_deepresearch_race_judge_fn() -> JudgeFn:
-    """Build the RACE judge from its default or ``$OLMO_EVAL_JUDGE``."""
-    return _build_judge_fn(DEEPRESEARCH_RACE_DEFAULT_JUDGE_SPEC, "DeepResearchBenchRACE")
+    """Build the RACE judge with medium effort unless a spec suffix overrides it."""
+    return _build_judge_fn(DEEPRESEARCH_RACE_DEFAULT_JUDGE_SPEC, "DeepResearchBenchRACE", "medium")
 
 
 def build_deepresearch_fact_judge_fn() -> JudgeFn:
-    """Build the shared FACT-stage judge from its default or ``$OLMO_EVAL_JUDGE``."""
-    return _build_judge_fn(DEEPRESEARCH_FACT_DEFAULT_JUDGE_SPEC, "DeepResearchBenchFACT")
+    """Build the FACT judge with low effort unless a spec suffix overrides it."""
+    return _build_judge_fn(DEEPRESEARCH_FACT_DEFAULT_JUDGE_SPEC, "DeepResearchBenchFACT", "low")
 
 
 @dataclass(frozen=True)

--- a/src/olmo_eval/evals/tasks/deepresearch_bench.py
+++ b/src/olmo_eval/evals/tasks/deepresearch_bench.py
@@ -1159,6 +1159,7 @@ class DeepResearchBench(Task):
         fact_judge = build_deepresearch_fact_judge_fn()
 
         race_failures = 0
+        fact_failures = 0
         for response in responses:
             output = response.outputs[0] if response.outputs else None
             answer = ""
@@ -1173,17 +1174,30 @@ class DeepResearchBench(Task):
                 race_scores, race_details, race_failed = await self._score_race(
                     response.instance, answer, race_judge
                 )
-                fact_scores, fact_details = await self._score_fact(
-                    response.instance, answer, fact_judge
-                )
+                try:
+                    fact_scores, fact_details = await self._score_fact(
+                        response.instance, answer, fact_judge
+                    )
+                    fact_failed = False
+                except Exception as exc:
+                    logger.warning(
+                        "DeepResearch Bench FACT scoring failed for id %r: %s",
+                        response.instance.metadata.get("id"),
+                        exc,
+                    )
+                    fact_scores = self._zero_fact_scores()
+                    fact_details = []
+                    fact_failed = True
             else:
                 race_scores = self._zero_race_scores()
                 race_details = None
                 race_failed = False
                 fact_scores = self._zero_fact_scores()
                 fact_details = []
+                fact_failed = False
 
             race_failures += int(race_failed)
+            fact_failures += int(fact_failed)
             response.scores.update(race_scores)
             response.scores.update(fact_scores)
             if output is not None:
@@ -1200,6 +1214,12 @@ class DeepResearchBench(Task):
                 "attempts; assigned zero and retained them in the denominator.",
                 race_failures,
                 DEEPRESEARCH_JUDGE_ATTEMPTS,
+            )
+        if fact_failures:
+            logger.warning(
+                "DeepResearch Bench FACT scoring failed for %d instance(s); assigned zero "
+                "and retained them in the denominator.",
+                fact_failures,
             )
         return responses
 
@@ -1399,10 +1419,14 @@ class DeepResearchBench(Task):
                 raw = await judge_fn(prompt)
                 parsed = cast(list[dict[str, Any]], _json_without_fences(raw))
                 for item in parsed:
+                    if not isinstance(item, Mapping) or "idx" not in item or "result" not in item:
+                        raise ValueError(
+                            "FACT validation item must be an object containing idx and result"
+                        )
                     item["idx"] -= 1
                 assert len(parsed) == len(facts), "FACT validation result length mismatch"
                 return parsed
-            except (AssertionError, json.JSONDecodeError, KeyError, TypeError) as exc:
+            except (AssertionError, json.JSONDecodeError, KeyError, TypeError, ValueError) as exc:
                 logger.warning(
                     "FACT validation attempt %d/%d failed: %s",
                     attempt + 1,

--- a/src/olmo_eval/evals/tasks/deepresearch_bench.py
+++ b/src/olmo_eval/evals/tasks/deepresearch_bench.py
@@ -1,0 +1,1319 @@
+"""DeepResearch Bench long-form research evaluation (arXiv 2506.11763).
+
+The task generates citation-rich research reports and applies both official
+scoring frameworks: RACE for criteria-weighted report quality and FACT for
+citation trustworthiness. Official bilingual judge prompts and score math are
+ported verbatim/faithfully from the benchmark repository.
+
+This integration deliberately deviates from the official implementation in
+six ways: (1) FACT scrapes with olmo-eval's crawl4ai-backed browsing logic
+instead of Jina Reader; (2) generated articles receive only deterministic
+``<think>`` stripping instead of the optional LLM ArticleCleaner, equivalent
+to evaluating with official cleaning skipped; (3) both judge models can be
+overridden with ``OLMO_EVAL_JUDGE``; and (4) the appended report-generation
+instruction is ours because the official benchmark leaves each deep-research
+system's generation prompting unspecified; (5) ``clean_urls`` is applied to
+every article rather than conditionally by source model, and text-fragment
+URLs are also normalized while grouping, merging citations to fragments of
+the same page; and (6) judge failures use three attempts with ``2**n``
+backoff, while the official RACE runner uses ten attempts with ``1.5**n``
+backoff. After final RACE judge/parse failure, an instance receives zero RACE
+scores and remains in every mean.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import re
+from abc import ABC
+from collections.abc import Iterator, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any, cast
+from urllib.parse import urlsplit
+
+from olmo_eval.common.metrics import Metric
+from olmo_eval.common.scorers.base import Scorer
+from olmo_eval.common.scorers.llm_judge import JudgeFn, build_openai_judge_fn
+from olmo_eval.common.types import (
+    Instance,
+    LMOutput,
+    LMRequest,
+    RequestType,
+    Response,
+    SamplingParams,
+    Split,
+)
+from olmo_eval.data import DataSource
+from olmo_eval.evals.tasks.common import Task, TaskConfig, register, register_variant
+
+logger = logging.getLogger(__name__)
+
+DEEPRESEARCH_BENCH_REPO = "allenai/deepresearch-bench"
+DEEPRESEARCH_RACE_DEFAULT_JUDGE_SPEC = "gpt-5.5"
+DEEPRESEARCH_FACT_DEFAULT_JUDGE_SPEC = "gpt-5.4-mini"
+DEEPRESEARCH_JUDGE_MAX_TOKENS = 64_000
+DEEPRESEARCH_JUDGE_ATTEMPTS = 3
+DEEPRESEARCH_SCRAPE_ATTEMPTS = 3
+DEEPRESEARCH_PAGE_CONTENT_LIMIT = 200_000
+DEEPRESEARCH_DIMENSIONS = (
+    "comprehensiveness",
+    "insight",
+    "instruction_following",
+    "readability",
+)
+
+DEEPRESEARCH_GENERATION_INSTRUCTIONS = {
+    "en": (
+        "Write a comprehensive research report in English. Research the task using the "
+        "available web-search and webpage-browsing tools before writing. Place an inline "
+        "Markdown citation in the exact form `[source title](url)` immediately after every "
+        "factual claim it supports. Synthesize the sources into a clear, detailed report."
+    ),
+    "zh": (
+        "请用中文撰写一份全面的研究报告。写作前请使用可用的网页搜索和网页浏览工具调研任务。"
+        "每项事实性主张后都应紧跟一个格式严格为 `[来源标题](url)` 的行内 Markdown 引用。"
+        "请综合各项来源，形成清晰、详尽的报告。"
+    ),
+}
+
+# Verbatim from prompt/score_prompt_en.py:generate_merged_score_prompt.
+RACE_SCORE_PROMPT_EN = """
+<system_role>You are a strict, meticulous, and objective research article evaluation expert. You excel at using specific assessment criteria to deeply compare two articles on the same task, providing precise scores and clear justifications.</system_role>
+
+<user_prompt>
+**Task Background**
+There is a deep research task, and you need to evaluate two research articles written for this task. We will assess the articles across four dimensions: Comprehensiveness, Insight, Instruction Following, and Readability. The content is as follows:
+<task>
+"{task_prompt}"
+</task>
+
+**Articles to Evaluate**
+<article_1>
+"{article_1}"
+</article_1>
+
+<article_2>
+"{article_2}"
+</article_2>
+
+**Evaluation Criteria**
+Now, you need to evaluate and compare these two articles based on the following **evaluation criteria list**, providing comparative analysis and scoring each on a scale of 0-10. Each criterion includes an explanation, please understand carefully.
+
+<criteria_list>
+{criteria_list}
+</criteria_list>
+
+<Instruction>
+**Your Task**
+Please strictly evaluate and compare `<article_1>` and `<article_2>` based on **each criterion** in the `<criteria_list>`. You need to:
+1.  **Analyze Each Criterion**: Consider how each article fulfills the requirements of each criterion.
+2.  **Comparative Evaluation**: Analyze how the two articles perform on each criterion, referencing the content and criterion explanation.
+3.  **Score Separately**: Based on your comparative analysis, score each article on each criterion (0-10 points).
+
+**Scoring Rules**
+For each criterion, score both articles on a scale of 0-10 (continuous values). The score should reflect the quality of performance on that criterion:
+*   0-2 points: Very poor performance. Almost completely fails to meet the criterion requirements.
+*   2-4 points: Poor performance. Minimally meets the criterion requirements with significant deficiencies.
+*   4-6 points: Average performance. Basically meets the criterion requirements, neither good nor bad.
+*   6-8 points: Good performance. Largely meets the criterion requirements with notable strengths.
+*   8-10 points: Excellent/outstanding performance. Fully meets or exceeds the criterion requirements.
+
+**Output Format Requirements**
+Please **strictly** follow the `<output_format>` below for each criterion evaluation. **Do not include any other unrelated content, introduction, or summary**. Start with "Standard 1" and proceed sequentially through all criteria:
+</Instruction>
+
+<output_format>
+{{
+    "comprehensiveness": [
+        {{
+            "criterion": [Text content of the first comprehensiveness evaluation criterion],
+            "analysis": [Comparative analysis],
+            "article_1_score": [Continuous score 0-10],
+            "article_2_score": [Continuous score 0-10]
+}},
+{{
+            "criterion": [Text content of the second comprehensiveness evaluation criterion],
+            "analysis": [Comparative analysis],
+            "article_1_score": [Continuous score 0-10],
+            "article_2_score": [Continuous score 0-10]
+        }},
+        ...
+    ],
+    "insight": [
+        {{
+            "criterion": [Text content of the first insight evaluation criterion],
+            "analysis": [Comparative analysis],
+            "article_1_score": [Continuous score 0-10],
+            "article_2_score": [Continuous score 0-10]
+        }},
+        ...
+    ],
+    ...
+}}
+</output_format>
+
+Now, please evaluate the two articles based on the research task and criteria, providing detailed comparative analysis and scores according to the requirements above. Ensure your output follows the specified `<output_format>` and that the JSON format is parsable, with all characters that might cause JSON parsing errors properly escaped.
+</user_prompt>
+"""
+
+# Verbatim from prompt/score_prompt_zh.py:generate_merged_score_prompt.
+RACE_SCORE_PROMPT_ZH = """
+<system_role>你是一名严格、细致、客观的调研文章评估专家。你擅长根据具体的评估标准，深入比较两篇针对同一任务的文章，并给出精确的评分和清晰的理由。</system_role>
+
+<user_prompt>
+**任务背景**
+有一个深度调研任务，你需要评估针对该任务撰写的两篇调研文章。我们会从以下四个维度评估文章：全面性、洞察力、指令遵循能力和可读性。内容如下：
+<task>
+"{task_prompt}"
+</task>
+
+**待评估文章**
+<article_1>
+"{article_1}"
+</article_1>
+
+<article_2>
+"{article_2}"
+</article_2>
+
+**评估标准**
+现在，你需要根据以下**评判标准列表**，逐条评估并比较这两篇文章的表现，输出对比分析，然后给出0-10的分数。每个标准都附有其解释，请仔细理解。
+
+<criteria_list>
+{criteria_list}
+</criteria_list>
+
+<Instruction>
+**你的任务**
+请严格按照 `<criteria_list>` 中的**每一条标准**，对比评估 `<article_1>` 和 `<article_2>` 在该标准上的具体表现。你需要：
+1.  **逐条分析**：针对列表中的每一条标准，分别思考两篇文章是如何满足该标准要求的。
+2.  **对比评估**：结合文章内容与标准解释，对比分析两篇文章在每一条标准上的表现。
+3.  **分别打分**：基于你的对比分析，为两篇文章在该条标准上的表现分别打分（0-10分）。
+
+**打分规则**
+对每一条标准，分别为两篇文章打分，打分范围为 0-10 分（连续的数值）。分数高低应体现文章在该标准上表现的好坏：
+*   0-2分：表现很差。几乎完全不符合标准要求。
+*   2-4分：表现较差。少量符合标准要求，但有明显不足。
+*   4-6分：表现中等。基本符合标准要求，不好不坏。
+*   6-8分：表现较好。大部分符合标准要求，有可取之处。
+*   8-10分：表现出色/极好。完全或超预期符合标准要求。
+
+**输出格式要求**
+请**严格**按照下列`<output_format>`格式输出每一条标准的评估结果，**不要包含任何其他无关内容、引言或总结**。从"标准1"开始，按顺序输出所有标准的评估：
+</Instruction>
+
+<output_format>
+{{
+    "comprehensiveness": [
+        {{
+            "criterion": [全面性维度的第一条评判标准文本内容],
+            "analysis": [对比分析],
+            "article_1_score": [0-10连续分数],
+            "article_2_score": [0-10连续分数]
+        }},
+        {{
+            "criterion": [全面性维度的第二条评判标准文本内容],
+            "analysis": [对比分析],
+            "article_1_score": [0-10连续分数],
+            "article_2_score": [0-10连续分数]
+        }},
+        ...
+    ],
+    "insight": [
+        {{
+            "criterion": [洞察力维度的第一条评判标准文本内容],
+            "analysis": [对比分析],
+            "article_1_score": [0-10连续分数],
+            "article_2_score": [0-10连续分数]
+        }},
+        ...
+    ],
+    ...
+}}
+</output_format>
+
+现在，请根据调研任务和标准，对两篇文章进行评估，并按照上述要求给出详细的对比分析和评分，请确保输出格式遵守上述`<output_format>`，而且保证其中的json格式可以解析，注意所有可能导致json解析错误的要转义的符号。
+</user_prompt>
+"""
+
+# Verbatim from utils/extract.py:prompt_template and prompt_template_en.
+FACT_EXTRACTION_PROMPT_ZH = """你会看到一篇研究报告，研究报告正文中会有一些对参考文献的引用。
+正文中的引用可能以如下形式出现：
+1. 一段文字+空格+数字，例如："李强基于收入、教育和职业构造了一个社会经济地位指数（SES），将社会划分为7个等级 15"
+2. 一段文字+[（一个或多个)数字]，例如："李强基于收入、教育和职业构造了一个社会经济地位指数（SES），将社会划分为7个等级[15]"
+3. 一段文字+[（一个或多个)数字†(一些行号等内容)]，例如："李强基于收入、教育和职业构造了一个社会经济地位指数（SES），将社会划分为7个等级[15†L10][5L23][7†summary][9summary]"
+4. [引用来源](引用链接)，例如："根据[ChinaFile: A Guide to Social Class in Modern China](https://www.chinafile.com/reporting-opinion/media/guide-social-class-modern-china)'s分类，中国社会可分为九个阶层"
+
+请从正文中找出**所有**引用了参考文献的地方，提取出(fact, ref_idx, url)三元组，提取的时候，注意以下事项：
+1. 由于后续需要检验这些facts是否正确，你可能需要在引用的前后寻找一些上下文，以确保fact是完整可理解的，而不是简单的词组或短语
+2. 如果一个fact引用了多个文献，那么它应该对应多个三元组，例如如果引用了2个文献，则应该是(fact, ref_idx_1, url_1)和(fact, ref_idx_2, url_2)
+3. 对于第三种形式的引用，ref_idx仅考虑第一个数字部分，不考虑其他指示具体位置的内容；对于第四种形式的引用（即引用来源和链接直接出现在正文中）的情况，ref_idx统一设置为0
+4. 如果正文中没有标出引用的具体位置（比如仅在文章结尾列出了参考文献列表，而没有在正文中标出），请返回空列表
+
+你应该返回json列表格式，列表中的每一项是一个三元组，例如：
+[
+    {{
+        "fact": "原文中的文本片段，注意中文引号要用全角, 英文引号前加单个反斜杠转义",
+        "ref_idx": "该段文字引用的参考文献在参考文献列表中的索引",
+        "url": "该段文字引用的参考文献链接（从研究报告结尾的参考文献列表或引用处的括号中提取）"
+    }}
+]
+
+下面是研究报告的正文：
+{report_text}
+
+下面开始提取，直接输出json列表，不要输出任何闲聊或解释。"""
+
+FACT_EXTRACTION_PROMPT_EN = """You will be provided with a research report. The body of the report will contain some citations to references.
+
+Citations in the main text may appear in the following forms:
+1. A segment of text + space + number, for example: "Li Qiang constructed a socioeconomic status index (SES) based on income, education, and occupation, dividing society into 7 levels 15"
+2. A segment of text + [number], for example: "Li Qiang constructed a socioeconomic status index (SES) based on income, education, and occupation, dividing society into 7 levels[15]"
+3. A segment of text + [number†(some line numbers, etc.)], for example: "Li Qiang constructed a socioeconomic status index (SES) based on income, education, and occupation, dividing society into 7 levels[15†L10][5L23][7†summary]"
+4. [Citation Source](Citation Link), for example: "According to [ChinaFile: A Guide to Social Class in Modern China](https://www.chinafile.com/reporting-opinion/media/guide-social-class-modern-china)'s classification, Chinese society can be divided into nine strata"
+
+Please identify **all** instances where references are cited in the main text, and extract (fact, ref_idx, url) triplets. When extracting, pay attention to the following:
+1. Since these facts will need to be verified later, you may need to look for some context before and after the citation to ensure that the fact is complete and understandable, rather than just a simple phrase or short expression.
+2. If a fact cites multiple references, then it should correspond to two triplets: (fact, ref_idx_1, url_1) and (fact, ref_idx_2, url_2).
+3. For the third form of citation (i.e., where the citation source and link appear directly in the text), the ref_idx should be uniformly set to 0.
+4. If the main text does not specify the exact location of the citation (for example, only the reference list is listed at the end of the article, without specifying the citation point in the text), please return an empty list.
+
+You should return a JSON list format, where each item in the list is a triplet, for example:
+[
+    {{
+        "fact": "Text segment from the original document. Note that Chinese quotation marks should use full-width marks. And add a single backslash before the English quotation mark to make it a readable for python json module.",
+        "ref_idx": "The index of the cited reference in the reference list for this text segment.",
+        "url": "The URL of the cited reference for this text segment (extracted from the reference list at the end of the research report or from the parentheses at the citation point)."
+    }}
+]
+
+Here is the main text of the research report:
+{report_text}
+
+Please begin the extraction now. Output only the JSON list directly, without any chitchat or explanations."""
+
+# Verbatim from utils/deduplicate.py:prompt_template and prompt_template_en.
+FACT_DEDUPLICATION_PROMPT_ZH = """你会看到一个statement列表，你需要对其去重，并返回去重后的statement序号列表，注意：只有表达完全一致的事情时，两个statement才被认为是重复的，如果列表中没有重复的statement，则返回完整的列表。
+
+你应该返回一个List(int)，列表中的每一项是去重后留下的，不重复的statement的序号，例如：
+[1, 3, 5]
+
+下面是你需要去重的statement列表
+{statements}
+
+下面开始提取，直接输出整数列表，不要输出任何闲聊或解释。"""
+
+FACT_DEDUPLICATION_PROMPT_EN = """You will be given a list of statements. You need to de-duplicate them and return a list of indices of the unique statements. Note: Two statements are considered duplicates only if they express *exactly the same thing*. If there are no duplicate statements in the list, return the complete list of indices.
+
+You should return a List(int), where each item in the list is the index of a unique, non-duplicated statement that has been retained. For example:
+[1, 3, 5]
+
+Below is the list of statements you need to de-duplicate:
+{statements}
+
+Please begin the extraction now. Output only the integer list, without any conversational text or explanations."""
+
+# Verbatim from utils/validate.py:prompt_template and prompt_template_en.
+FACT_VALIDATION_PROMPT_ZH = """你会看到一个参考资料和一些statement，请你判断对于参考资料来说statement是supported、unsupported、或者unknown，注意：
+首先判断参考资料是否存在有效内容，如果参考资料中没有任何有效信息，如"page not found"页面，则认为所有statement的状态都是unknown。
+除此之外，参考资料有效的情况下，对于一个statement来说，如果它包含的事实或数据在参考资料中可以全部或部分找到，就认为它是supported的（数据接受四舍五入）；如果statement中所有的事实和数据在参考资料中都找不到，认为它是unsupported的。
+
+你应该返回json列表格式，列表中的每一项包含statement的序号和判断结果，例如：
+[
+    {{
+        "idx": 1,
+        "result": "supported"
+    }},
+    {{
+        "idx": 2,
+        "result": "unsupported"
+    }}
+]
+
+下面是参考资料和statements：
+<reference>
+{reference}
+</reference>
+
+<statements>
+{statements}
+</statements>
+
+下面开始判断，直接输出json列表，不要输出任何闲聊或解释。"""
+
+FACT_VALIDATION_PROMPT_EN = """You will be provided with a reference and some statements. Please determine whether each statement is 'supported', 'unsupported', or 'unknown' with respect to the reference. Please note:
+First, assess whether the reference contains any valid content. If the reference contains no valid information, such as a 'page not found' message, then all statements should be considered 'unknown'.
+If the reference is valid, for a given statement: if the facts or data it contains can be found entirely or partially within the reference, it is considered 'supported' (data accepts rounding); if all facts and data in the statement cannot be found in the reference, it is considered 'unsupported'.
+
+You should return the result in a JSON list format, where each item in the list contains the statement's index and the judgment result, for example:
+[
+    {{
+        "idx": 1,
+        "result": "supported"
+    }},
+    {{
+        "idx": 2,
+        "result": "unsupported"
+    }}
+]
+
+Below are the reference and statements:
+<reference>
+{reference}
+</reference>
+
+<statements>
+{statements}
+</statements>
+
+Begin the assessment now. Output only the JSON list, without any conversational text or explanations."""
+
+
+def format_criteria_list(criteria_data: Mapping[str, Any]) -> str:
+    """Format criteria for the judge without revealing official weights."""
+    criteria_for_prompt: dict[str, list[dict[str, Any]]] = {}
+    criterions_dict = criteria_data.get("criterions", {})
+    if not isinstance(criterions_dict, Mapping):
+        criterions_dict = {}
+
+    for dimension, criterions_list in criterions_dict.items():
+        if not isinstance(dimension, str) or not isinstance(criterions_list, list):
+            logger.warning("Invalid criteria list for dimension %r; skipping", dimension)
+            continue
+        criteria_for_prompt[dimension] = []
+        for criterion_item in criterions_list:
+            if (
+                isinstance(criterion_item, Mapping)
+                and "criterion" in criterion_item
+                and "explanation" in criterion_item
+            ):
+                criteria_for_prompt[dimension].append(
+                    {
+                        "criterion": criterion_item["criterion"],
+                        "explanation": criterion_item["explanation"],
+                    }
+                )
+            else:
+                logger.warning("Invalid criterion in dimension %r; skipping", dimension)
+
+    try:
+        return json.dumps(criteria_for_prompt, ensure_ascii=False, indent=2)
+    except TypeError as exc:
+        raise ValueError(f"Failed to serialize criteria to JSON: {exc}") from exc
+
+
+def extract_json_from_markdown(text: Any) -> str | None:
+    """Port the official layered JSON extraction and score-specific fallback."""
+    if not isinstance(text, str):
+        return None
+
+    stripped = text.strip()
+    if stripped.startswith("{") and stripped.endswith("}"):
+        try:
+            json.loads(stripped)
+            return stripped
+        except json.JSONDecodeError:
+            pass
+
+    marker_start = text.find("```json")
+    if marker_start >= 0:
+        start = marker_start + len("```json")
+        end = text.find("```", start)
+        if end > start:
+            candidate = text[start:end].strip()
+            try:
+                json.loads(candidate)
+                return candidate
+            except json.JSONDecodeError:
+                pass
+
+    match = re.search(r"```json\s*([\s\S]*?)\s*```", text)
+    if match:
+        candidate = match.group(1).strip()
+        try:
+            json.loads(candidate)
+            return candidate
+        except json.JSONDecodeError:
+            pass
+
+    try:
+        json.loads(stripped)
+        return stripped
+    except json.JSONDecodeError:
+        pass
+
+    start = text.find("{")
+    if start != -1:
+        level = 0
+        for offset, character in enumerate(text[start:]):
+            if character == "{":
+                level += 1
+            elif character == "}":
+                level -= 1
+                if level == 0:
+                    candidate = text[start : start + offset + 1]
+                    try:
+                        json.loads(candidate)
+                        return candidate
+                    except json.JSONDecodeError:
+                        pass
+                    break
+
+    start = text.find("{")
+    end = text.rfind("}")
+    if start != -1 and end > start:
+        candidate = text[start : end + 1]
+        try:
+            json.loads(candidate)
+            return candidate
+        except json.JSONDecodeError:
+            pass
+
+    if "comprehensiveness" in text and "article_1_score" in text and "article_2_score" in text:
+        dimensions = list(DEEPRESEARCH_DIMENSIONS)
+        result: dict[str, list[dict[str, Any]]] = {}
+        for dimension in dimensions:
+            if dimension not in text:
+                continue
+            result[dimension] = []
+            dimension_start = text.find(f'"{dimension}"')
+            if dimension_start == -1:
+                dimension_start = text.find(f"'{dimension}'")
+            if dimension_start == -1:
+                dimension_start = text.find(dimension)
+            if dimension_start == -1:
+                continue
+
+            next_dimension_start = len(text)
+            for next_dimension in dimensions:
+                if next_dimension == dimension:
+                    continue
+                position = text.find(f'"{next_dimension}"', dimension_start)
+                if position == -1:
+                    position = text.find(f"'{next_dimension}'", dimension_start)
+                if position == -1:
+                    position = text.find(next_dimension, dimension_start + len(dimension))
+                if position != -1:
+                    next_dimension_start = min(next_dimension_start, position)
+
+            dimension_content = text[dimension_start:next_dimension_start]
+            criteria = re.findall(r'"criterion"\s*:\s*"([^"]+)"', dimension_content)
+            scores_1 = re.findall(r'"article_1_score"\s*:\s*(\d+\.?\d*)', dimension_content)
+            scores_2 = re.findall(r'"article_2_score"\s*:\s*(\d+\.?\d*)', dimension_content)
+            for index in range(min(len(criteria), len(scores_1), len(scores_2))):
+                result[dimension].append(
+                    {
+                        "criterion": criteria[index],
+                        "article_1_score": float(scores_1[index]),
+                        "article_2_score": float(scores_2[index]),
+                    }
+                )
+        if any(result.values()):
+            return json.dumps(result)
+    return None
+
+
+def calculate_weighted_scores(
+    llm_output_json: Mapping[str, Any],
+    criteria_data: Mapping[str, Any],
+    language: str = "en",
+) -> dict[str, dict[str, Any]]:
+    """Faithfully port the official criteria and dimension weighting math."""
+    del language  # Kept for API parity with the official implementation.
+    results: dict[str, dict[str, Any]] = {
+        "target": {"dims": {}, "total": 0.0},
+        "reference": {"dims": {}, "total": 0.0},
+    }
+    total_target_score = 0.0
+    total_reference_score = 0.0
+    dimension_weights = criteria_data.get("dimension_weight", {})
+    task_id = criteria_data.get("id", "Unknown")
+    if not isinstance(dimension_weights, Mapping):
+        dimension_weights = {}
+
+    criterions_data = criteria_data.get("criterions")
+    if not isinstance(criterions_data, Mapping) or not criterions_data:
+        raise ValueError(
+            f"ID: {task_id} - Missing required criterions data, cannot calculate weighted scores"
+        )
+
+    criterion_weights: dict[str, dict[str, Any]] = {}
+    for dimension, criterions in criterions_data.items():
+        if not isinstance(dimension, str) or not isinstance(criterions, list):
+            continue
+        criterion_weights[dimension] = {
+            criterion["criterion"]: criterion["weight"]
+            for criterion in criterions
+            if isinstance(criterion, Mapping)
+            and isinstance(criterion.get("criterion"), str)
+            and "weight" in criterion
+        }
+
+    unmatched_criteria: set[str] = set()
+    for dimension, scores_list in llm_output_json.items():
+        if not isinstance(dimension, str) or not isinstance(scores_list, list):
+            logger.warning(
+                "ID: %s - Dimension %r in LLM output is not a list; skipping",
+                task_id,
+                dimension,
+            )
+            continue
+        if dimension not in dimension_weights or dimension not in criterion_weights:
+            logger.warning(
+                "ID: %s - Dimension %r is absent from criteria weights/details; skipping",
+                task_id,
+                dimension,
+            )
+            continue
+
+        dimension_map = criterion_weights[dimension]
+        if not dimension_map:
+            logger.warning("ID: %s - No criteria mapping for %r; skipping", task_id, dimension)
+            continue
+
+        target_weighted_sum = 0.0
+        reference_weighted_sum = 0.0
+        total_weight = 0.0
+        article_2_score: float | None = None
+
+        for score_item in scores_list:
+            if not isinstance(score_item, Mapping):
+                logger.warning(
+                    "ID: %s - Non-mapping score item in %r; skipping", task_id, dimension
+                )
+                continue
+            raw_criterion = score_item.get("criterion")
+            criterion_text = raw_criterion.strip() if isinstance(raw_criterion, str) else None
+            article_1_raw = score_item.get("article_1_score")
+            article_2_raw = score_item.get("article_2_score")
+            target_raw = score_item.get("target_score")
+            if target_raw is not None and article_1_raw is None:
+                article_1_raw = target_raw
+
+            try:
+                article_1_score = float(article_1_raw) if article_1_raw is not None else None
+                article_2_score = float(article_2_raw) if article_2_raw is not None else None
+            except (TypeError, ValueError):
+                logger.warning(
+                    "ID: %s - Invalid scores for criterion %r in %r; skipping",
+                    task_id,
+                    criterion_text,
+                    dimension,
+                )
+                continue
+
+            if not criterion_text or article_1_score is None:
+                logger.warning(
+                    "ID: %s - Missing criterion text or target score in %r; skipping",
+                    task_id,
+                    dimension,
+                )
+                continue
+
+            weight = dimension_map.get(criterion_text)
+            criterion_lower = criterion_text.lower()
+            if weight is None:
+                for key, value in dimension_map.items():
+                    if key.lower() == criterion_lower:
+                        weight = value
+                        break
+            if weight is None:
+                for key, value in dimension_map.items():
+                    if criterion_lower in key.lower() or key.lower() in criterion_lower:
+                        weight = value
+                        break
+            if weight is None:
+                unmatched_criteria.add(f"{dimension}:{criterion_text}")
+                weight = sum(dimension_map.values()) / len(dimension_map)
+
+            target_weighted_sum += article_1_score * weight
+            total_weight += weight
+            if article_2_score is not None:
+                reference_weighted_sum += article_2_score * weight
+
+        if total_weight > 0:
+            target_average = target_weighted_sum / total_weight
+            # Official code keys this on the last parsed item. Preserve it: mixed
+            # single/comparative output can therefore change the reference result.
+            reference_average = (
+                reference_weighted_sum / total_weight if article_2_score is not None else 0.0
+            )
+        else:
+            target_average = 0.0
+            reference_average = 0.0
+
+        dimension_key = f"{dimension}_weighted_avg"
+        results["target"]["dims"][dimension_key] = target_average
+        results["reference"]["dims"][dimension_key] = reference_average
+        dimension_weight = dimension_weights.get(dimension, 0)
+        total_target_score += target_average * dimension_weight
+        total_reference_score += reference_average * dimension_weight
+
+    if unmatched_criteria:
+        logger.warning(
+            "ID: %s - %d criteria used average-weight fallback: %s",
+            task_id,
+            len(unmatched_criteria),
+            unmatched_criteria,
+        )
+    results["target"]["total"] = total_target_score
+    results["reference"]["total"] = total_reference_score
+    return results
+
+
+def normalize_comparative_score(target: float, reference: float) -> float:
+    """Normalize one target/reference score pair with the official zero guard."""
+    denominator = target + reference
+    return target / denominator if denominator > 0 else 0.0
+
+
+def normalize_weighted_scores(scores: Mapping[str, Any]) -> dict[str, float]:
+    """Return official overall and per-dimension target shares."""
+    target = scores["target"]
+    reference = scores["reference"]
+    normalized = {
+        "race_overall": normalize_comparative_score(
+            float(target["total"]), float(reference["total"])
+        )
+    }
+    for dimension in DEEPRESEARCH_DIMENSIONS:
+        key = f"{dimension}_weighted_avg"
+        target_score = float(target["dims"].get(key, 0.0))
+        reference_score = float(reference["dims"].get(key, 0.0))
+        normalized[f"race_{dimension}"] = normalize_comparative_score(target_score, reference_score)
+    return normalized
+
+
+def clean_urls(input_text: str) -> str:
+    """Strip text-fragment suffixes from inline Markdown citation URLs."""
+    pattern = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
+
+    def replace(match: re.Match[str]) -> str:
+        title, url = match.groups()
+        return f"[{title}]({clean_citation_url(url)})"
+
+    return pattern.sub(replace, input_text)
+
+
+def clean_citation_url(url: str) -> str:
+    """Apply the official ``#:~:text=`` URL cleanup to a raw URL."""
+    return url.split("#:~:text=", maxsplit=1)[0]
+
+
+def remove_urls(input_text: str) -> str:
+    """Remove URL targets from Markdown citations while retaining their titles."""
+    return re.sub(r"\[([^\]]+)\]\(([^)]+)\)", r"[\1]", input_text)
+
+
+def clean_escape(input_text: str) -> str:
+    """Remove the four illegal JSON escapes handled by the official extractor."""
+    for escaped, replacement in ((r"\>", ">"), (r"\<", "<"), (r"\+", "+"), (r"\~", "~")):
+        input_text = input_text.replace(escaped, replacement)
+    return input_text
+
+
+def group_citations_by_url(
+    citations: Sequence[Mapping[str, Any]],
+) -> dict[str, list[dict[str, Any]]]:
+    """Group extracted citation triplets by their cleaned URL."""
+    groups: dict[str, list[dict[str, Any]]] = {}
+    for citation in citations:
+        url = citation.get("url")
+        fact = citation.get("fact")
+        if not isinstance(url, str) or not url or not isinstance(fact, str) or not fact:
+            continue
+        cleaned_url = clean_citation_url(url)
+        if not cleaned_url:
+            continue
+        groups.setdefault(cleaned_url, []).append(dict(citation, url=cleaned_url))
+    return groups
+
+
+def _json_without_fences(raw: str) -> Any:
+    return json.loads(raw.replace("```json", "").replace("```", ""))
+
+
+def _try_parse_dedup_indices(raw: str, group_size: int) -> list[int] | None:
+    try:
+        parsed = cast(list[int], _json_without_fences(raw))
+    except json.JSONDecodeError:
+        return None
+    if not parsed or 0 in parsed or len(parsed) > group_size:
+        return list(range(1, group_size + 1))
+    if any(index > group_size or index <= -group_size for index in parsed):
+        # The official list access raises IndexError here; retain every fact instead.
+        return list(range(1, group_size + 1))
+    return parsed
+
+
+def parse_dedup_indices(raw: str, group_size: int) -> list[int]:
+    """Parse official one-based dedup indices, falling back to every statement."""
+    parsed = _try_parse_dedup_indices(raw, group_size)
+    return parsed if parsed is not None else list(range(1, group_size + 1))
+
+
+def calculate_fact_statistics(results: Sequence[str], n_tasks: int) -> dict[str, float]:
+    """Calculate official FACT statistics for citation-bearing tasks."""
+    supported = sum(result == "supported" for result in results)
+    evaluated = sum(result != "unknown" for result in results)
+    return {
+        "fact_citation_accuracy": supported / evaluated if evaluated else 0.0,
+        "fact_avg_effective_citations": supported / n_tasks if n_tasks else 0.0,
+        "fact_avg_citations": evaluated / n_tasks if n_tasks else 0.0,
+    }
+
+
+def _unknown_results(fact_count: int) -> list[dict[str, Any]]:
+    return [{"idx": index, "result": "unknown"} for index in range(fact_count)]
+
+
+def is_obvious_scrape_failure(page_text: str) -> bool:
+    """Identify fetch-layer failures that cannot support any statement."""
+    normalized = page_text.strip().lower()
+    return not normalized or normalized.startswith(
+        (
+            "error:",
+            "error fetching webpage:",
+            "scrape failed:",
+            "no content extracted from webpage.",
+        )
+    )
+
+
+def scrape_failure_unknown_results(page_text: str, fact_count: int) -> list[dict[str, Any]] | None:
+    """Short-circuit obvious fetch errors; valid pages still go to the judge."""
+    return _unknown_results(fact_count) if is_obvious_scrape_failure(page_text) else None
+
+
+async def fetch_crawl4ai_page(url: str) -> str:
+    """Call crawl4ai's underlying fetch logic without the registered-tool truncation."""
+    sanitized_url = url.strip()
+    if not sanitized_url:
+        return "Error: Empty URL."
+    if urlsplit(sanitized_url).scheme.lower() not in {"http", "https"}:
+        return "Error: Only http(s) URLs are supported."
+
+    try:
+        from crawl4ai import AsyncWebCrawler
+    except ImportError:
+        raise RuntimeError(
+            "DeepResearch Bench FACT scoring requires crawl4ai. "
+            "Install it with `pip install 'olmo-eval[crawl4ai]'`."
+        ) from None
+
+    try:
+        async with AsyncWebCrawler() as crawler:
+            result = await crawler.arun(sanitized_url)
+    except Exception as exc:
+        logger.exception("crawl4ai FACT fetch failed for %r", sanitized_url)
+        return f"Error fetching webpage: {exc}"
+
+    if not getattr(result, "success", False):
+        error_message = getattr(result, "error_message", None)
+        if error_message:
+            return f"Error fetching webpage: {error_message}"
+        status_code = getattr(result, "status_code", None)
+        if status_code is not None:
+            return f"Error fetching webpage: HTTP {status_code}"
+        return "Error fetching webpage: unknown error"
+
+    markdown = getattr(result, "markdown", None)
+    text = getattr(markdown, "raw_markdown", None) or str(markdown or "")
+    if not text.strip():
+        return "No content extracted from webpage."
+    if len(text) > DEEPRESEARCH_PAGE_CONTENT_LIMIT:
+        text = text[:DEEPRESEARCH_PAGE_CONTENT_LIMIT]
+    return text
+
+
+def _build_judge_fn(default_spec: str, scorer_name: str) -> JudgeFn:
+    spec = os.getenv("OLMO_EVAL_JUDGE", default_spec)
+    model, separator, effort = spec.partition(":")
+    return build_openai_judge_fn(
+        model=model,
+        temperature=0.0,
+        max_tokens=DEEPRESEARCH_JUDGE_MAX_TOKENS,
+        scorer_name=scorer_name,
+        reasoning_effort=(effort if separator else None),
+    )
+
+
+def build_deepresearch_race_judge_fn() -> JudgeFn:
+    """Build the RACE judge from its default or ``$OLMO_EVAL_JUDGE``."""
+    return _build_judge_fn(DEEPRESEARCH_RACE_DEFAULT_JUDGE_SPEC, "DeepResearchBenchRACE")
+
+
+def build_deepresearch_fact_judge_fn() -> JudgeFn:
+    """Build the shared FACT-stage judge from its default or ``$OLMO_EVAL_JUDGE``."""
+    return _build_judge_fn(DEEPRESEARCH_FACT_DEFAULT_JUDGE_SPEC, "DeepResearchBenchFACT")
+
+
+@dataclass(frozen=True)
+class DeepResearchBenchScorer(Scorer):
+    """Placeholder scorer; the task precomputes all RACE and FACT channels."""
+
+    name: str = "deepresearch_bench"
+    score_key: str = "race_overall"
+
+    def score(self, instance: Instance, output: LMOutput) -> float:
+        return float((output.metadata or {}).get(self.score_key, 0.0))
+
+
+class DeepResearchMetricBase(Metric, ABC):
+    scorer: type[Scorer] = DeepResearchBenchScorer
+
+    def supports_pairwise_scorer_fallback(self) -> bool:
+        return False
+
+
+@dataclass(frozen=True)
+class DeepResearchMeanMetric(DeepResearchMetricBase):
+    """Arithmetic mean of a precomputed per-task score."""
+
+    name: str = "race_overall"
+    scorer: type[Scorer] = DeepResearchBenchScorer
+
+    def compute(self, responses: Sequence[Response]) -> float:
+        if not responses:
+            return 0.0
+        return sum(response.scores.get(self.name, 0.0) for response in responses) / len(responses)
+
+    def pairwise_display_format(self) -> str:
+        return "percentage" if self.name.startswith("race_") else "raw"
+
+    def pairwise_unit(self) -> str:
+        return "proportion" if self.name.startswith("race_") else self.name
+
+
+@dataclass(frozen=True)
+class FactCitationAccuracyMetric(DeepResearchMetricBase):
+    """Corpus-level supported / non-unknown FACT accuracy."""
+
+    name: str = "fact_citation_accuracy"
+    scorer: type[Scorer] = DeepResearchBenchScorer
+
+    def compute(self, responses: Sequence[Response]) -> float:
+        supported = sum(
+            response.scores.get("fact_avg_effective_citations", 0.0) for response in responses
+        )
+        evaluated = sum(response.scores.get("fact_avg_citations", 0.0) for response in responses)
+        return supported / evaluated if evaluated else 0.0
+
+    def pairwise_display_format(self) -> str:
+        return "percentage"
+
+    def pairwise_unit(self) -> str:
+        return "proportion"
+
+
+@dataclass(frozen=True)
+class FactAverageCitationMetric(DeepResearchMetricBase):
+    """Average a FACT count over responses with at least one extracted citation."""
+
+    name: str = "fact_avg_citations"
+    scorer: type[Scorer] = DeepResearchBenchScorer
+
+    def compute(self, responses: Sequence[Response]) -> float:
+        numerator = sum(response.scores.get(self.name, 0.0) for response in responses)
+        citation_bearing = sum(
+            response.scores.get("fact_has_citations", 0.0) for response in responses
+        )
+        return numerator / citation_bearing if citation_bearing else 0.0
+
+    def pairwise_display_format(self) -> str:
+        return "raw"
+
+    def pairwise_unit(self) -> str:
+        return self.name
+
+
+RACE_OVERALL_METRIC = DeepResearchMeanMetric(name="race_overall")
+DEEPRESEARCH_METRICS = (
+    RACE_OVERALL_METRIC,
+    *(DeepResearchMeanMetric(name=f"race_{dimension}") for dimension in DEEPRESEARCH_DIMENSIONS),
+    FactCitationAccuracyMetric(),
+    FactAverageCitationMetric(name="fact_avg_effective_citations"),
+    FactAverageCitationMetric(name="fact_avg_citations"),
+)
+
+
+def strip_think_block(text: str) -> str:
+    """Strip a leading reasoning block using the ResearchQA helper pattern."""
+    think_end = text.find("</think>")
+    if think_end >= 0:
+        text = text[think_end + len("</think>") :]
+    return text.strip()
+
+
+def _validated_criteria(doc: Mapping[str, Any]) -> dict[str, Any] | None:
+    criteria = doc.get("criteria")
+    if not isinstance(criteria, Mapping):
+        return None
+    dimension_weight = criteria.get("dimension_weight")
+    criterions = criteria.get("criterions")
+    if not isinstance(dimension_weight, Mapping) or not isinstance(criterions, Mapping):
+        return None
+    return {
+        "dimension_weight": dict(dimension_weight),
+        "criterions": {key: value for key, value in criterions.items()},
+    }
+
+
+@register("deepresearch_bench")
+class DeepResearchBench(Task):
+    """DeepResearch Bench RACE + FACT evaluation."""
+
+    split = Split.TEST
+    data_source = DataSource(path=DEEPRESEARCH_BENCH_REPO, subset="default", split="test")
+    metrics = DEEPRESEARCH_METRICS
+    primary_metric = RACE_OVERALL_METRIC
+    sampling_params = SamplingParams(temperature=0.0, max_tokens=16_384)
+    required_secrets = ("OPENAI_API_KEY",)
+
+    def __init__(self, config: TaskConfig) -> None:
+        super().__init__(config)
+        self._scrape_cache: dict[str, str] = {}
+
+    @property
+    def instances(self) -> Iterator[Instance]:
+        split = (
+            self.config.data_source.split
+            if isinstance(self.config.data_source, DataSource)
+            else None
+        )
+        yield from self._load_instances_cached(split=split)
+
+    def process_doc(self, doc: dict[str, Any], index: int = 0) -> Instance | None:
+        language = doc.get("language")
+        if language not in {"en", "zh"}:
+            return None
+        prompt = doc.get("prompt")
+        reference_article = doc.get("reference_article")
+        criteria = _validated_criteria(doc)
+        if (
+            not isinstance(prompt, str)
+            or not prompt
+            or not isinstance(reference_article, str)
+            or not reference_article
+            or criteria is None
+        ):
+            return None
+
+        identifier = doc.get("id", index + 1)
+        generation_instruction = DEEPRESEARCH_GENERATION_INSTRUCTIONS[language]
+        return Instance(
+            question=f"{prompt}\n\n{generation_instruction}",
+            metadata={
+                "id": identifier,
+                "case_id": identifier,
+                "language": language,
+                "topic": doc.get("topic", ""),
+                "prompt": prompt,
+                "criteria": criteria,
+                "reference_article": reference_article,
+                "index": index,
+            },
+        )
+
+    def format_request(self, instance: Instance) -> LMRequest:
+        return LMRequest(
+            request_type=RequestType.CHAT,
+            messages=({"role": "user", "content": instance.question},),
+        )
+
+    def extract_answer(self, output: LMOutput) -> str:
+        return strip_think_block(output.text)
+
+    async def score_responses(
+        self,
+        responses: Sequence[Response],
+        context: Any = None,
+    ) -> Sequence[Response]:
+        """Run RACE and FACT, retaining every instance in aggregate denominators."""
+        del context
+        self._extract_answers(responses)
+        race_judge = build_deepresearch_race_judge_fn()
+        fact_judge = build_deepresearch_fact_judge_fn()
+
+        race_failures = 0
+        for response in responses:
+            output = response.outputs[0] if response.outputs else None
+            answer = ""
+            if output is not None:
+                answer = (
+                    output.extracted_answer
+                    if isinstance(output.extracted_answer, str)
+                    else output.text
+                )
+
+            if answer:
+                race_scores, race_details, race_failed = await self._score_race(
+                    response.instance, answer, race_judge
+                )
+                fact_scores, fact_details = await self._score_fact(
+                    response.instance, answer, fact_judge
+                )
+            else:
+                race_scores = self._zero_race_scores()
+                race_details = None
+                race_failed = False
+                fact_scores = self._zero_fact_scores()
+                fact_details = []
+
+            race_failures += int(race_failed)
+            response.scores.update(race_scores)
+            response.scores.update(fact_scores)
+            if output is not None:
+                if output.metadata is None:
+                    output.metadata = {}
+                output.metadata["deepresearch_race"] = race_details
+                output.metadata["deepresearch_fact"] = fact_details
+                for metric_name, score in response.scores.items():
+                    output.metadata[f"score:{metric_name}"] = score
+
+        if race_failures:
+            logger.warning(
+                "DeepResearch Bench RACE judge failed for %d instance(s) after %d "
+                "attempts; assigned zero and retained them in the denominator.",
+                race_failures,
+                DEEPRESEARCH_JUDGE_ATTEMPTS,
+            )
+        return responses
+
+    async def _score_race(
+        self,
+        instance: Instance,
+        answer: str,
+        judge_fn: JudgeFn,
+    ) -> tuple[dict[str, float], dict[str, Any] | None, bool]:
+        metadata = instance.metadata
+        criteria = metadata["criteria"]
+        language = metadata["language"]
+        prompt_template = RACE_SCORE_PROMPT_ZH if language == "zh" else RACE_SCORE_PROMPT_EN
+        judge_prompt = prompt_template.format(
+            task_prompt=metadata["prompt"],
+            article_1=answer,
+            article_2=metadata["reference_article"],
+            criteria_list=format_criteria_list(criteria),
+        )
+
+        for attempt in range(DEEPRESEARCH_JUDGE_ATTEMPTS):
+            try:
+                raw = await judge_fn(judge_prompt)
+                extracted_json = extract_json_from_markdown(raw)
+                if extracted_json is None:
+                    raise ValueError("Failed to extract JSON from RACE judge response")
+                parsed = json.loads(extracted_json)
+                if not isinstance(parsed, dict):
+                    raise TypeError("RACE judge response must be a JSON object")
+                missing = [
+                    dimension for dimension in DEEPRESEARCH_DIMENSIONS if dimension not in parsed
+                ]
+                if missing:
+                    raise ValueError(f"RACE judge response is missing dimensions: {missing}")
+                weighted = calculate_weighted_scores(parsed, criteria, language)
+                normalized = normalize_weighted_scores(weighted)
+                return normalized, {"judge_scores": parsed, "weighted_scores": weighted}, False
+            except (json.JSONDecodeError, TypeError, ValueError, KeyError) as exc:
+                logger.warning(
+                    "DeepResearch Bench RACE attempt %d/%d failed for id %r: %s",
+                    attempt + 1,
+                    DEEPRESEARCH_JUDGE_ATTEMPTS,
+                    metadata.get("id"),
+                    exc,
+                )
+            except Exception as exc:
+                logger.warning(
+                    "DeepResearch Bench RACE judge call %d/%d failed for id %r: %s",
+                    attempt + 1,
+                    DEEPRESEARCH_JUDGE_ATTEMPTS,
+                    metadata.get("id"),
+                    exc,
+                )
+            if attempt < DEEPRESEARCH_JUDGE_ATTEMPTS - 1:
+                await asyncio.sleep(2**attempt)
+        return self._zero_race_scores(), None, True
+
+    async def _score_fact(
+        self,
+        instance: Instance,
+        answer: str,
+        judge_fn: JudgeFn,
+    ) -> tuple[dict[str, float], list[dict[str, Any]]]:
+        language = instance.metadata["language"]
+        citations = await self._extract_citations(answer, language, judge_fn)
+        fact_has_citations = float(bool(citations))
+        groups = group_citations_by_url(citations)
+        validation_details: list[dict[str, Any]] = []
+
+        for url, group in groups.items():
+            facts = [str(citation["fact"]) for citation in group]
+            if len(facts) > 1:
+                facts = await self._deduplicate_facts(facts, language, judge_fn)
+
+            page_text = await self._fetch_page(url)
+            validation_results = scrape_failure_unknown_results(page_text, len(facts))
+            if validation_results is None:
+                validation_results = await self._validate_facts(
+                    facts, page_text, language, judge_fn
+                )
+            for position, validation in enumerate(validation_results):
+                returned_index = validation["idx"]
+                fact_index = (
+                    returned_index
+                    if isinstance(returned_index, int) and 0 <= returned_index < len(facts)
+                    else position
+                )
+                validation_details.append(
+                    {
+                        "url": url,
+                        "fact": facts[fact_index],
+                        "result": validation["result"],
+                    }
+                )
+
+        statuses = [detail["result"] for detail in validation_details]
+        statistics = calculate_fact_statistics(statuses, n_tasks=1)
+        statistics["fact_has_citations"] = fact_has_citations
+        return statistics, validation_details
+
+    async def _extract_citations(
+        self, answer: str, language: str, judge_fn: JudgeFn
+    ) -> list[dict[str, Any]]:
+        template = FACT_EXTRACTION_PROMPT_ZH if language == "zh" else FACT_EXTRACTION_PROMPT_EN
+        prompt = template.format(report_text=clean_urls(answer))
+        for attempt in range(DEEPRESEARCH_JUDGE_ATTEMPTS):
+            try:
+                raw = clean_escape(await judge_fn(prompt))
+                parsed = _json_without_fences(raw)
+                if not isinstance(parsed, list):
+                    raise TypeError("FACT extraction result must be a list")
+                citations: list[dict[str, Any]] = []
+                for item in parsed:
+                    if not isinstance(item, Mapping):
+                        raise TypeError("FACT extraction item must be an object")
+                    fact = item.get("fact")
+                    url = item.get("url")
+                    if not isinstance(fact, str) or not isinstance(url, str):
+                        raise TypeError("FACT extraction fact and url must be strings")
+                    citations.append(
+                        {
+                            "fact": remove_urls(fact),
+                            "ref_idx": item.get("ref_idx"),
+                            "url": clean_citation_url(url),
+                        }
+                    )
+                return citations
+            except (json.JSONDecodeError, TypeError) as exc:
+                logger.warning(
+                    "FACT extraction attempt %d/%d failed: %s",
+                    attempt + 1,
+                    DEEPRESEARCH_JUDGE_ATTEMPTS,
+                    exc,
+                )
+            except Exception as exc:
+                logger.warning(
+                    "FACT extraction judge call %d/%d failed: %s",
+                    attempt + 1,
+                    DEEPRESEARCH_JUDGE_ATTEMPTS,
+                    exc,
+                )
+            if attempt < DEEPRESEARCH_JUDGE_ATTEMPTS - 1:
+                await asyncio.sleep(2**attempt)
+        return []
+
+    async def _deduplicate_facts(
+        self, facts: list[str], language: str, judge_fn: JudgeFn
+    ) -> list[str]:
+        statements = "\n".join(f"{index + 1}. {fact}" for index, fact in enumerate(facts))
+        template = (
+            FACT_DEDUPLICATION_PROMPT_ZH if language == "zh" else FACT_DEDUPLICATION_PROMPT_EN
+        )
+        prompt = template.format(statements=statements)
+        indices: list[int] | None = None
+        for attempt in range(DEEPRESEARCH_JUDGE_ATTEMPTS):
+            try:
+                indices = _try_parse_dedup_indices(await judge_fn(prompt), len(facts))
+                if indices is not None:
+                    break
+                raise ValueError("FACT deduplication result must be valid JSON")
+            except Exception as exc:
+                logger.warning(
+                    "FACT deduplication attempt %d/%d failed: %s",
+                    attempt + 1,
+                    DEEPRESEARCH_JUDGE_ATTEMPTS,
+                    exc,
+                )
+            if attempt < DEEPRESEARCH_JUDGE_ATTEMPTS - 1:
+                await asyncio.sleep(2**attempt)
+        indices = indices or list(range(1, len(facts) + 1))
+        return [facts[index - 1] for index in indices]
+
+    async def _fetch_page(self, url: str) -> str:
+        if url not in self._scrape_cache:
+            page_text = ""
+            for attempt in range(DEEPRESEARCH_SCRAPE_ATTEMPTS):
+                page_text = await fetch_crawl4ai_page(url)
+                if not is_obvious_scrape_failure(page_text):
+                    break
+                if attempt < DEEPRESEARCH_SCRAPE_ATTEMPTS - 1:
+                    await asyncio.sleep(1)
+            self._scrape_cache[url] = page_text
+        return self._scrape_cache[url]
+
+    async def _validate_facts(
+        self,
+        facts: list[str],
+        page_text: str,
+        language: str,
+        judge_fn: JudgeFn,
+    ) -> list[dict[str, Any]]:
+        statements = "\n".join(f"{index + 1}. {fact}" for index, fact in enumerate(facts))
+        template = FACT_VALIDATION_PROMPT_ZH if language == "zh" else FACT_VALIDATION_PROMPT_EN
+        prompt = template.format(reference=page_text, statements=statements)
+        for attempt in range(DEEPRESEARCH_JUDGE_ATTEMPTS):
+            try:
+                raw = await judge_fn(prompt)
+                parsed = cast(list[dict[str, Any]], _json_without_fences(raw))
+                for item in parsed:
+                    item["idx"] -= 1
+                assert len(parsed) == len(facts), "FACT validation result length mismatch"
+                return parsed
+            except (AssertionError, json.JSONDecodeError, KeyError, TypeError) as exc:
+                logger.warning(
+                    "FACT validation attempt %d/%d failed: %s",
+                    attempt + 1,
+                    DEEPRESEARCH_JUDGE_ATTEMPTS,
+                    exc,
+                )
+            except Exception as exc:
+                logger.warning("FACT validation judge call failed: %s", exc)
+            if attempt < DEEPRESEARCH_JUDGE_ATTEMPTS - 1:
+                await asyncio.sleep(2**attempt)
+        return _unknown_results(len(facts))
+
+    @staticmethod
+    def _zero_race_scores() -> dict[str, float]:
+        return {
+            "race_overall": 0.0,
+            **{f"race_{dimension}": 0.0 for dimension in DEEPRESEARCH_DIMENSIONS},
+        }
+
+    @staticmethod
+    def _zero_fact_scores() -> dict[str, float]:
+        return {
+            "fact_citation_accuracy": 0.0,
+            "fact_avg_effective_citations": 0.0,
+            "fact_avg_citations": 0.0,
+            "fact_has_citations": 0.0,
+        }
+
+
+register_variant(
+    "deepresearch_bench",
+    "en",
+    data_source=DataSource(path=DEEPRESEARCH_BENCH_REPO, subset="en", split="test"),
+)

--- a/src/olmo_eval/evals/tasks/deepresearch_bench.py
+++ b/src/olmo_eval/evals/tasks/deepresearch_bench.py
@@ -857,12 +857,20 @@ def _fact_scoring_disabled() -> bool:
 
 def build_deepresearch_race_judge_fn() -> JudgeFn:
     """Build the RACE judge with medium effort unless a spec suffix overrides it."""
-    return _build_judge_fn(DEEPRESEARCH_RACE_DEFAULT_JUDGE_SPEC, "DeepResearchBenchRACE", "medium")
+    return _build_judge_fn(
+        os.getenv("OLMO_EVAL_JUDGE", DEEPRESEARCH_RACE_DEFAULT_JUDGE_SPEC),
+        "DeepResearchBenchRACE",
+        "medium",
+    )
 
 
 def build_deepresearch_fact_judge_fn() -> JudgeFn:
     """Build the FACT judge with low effort unless a spec suffix overrides it."""
-    return _build_judge_fn(DEEPRESEARCH_FACT_DEFAULT_JUDGE_SPEC, "DeepResearchBenchFACT", "low")
+    return _build_judge_fn(
+        os.getenv("OLMO_EVAL_JUDGE", DEEPRESEARCH_FACT_DEFAULT_JUDGE_SPEC),
+        "DeepResearchBenchFACT",
+        "low",
+    )
 
 
 @dataclass(frozen=True)

--- a/src/olmo_eval/evals/tasks/deepscholar_bench.py
+++ b/src/olmo_eval/evals/tasks/deepscholar_bench.py
@@ -10,14 +10,15 @@ The generation prompt is VERBATIM the one lit-agents runs
 character makes the two systems' outputs incomparable, so the template is
 pinned by a golden-string test.
 
-Scoring here is a placeholder. DeepScholar-Bench's published metrics (nugget
-coverage, citation precision, reference coverage) are a second pass run outside
-this repo: :mod:`olmo_eval.evals.tasks.deepscholar_export` converts saved
-predictions into the per-query ``{intro.md, final_report.md, paper.csv}``
-folders the upstream scorer reads. The metric computed here reports only
-whether a response is exportable at all -- it has answer text and at least one
-arXiv source in its trajectory -- so a run that produced nothing is visible
-without this task pretending to measure quality.
+Scoring here is a placeholder. DeepScholar-Bench's published metrics run as a
+second pass outside this repo, on the per-query folders
+:mod:`olmo_eval.evals.tasks.deepscholar_export` writes. What this task computes
+is whether that second pass will find anything at all: the prompt mandates
+numbered citations while the upstream parser only credits markdown links to
+arxiv.org/abs, so :mod:`olmo_eval.evals.tasks.deepscholar_citations` has to
+bridge the two, and ``exportable_rate`` runs that same bridge and counts the
+answers it succeeds on. A run whose citations never resolve is therefore
+visible here rather than only after external scoring returns zeros.
 
 Requirements: this task only produces signal under a tool-providing agentic
 harness exposing ``arxiv_paper_search`` (the ``arxiv_paper_search_agent``
@@ -51,6 +52,11 @@ from olmo_eval.common.types import (
     SamplingParams,
 )
 from olmo_eval.evals.tasks.common import Task, register
+from olmo_eval.evals.tasks.deepscholar_citations import (
+    reference_list,
+    resolve_numbering,
+    rewrite_intro,
+)
 from olmo_eval.harness.tools.search import normalize_arxiv_id
 
 logger = logging.getLogger(__name__)
@@ -76,7 +82,11 @@ _RESULT_SEPARATOR = "\n\n---\n\n"
 # The search tool marks a date it could only resolve to a month.
 _MONTH_PRECISION_SUFFIX = " (month precision)"
 _RESULT_FIELD_RE = re.compile(r"^(Authors|Year|Published|Abstract|arXiv|URL):[ \t]*(.*)$")
-_RESULT_TITLE_RE = re.compile(r"^\*\*(.+?)\*\*(?:\s*\[context only.*\])?$")
+_RESULT_TITLE_RE = re.compile(r"^\*\*(.+?)\*\*(?:\s*\[context only.*\])?$", re.DOTALL)
+# An ID on its own line. Read separately from the block parse so a result whose
+# free-text fields defeat the parser still contributes the one field the export
+# genuinely needs.
+_ARXIV_ID_LINE_RE = re.compile(r"^arXiv:[ \t]*(\S+)[ \t]*$", re.MULTILINE)
 
 
 def _first_nonempty(row: Mapping[str, Any], *keys: str) -> str:
@@ -160,10 +170,11 @@ def _parse_published_field(value: str) -> tuple[str, str]:
 def parse_arxiv_tool_results(content: str) -> list[dict[str, str]]:
     """Parse ``arxiv_paper_search`` output back into its per-result fields.
 
-    The rendered tool output is the only record of what the agent was shown, so
-    the export path reads it rather than re-querying Semantic Scholar; the same
-    query months later would not return the same page. Results marked context
-    only carry no arXiv ID and are skipped, because nothing can cite them.
+    Best-effort metadata only. The export re-fetches title and abstract from
+    Semantic Scholar, so a block this cannot parse costs a fallback snippet
+    rather than the source itself -- :func:`sources_from_trajectory` takes the
+    arXiv ID from its own line instead of from here. Results marked context only
+    carry no arXiv ID and are skipped, because nothing can cite them.
     """
     parsed: list[dict[str, str]] = []
     for block in (content or "").split(_RESULT_SEPARATOR):
@@ -185,7 +196,7 @@ def parse_arxiv_tool_results(content: str) -> list[dict[str, str]]:
                 # An abstract can wrap across lines; keep it whole.
                 fields[current] = f"{fields[current]}\n{line}"
 
-        arxiv_id = normalize_arxiv_id(fields.get("arxiv", ""))
+        arxiv_id = normalize_arxiv_id(fields.get("arxiv", "").strip())
         if not arxiv_id:
             continue
         published_date, date_precision = _parse_published_field(fields.get("published", ""))
@@ -205,22 +216,65 @@ def parse_arxiv_tool_results(content: str) -> list[dict[str, str]]:
 
 
 def sources_from_trajectory(trajectory: Any) -> list[dict[str, str]]:
-    """Collect every arXiv source the search tool showed, first mention winning."""
+    """Collect every arXiv source the search tool showed, first mention winning.
+
+    Only results of ``SEARCH_TOOL_NAME`` calls are read. Another tool's output
+    can mention an arXiv ID without the agent ever having been shown that paper
+    as a citable result, and crediting it would let a citation resolve against a
+    source the search never returned.
+    """
     if trajectory is None:
         return []
+    search_call_ids = {
+        call.id for call in trajectory.tool_call_sequence if call.function.name == SEARCH_TOOL_NAME
+    }
     by_id: dict[str, dict[str, str]] = {}
     for result in trajectory.tool_result_sequence:
-        for source in parse_arxiv_tool_results(result.content or ""):
-            by_id.setdefault(source["arxiv_id"], source)
+        if result.tool_call_id not in search_call_ids:
+            continue
+        content = result.content or ""
+        parsed = {item["arxiv_id"]: item for item in parse_arxiv_tool_results(content)}
+        for match in _ARXIV_ID_LINE_RE.finditer(content):
+            arxiv_id = normalize_arxiv_id(match.group(1))
+            if arxiv_id:
+                by_id.setdefault(arxiv_id, parsed.get(arxiv_id) or {"arxiv_id": arxiv_id})
     return list(by_id.values())
+
+
+def score_answer(answer: str, sources: Sequence[Mapping[str, str]]) -> dict[str, float]:
+    """Run the citation bridge over one answer and report what it achieved.
+
+    ``exportable_rate`` is whether the rewritten intro holds at least one
+    resolvable arxiv.org citation, which is exactly the condition under which
+    the upstream parser returns any documents for this query.
+    ``citation_resolution_rate`` is the share of the reference list the answer
+    published that resolved to a retrieved source -- the diagnostic that
+    separates "the model cited nothing" from "the model cited papers it never
+    retrieved" from "the bridge failed".
+    """
+    _, cited = rewrite_intro(answer, list(sources))
+    published_refs = reference_list(answer)
+    resolved = resolve_numbering(answer, list(sources))
+    return {
+        "exportable_rate": 1.0 if cited else 0.0,
+        "citation_resolution_rate": (
+            len(resolved) / len(published_refs) if published_refs else 0.0
+        ),
+    }
 
 
 @dataclass(frozen=True)
 class DeepScholarBenchScorer(Scorer):
-    """Placeholder scorer; DeepScholar-Bench scores are an external second pass."""
+    """Interface stub; both metrics read values ``score_responses`` precomputes.
+
+    ``Task.score_responses`` is overridden here, so the scorer pipeline never
+    runs and this method is never called. It reads the same key
+    ``score_responses`` writes so that if it ever is called it cannot report a
+    silent zero.
+    """
 
     name: str = "deepscholar_bench"
-    score_key: str = "exportable_rate"
+    score_key: str = "score:exportable_rate"
 
     def score(self, instance: Instance, output: LMOutput) -> float:
         return (output.metadata or {}).get(self.score_key, 0.0)
@@ -239,35 +293,27 @@ class _DeepScholarMetricBase(Metric, ABC):
 
 @dataclass(frozen=True)
 class ExportableRateMetric(_DeepScholarMetricBase):
-    """Fraction of responses that can be scored externally at all.
+    """Fraction of answers the external scoring pass will find citations in.
 
-    Not a quality measure: it is 1.0 for any response holding answer text and at
-    least one retrieved arXiv source, which is exactly the condition
-    ``deepscholar_export`` needs to write a query folder. Its job is to make a
-    run that generated nothing impossible to mistake for a run that scored zero.
+    Not a quality measure. It is 1.0 when the citation bridge turns the answer
+    into an intro holding at least one resolvable arxiv.org link, which is the
+    condition for the upstream parser to return any documents at all. Its job is
+    to make a run whose citations never resolve impossible to mistake for a run
+    that was scored and did badly.
     """
 
     name: str = "exportable_rate"
 
 
 @dataclass(frozen=True)
-class ArxivCitationRateMetric(_DeepScholarMetricBase):
-    """Fraction of responses whose answer cites at least one arxiv.org URL.
+class CitationResolutionRateMetric(_DeepScholarMetricBase):
+    """Share of each answer's published reference list that named a retrieved paper."""
 
-    The benchmark's citation parser credits arxiv.org URLs alone, so an answer
-    without one scores zero downstream however good its prose is.
-    """
-
-    name: str = "arxiv_citation_rate"
+    name: str = "citation_resolution_rate"
 
 
 EXPORTABLE_RATE_METRIC = ExportableRateMetric()
-DEEPSCHOLAR_METRICS = (EXPORTABLE_RATE_METRIC, ArxivCitationRateMetric())
-
-_ANSWER_ARXIV_URL_RE = re.compile(
-    r"https?://(?:www\.)?arxiv\.org/(?:abs|pdf)/([^)\s?#\]]+)",
-    re.IGNORECASE,
-)
+DEEPSCHOLAR_METRICS = (EXPORTABLE_RATE_METRIC, CitationResolutionRateMetric())
 
 
 @register("deepscholar_bench")
@@ -338,34 +384,26 @@ class DeepScholarBench(Task):
         responses: Sequence[Response],
         context: Any = None,
     ) -> Sequence[Response]:
-        """Record export readiness and stash the sources the export pass needs."""
+        """Run the citation bridge over each answer and record what it achieved."""
         missing_trajectory = 0
         for response in responses:
             if response.trajectory is None:
                 missing_trajectory += 1
             sources = sources_from_trajectory(response.trajectory)
             answer = response.outputs[0].text if response.outputs else ""
-            cited = {
-                normalize_arxiv_id(match.group(1))
-                for match in _ANSWER_ARXIV_URL_RE.finditer(answer or "")
-            }
-
-            response.scores.update(
-                {
-                    "exportable_rate": 1.0 if (answer.strip() and sources) else 0.0,
-                    "arxiv_citation_rate": 1.0 if cited else 0.0,
-                }
-            )
+            scores = score_answer(answer, sources)
+            response.scores.update(scores)
 
             if response.outputs:
                 meta = response.outputs[0].metadata
                 meta["deepscholar_source_arxiv_ids"] = [s["arxiv_id"] for s in sources]
-                meta["deepscholar_cited_arxiv_ids"] = sorted(cited)
                 meta["deepscholar_num_searches"] = (
                     len(response.trajectory.tool_calls_by_name(SEARCH_TOOL_NAME))
                     if response.trajectory is not None
                     else 0
                 )
+                for name, value in scores.items():
+                    meta[f"score:{name}"] = value
 
         if missing_trajectory:
             logger.warning(

--- a/src/olmo_eval/evals/tasks/deepscholar_bench.py
+++ b/src/olmo_eval/evals/tasks/deepscholar_bench.py
@@ -56,7 +56,7 @@ from olmo_eval.evals.tasks.deepscholar_citations import (
     reference_list,
     resolve_numbering,
     rewrite_intro,
-    split_final_report,
+    select_scored_text,
     strip_references,
     unresolved_citation_forms,
 )
@@ -268,15 +268,22 @@ def score_answer(answer: str, sources: Sequence[Mapping[str, str]]) -> dict[str,
     before, and this only records how often that happened, because the same
     prompt run on a different backbone can comply at a very different rate.
 
+    ``marker_misuse_rate`` is the share that wrote the marker and then put the
+    report above it. Those are scored on their full text rather than on the
+    empty half they nominated, so the number costs nothing -- it exists because
+    a backbone doing this is telling you the prompt is ambiguous to it.
+
     ``unresolved_citation_forms`` counts citation shapes no pass can turn into a
     link -- superscripts, footnote markers, author-year brackets. An answer that
     cited carefully in a style this bridge does not read scores zero on the other
     two, and without this it would look identical to one that never cited.
     """
-    # Everything below the marker, or the whole answer when there is none --
-    # the same split the export applies, so a number reported during the run
-    # and a number reported after export describe the same text.
-    report, marker_found = split_final_report(answer)
+    # Everything below the marker, or the whole answer when there is none, or
+    # the whole answer again when the marker was honoured but the report was
+    # written above it -- the same choice the export makes, so a number
+    # reported during the run and one reported after export describe the same
+    # text.
+    report, marker_found, marker_misused = select_scored_text(answer, list(sources))
     _, cited = rewrite_intro(report, list(sources))
     published_refs = reference_list(report)
     resolved = resolve_numbering(report, list(sources))
@@ -287,6 +294,7 @@ def score_answer(answer: str, sources: Sequence[Mapping[str, str]]) -> dict[str,
         ),
         "unresolved_citation_forms": float(unresolved_citation_forms(strip_references(report))),
         "marker_compliance_rate": 1.0 if marker_found else 0.0,
+        "marker_misuse_rate": 1.0 if marker_misused else 0.0,
     }
 
 
@@ -366,12 +374,27 @@ class MarkerComplianceRateMetric(_DeepScholarMetricBase):
     name: str = "marker_compliance_rate"
 
 
+@dataclass(frozen=True)
+class MarkerMisuseRateMetric(_DeepScholarMetricBase):
+    """Share of answers that wrote the marker and put the report above it.
+
+    Costs the answer nothing -- the export falls back to its full text, which
+    is what it would have been scored on with no marker at all. It is reported
+    because it is the one number that separates a backbone that cannot follow
+    the instruction from a prompt that reads two ways, and the first version of
+    this preset's prompt read two ways to Qwen3.5-9B.
+    """
+
+    name: str = "marker_misuse_rate"
+
+
 EXPORTABLE_RATE_METRIC = ExportableRateMetric()
 DEEPSCHOLAR_METRICS = (
     EXPORTABLE_RATE_METRIC,
     CitationResolutionRateMetric(),
     UnresolvedCitationFormsMetric(),
     MarkerComplianceRateMetric(),
+    MarkerMisuseRateMetric(),
 )
 
 

--- a/src/olmo_eval/evals/tasks/deepscholar_bench.py
+++ b/src/olmo_eval/evals/tasks/deepscholar_bench.py
@@ -56,6 +56,8 @@ from olmo_eval.evals.tasks.deepscholar_citations import (
     reference_list,
     resolve_numbering,
     rewrite_intro,
+    strip_references,
+    unresolved_citation_forms,
 )
 from olmo_eval.harness.tools.search import normalize_arxiv_id
 
@@ -81,12 +83,11 @@ DEEPSCHOLAR_QUERY_TEMPLATE = """Your task is to write a Related Works section fo
 _RESULT_SEPARATOR = "\n\n---\n\n"
 # The search tool marks a date it could only resolve to a month.
 _MONTH_PRECISION_SUFFIX = " (month precision)"
-_RESULT_FIELD_RE = re.compile(r"^(Authors|Year|Published|Abstract|arXiv|URL):[ \t]*(.*)$")
-_RESULT_TITLE_RE = re.compile(r"^\*\*(.+?)\*\*(?:\s*\[context only.*\])?$", re.DOTALL)
-# An ID on its own line. Read separately from the block parse so a result whose
-# free-text fields defeat the parser still contributes the one field the export
-# genuinely needs.
-_ARXIV_ID_LINE_RE = re.compile(r"^arXiv:[ \t]*(\S+)[ \t]*$", re.MULTILINE)
+# Fields the search tool renders before the abstract. Matched only while still
+# in a block's header: once the abstract starts, every remaining line is text.
+_RESULT_HEADER_FIELD_RE = re.compile(r"^(Authors|Year|Published|arXiv|URL):[ \t]*(.*)$")
+_ABSTRACT_FIELD_PREFIX = "Abstract:"
+_RESULT_TITLE_RE = re.compile(r"^\*\*(.+?)\*\*(?:\s*\[context only.*\])?$")
 
 
 def _first_nonempty(row: Mapping[str, Any], *keys: str) -> str:
@@ -170,31 +171,42 @@ def _parse_published_field(value: str) -> tuple[str, str]:
 def parse_arxiv_tool_results(content: str) -> list[dict[str, str]]:
     """Parse ``arxiv_paper_search`` output back into its per-result fields.
 
-    Best-effort metadata only. The export re-fetches title and abstract from
-    Semantic Scholar, so a block this cannot parse costs a fallback snippet
-    rather than the source itself -- :func:`sources_from_trajectory` takes the
-    arXiv ID from its own line instead of from here. Results marked context only
-    carry no arXiv ID and are skipped, because nothing can cite them.
+    A block's identity comes from its header -- the lines between the title and
+    the abstract -- and from nowhere else. The abstract is the one field a paper
+    controls the text of, so once it starts, every remaining line in the block is
+    read as text even when it is shaped exactly like a field. Without that, a
+    paper whose abstract contains "arXiv: 1234.56789" on its own line would
+    rename itself, and a context-only block quoting one would invent a citable
+    source out of a result the tool explicitly refused to make citable.
+
+    A block with no arXiv ID in its header is not a citable result: that covers
+    the context-only blocks and any prose the tool emitted around them.
     """
     parsed: list[dict[str, str]] = []
     for block in (content or "").split(_RESULT_SEPARATOR):
         lines = block.strip().splitlines()
         if not lines:
             continue
-        title_match = _RESULT_TITLE_RE.match(lines[0].strip())
-        if title_match is None:
-            continue
 
-        fields: dict[str, str] = {"title": title_match.group(1).strip()}
-        current: str | None = None
+        title_match = _RESULT_TITLE_RE.match(lines[0].strip())
+        # A title the renderer mangled still leaves a readable header, and the
+        # export re-fetches titles anyway, so this does not reject the block.
+        fields: dict[str, str] = {
+            "title": title_match.group(1).strip() if title_match else lines[0].strip("* ").strip()
+        }
+        abstract_lines: list[str] = []
+        in_abstract = False
         for line in lines[1:]:
-            field_match = _RESULT_FIELD_RE.match(line)
+            if in_abstract:
+                abstract_lines.append(line)
+                continue
+            if line.startswith(_ABSTRACT_FIELD_PREFIX):
+                in_abstract = True
+                abstract_lines.append(line[len(_ABSTRACT_FIELD_PREFIX) :].strip())
+                continue
+            field_match = _RESULT_HEADER_FIELD_RE.match(line)
             if field_match is not None:
-                current = field_match.group(1).lower()
-                fields[current] = field_match.group(2)
-            elif current is not None:
-                # An abstract can wrap across lines; keep it whole.
-                fields[current] = f"{fields[current]}\n{line}"
+                fields[field_match.group(1).lower()] = field_match.group(2)
 
         arxiv_id = normalize_arxiv_id(fields.get("arxiv", "").strip())
         if not arxiv_id:
@@ -208,7 +220,7 @@ def parse_arxiv_tool_results(content: str) -> list[dict[str, str]]:
                 "year": fields.get("year", "").strip(),
                 "published_date": published_date,
                 "date_precision": date_precision,
-                "abstract": fields.get("abstract", "").strip(),
+                "abstract": "\n".join(abstract_lines).strip(),
                 "url": fields.get("url", "").strip() or f"https://arxiv.org/abs/{arxiv_id}",
             }
         )
@@ -221,7 +233,8 @@ def sources_from_trajectory(trajectory: Any) -> list[dict[str, str]]:
     Only results of ``SEARCH_TOOL_NAME`` calls are read. Another tool's output
     can mention an arXiv ID without the agent ever having been shown that paper
     as a citable result, and crediting it would let a citation resolve against a
-    source the search never returned.
+    source the search never returned. Within those results, identity comes from
+    each block's header; see :func:`parse_arxiv_tool_results`.
     """
     if trajectory is None:
         return []
@@ -232,12 +245,8 @@ def sources_from_trajectory(trajectory: Any) -> list[dict[str, str]]:
     for result in trajectory.tool_result_sequence:
         if result.tool_call_id not in search_call_ids:
             continue
-        content = result.content or ""
-        parsed = {item["arxiv_id"]: item for item in parse_arxiv_tool_results(content)}
-        for match in _ARXIV_ID_LINE_RE.finditer(content):
-            arxiv_id = normalize_arxiv_id(match.group(1))
-            if arxiv_id:
-                by_id.setdefault(arxiv_id, parsed.get(arxiv_id) or {"arxiv_id": arxiv_id})
+        for source in parse_arxiv_tool_results(result.content or ""):
+            by_id.setdefault(source["arxiv_id"], source)
     return list(by_id.values())
 
 
@@ -251,6 +260,11 @@ def score_answer(answer: str, sources: Sequence[Mapping[str, str]]) -> dict[str,
     published that resolved to a retrieved source -- the diagnostic that
     separates "the model cited nothing" from "the model cited papers it never
     retrieved" from "the bridge failed".
+
+    ``unresolved_citation_forms`` counts citation shapes no pass can turn into a
+    link -- superscripts, footnote markers, author-year brackets. An answer that
+    cited carefully in a style this bridge does not read scores zero on the other
+    two, and without this it would look identical to one that never cited.
     """
     _, cited = rewrite_intro(answer, list(sources))
     published_refs = reference_list(answer)
@@ -260,6 +274,7 @@ def score_answer(answer: str, sources: Sequence[Mapping[str, str]]) -> dict[str,
         "citation_resolution_rate": (
             len(resolved) / len(published_refs) if published_refs else 0.0
         ),
+        "unresolved_citation_forms": float(unresolved_citation_forms(strip_references(answer))),
     }
 
 
@@ -312,8 +327,24 @@ class CitationResolutionRateMetric(_DeepScholarMetricBase):
     name: str = "citation_resolution_rate"
 
 
+@dataclass(frozen=True)
+class UnresolvedCitationFormsMetric(_DeepScholarMetricBase):
+    """Mean count per answer of citation shapes the bridge cannot read.
+
+    A count, not a rate. Non-zero means answers are citing in a style -- footnote
+    markers, superscripts, author-year -- that scores zero here for a reason that
+    has nothing to do with the papers they found.
+    """
+
+    name: str = "unresolved_citation_forms"
+
+
 EXPORTABLE_RATE_METRIC = ExportableRateMetric()
-DEEPSCHOLAR_METRICS = (EXPORTABLE_RATE_METRIC, CitationResolutionRateMetric())
+DEEPSCHOLAR_METRICS = (
+    EXPORTABLE_RATE_METRIC,
+    CitationResolutionRateMetric(),
+    UnresolvedCitationFormsMetric(),
+)
 
 
 @register("deepscholar_bench")

--- a/src/olmo_eval/evals/tasks/deepscholar_bench.py
+++ b/src/olmo_eval/evals/tasks/deepscholar_bench.py
@@ -1,0 +1,356 @@
+"""DeepScholar-Bench related-works generation (github.com/guestrin-lab/deepscholar).
+
+63 recent arXiv papers, each supplying its abstract and its own publication
+date. The model writes that paper's Related Works section and may cite only
+arXiv papers published before that date, which is what makes this a live
+literature-search task rather than a recall-from-memory one.
+
+The generation prompt is VERBATIM the one lit-agents runs
+(``integrated/shared/deepscholar.py::QUERY_TEMPLATE``). A single changed
+character makes the two systems' outputs incomparable, so the template is
+pinned by a golden-string test.
+
+Scoring here is a placeholder. DeepScholar-Bench's published metrics (nugget
+coverage, citation precision, reference coverage) are a second pass run outside
+this repo: :mod:`olmo_eval.evals.tasks.deepscholar_export` converts saved
+predictions into the per-query ``{intro.md, final_report.md, paper.csv}``
+folders the upstream scorer reads. The metric computed here reports only
+whether a response is exportable at all -- it has answer text and at least one
+arXiv source in its trajectory -- so a run that produced nothing is visible
+without this task pretending to measure quality.
+
+Requirements: this task only produces signal under a tool-providing agentic
+harness exposing ``arxiv_paper_search`` (the ``arxiv_paper_search_agent``
+preset). The per-instance cutoff reaches that tool through
+``Instance.metadata["retrieval_date_cutoff"]``, which the runner forwards into
+the scaffold's ``search_date_cutoff`` block.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from abc import ABC
+from collections.abc import Iterator, Mapping, Sequence
+from dataclasses import dataclass
+from datetime import date, datetime
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from olmo_eval.common.metrics import Metric
+from olmo_eval.common.scorers.base import Scorer
+from olmo_eval.common.types import (
+    Instance,
+    LMOutput,
+    LMRequest,
+    RequestType,
+    Response,
+    SamplingParams,
+)
+from olmo_eval.evals.tasks.common import Task, register
+from olmo_eval.harness.tools.search import normalize_arxiv_id
+
+logger = logging.getLogger(__name__)
+
+DEEPSCHOLAR_REPO = "guestrin-lab/deepscholar"
+# Pinned rather than tracking a branch: this file is the query set, so a silent
+# upstream edit would change what the reported numbers mean.
+DEEPSCHOLAR_COMMIT = "c95413b3b2f3255b461b90d0ce650f685ae2d1ff"
+DEEPSCHOLAR_DATASET_PATH = "dataset/papers_with_related_works.csv"
+DEEPSCHOLAR_DATASET_URL = (
+    f"https://raw.githubusercontent.com/{DEEPSCHOLAR_REPO}/"
+    f"{DEEPSCHOLAR_COMMIT}/{DEEPSCHOLAR_DATASET_PATH}"
+)
+
+SEARCH_TOOL_NAME = "arxiv_paper_search"
+
+# VERBATIM from lit-agents' shared/deepscholar.py::QUERY_TEMPLATE, which is what
+# the systems this task is compared against were prompted with.
+DEEPSCHOLAR_QUERY_TEMPLATE = """Your task is to write a Related Works section for an academic paper given the paper's abstract. Your response should provide the Related Works section and references. Only include references from arXiv that are published before {cutoff_date}. Mention them in a separate, numbered reference list at the end and use the reference numbers to provide in-line citations in the Related Works section for all claims referring to a source (e.g., description of source [3]. Further details [6][7][8][9][10].) Each in-line citation must consist of a single reference number within a pair of brackets. Do not use any other citation format. Do not exceed 600 words for the related works section. Here is the paper abstract: {abstract}"""
+
+# The blocks and labels arxiv_paper_search renders (see harness/tools/search.py).
+_RESULT_SEPARATOR = "\n\n---\n\n"
+_RESULT_FIELD_RE = re.compile(r"^(Authors|Year|Abstract|arXiv|URL):[ \t]*(.*)$")
+_RESULT_TITLE_RE = re.compile(r"^\*\*(.+?)\*\*(?:\s*\[context only.*\])?$")
+
+
+def _first_nonempty(row: Mapping[str, Any], *keys: str) -> str:
+    """First key holding a non-blank value, stripped; "" when none does.
+
+    Mirrors lit-agents' loader so an instance built here carries exactly the
+    text lit-agents would interpolate into the same prompt.
+    """
+    for key in keys:
+        value = row.get(key)
+        if value is not None and str(value).strip():
+            return str(value).strip()
+    return ""
+
+
+def _parse_iso_date(value: str) -> date | None:
+    """Parse an ISO timestamp or date into a date, or None when unparseable."""
+    text = value.strip()
+    if not text:
+        return None
+    try:
+        return datetime.fromisoformat(text.replace("Z", "+00:00")).date()
+    except ValueError:
+        try:
+            return date.fromisoformat(text[:10])
+        except ValueError:
+            return None
+
+
+def _dataset_cache_dir() -> Path:
+    """Cache root, following the same env-var precedence as the RULER loader."""
+    cache_dir = os.environ.get("HF_DATASETS_CACHE")
+    if not cache_dir:
+        hf_home = os.environ.get("HF_HOME") or os.path.join(
+            os.environ.get("XDG_CACHE_HOME", "~/.cache"), "huggingface"
+        )
+        cache_dir = os.path.join(hf_home, "datasets")
+    return Path(os.path.expanduser(cache_dir)) / "guestrin-lab--deepscholar"
+
+
+def download_deepscholar_dataset() -> Path:
+    """Fetch the pinned dataset CSV once, returning its cached path."""
+    target = _dataset_cache_dir() / f"{DEEPSCHOLAR_COMMIT}-papers_with_related_works.csv"
+    if target.exists():
+        return target
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+    logger.info("Downloading DeepScholar-Bench dataset to %s", target)
+    response = httpx.get(DEEPSCHOLAR_DATASET_URL, timeout=60.0, follow_redirects=True)
+    response.raise_for_status()
+    # Written via a temporary so a killed download cannot leave a truncated CSV
+    # that later runs would treat as the pinned dataset.
+    temporary = target.with_name(f".{target.name}.{os.getpid()}.tmp")
+    temporary.write_bytes(response.content)
+    os.replace(temporary, target)
+    return target
+
+
+def build_deepscholar_prompt(cutoff_date: str, abstract: str) -> str:
+    """Fill the verbatim DeepScholar-Bench template for one paper."""
+    return DEEPSCHOLAR_QUERY_TEMPLATE.format(cutoff_date=cutoff_date, abstract=abstract)
+
+
+def parse_arxiv_tool_results(content: str) -> list[dict[str, str]]:
+    """Parse ``arxiv_paper_search`` output back into its per-result fields.
+
+    The rendered tool output is the only record of what the agent was shown, so
+    the export path reads it rather than re-querying Semantic Scholar; the same
+    query months later would not return the same page. Results marked context
+    only carry no arXiv ID and are skipped, because nothing can cite them.
+    """
+    parsed: list[dict[str, str]] = []
+    for block in (content or "").split(_RESULT_SEPARATOR):
+        lines = block.strip().splitlines()
+        if not lines:
+            continue
+        title_match = _RESULT_TITLE_RE.match(lines[0].strip())
+        if title_match is None:
+            continue
+
+        fields: dict[str, str] = {"title": title_match.group(1).strip()}
+        current: str | None = None
+        for line in lines[1:]:
+            field_match = _RESULT_FIELD_RE.match(line)
+            if field_match is not None:
+                current = field_match.group(1).lower()
+                fields[current] = field_match.group(2)
+            elif current is not None:
+                # An abstract can wrap across lines; keep it whole.
+                fields[current] = f"{fields[current]}\n{line}"
+
+        arxiv_id = normalize_arxiv_id(fields.get("arxiv", ""))
+        if not arxiv_id:
+            continue
+        parsed.append(
+            {
+                "arxiv_id": arxiv_id,
+                "title": fields["title"],
+                "authors": fields.get("authors", "").strip(),
+                "year": fields.get("year", "").strip(),
+                "abstract": fields.get("abstract", "").strip(),
+                "url": fields.get("url", "").strip() or f"https://arxiv.org/abs/{arxiv_id}",
+            }
+        )
+    return parsed
+
+
+def sources_from_trajectory(trajectory: Any) -> list[dict[str, str]]:
+    """Collect every arXiv source the search tool showed, first mention winning."""
+    if trajectory is None:
+        return []
+    by_id: dict[str, dict[str, str]] = {}
+    for result in trajectory.tool_result_sequence:
+        for source in parse_arxiv_tool_results(result.content or ""):
+            by_id.setdefault(source["arxiv_id"], source)
+    return list(by_id.values())
+
+
+@dataclass(frozen=True)
+class DeepScholarBenchScorer(Scorer):
+    """Placeholder scorer; DeepScholar-Bench scores are an external second pass."""
+
+    name: str = "deepscholar_bench"
+    score_key: str = "exportable_rate"
+
+    def score(self, instance: Instance, output: LMOutput) -> float:
+        return (output.metadata or {}).get(self.score_key, 0.0)
+
+
+class _DeepScholarMetricBase(Metric, ABC):
+    """Base for metrics reading values precomputed in ``score_responses``."""
+
+    scorer: type[Scorer] = DeepScholarBenchScorer
+
+    def compute(self, responses: Sequence[Response]) -> float:
+        if not responses:
+            return 0.0
+        return sum(r.scores.get(self.name, 0.0) for r in responses) / len(responses)
+
+
+@dataclass(frozen=True)
+class ExportableRateMetric(_DeepScholarMetricBase):
+    """Fraction of responses that can be scored externally at all.
+
+    Not a quality measure: it is 1.0 for any response holding answer text and at
+    least one retrieved arXiv source, which is exactly the condition
+    ``deepscholar_export`` needs to write a query folder. Its job is to make a
+    run that generated nothing impossible to mistake for a run that scored zero.
+    """
+
+    name: str = "exportable_rate"
+
+
+@dataclass(frozen=True)
+class ArxivCitationRateMetric(_DeepScholarMetricBase):
+    """Fraction of responses whose answer cites at least one arxiv.org URL.
+
+    The benchmark's citation parser credits arxiv.org URLs alone, so an answer
+    without one scores zero downstream however good its prose is.
+    """
+
+    name: str = "arxiv_citation_rate"
+
+
+EXPORTABLE_RATE_METRIC = ExportableRateMetric()
+DEEPSCHOLAR_METRICS = (EXPORTABLE_RATE_METRIC, ArxivCitationRateMetric())
+
+_ANSWER_ARXIV_URL_RE = re.compile(
+    r"https?://(?:www\.)?arxiv\.org/(?:abs|pdf)/([^)\s?#\]]+)",
+    re.IGNORECASE,
+)
+
+
+@register("deepscholar_bench")
+class DeepScholarBench(Task):
+    """DeepScholar-Bench related-works generation over live arXiv search."""
+
+    metrics = DEEPSCHOLAR_METRICS
+    primary_metric = EXPORTABLE_RATE_METRIC
+    # A related-works section plus its reference list is long-form output; this
+    # matches deepresearch_bench rather than the short-answer tasks'. Whether it
+    # takes effect depends on the harness threading sampling_params through.
+    sampling_params = SamplingParams(temperature=0.0, max_tokens=16_384)
+
+    @property
+    def instances(self) -> Iterator[Instance]:
+        """Load the pinned CSV, keeping upstream's positional query IDs."""
+        if self._instances_cache is None:
+            from olmo_eval.data import DataLoader, DataSource
+
+            loader = DataLoader()
+            source = DataSource(path=str(download_deepscholar_dataset()))
+            self._instances_cache = []
+            for index, doc in enumerate(loader.load(source)):
+                instance = self.process_doc(doc, index)
+                if instance is not None:
+                    self._instances_cache.append(instance)
+        yield from self._instances_cache
+
+    def process_doc(self, doc: dict[str, Any], index: int = 0) -> Instance | None:
+        abstract = _first_nonempty(doc, "abstract")
+        cutoff = _parse_iso_date(_first_nonempty(doc, "published_date", "cutoff_date"))
+        if not abstract or cutoff is None:
+            return None
+
+        return Instance(
+            question=abstract,
+            metadata={
+                # Upstream identifies a query by its row position, and the export
+                # folders are named for it, so the ID has to stay positional.
+                "id": str(index),
+                "case_id": f"deepscholar_{index}",
+                "index": index,
+                "title": _first_nonempty(doc, "title") or f"DeepScholar query {index}",
+                "arxiv_id": normalize_arxiv_id(_first_nonempty(doc, "arxiv_id")),
+                "cutoff_date": cutoff.isoformat(),
+                # Read by the runner and applied to the search tools as this
+                # instance's date cutoff.
+                "retrieval_date_cutoff": cutoff.isoformat(),
+            },
+        )
+
+    def format_request(self, instance: Instance) -> LMRequest:
+        return LMRequest(
+            request_type=RequestType.CHAT,
+            messages=(
+                {
+                    "role": "user",
+                    "content": build_deepscholar_prompt(
+                        cutoff_date=instance.metadata["cutoff_date"],
+                        abstract=instance.question,
+                    ),
+                },
+            ),
+        )
+
+    async def score_responses(
+        self,
+        responses: Sequence[Response],
+        context: Any = None,
+    ) -> Sequence[Response]:
+        """Record export readiness and stash the sources the export pass needs."""
+        missing_trajectory = 0
+        for response in responses:
+            if response.trajectory is None:
+                missing_trajectory += 1
+            sources = sources_from_trajectory(response.trajectory)
+            answer = response.outputs[0].text if response.outputs else ""
+            cited = {
+                normalize_arxiv_id(match.group(1))
+                for match in _ANSWER_ARXIV_URL_RE.finditer(answer or "")
+            }
+
+            response.scores.update(
+                {
+                    "exportable_rate": 1.0 if (answer.strip() and sources) else 0.0,
+                    "arxiv_citation_rate": 1.0 if cited else 0.0,
+                }
+            )
+
+            if response.outputs:
+                meta = response.outputs[0].metadata
+                meta["deepscholar_source_arxiv_ids"] = [s["arxiv_id"] for s in sources]
+                meta["deepscholar_cited_arxiv_ids"] = sorted(cited)
+                meta["deepscholar_num_searches"] = (
+                    len(response.trajectory.tool_calls_by_name(SEARCH_TOOL_NAME))
+                    if response.trajectory is not None
+                    else 0
+                )
+
+        if missing_trajectory:
+            logger.warning(
+                "DeepScholar-Bench scored %d/%d responses with no trajectory; this task needs "
+                "an agentic harness exposing the %s tool, else nothing is exportable.",
+                missing_trajectory,
+                len(responses),
+                SEARCH_TOOL_NAME,
+            )
+        return responses

--- a/src/olmo_eval/evals/tasks/deepscholar_bench.py
+++ b/src/olmo_eval/evals/tasks/deepscholar_bench.py
@@ -73,7 +73,9 @@ DEEPSCHOLAR_QUERY_TEMPLATE = """Your task is to write a Related Works section fo
 
 # The blocks and labels arxiv_paper_search renders (see harness/tools/search.py).
 _RESULT_SEPARATOR = "\n\n---\n\n"
-_RESULT_FIELD_RE = re.compile(r"^(Authors|Year|Abstract|arXiv|URL):[ \t]*(.*)$")
+# The search tool marks a date it could only resolve to a month.
+_MONTH_PRECISION_SUFFIX = " (month precision)"
+_RESULT_FIELD_RE = re.compile(r"^(Authors|Year|Published|Abstract|arXiv|URL):[ \t]*(.*)$")
 _RESULT_TITLE_RE = re.compile(r"^\*\*(.+?)\*\*(?:\s*\[context only.*\])?$")
 
 
@@ -138,6 +140,23 @@ def build_deepscholar_prompt(cutoff_date: str, abstract: str) -> str:
     return DEEPSCHOLAR_QUERY_TEMPLATE.format(cutoff_date=cutoff_date, abstract=abstract)
 
 
+def _parse_published_field(value: str) -> tuple[str, str]:
+    """Split a rendered ``Published`` line into an ISO date and its precision.
+
+    Returns ``("", "")`` for anything unparseable, which sends the caller to the
+    arXiv-ID fallback rather than writing a date the contract would reject.
+    """
+    text = value.strip()
+    if not text:
+        return "", ""
+    if text.endswith(_MONTH_PRECISION_SUFFIX):
+        month = text[: -len(_MONTH_PRECISION_SUFFIX)].strip()
+        parsed = _parse_iso_date(f"{month}-01")
+        return ("", "") if parsed is None else (parsed.isoformat(), "month")
+    parsed = _parse_iso_date(text)
+    return ("", "") if parsed is None else (parsed.isoformat(), "day")
+
+
 def parse_arxiv_tool_results(content: str) -> list[dict[str, str]]:
     """Parse ``arxiv_paper_search`` output back into its per-result fields.
 
@@ -169,12 +188,15 @@ def parse_arxiv_tool_results(content: str) -> list[dict[str, str]]:
         arxiv_id = normalize_arxiv_id(fields.get("arxiv", ""))
         if not arxiv_id:
             continue
+        published_date, date_precision = _parse_published_field(fields.get("published", ""))
         parsed.append(
             {
                 "arxiv_id": arxiv_id,
                 "title": fields["title"],
                 "authors": fields.get("authors", "").strip(),
                 "year": fields.get("year", "").strip(),
+                "published_date": published_date,
+                "date_precision": date_precision,
                 "abstract": fields.get("abstract", "").strip(),
                 "url": fields.get("url", "").strip() or f"https://arxiv.org/abs/{arxiv_id}",
             }

--- a/src/olmo_eval/evals/tasks/deepscholar_bench.py
+++ b/src/olmo_eval/evals/tasks/deepscholar_bench.py
@@ -56,6 +56,7 @@ from olmo_eval.evals.tasks.deepscholar_citations import (
     reference_list,
     resolve_numbering,
     rewrite_intro,
+    split_final_report,
     strip_references,
     unresolved_citation_forms,
 )
@@ -261,20 +262,31 @@ def score_answer(answer: str, sources: Sequence[Mapping[str, str]]) -> dict[str,
     separates "the model cited nothing" from "the model cited papers it never
     retrieved" from "the bridge failed".
 
+    ``marker_compliance_rate`` is whether the answer delivered its report under
+    the marker line the preset's system prompt mandates. Bookkeeping, not
+    quality: an answer without the marker is scored on its full text exactly as
+    before, and this only records how often that happened, because the same
+    prompt run on a different backbone can comply at a very different rate.
+
     ``unresolved_citation_forms`` counts citation shapes no pass can turn into a
     link -- superscripts, footnote markers, author-year brackets. An answer that
     cited carefully in a style this bridge does not read scores zero on the other
     two, and without this it would look identical to one that never cited.
     """
-    _, cited = rewrite_intro(answer, list(sources))
-    published_refs = reference_list(answer)
-    resolved = resolve_numbering(answer, list(sources))
+    # Everything below the marker, or the whole answer when there is none --
+    # the same split the export applies, so a number reported during the run
+    # and a number reported after export describe the same text.
+    report, marker_found = split_final_report(answer)
+    _, cited = rewrite_intro(report, list(sources))
+    published_refs = reference_list(report)
+    resolved = resolve_numbering(report, list(sources))
     return {
         "exportable_rate": 1.0 if cited else 0.0,
         "citation_resolution_rate": (
             len(resolved) / len(published_refs) if published_refs else 0.0
         ),
-        "unresolved_citation_forms": float(unresolved_citation_forms(strip_references(answer))),
+        "unresolved_citation_forms": float(unresolved_citation_forms(strip_references(report))),
+        "marker_compliance_rate": 1.0 if marker_found else 0.0,
     }
 
 
@@ -339,11 +351,27 @@ class UnresolvedCitationFormsMetric(_DeepScholarMetricBase):
     name: str = "unresolved_citation_forms"
 
 
+@dataclass(frozen=True)
+class MarkerComplianceRateMetric(_DeepScholarMetricBase):
+    """Share of answers that delivered under the mandated final-report marker.
+
+    Not a quality measure and never a penalty: an answer that skips the marker
+    is scored on its whole text, as every answer was before the contract
+    existed. It is here because compliance is a property of the backbone rather
+    than of the prompt -- one model puts the line where it was asked to and the
+    next buries it in prose -- and scored deliberation looks like a bad report
+    unless this number says otherwise.
+    """
+
+    name: str = "marker_compliance_rate"
+
+
 EXPORTABLE_RATE_METRIC = ExportableRateMetric()
 DEEPSCHOLAR_METRICS = (
     EXPORTABLE_RATE_METRIC,
     CitationResolutionRateMetric(),
     UnresolvedCitationFormsMetric(),
+    MarkerComplianceRateMetric(),
 )
 
 

--- a/src/olmo_eval/evals/tasks/deepscholar_bench.py
+++ b/src/olmo_eval/evals/tasks/deepscholar_bench.py
@@ -53,6 +53,7 @@ from olmo_eval.common.types import (
 )
 from olmo_eval.evals.tasks.common import Task, register
 from olmo_eval.evals.tasks.deepscholar_citations import (
+    SPLIT_TIER_NONE,
     reference_list,
     resolve_numbering,
     rewrite_intro,
@@ -283,7 +284,7 @@ def score_answer(answer: str, sources: Sequence[Mapping[str, str]]) -> dict[str,
     # written above it -- the same choice the export makes, so a number
     # reported during the run and one reported after export describe the same
     # text.
-    report, marker_found, marker_misused = select_scored_text(answer, list(sources))
+    report, split_tier, marker_found, marker_misused = select_scored_text(answer, list(sources))
     _, cited = rewrite_intro(report, list(sources))
     published_refs = reference_list(report)
     resolved = resolve_numbering(report, list(sources))
@@ -295,6 +296,7 @@ def score_answer(answer: str, sources: Sequence[Mapping[str, str]]) -> dict[str,
         "unresolved_citation_forms": float(unresolved_citation_forms(strip_references(report))),
         "marker_compliance_rate": 1.0 if marker_found else 0.0,
         "marker_misuse_rate": 1.0 if marker_misused else 0.0,
+        "split_coverage_rate": 0.0 if split_tier == SPLIT_TIER_NONE else 1.0,
     }
 
 
@@ -388,6 +390,19 @@ class MarkerMisuseRateMetric(_DeepScholarMetricBase):
     name: str = "marker_misuse_rate"
 
 
+@dataclass(frozen=True)
+class SplitCoverageRateMetric(_DeepScholarMetricBase):
+    """Share of answers whose report some tier located.
+
+    Not quality either. It is 0 for an answer the splitter had to keep whole,
+    which is the case where the scored text still carries the model's
+    planning. A run with high exportable_rate and low coverage is being
+    judged largely on deliberation.
+    """
+
+    name: str = "split_coverage_rate"
+
+
 EXPORTABLE_RATE_METRIC = ExportableRateMetric()
 DEEPSCHOLAR_METRICS = (
     EXPORTABLE_RATE_METRIC,
@@ -395,6 +410,7 @@ DEEPSCHOLAR_METRICS = (
     UnresolvedCitationFormsMetric(),
     MarkerComplianceRateMetric(),
     MarkerMisuseRateMetric(),
+    SplitCoverageRateMetric(),
 )
 
 

--- a/src/olmo_eval/evals/tasks/deepscholar_citations.py
+++ b/src/olmo_eval/evals/tasks/deepscholar_citations.py
@@ -1,0 +1,313 @@
+"""Rewrite a DeepScholar-Bench answer's citations into the form the scorer reads.
+
+The benchmark prompt mandates numbered inline citations ("[3]") plus a numbered
+reference list. The upstream scorer disagrees: ``DeepScholarBaseParser`` (at the
+pinned commit c95413b3b2f3255b461b90d0ce650f685ae2d1ff,
+``eval/parsers/deepscholar_base.py``) recognises a citation *only* as a markdown
+link whose URL matches ``arxiv.org/abs/``, and a query whose ``intro.md`` holds
+none of those yields no documents at all. A prompt-compliant answer therefore
+scores zero unless something bridges the two forms.
+
+lit-agents bridges it in ``shared/deepscholar.py::render_intro`` (read-only
+reference), and this module mirrors that function's semantics: strip the
+reference list, resolve every inline citation against the retrieved sources,
+rewrite each resolved one as ``[Title](https://arxiv.org/abs/<id>)``, and delete
+the ones that resolve to nothing rather than leave a marker the parser would
+misread.
+
+The one thing it cannot mirror is where the numbering comes from. lit-agents'
+graphs publish a ``citation_order`` in their state, recording which paper each
+number means. Here the model writes its own reference list and nothing else
+records the mapping, so :func:`resolve_numbering` parses that list back out of
+the answer and matches each entry to a retrieved source by arXiv ID first, then
+by title.
+
+Version suffixes are normalised everywhere. The upstream parser keys its
+reference map on the raw text between ``arxiv.org/abs/`` and the closing paren,
+and compares it against ``paper.csv``'s ``id`` column, so a generated URL
+ending ``v2`` against a normalised CSV row silently resolves to an empty title
+and abstract.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable, Mapping, Sequence
+from typing import Any
+
+from olmo_eval.harness.tools.search import normalize_arxiv_id
+
+# Mirrors of the patterns in lit-agents' shared/deepscholar.py. The two link
+# patterns capture the whitespace introducing the citation so that a citation
+# resolving to nothing can be removed without leaving a gap in the sentence.
+_ARXIV_URL_RE = re.compile(
+    r"https?://(?:www\.)?arxiv\.org/(?:abs|pdf)/([^)\s?#]+)",
+    re.IGNORECASE,
+)
+_MARKDOWN_LINK_RE = re.compile(r"([ \t]*)\[([^\]]*)\]\((https?://[^)\s]+)\)")
+_SUPERSCRIPT_LINK_RE = re.compile(r"([ \t]*)\[<sup>\[([1-9][0-9]*)\]</sup>\]\((https?://[^)\s]+)\)")
+_BRACKET_RE = re.compile(r"\[([^\[\]]+)\]")
+# A bracket holding only numbers, not followed by "(" so a rendered link label
+# can never match. Captures the space that introduces it.
+_LEFTOVER_NUMBER_RE = re.compile(
+    r"([ \t]*)\[[ \t]*\d{1,3}(?:[ \t]*[,;][ \t]*\d{1,3})*[ \t]*\](?!\()"
+)
+# A citation label that is only a number is a marker rather than prose.
+_NUMERIC_LABEL_RE = re.compile(r"\d{1,3}(?:[ \t]*[,;][ \t]*\d{1,3})*")
+_ORPHANED_SPACE_RE = re.compile(r"[ \t]+([.,;:)])")
+_REPEATED_SPACE_RE = re.compile(r"[ \t]{2,}")
+_REFERENCE_HEADING_RE = re.compile(r"(?im)^\s{0,3}(?:#{1,6}\s*)?references\s*:?\s*$")
+
+# One entry of the numbered reference list the prompt asks for: "[3] ..." or
+# "3. ..." or "3) ...".
+_REFERENCE_ENTRY_RE = re.compile(r"^\s{0,3}(?:\[(\d{1,3})\]|(\d{1,3})[.)])\s+(.*)$")
+# An arXiv ID written as prose rather than as a URL, e.g. "arXiv:2401.01234v2".
+_ARXIV_PROSE_ID_RE = re.compile(
+    r"(?i)arxiv[:\s]\s*(\d{4}\.\d{4,5}(?:v\d+)?|[a-z-]+/\d{7}(?:v\d+)?)",
+)
+_TITLE_NOISE_RE = re.compile(r"[^a-z0-9]+")
+# Below this, a "title" is too generic to identify a paper by containment.
+_MIN_TITLE_MATCH_CHARS = 12
+
+
+# Exactly what DeepScholarBaseParser credits, copied from its own patterns: a
+# markdown link whose URL contains arxiv.org/abs. A bare URL sitting in prose is
+# invisible to it, so it must be invisible here too -- counting one would report
+# a citation the scorer will never see.
+_PARSER_CITATION_RE = re.compile(r"\[([^\]]+?)\]\((https?://[^\)]+)\)")
+_PARSER_ARXIV_URL_RE = re.compile(r"arxiv\.org/abs/([^)\s]+)")
+
+
+def cited_arxiv_ids(body: str) -> list[str]:
+    """The arXiv IDs the upstream parser would credit this text with citing."""
+    found = []
+    for _, url in _PARSER_CITATION_RE.findall(body):
+        match = _PARSER_ARXIV_URL_RE.search(url)
+        if match is not None:
+            arxiv_id = normalize_arxiv_id(match.group(1))
+            if arxiv_id:
+                found.append(arxiv_id)
+    return found
+
+
+def abs_url(arxiv_id: str) -> str:
+    """The only citation URL form the benchmark's parser credits."""
+    return f"https://arxiv.org/abs/{normalize_arxiv_id(arxiv_id)}"
+
+
+def _normalize_alias(value: str) -> str:
+    return value.strip().casefold().rstrip("/")
+
+
+def _normalize_title(value: str) -> str:
+    return _TITLE_NOISE_RE.sub(" ", value.casefold()).strip()
+
+
+def arxiv_ids_in_text(text: str) -> list[str]:
+    """Every arXiv ID the text names, as a URL or in prose, normalised."""
+    found = [normalize_arxiv_id(match.group(1)) for match in _ARXIV_URL_RE.finditer(text)]
+    found.extend(normalize_arxiv_id(match.group(1)) for match in _ARXIV_PROSE_ID_RE.finditer(text))
+    return [arxiv_id for arxiv_id in found if arxiv_id]
+
+
+def strip_references(report: str) -> str:
+    """Drop the reference list; the scorer reads citations from the prose only."""
+    match = _REFERENCE_HEADING_RE.search(report)
+    return report[: match.start()].rstrip() if match else report.rstrip()
+
+
+def reference_list(report: str) -> dict[str, str]:
+    """Parse the answer's own numbered reference list into number -> entry text.
+
+    Continuation lines belong to the entry above them, because a reference that
+    wraps is still one reference.
+    """
+    match = _REFERENCE_HEADING_RE.search(report)
+    tail = report[match.end() :] if match else report
+    entries: dict[str, list[str]] = {}
+    current: str | None = None
+    for line in tail.splitlines():
+        entry_match = _REFERENCE_ENTRY_RE.match(line)
+        if entry_match is not None:
+            number = entry_match.group(1) or entry_match.group(2)
+            current = str(int(number))
+            entries.setdefault(current, []).append(entry_match.group(3).strip())
+        elif current is not None and line.strip():
+            entries[current].append(line.strip())
+        elif not line.strip():
+            current = None
+    return {number: " ".join(parts).strip() for number, parts in entries.items()}
+
+
+def _match_reference(
+    entry: str,
+    by_arxiv_id: Mapping[str, Mapping[str, Any]],
+    by_title: Sequence[tuple[str, Mapping[str, Any]]],
+) -> Mapping[str, Any] | None:
+    """Find the retrieved source a reference-list entry names.
+
+    ID first because it is exact; title only as a fallback, longest first so a
+    short title cannot claim a match that belongs to a longer one containing it.
+    """
+    for arxiv_id in arxiv_ids_in_text(entry):
+        source = by_arxiv_id.get(arxiv_id)
+        if source is not None:
+            return source
+
+    normalized_entry = _normalize_title(entry)
+    for title, source in by_title:
+        if len(title) >= _MIN_TITLE_MATCH_CHARS and title in normalized_entry:
+            return source
+    return None
+
+
+def resolve_numbering(
+    report: str,
+    sources: Sequence[Mapping[str, Any]],
+) -> dict[str, Mapping[str, Any]]:
+    """Map each reference number the answer published to a retrieved source.
+
+    This stands in for the ``citation_order`` lit-agents' graphs publish as
+    state. A number whose entry names no retrieved source stays unmapped, and
+    its inline citations are dropped rather than pointed at the wrong paper.
+    """
+    by_arxiv_id = {normalize_arxiv_id(str(s.get("arxiv_id") or "")): s for s in sources}
+    by_title = sorted(
+        (
+            (_normalize_title(str(s.get("title") or "")), s)
+            for s in sources
+            if str(s.get("title") or "").strip()
+        ),
+        key=lambda item: len(item[0]),
+        reverse=True,
+    )
+
+    resolved: dict[str, Mapping[str, Any]] = {}
+    for number, entry in reference_list(report).items():
+        source = _match_reference(entry, by_arxiv_id, by_title)
+        if source is not None:
+            resolved[number] = source
+    return resolved
+
+
+def _markdown_citation(source: Mapping[str, Any]) -> str:
+    arxiv_id = normalize_arxiv_id(str(source.get("arxiv_id") or ""))
+    visible = str(source.get("title") or arxiv_id).replace("[", "").replace("]", "").strip()
+    return f"[{visible or arxiv_id}]({abs_url(arxiv_id)})"
+
+
+def _deduplicate(sources: Iterable[Mapping[str, Any]]) -> list[Mapping[str, Any]]:
+    by_id: dict[str, Mapping[str, Any]] = {}
+    for source in sources:
+        arxiv_id = normalize_arxiv_id(str(source.get("arxiv_id") or ""))
+        if arxiv_id:
+            by_id.setdefault(arxiv_id, source)
+    return list(by_id.values())
+
+
+def rewrite_intro(
+    report: str,
+    sources: Sequence[Mapping[str, Any]],
+) -> tuple[str, list[Mapping[str, Any]]]:
+    """Rewrite one answer's citations into resolvable arxiv.org links.
+
+    Mirrors lit-agents' ``render_intro``. Returns the rewritten body and the
+    sources it ends up citing, in retrieval order. An empty source list is the
+    caller's signal that this answer yields nothing the upstream parser can
+    score -- which is a result to record, not an error to raise, because a model
+    that cited only papers it never retrieved has genuinely produced nothing
+    citable.
+    """
+    if not report.strip():
+        return "", []
+    ordered = _deduplicate(sources)
+    if not ordered:
+        return "", []
+
+    alias_map: dict[str, Mapping[str, Any]] = {}
+    for source in ordered:
+        arxiv_id = normalize_arxiv_id(str(source.get("arxiv_id") or ""))
+        alias_map[_normalize_alias(arxiv_id)] = source
+        alias_map[_normalize_alias(f"arXiv:{arxiv_id}")] = source
+        alias_map[_normalize_alias(abs_url(arxiv_id))] = source
+        title = str(source.get("title") or "").strip()
+        if title:
+            alias_map[_normalize_alias(title)] = source
+    alias_map.update(resolve_numbering(report, ordered))
+
+    body = strip_references(report)
+    removals = 0
+
+    def strip_citation(leading: str, label: str) -> str:
+        """Drop a citation that resolves to nothing, keeping any prose label.
+
+        The visible label survives, which is what the upstream parser does with
+        a link it cannot resolve. A label that is only a number carries no
+        prose: it is a citation marker, and leaving one behind is what makes the
+        parser read citation 8 of a six-document list.
+        """
+        nonlocal removals
+        removals += 1
+        if _NUMERIC_LABEL_RE.fullmatch(label.strip()):
+            return ""
+        return f"{leading}{label}"
+
+    def replace_superscript(match: re.Match[str]) -> str:
+        source = alias_map.get(_normalize_alias(match.group(3)))
+        if source is not None:
+            return f"{match.group(1)}{_markdown_citation(source)}"
+        return strip_citation(match.group(1), match.group(2))
+
+    body = _SUPERSCRIPT_LINK_RE.sub(replace_superscript, body)
+
+    def replace_link(match: re.Match[str]) -> str:
+        source = alias_map.get(_normalize_alias(match.group(3)))
+        if source is None:
+            ids = arxiv_ids_in_text(match.group(3))
+            source = alias_map.get(_normalize_alias(ids[0])) if ids else None
+        if source is not None:
+            return f"{match.group(1)}{_markdown_citation(source)}"
+        return strip_citation(match.group(1), match.group(2))
+
+    body = _MARKDOWN_LINK_RE.sub(replace_link, body)
+
+    def replace_bracket(match: re.Match[str]) -> str:
+        content = match.group(1).strip()
+        direct = alias_map.get(_normalize_alias(content))
+        if direct is not None:
+            return _markdown_citation(direct)
+        tokens = [token for token in re.split(r"[\s,;]+", content) if token]
+        resolved = [alias_map.get(_normalize_alias(token)) for token in tokens]
+        if tokens and all(source is not None for source in resolved):
+            seen: dict[str, Mapping[str, Any]] = {}
+            for source in resolved:
+                if source is not None:
+                    seen.setdefault(normalize_arxiv_id(str(source.get("arxiv_id") or "")), source)
+            return "".join(_markdown_citation(source) for source in seen.values())
+        return match.group(0)
+
+    body = _BRACKET_RE.sub(replace_bracket, body)
+
+    # A bracket number no pass above resolved is not a citation this benchmark
+    # can score, and leaving it in makes the parser number a document that has
+    # no row in paper.csv.
+    leftovers = _LEFTOVER_NUMBER_RE.findall(body)
+    if leftovers:
+        removals += len(leftovers)
+        body = _LEFTOVER_NUMBER_RE.sub("", body)
+    # Tidy only when something was removed, so a report needing no deletion
+    # comes back exactly as the passes above rendered it.
+    if removals:
+        body = _REPEATED_SPACE_RE.sub(" ", body)
+        body = _ORPHANED_SPACE_RE.sub(r"\1", body)
+    body = body.strip()
+
+    cited = list(dict.fromkeys(cited_arxiv_ids(body)))
+    exported = [
+        source
+        for source in ordered
+        if normalize_arxiv_id(str(source.get("arxiv_id") or "")) in cited
+    ]
+    if not exported:
+        return "", []
+    return body + "\n", exported

--- a/src/olmo_eval/evals/tasks/deepscholar_citations.py
+++ b/src/olmo_eval/evals/tasks/deepscholar_citations.py
@@ -31,11 +31,14 @@ and abstract.
 
 from __future__ import annotations
 
+import logging
 import re
 from collections.abc import Iterable, Mapping, Sequence
 from typing import Any
 
 from olmo_eval.harness.tools.search import normalize_arxiv_id
+
+logger = logging.getLogger(__name__)
 
 # Mirrors of the patterns in lit-agents' shared/deepscholar.py. The two link
 # patterns capture the whitespace introducing the citation so that a citation
@@ -46,7 +49,11 @@ _ARXIV_URL_RE = re.compile(
 )
 _MARKDOWN_LINK_RE = re.compile(r"([ \t]*)\[([^\]]*)\]\((https?://[^)\s]+)\)")
 _SUPERSCRIPT_LINK_RE = re.compile(r"([ \t]*)\[<sup>\[([1-9][0-9]*)\]</sup>\]\((https?://[^)\s]+)\)")
-_BRACKET_RE = re.compile(r"\[([^\[\]]+)\]")
+# Deviation from lit-agents' bracket pattern: the negative lookahead. The
+# link pass runs first and its output is `[Title](url)`, whose `[Title]` this
+# pattern would otherwise match -- and, since titles are aliases, resolve --
+# rewriting it to `[Title](url)(url)`.
+_BRACKET_RE = re.compile(r"\[([^\[\]]+)\](?!\()")
 # A bracket holding only numbers, not followed by "(" so a rendered link label
 # can never match. Captures the space that introduces it.
 _LEFTOVER_NUMBER_RE = re.compile(
@@ -56,7 +63,31 @@ _LEFTOVER_NUMBER_RE = re.compile(
 _NUMERIC_LABEL_RE = re.compile(r"\d{1,3}(?:[ \t]*[,;][ \t]*\d{1,3})*")
 _ORPHANED_SPACE_RE = re.compile(r"[ \t]+([.,;:)])")
 _REPEATED_SPACE_RE = re.compile(r"[ \t]{2,}")
-_REFERENCE_HEADING_RE = re.compile(r"(?im)^\s{0,3}(?:#{1,6}\s*)?references\s*:?\s*$")
+# lit-agents' _strip_references matches "references" alone (case-insensitive,
+# optional heading markup, optional colon). Deliberate deviation: models also
+# title this section Bibliography, Works Cited or Sources, and a tail left
+# standing is worse than a tail wrongly stripped -- its numbered entries are
+# read as prose and every "[1]" in them becomes a fabricated inline citation.
+# A strip under any heading but "references" is logged, so the deviation shows
+# up in a run rather than only in this comment.
+_REFERENCE_HEADING_RE = re.compile(
+    r"(?im)^\s{0,3}(?:#{1,6}\s*)?(references|bibliography|works\s+cited|sources)\s*:?\s*$"
+)
+_CANONICAL_REFERENCE_HEADING = "references"
+
+# Citation shapes neither this module nor lit-agents' render_intro resolves.
+# Counted rather than ignored: an answer full of them scores zero for a reason
+# worth seeing, and silence would make that look like a model that cited nothing.
+_UNRESOLVED_FORM_RES = (
+    re.compile(r"(?i)<sup>.*?</sup>"),
+    re.compile(r"[\u00b9\u00b2\u00b3\u2070\u2074-\u2079]+"),
+    re.compile(r"\[\^[^\]]{1,32}\]"),
+    re.compile(r"\[[^\]\d]{2,60},\s*(?:19|20)\d{2}[a-z]?\]"),
+)
+# "[1-3]" and "[1--3]" mean three citations; lit-agents never sees one because
+# its graphs emit a citation per paper.
+_NUMERIC_RANGE_RE = re.compile(r"^(\d{1,3})\s*[-\u2010-\u2015]\s*(\d{1,3})$")
+_MAX_RANGE_SPAN = 50
 
 # One entry of the numbered reference list the prompt asks for: "[3] ..." or
 # "3. ..." or "3) ...".
@@ -113,7 +144,27 @@ def arxiv_ids_in_text(text: str) -> list[str]:
 def strip_references(report: str) -> str:
     """Drop the reference list; the scorer reads citations from the prose only."""
     match = _REFERENCE_HEADING_RE.search(report)
-    return report[: match.start()].rstrip() if match else report.rstrip()
+    if match is None:
+        return report.rstrip()
+    heading = match.group(1).strip().casefold()
+    if heading != _CANONICAL_REFERENCE_HEADING:
+        logger.warning(
+            "Stripped a reference tail under the heading %r; lit-agents strips "
+            "only 'References', so this answer is treated differently there.",
+            match.group(1).strip(),
+        )
+    return report[: match.start()].rstrip()
+
+
+def unresolved_citation_forms(body: str) -> int:
+    """Count citation-shaped fragments no pass here can turn into a link.
+
+    Superscripts, footnote markers and author-year brackets are real citation
+    styles that neither this module nor render_intro resolves. They are reported
+    so an answer that cited diligently in an unsupported style is distinguishable
+    from one that did not cite at all.
+    """
+    return sum(len(pattern.findall(body)) for pattern in _UNRESOLVED_FORM_RES)
 
 
 def reference_list(report: str) -> dict[str, str]:
@@ -188,6 +239,31 @@ def resolve_numbering(
         if source is not None:
             resolved[number] = source
     return resolved
+
+
+def _citation_tokens(content: str) -> list[str]:
+    """Split a bracket's contents into the citation markers it stands for.
+
+    Expands "1-3" into 1, 2, 3 and drops the caret of a "^1" footnote marker, so
+    both resolve through the same numbering as a plain "[1]". A range wider than
+    _MAX_RANGE_SPAN is left alone: at that width it is far likelier to be a page
+    range or a year span than a citation.
+    """
+    tokens: list[str] = []
+    for raw in re.split(r"[\s,;]+", content):
+        token = raw.strip().lstrip("^")
+        if not token:
+            continue
+        span = _NUMERIC_RANGE_RE.match(token)
+        if span is None:
+            tokens.append(token)
+            continue
+        first, last = int(span.group(1)), int(span.group(2))
+        if first > last or last - first > _MAX_RANGE_SPAN:
+            tokens.append(token)
+            continue
+        tokens.extend(str(number) for number in range(first, last + 1))
+    return tokens
 
 
 def _markdown_citation(source: Mapping[str, Any]) -> str:
@@ -276,7 +352,7 @@ def rewrite_intro(
         direct = alias_map.get(_normalize_alias(content))
         if direct is not None:
             return _markdown_citation(direct)
-        tokens = [token for token in re.split(r"[\s,;]+", content) if token]
+        tokens = _citation_tokens(content)
         resolved = [alias_map.get(_normalize_alias(token)) for token in tokens]
         if tokens and all(source is not None for source in resolved):
             seen: dict[str, Mapping[str, Any]] = {}

--- a/src/olmo_eval/evals/tasks/deepscholar_citations.py
+++ b/src/olmo_eval/evals/tasks/deepscholar_citations.py
@@ -75,6 +75,14 @@ _REFERENCE_HEADING_RE = re.compile(
 )
 _CANONICAL_REFERENCE_HEADING = "references"
 
+# Which rule supplied the scored text. Reported per query so a run can say
+# how it recovered its reports, not merely that it did.
+SPLIT_TIER_SENTINEL = "sentinel"
+SPLIT_TIER_HEADING = "heading"
+SPLIT_TIER_PROSE = "prose"
+SPLIT_TIER_NONE = "none"
+SPLIT_TIERS = (SPLIT_TIER_SENTINEL, SPLIT_TIER_HEADING, SPLIT_TIER_PROSE, SPLIT_TIER_NONE)
+
 # The delimiter the arxiv_paper_search_agent preset's system prompt asks for.
 # Deliberation is not banned -- an agent that plans in prose writes a better
 # related-works section, and the benchmark's own user prompt is verbatim and
@@ -428,13 +436,113 @@ def rewrite_intro(
     return body + "\n", exported
 
 
+# The model's own Related Works heading, in the four shapes the archived runs
+# actually produced: markdown hashes, bold, a numbered section, or a bare line.
+# This is the fallback that does the real work -- a marker is only present on 55%
+# of 9B answers, while a heading is present on 60-95% depending on the backbone.
+_RELATED_WORKS_TITLE = r"related[ \t]+works?(?:[ \t]+(?:and|/)[ \t]+background)?"
+_HEADING_PATTERNS = tuple(
+    re.compile(pattern, re.IGNORECASE | re.MULTILINE)
+    for pattern in (
+        r"^[ \t]{0,3}#{1,6}[ \t]*" + _RELATED_WORKS_TITLE + r"[ \t]*:?[ \t]*$",
+        r"^[ \t]{0,3}\*\*[ \t]*" + _RELATED_WORKS_TITLE + r"[ \t]*\*\*[ \t]*:?[ \t]*$",
+        r"^[ \t]{0,3}\d{1,2}[.)]?[ \t]+" + _RELATED_WORKS_TITLE + r"[ \t]*:?[ \t]*$",
+        r"^[ \t]{0,3}" + _RELATED_WORKS_TITLE + r"[ \t]*:?[ \t]*$",
+    )
+)
+# A line that opens a numbered reference entry, and the share of such lines above
+# which a paragraph is a reference list rather than prose.
+_REFERENCE_ENTRY_LINE_RE = re.compile(r"^[ \t]{0,3}(?:\[\d{1,3}\]|\d{1,3}[.)])[ \t]+")
+_REFERENCE_BLOCK_RATIO = 0.5
+_INLINE_NUMERIC_CITATION_RE = re.compile(r"\[[ \t]*\d{1,3}(?:[ \t]*[-,;][ \t]*\d{1,3})*[ \t]*\]")
+_ARXIV_MARKDOWN_LINK_RE = re.compile(r"\[[^\]]*\]\([^)]*arxiv\.org/abs[^)]*\)", re.IGNORECASE)
+# Below this a paragraph is too short to be the opening of a related-works
+# section; it is a caption, a fragment, or a note to self.
+_MIN_PROSE_WORDS = 30
+
+
+def _reference_heading_start(report: str) -> int | None:
+    match = _REFERENCE_HEADING_RE.search(report)
+    return match.start() if match else None
+
+
+def heading_split(report: str) -> str | None:
+    """Everything from the model's FIRST Related Works heading, or None.
+
+    First rather than last, which is the opposite of the sentinel's rule and was
+    settled by measurement (U0009) rather than by analogy. Last-wins loses to a
+    late skeleton draft -- 27B writes `Related Works ... References 1. ... Need
+    maybe reference list not counted? fine.` near the end of some answers, and
+    that outranks the real report written earlier. First-wins never lands after
+    the sentinel on any answer where both exist, so it cannot cut into a report.
+
+    The heading is retained, not stripped: it is part of the report and is clean
+    markdown for the organisation judge.
+    """
+    limit = _reference_heading_start(report)
+    starts = sorted(
+        match.start()
+        for pattern in _HEADING_PATTERNS
+        for match in pattern.finditer(report)
+        if limit is None or match.start() < limit
+    )
+    return report[starts[0] :] if starts else None
+
+
+def _is_reference_block(block: str) -> bool:
+    lines = [line for line in block.splitlines() if line.strip()]
+    if not lines:
+        return False
+    entries = sum(1 for line in lines if _REFERENCE_ENTRY_LINE_RE.match(line))
+    return entries / len(lines) >= _REFERENCE_BLOCK_RATIO
+
+
+def prose_split(report: str) -> str | None:
+    """Everything from the first citation-bearing prose paragraph, or None.
+
+    The last resort, for an answer that marks its report neither with the
+    sentinel nor with a heading. It only ever drops LEADING paragraphs, so it
+    cannot damage a reference list or truncate a report that began earlier; its
+    worst case is trimming too little, which the measurements confirm is how it
+    fails.
+    """
+    limit = _reference_heading_start(report)
+    position = 0
+    for separator in re.finditer(r"\n[ \t]*\n", report):
+        block = report[position : separator.start()]
+        if limit is not None and position >= limit:
+            return None
+        if _qualifies_as_report_opening(block):
+            return report[position:]
+        position = separator.end()
+    if (limit is None or position < limit) and _qualifies_as_report_opening(report[position:]):
+        return report[position:]
+    return None
+
+
+def _qualifies_as_report_opening(block: str) -> bool:
+    if _is_reference_block(block):
+        return False
+    if len(block.split()) < _MIN_PROSE_WORDS:
+        return False
+    return bool(_INLINE_NUMERIC_CITATION_RE.search(block) or _ARXIV_MARKDOWN_LINK_RE.search(block))
+
+
 def select_scored_text(
     report: str,
     sources: Sequence[Mapping[str, Any]],
-) -> tuple[str, bool, bool]:
-    """Choose the text to score, and say whether the marker chose it.
+) -> tuple[str, str, bool, bool]:
+    """Choose the text to score, and say which rule chose it.
 
-    Returns ``(text, marker_found, marker_misused)``.
+    Returns ``(text, split_tier, marker_found, marker_misused)`` where
+    ``split_tier`` is one of ``sentinel``, ``heading``, ``prose`` or ``none``.
+
+    Three rules are tried in descending order of how explicitly the model marked
+    its report: the sentinel it was asked to write, its own Related Works
+    heading, then the first citation-bearing paragraph. Each candidate must pass
+    the same fuse before it is accepted, so a tier that would cost the answer its
+    citations is skipped rather than trusted, and ``none`` means every rule was
+    refused and the full text was kept.
 
     :func:`split_final_report` decides where the deliverable starts; this decides
     whether trusting it would cost the answer its export. A model can honour the
@@ -457,18 +565,40 @@ def select_scored_text(
     heading is not stripped, so it survives as prose and the emptiness test never
     fires -- which is exactly the shape both real 9B failures took.
     """
-    tail, marker_found = split_final_report(report)
-    if not marker_found:
-        return report, False, False
-
-    _, cited_from_tail = rewrite_intro(tail, sources)
-    if cited_from_tail:
-        return tail, True, False
-
+    sources = list(sources)
     _, cited_from_full = rewrite_intro(report, sources)
-    if cited_from_full:
-        return report, True, True
+    full_is_scoreable = bool(cited_from_full)
 
-    # Nothing is scoreable either way, so there is nothing to save; keep the
-    # tail, which is at least the text the model nominated.
-    return tail, True, False
+    sentinel_tail, marker_found = split_final_report(report)
+    marker_misused = False
+    if marker_found:
+        _, cited_from_sentinel = rewrite_intro(sentinel_tail, sources)
+        # The marker was written and the report was not put under it. Recorded
+        # whatever any later tier manages to recover, because it measures the
+        # prompt being misread, not the outcome.
+        marker_misused = not cited_from_sentinel and full_is_scoreable
+
+    candidates: list[tuple[str, str]] = []
+    if marker_found:
+        candidates.append((SPLIT_TIER_SENTINEL, sentinel_tail))
+    heading_tail = heading_split(report)
+    if heading_tail is not None:
+        candidates.append((SPLIT_TIER_HEADING, heading_tail))
+    prose_tail = prose_split(report)
+    if prose_tail is not None:
+        candidates.append((SPLIT_TIER_PROSE, prose_tail))
+
+    for tier, tail in candidates:
+        _, cited = rewrite_intro(tail, sources)
+        if cited:
+            return tail, tier, marker_found, marker_misused
+
+    if full_is_scoreable:
+        # Every tier would have cost the answer its citations, so keep all of it.
+        return report, SPLIT_TIER_NONE, marker_found, marker_misused
+    if candidates:
+        # Nothing is scoreable anywhere; prefer the most specific candidate,
+        # which is at least the text the model nominated.
+        tier, tail = candidates[0]
+        return tail, tier, marker_found, marker_misused
+    return report, SPLIT_TIER_NONE, marker_found, marker_misused

--- a/src/olmo_eval/evals/tasks/deepscholar_citations.py
+++ b/src/olmo_eval/evals/tasks/deepscholar_citations.py
@@ -75,6 +75,22 @@ _REFERENCE_HEADING_RE = re.compile(
 )
 _CANONICAL_REFERENCE_HEADING = "references"
 
+# The delimiter the arxiv_paper_search_agent preset's system prompt asks for.
+# Deliberation is not banned -- an agent that plans in prose writes a better
+# related-works section, and the benchmark's own user prompt is verbatim and
+# cannot be edited to forbid it -- so the contract is a marker instead: think
+# above the line, deliver below it.
+FINAL_REPORT_MARKER = "=== FINAL REPORT ==="
+# Line-exact by construction. A model that names the sentinel inside a sentence
+# ("I will write === FINAL REPORT === once I have searched") must not split its
+# own answer, so only a whole line can match: MULTILINE anchors with nothing but
+# whitespace either side. The run of '=' is loosened to two-or-more because a
+# model that pads the rule still means the marker.
+_FINAL_REPORT_MARKER_RE = re.compile(
+    r"^\s*={2,}\s*FINAL REPORT\s*={2,}\s*$",
+    re.MULTILINE,
+)
+
 # Citation shapes neither this module nor lit-agents' render_intro resolves.
 # Counted rather than ignored: an answer full of them scores zero for a reason
 # worth seeing, and silence would make that look like a model that cited nothing.
@@ -139,6 +155,29 @@ def arxiv_ids_in_text(text: str) -> list[str]:
     found = [normalize_arxiv_id(match.group(1)) for match in _ARXIV_URL_RE.finditer(text)]
     found.extend(normalize_arxiv_id(match.group(1)) for match in _ARXIV_PROSE_ID_RE.finditer(text))
     return [arxiv_id for arxiv_id in found if arxiv_id]
+
+
+def split_final_report(answer: str) -> tuple[str, bool]:
+    """Return the deliverable half of an answer, and whether a marker chose it.
+
+    The LAST line-exact marker wins. A model that starts its report, thinks
+    better of it and starts again writes the marker twice, and the attempt it
+    stood behind is the last one; taking the first would score the draft it
+    abandoned. Everything above the winning marker is deliberation the
+    benchmark never asked for and is dropped along with the marker line itself,
+    so the retained tail is what the reference-list and citation passes read.
+
+    An answer with no line-exact marker comes back whole, which is exactly what
+    this module did before the contract existed -- a backbone that ignores the
+    instruction is scored no worse than it was. That fallback is deliberate but
+    not silent: the second return value is what ``marker_compliance_rate``
+    counts, so non-compliance surfaces as a number per backbone rather than as
+    unexplained deliberation sitting in the scored text.
+    """
+    matches = list(_FINAL_REPORT_MARKER_RE.finditer(answer))
+    if not matches:
+        return answer, False
+    return answer[matches[-1].end() :].lstrip("\n"), True
 
 
 def strip_references(report: str) -> str:

--- a/src/olmo_eval/evals/tasks/deepscholar_citations.py
+++ b/src/olmo_eval/evals/tasks/deepscholar_citations.py
@@ -426,3 +426,49 @@ def rewrite_intro(
     if not exported:
         return "", []
     return body + "\n", exported
+
+
+def select_scored_text(
+    report: str,
+    sources: Sequence[Mapping[str, Any]],
+) -> tuple[str, bool, bool]:
+    """Choose the text to score, and say whether the marker chose it.
+
+    Returns ``(text, marker_found, marker_misused)``.
+
+    :func:`split_final_report` decides where the deliverable starts; this decides
+    whether trusting it would cost the answer its export. A model can honour the
+    marker and still misplace the report -- Qwen3.5-9B wrote its whole Related
+    Works section while deliberating and put only the numbered list below the
+    line -- and the split would then hand the scorer a reference list with
+    nothing citing into it, turning an exportable answer into an unscoreable one.
+
+    So the split is applied only when it keeps something scoreable. If the tail
+    resolves no citation but the full answer does, the full answer is kept: the
+    marker-absent path exactly, which makes the split lossless by construction --
+    it can never lower ``exportable_rate`` relative to not splitting at all.
+    ``marker_misused`` counts those saves, and is deliberately distinct from
+    ``marker_compliance_rate``: the instruction was followed, the report was put
+    in the wrong place, and a run needs to tell those apart to know whether the
+    prompt or the backbone is at fault.
+
+    Note the test is "resolves no citation", not "is empty after
+    :func:`strip_references`". A bare numbered list carrying no ``References``
+    heading is not stripped, so it survives as prose and the emptiness test never
+    fires -- which is exactly the shape both real 9B failures took.
+    """
+    tail, marker_found = split_final_report(report)
+    if not marker_found:
+        return report, False, False
+
+    _, cited_from_tail = rewrite_intro(tail, sources)
+    if cited_from_tail:
+        return tail, True, False
+
+    _, cited_from_full = rewrite_intro(report, sources)
+    if cited_from_full:
+        return report, True, True
+
+    # Nothing is scoreable either way, so there is nothing to save; keep the
+    # tail, which is at least the text the model nominated.
+    return tail, True, False

--- a/src/olmo_eval/evals/tasks/deepscholar_export.py
+++ b/src/olmo_eval/evals/tasks/deepscholar_export.py
@@ -65,7 +65,7 @@ from olmo_eval.evals.tasks.deepscholar_bench import (
     download_deepscholar_dataset,
     sources_from_trajectory,
 )
-from olmo_eval.evals.tasks.deepscholar_citations import rewrite_intro, split_final_report
+from olmo_eval.evals.tasks.deepscholar_citations import rewrite_intro, select_scored_text
 from olmo_eval.harness.tools.search import date_from_arxiv_id, normalize_arxiv_id
 
 logger = logging.getLogger(__name__)
@@ -517,26 +517,28 @@ def export_predictions(
                 f"Prediction {identifier} is not a query in the pinned dataset at "
                 f"{DEEPSCHOLAR_COMMIT}"
             )
-        # The delimiter contract is applied before anything reads the answer,
-        # so the reference list parsed below is the one under the marker and
-        # not a numbered list the model happened to draft while deliberating.
-        answer, marker_found = split_final_report(answer_text(prediction))
         raw_trajectory = prediction.get("trajectory")
         trajectory = (
             AgentTrajectory.from_dict(raw_trajectory) if isinstance(raw_trajectory, dict) else None
         )
         sources = sources_from_trajectory(trajectory)
+        # The delimiter contract is applied before anything reads the answer,
+        # so the reference list parsed below is the one under the marker and
+        # not a numbered list the model happened to draft while deliberating.
+        # The sources are needed first: the split is kept only where it leaves
+        # something citable, so it can never cost a query its export.
+        answer, marker_found, marker_misused = select_scored_text(answer_text(prediction), sources)
         # A first pass only to learn which abstracts are worth re-fetching; the
         # binding pass runs below, once the fetched dates can be validated.
         _, provisional = rewrite_intro(answer, sources)
-        prepared.append((identifier, answer, sources, provisional, marker_found))
+        prepared.append((identifier, answer, sources, provisional, marker_found, marker_misused))
 
     fetched: dict[str, dict[str, str]] = {}
     if fetch_abstracts:
         wanted = list(
             dict.fromkeys(
                 normalize_arxiv_id(str(source.get("arxiv_id") or ""))
-                for _, _, _, provisional, _ in prepared
+                for _, _, _, provisional, _, _ in prepared
                 for source in provisional
             )
         )
@@ -546,7 +548,8 @@ def export_predictions(
     exported: list[int] = []
     answers_with_text = 0
     markers_found = 0
-    for identifier, answer, sources, _, marker_found in prepared:
+    markers_misused = 0
+    for identifier, answer, sources, _, marker_found, marker_misused in prepared:
         record = records[identifier]
         # A query that generated nothing can neither honour the delimiter
         # contract nor break it, so it stays out of the rate's denominator. A
@@ -556,6 +559,7 @@ def export_predictions(
         if answer.strip() or marker_found:
             answers_with_text += 1
             markers_found += int(marker_found)
+            markers_misused += int(marker_misused)
         if not answer.strip():
             summary.append(
                 {
@@ -570,6 +574,7 @@ def export_predictions(
                     "termination_reason": "empty_response",
                     "papers_retrieved": len(sources),
                     "marker_found": marker_found,
+                    "marker_misused": marker_misused,
                 }
             )
             continue
@@ -589,6 +594,7 @@ def export_predictions(
                     "sources_considered": len(sources),
                     "source_rejections": {"unexportable_after_validation": len(sources)},
                     "marker_found": marker_found,
+                    "marker_misused": marker_misused,
                 }
             )
             continue
@@ -609,6 +615,7 @@ def export_predictions(
                 "status": "success",
                 "num_papers": len(rows),
                 "marker_found": marker_found,
+                "marker_misused": marker_misused,
             }
         )
 
@@ -650,6 +657,11 @@ def export_predictions(
         "answers_with_text": answers_with_text,
         "markers_found": markers_found,
         "marker_compliance_rate": (markers_found / answers_with_text if answers_with_text else 0.0),
+        # Answers that wrote the marker and then put the report above it. The
+        # fuse kept their full text, so this costs nothing and is not a
+        # penalty; it rises when the prompt reads two ways to a backbone.
+        "markers_misused": markers_misused,
+        "marker_misuse_rate": (markers_misused / answers_with_text if answers_with_text else 0.0),
     }
 
 

--- a/src/olmo_eval/evals/tasks/deepscholar_export.py
+++ b/src/olmo_eval/evals/tasks/deepscholar_export.py
@@ -38,9 +38,11 @@ import hashlib
 import json
 import logging
 import os
+import shutil
 import sys
 import tempfile
-from collections.abc import Iterator, Mapping, Sequence
+from collections.abc import Mapping, Sequence
+from datetime import date
 from pathlib import Path
 from typing import Any, cast
 
@@ -80,23 +82,42 @@ GENERATION_MANIFEST_NAME = "generation_manifest.json"
 # agent, searching and writing its own numbered reference list -- is
 # single_agent_1's, so that is the name the manifests carry by default.
 DEFAULT_SYSTEM = "single_agent_1"
+# Dropping a row can drop a citation, which can drop another row. Three
+# passes is far past what any real answer needs; the fourth means a bug.
+_MAX_EXPORT_PASSES = 4
 
 S2_BATCH_URL = "https://api.semanticscholar.org/graph/v1/paper/batch"
 S2_BATCH_FIELDS = "title,abstract,publicationDate"
 S2_BATCH_MAX_IDS = 500
 
 
-def read_predictions(path: str | Path) -> Iterator[dict[str, Any]]:
-    """Yield the prediction rows of a JSONL file, skipping blank lines."""
+def read_predictions(path: str | Path) -> list[dict[str, Any]]:
+    """Read every prediction row, refusing the file if any line is unreadable.
+
+    A malformed line used to be skipped with a warning, which silently shrank
+    both the export and the manifests built from it: a truncated run produced a
+    folder that looked complete and scored as though it were. Naming the lines
+    and stopping is the only honest option, because nothing here can tell a
+    half-written line from a query that legitimately produced nothing.
+    """
+    rows: list[dict[str, Any]] = []
+    malformed: list[int] = []
     with Path(path).open(encoding="utf-8") as stream:
         for line_number, line in enumerate(stream, start=1):
             text = line.strip()
             if not text:
                 continue
             try:
-                yield json.loads(text)
+                rows.append(json.loads(text))
             except json.JSONDecodeError:
-                logger.warning("Skipping unparseable prediction on line %d", line_number)
+                malformed.append(line_number)
+    if malformed:
+        raise ValueError(
+            f"{path} has unreadable prediction rows on line(s) "
+            f"{', '.join(str(number) for number in malformed)}; refusing to export a "
+            "partial run. Re-run the task or remove the truncated rows deliberately."
+        )
+    return rows
 
 
 def answer_text(prediction: Mapping[str, Any]) -> str:
@@ -197,15 +218,37 @@ def fetch_full_abstracts(
     return fetched
 
 
+def _row_precedes_cutoff(published: str, precision: str, cutoff: date) -> bool:
+    """The contract's own date test, mirroring lit-agents' _validate_source_rows.
+
+    Month precision compares months, day precision compares days, and any other
+    precision is invalid rather than assumed. Strictly before, in both cases.
+    """
+    parsed = _parse_iso_date(published)
+    if parsed is None:
+        return False
+    if precision == "month":
+        return (parsed.year, parsed.month) < (cutoff.year, cutoff.month)
+    if precision == "day":
+        return parsed < cutoff
+    return False
+
+
 def build_paper_rows(
     sources: Sequence[Mapping[str, str]],
     fetched: Mapping[str, Mapping[str, str]] | None = None,
+    cutoff: date | None = None,
 ) -> list[dict[str, str]]:
     """Build paper.csv rows for the cited sources, dropping any that cannot stand.
 
     A row needs a non-empty title and snippet and a resolvable date, because
     those are exactly the conditions the contract checks; shipping a row that
     fails them turns a scoreable query into a rejected one.
+
+    ``cutoff`` is the strict half of the two-layer design: retrieval admits a
+    paper on the month its arXiv ID encodes, and the batch re-fetch can then
+    return a real publication date that turns out to fall on or after the query's
+    cutoff. Such a paper was never citable, and only this test catches it.
     """
     fetched = fetched or {}
     rows: list[dict[str, str]] = []
@@ -231,6 +274,15 @@ def build_paper_rows(
         if not title.strip() or not snippet.strip():
             logger.warning("Dropping source %s: it has no title or no abstract", arxiv_id)
             continue
+        if cutoff is not None and not _row_precedes_cutoff(published, precision, cutoff):
+            logger.warning(
+                "Dropping source %s: %s (%s precision) does not precede the cutoff %s",
+                arxiv_id,
+                published,
+                precision,
+                cutoff.isoformat(),
+            )
+            continue
 
         rows.append(
             {
@@ -246,6 +298,50 @@ def build_paper_rows(
             }
         )
     return rows
+
+
+def resolve_export(
+    answer: str,
+    sources: Sequence[Mapping[str, str]],
+    fetched: Mapping[str, Mapping[str, str]],
+    cutoff: date | None,
+) -> tuple[str, list[Mapping[str, str]], list[dict[str, str]]]:
+    """Rewrite the answer and build its rows until the two agree.
+
+    A cited source can still fail at export -- no title, no abstract, a date the
+    re-fetch moved on or after the cutoff -- and dropping its row while leaving
+    its link standing in intro.md leaves the folder contradicting itself: the
+    contract checks that every cited ID has a row, and the parser would render a
+    citation whose title and snippet are empty. So the rewrite is re-run with the
+    failed source withheld, which is what render_intro does with a source it
+    rejects, and the citation comes out of the prose along with the row.
+
+    Returns empty results when nothing survives, which is a query to record as
+    unscoreable rather than an error: an answer citing only papers that fail the
+    contract has genuinely produced nothing this benchmark can score.
+    """
+    allowed = list(sources)
+    for _ in range(_MAX_EXPORT_PASSES):
+        intro, cited = rewrite_intro(answer, allowed)
+        if not cited:
+            return "", [], []
+        rows = build_paper_rows(cited, fetched, cutoff)
+        kept = {row["id"] for row in rows}
+        cited_ids = {normalize_arxiv_id(str(source.get("arxiv_id") or "")) for source in cited}
+        if kept == cited_ids:
+            return intro, cited, rows
+        allowed = [
+            source
+            for source in allowed
+            if normalize_arxiv_id(str(source.get("arxiv_id") or "")) in kept
+        ]
+        if not allowed:
+            return "", [], []
+    logger.warning(
+        "Export did not settle after %d passes; treating the query as unscoreable",
+        _MAX_EXPORT_PASSES,
+    )
+    return "", [], []
 
 
 def _resolve_row_date(
@@ -366,6 +462,30 @@ def write_query_folder(
         os.replace(temporary, target)
 
 
+def _prepare_output_root(root: Path, *, force: bool) -> None:
+    """Refuse to write into an export that is already there.
+
+    Numeric query folders from an earlier run survive a new run that happens not
+    to export the same queries, and preflight compares the folders on disk
+    against summary.json -- so a stale folder fails the whole export with an
+    error naming the run that is not at fault.
+    """
+    if not root.exists():
+        root.mkdir(parents=True, exist_ok=True)
+        return
+    existing = sorted(child.name for child in root.iterdir() if not child.name.startswith("."))
+    if not existing:
+        return
+    if not force:
+        shown = ", ".join(existing[:5]) + (", ..." if len(existing) > 5 else "")
+        raise FileExistsError(
+            f"Output directory {root} already holds {shown}. Exporting into it would "
+            "mix two runs; pass --force to replace its contents, or choose a new directory."
+        )
+    shutil.rmtree(root)
+    root.mkdir(parents=True, exist_ok=True)
+
+
 def export_predictions(
     predictions_path: str | Path,
     output_dir: str | Path,
@@ -374,10 +494,11 @@ def export_predictions(
     dataset_path: str | Path | None = None,
     fetch_abstracts: bool = True,
     client: httpx.Client | None = None,
+    force: bool = False,
 ) -> dict[str, Any]:
     """Export every prediction, returning the summary it also writes to disk."""
     root = Path(output_dir)
-    root.mkdir(parents=True, exist_ok=True)
+    _prepare_output_root(root, force=force)
     records = load_query_records(dataset_path)
 
     prepared = []
@@ -394,23 +515,25 @@ def export_predictions(
             AgentTrajectory.from_dict(raw_trajectory) if isinstance(raw_trajectory, dict) else None
         )
         sources = sources_from_trajectory(trajectory)
-        intro, cited = rewrite_intro(answer, sources)
-        prepared.append((identifier, answer, sources, intro, cited))
+        # A first pass only to learn which abstracts are worth re-fetching; the
+        # binding pass runs below, once the fetched dates can be validated.
+        _, provisional = rewrite_intro(answer, sources)
+        prepared.append((identifier, answer, sources, provisional))
 
     fetched: dict[str, dict[str, str]] = {}
     if fetch_abstracts:
         wanted = list(
             dict.fromkeys(
                 normalize_arxiv_id(str(source.get("arxiv_id") or ""))
-                for _, _, _, _, cited in prepared
-                for source in cited
+                for _, _, _, provisional in prepared
+                for source in provisional
             )
         )
         fetched = fetch_full_abstracts([w for w in wanted if w], client=client)
 
     summary: list[dict[str, Any]] = []
     exported: list[int] = []
-    for identifier, answer, sources, intro, cited in prepared:
+    for identifier, answer, sources, _ in prepared:
         record = records[identifier]
         if not answer.strip():
             summary.append(
@@ -424,7 +547,9 @@ def export_predictions(
                 }
             )
             continue
-        rows = build_paper_rows(cited, fetched)
+
+        cutoff = _parse_iso_date(record["cutoff_date"])
+        intro, cited, rows = resolve_export(answer, sources, fetched, cutoff)
         if not rows:
             summary.append(
                 {
@@ -432,15 +557,11 @@ def export_predictions(
                     "arxiv_id": record["arxiv_id"],
                     "status": "no_eligible_source",
                     "reason": (
-                        "no citation in the answer resolved to a retrieved arXiv source"
-                        if not cited
-                        else "every cited source lacked a title, an abstract or a date"
+                        "no citation in the answer resolved to a retrieved arXiv source that "
+                        "satisfies the export contract"
                     ),
                     "sources_considered": len(sources),
-                    "source_rejections": {
-                        "unresolved_citations": len(sources) - len(cited),
-                        "unexportable_rows": len(cited) - len(rows),
-                    },
+                    "source_rejections": {"unexportable_after_validation": len(sources)},
                 }
             )
             continue
@@ -524,6 +645,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         action="store_true",
         help="Skip the Semantic Scholar lookup and use the truncated tool snippets",
     )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Replace the contents of a non-empty output directory",
+    )
     args = parser.parse_args(argv)
 
     logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
@@ -532,6 +658,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         args.output,
         system=args.system,
         fetch_abstracts=not args.no_fetch_abstracts,
+        force=args.force,
     )
     print(json.dumps(summary, indent=2, sort_keys=True))
     return 0 if summary["exported_count"] else 1

--- a/src/olmo_eval/evals/tasks/deepscholar_export.py
+++ b/src/olmo_eval/evals/tasks/deepscholar_export.py
@@ -10,10 +10,11 @@ matching what lit-agents' exporter writes. ``paper.csv`` holds every arXiv
 source the search tool showed the agent -- not only the cited ones -- because
 the contract the scorer checks is that cited IDs are a subset of the CSV.
 
-Publication dates come from the arXiv ID, which encodes only a month, so every
-row is written with ``date_precision: month``. That is the same fallback
-lit-agents uses when Semantic Scholar reports no date, and it is what the
-rendered tool output can support: the tool shows a year, not a day.
+Publication dates come from the ``Published`` line the search tool renders: day
+precision when Semantic Scholar dated the paper, month precision when only the
+arXiv ID could. The distinction matters because the contract rejects a
+month-precise source dated inside the cutoff's own month, so reporting a known
+day as a month would silently discard citable work.
 
 Usage:
     python -m olmo_eval.evals.tasks.deepscholar_export \\
@@ -82,26 +83,33 @@ def query_id(prediction: Mapping[str, Any]) -> str:
 
 
 def build_paper_rows(sources: Sequence[Mapping[str, str]]) -> list[dict[str, str]]:
-    """Build paper.csv rows, dropping sources whose ID encodes no date.
+    """Build paper.csv rows, dropping sources nothing can date.
 
-    A row the upstream contract cannot date is one it would reject, so dropping
-    it here keeps the export self-consistent rather than shipping a row that
-    fails validation later.
+    Dates come from the search tool's Published line, falling back to the month
+    the arXiv ID encodes. A row the upstream contract cannot date is one it
+    would reject, so dropping it here keeps the export self-consistent rather
+    than shipping a row that fails validation later.
     """
     rows: list[dict[str, str]] = []
     for source in sources:
         arxiv_id = source["arxiv_id"]
-        published = date_from_arxiv_id(arxiv_id)
-        if published is None:
-            logger.warning("Dropping source %s: its arXiv ID encodes no date", arxiv_id)
-            continue
+        published = source.get("published_date", "")
+        precision = source.get("date_precision", "")
+        if not published or not precision:
+            # Predictions saved before the tool rendered a Published line still
+            # carry the month their arXiv ID encodes.
+            fallback = date_from_arxiv_id(arxiv_id)
+            if fallback is None:
+                logger.warning("Dropping source %s: it has no resolvable date", arxiv_id)
+                continue
+            published, precision = fallback.isoformat(), "month"
         rows.append(
             {
                 "id": arxiv_id,
                 "title": source.get("title", ""),
                 "snippet": source.get("abstract", ""),
-                "published_date": published.isoformat(),
-                "date_precision": "month",
+                "published_date": published,
+                "date_precision": precision,
                 # The rendered tool output carries no Semantic Scholar paper ID,
                 # and the arXiv ID is already the unique key for a source here.
                 "paper_id": arxiv_id,

--- a/src/olmo_eval/evals/tasks/deepscholar_export.py
+++ b/src/olmo_eval/evals/tasks/deepscholar_export.py
@@ -1,0 +1,186 @@
+"""Convert saved deepscholar_bench predictions into DeepScholar-Bench folders.
+
+The upstream scorer reads one directory per query holding ``intro.md``,
+``final_report.md`` and ``paper.csv``; this script writes exactly that shape
+from a run's ``*-predictions.jsonl``, so generation and scoring stay two
+separate passes and a scoring change never requires re-running the model.
+
+``intro.md`` and ``final_report.md`` are both the answer text, byte for byte,
+matching what lit-agents' exporter writes. ``paper.csv`` holds every arXiv
+source the search tool showed the agent -- not only the cited ones -- because
+the contract the scorer checks is that cited IDs are a subset of the CSV.
+
+Publication dates come from the arXiv ID, which encodes only a month, so every
+row is written with ``date_precision: month``. That is the same fallback
+lit-agents uses when Semantic Scholar reports no date, and it is what the
+rendered tool output can support: the tool shows a year, not a day.
+
+Usage:
+    python -m olmo_eval.evals.tasks.deepscholar_export \\
+        --predictions <run>/deepscholar_bench-predictions.jsonl \\
+        --output <dir>
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import logging
+import sys
+from collections.abc import Iterator, Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from olmo_eval.common.types.trajectory import AgentTrajectory
+from olmo_eval.evals.tasks.deepscholar_bench import sources_from_trajectory
+from olmo_eval.harness.tools.search import date_from_arxiv_id
+
+logger = logging.getLogger(__name__)
+
+PAPER_CSV_FIELDS = ("id", "title", "snippet", "published_date", "date_precision", "paper_id")
+EXPORTED_FILES = ("intro.md", "final_report.md", "paper.csv")
+
+
+def read_predictions(path: str | Path) -> Iterator[dict[str, Any]]:
+    """Yield the prediction rows of a JSONL file, skipping blank lines."""
+    with Path(path).open(encoding="utf-8") as stream:
+        for line_number, line in enumerate(stream, start=1):
+            text = line.strip()
+            if not text:
+                continue
+            try:
+                yield json.loads(text)
+            except json.JSONDecodeError:
+                logger.warning("Skipping unparseable prediction on line %d", line_number)
+
+
+def answer_text(prediction: Mapping[str, Any]) -> str:
+    """The final answer a prediction row carries, or "" when it has none."""
+    final_output = prediction.get("final_output")
+    if isinstance(final_output, str) and final_output.strip():
+        return final_output
+    outputs = prediction.get("model_output") or []
+    if outputs and isinstance(outputs[0], Mapping):
+        text = outputs[0].get("text")
+        if isinstance(text, str):
+            return text
+    return ""
+
+
+def query_id(prediction: Mapping[str, Any]) -> str:
+    """The upstream positional query ID this prediction belongs to.
+
+    Folders are named for it, and upstream identifies a query by its row
+    position in the dataset CSV, so a row without one cannot be exported.
+    """
+    native_id = prediction.get("native_id")
+    if isinstance(native_id, str) and native_id.isdigit():
+        return native_id
+    doc_id = prediction.get("doc_id")
+    return str(doc_id) if isinstance(doc_id, int) else ""
+
+
+def build_paper_rows(sources: Sequence[Mapping[str, str]]) -> list[dict[str, str]]:
+    """Build paper.csv rows, dropping sources whose ID encodes no date.
+
+    A row the upstream contract cannot date is one it would reject, so dropping
+    it here keeps the export self-consistent rather than shipping a row that
+    fails validation later.
+    """
+    rows: list[dict[str, str]] = []
+    for source in sources:
+        arxiv_id = source["arxiv_id"]
+        published = date_from_arxiv_id(arxiv_id)
+        if published is None:
+            logger.warning("Dropping source %s: its arXiv ID encodes no date", arxiv_id)
+            continue
+        rows.append(
+            {
+                "id": arxiv_id,
+                "title": source.get("title", ""),
+                "snippet": source.get("abstract", ""),
+                "published_date": published.isoformat(),
+                "date_precision": "month",
+                # The rendered tool output carries no Semantic Scholar paper ID,
+                # and the arXiv ID is already the unique key for a source here.
+                "paper_id": arxiv_id,
+            }
+        )
+    return rows
+
+
+def write_query_folder(folder: Path, answer: str, rows: Sequence[Mapping[str, str]]) -> None:
+    """Write one query's three scorer inputs into ``folder``."""
+    folder.mkdir(parents=True, exist_ok=True)
+    (folder / "intro.md").write_text(answer, encoding="utf-8")
+    (folder / "final_report.md").write_text(answer, encoding="utf-8")
+    with (folder / "paper.csv").open("w", newline="", encoding="utf-8") as stream:
+        writer = csv.DictWriter(stream, fieldnames=list(PAPER_CSV_FIELDS))
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def export_predictions(predictions_path: str | Path, output_dir: str | Path) -> dict[str, Any]:
+    """Export every exportable prediction, returning a summary of what happened."""
+    root = Path(output_dir)
+    root.mkdir(parents=True, exist_ok=True)
+
+    exported: list[str] = []
+    skipped: list[dict[str, str]] = []
+    for prediction in read_predictions(predictions_path):
+        identifier = query_id(prediction)
+        if not identifier:
+            skipped.append({"idx": "", "reason": "no query ID"})
+            continue
+
+        answer = answer_text(prediction)
+        if not answer.strip():
+            skipped.append({"idx": identifier, "reason": "no answer text"})
+            continue
+
+        raw_trajectory = prediction.get("trajectory")
+        trajectory = (
+            AgentTrajectory.from_dict(raw_trajectory) if isinstance(raw_trajectory, dict) else None
+        )
+        rows = build_paper_rows(sources_from_trajectory(trajectory))
+        if not rows:
+            # An empty paper.csv fails the upstream contract, so an unciteable
+            # run is recorded as skipped rather than written out as a folder.
+            skipped.append({"idx": identifier, "reason": "no arXiv sources in trajectory"})
+            continue
+
+        write_query_folder(root / identifier, answer, rows)
+        exported.append(identifier)
+
+    return {
+        "output_dir": str(root),
+        "exported_ids": exported,
+        "exported_count": len(exported),
+        "skipped": skipped,
+        "skipped_count": len(skipped),
+    }
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--predictions",
+        required=True,
+        help="Path to a deepscholar_bench *-predictions.jsonl file",
+    )
+    parser.add_argument(
+        "--output",
+        required=True,
+        help="Directory to write the per-query scorer folders into",
+    )
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+    summary = export_predictions(args.predictions, args.output)
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0 if summary["exported_count"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/olmo_eval/evals/tasks/deepscholar_export.py
+++ b/src/olmo_eval/evals/tasks/deepscholar_export.py
@@ -65,7 +65,11 @@ from olmo_eval.evals.tasks.deepscholar_bench import (
     download_deepscholar_dataset,
     sources_from_trajectory,
 )
-from olmo_eval.evals.tasks.deepscholar_citations import rewrite_intro, select_scored_text
+from olmo_eval.evals.tasks.deepscholar_citations import (
+    SPLIT_TIERS,
+    rewrite_intro,
+    select_scored_text,
+)
 from olmo_eval.harness.tools.search import date_from_arxiv_id, normalize_arxiv_id
 
 logger = logging.getLogger(__name__)
@@ -527,18 +531,22 @@ def export_predictions(
         # not a numbered list the model happened to draft while deliberating.
         # The sources are needed first: the split is kept only where it leaves
         # something citable, so it can never cost a query its export.
-        answer, marker_found, marker_misused = select_scored_text(answer_text(prediction), sources)
+        answer, split_tier, marker_found, marker_misused = select_scored_text(
+            answer_text(prediction), sources
+        )
         # A first pass only to learn which abstracts are worth re-fetching; the
         # binding pass runs below, once the fetched dates can be validated.
         _, provisional = rewrite_intro(answer, sources)
-        prepared.append((identifier, answer, sources, provisional, marker_found, marker_misused))
+        prepared.append(
+            (identifier, answer, sources, provisional, marker_found, marker_misused, split_tier)
+        )
 
     fetched: dict[str, dict[str, str]] = {}
     if fetch_abstracts:
         wanted = list(
             dict.fromkeys(
                 normalize_arxiv_id(str(source.get("arxiv_id") or ""))
-                for _, _, _, provisional, _, _ in prepared
+                for _, _, _, provisional, _, _, _ in prepared
                 for source in provisional
             )
         )
@@ -549,7 +557,9 @@ def export_predictions(
     answers_with_text = 0
     markers_found = 0
     markers_misused = 0
-    for identifier, answer, sources, _, marker_found, marker_misused in prepared:
+    split_tier_counts = dict.fromkeys(SPLIT_TIERS, 0)
+    for identifier, answer, sources, _, marker_found, marker_misused, split_tier in prepared:
+        split_tier_counts[split_tier] += 1
         record = records[identifier]
         # A query that generated nothing can neither honour the delimiter
         # contract nor break it, so it stays out of the rate's denominator. A
@@ -575,6 +585,7 @@ def export_predictions(
                     "papers_retrieved": len(sources),
                     "marker_found": marker_found,
                     "marker_misused": marker_misused,
+                    "split_tier": split_tier,
                 }
             )
             continue
@@ -595,6 +606,7 @@ def export_predictions(
                     "source_rejections": {"unexportable_after_validation": len(sources)},
                     "marker_found": marker_found,
                     "marker_misused": marker_misused,
+                    "split_tier": split_tier,
                 }
             )
             continue
@@ -616,6 +628,7 @@ def export_predictions(
                 "num_papers": len(rows),
                 "marker_found": marker_found,
                 "marker_misused": marker_misused,
+                "split_tier": split_tier,
             }
         )
 
@@ -662,6 +675,13 @@ def export_predictions(
         # penalty; it rises when the prompt reads two ways to a backbone.
         "markers_misused": markers_misused,
         "marker_misuse_rate": (markers_misused / answers_with_text if answers_with_text else 0.0),
+        # Which rule recovered each report. 'none' is the keep-all fallback,
+        # so a run whose reports are mostly 'none' is one the splitter could
+        # not help and whose scored text is still mostly deliberation.
+        "split_tier_counts": split_tier_counts,
+        "split_coverage_rate": (
+            (len(prepared) - split_tier_counts["none"]) / len(prepared) if prepared else 0.0
+        ),
     }
 
 

--- a/src/olmo_eval/evals/tasks/deepscholar_export.py
+++ b/src/olmo_eval/evals/tasks/deepscholar_export.py
@@ -5,7 +5,15 @@ The upstream scorer reads one directory per query holding ``intro.md``,
 run's ``*-predictions.jsonl``, so generation and scoring stay separate passes
 and a scoring change never requires re-running the model.
 
-``intro.md`` is NOT the raw answer. The benchmark prompt mandates numbered
+``intro.md`` is NOT the raw answer, and it is not even the whole answer. The
+preset's system prompt lets the model deliberate before it delivers, provided
+the deliverable begins at a marker line, so
+:func:`olmo_eval.evals.tasks.deepscholar_citations.split_final_report` drops
+everything above that line first; an answer carrying no marker is kept whole,
+and ``marker_compliance_rate`` in the returned summary records how often that
+fallback was needed.
+
+What remains is still rewritten. The benchmark prompt mandates numbered
 inline citations, while ``DeepScholarBaseParser`` credits only markdown links to
 arxiv.org/abs and returns no documents for a query without one, so the answer's
 citations are rewritten by
@@ -57,7 +65,7 @@ from olmo_eval.evals.tasks.deepscholar_bench import (
     download_deepscholar_dataset,
     sources_from_trajectory,
 )
-from olmo_eval.evals.tasks.deepscholar_citations import rewrite_intro
+from olmo_eval.evals.tasks.deepscholar_citations import rewrite_intro, split_final_report
 from olmo_eval.harness.tools.search import date_from_arxiv_id, normalize_arxiv_id
 
 logger = logging.getLogger(__name__)
@@ -509,7 +517,10 @@ def export_predictions(
                 f"Prediction {identifier} is not a query in the pinned dataset at "
                 f"{DEEPSCHOLAR_COMMIT}"
             )
-        answer = answer_text(prediction)
+        # The delimiter contract is applied before anything reads the answer,
+        # so the reference list parsed below is the one under the marker and
+        # not a numbered list the model happened to draft while deliberating.
+        answer, marker_found = split_final_report(answer_text(prediction))
         raw_trajectory = prediction.get("trajectory")
         trajectory = (
             AgentTrajectory.from_dict(raw_trajectory) if isinstance(raw_trajectory, dict) else None
@@ -518,14 +529,14 @@ def export_predictions(
         # A first pass only to learn which abstracts are worth re-fetching; the
         # binding pass runs below, once the fetched dates can be validated.
         _, provisional = rewrite_intro(answer, sources)
-        prepared.append((identifier, answer, sources, provisional))
+        prepared.append((identifier, answer, sources, provisional, marker_found))
 
     fetched: dict[str, dict[str, str]] = {}
     if fetch_abstracts:
         wanted = list(
             dict.fromkeys(
                 normalize_arxiv_id(str(source.get("arxiv_id") or ""))
-                for _, _, _, provisional in prepared
+                for _, _, _, provisional, _ in prepared
                 for source in provisional
             )
         )
@@ -533,17 +544,32 @@ def export_predictions(
 
     summary: list[dict[str, Any]] = []
     exported: list[int] = []
-    for identifier, answer, sources, _ in prepared:
+    answers_with_text = 0
+    markers_found = 0
+    for identifier, answer, sources, _, marker_found in prepared:
         record = records[identifier]
+        # A query that generated nothing can neither honour the delimiter
+        # contract nor break it, so it stays out of the rate's denominator. A
+        # marker followed by nothing did generate text and counts as compliant:
+        # the instruction was followed and the report was not written, and
+        # those are different failures.
+        if answer.strip() or marker_found:
+            answers_with_text += 1
+            markers_found += int(marker_found)
         if not answer.strip():
             summary.append(
                 {
                     "idx": identifier,
                     "arxiv_id": record["arxiv_id"],
                     "status": "no_answer",
-                    "reason": "the run produced no answer text",
+                    "reason": (
+                        "the answer's final-report marker was followed by no text"
+                        if marker_found
+                        else "the run produced no answer text"
+                    ),
                     "termination_reason": "empty_response",
                     "papers_retrieved": len(sources),
+                    "marker_found": marker_found,
                 }
             )
             continue
@@ -562,6 +588,7 @@ def export_predictions(
                     ),
                     "sources_considered": len(sources),
                     "source_rejections": {"unexportable_after_validation": len(sources)},
+                    "marker_found": marker_found,
                 }
             )
             continue
@@ -581,6 +608,7 @@ def export_predictions(
                 "arxiv_id": record["arxiv_id"],
                 "status": "success",
                 "num_papers": len(rows),
+                "marker_found": marker_found,
             }
         )
 
@@ -612,6 +640,16 @@ def export_predictions(
         "skipped": [item for item in summary if item["status"] != "success"],
         "skipped_count": sum(1 for item in summary if item["status"] != "success"),
         "snippet_fallback_rows": fallback_rows,
+        # Bookkeeping, not a score. The delimiter contract is measured and
+        # never enforced: an answer that skips the marker still exports, and
+        # this is how that shows up instead of being invisible. The per-query
+        # flags in summary.json make the rate recomputable from disk, which is
+        # where it has to live -- lit-agents' preflight rejects any extra key
+        # in export_manifest.json, so the per-query manifests keep its exact
+        # shape.
+        "answers_with_text": answers_with_text,
+        "markers_found": markers_found,
+        "marker_compliance_rate": (markers_found / answers_with_text if answers_with_text else 0.0),
     }
 
 

--- a/src/olmo_eval/evals/tasks/deepscholar_export.py
+++ b/src/olmo_eval/evals/tasks/deepscholar_export.py
@@ -1,20 +1,28 @@
 """Convert saved deepscholar_bench predictions into DeepScholar-Bench folders.
 
 The upstream scorer reads one directory per query holding ``intro.md``,
-``final_report.md`` and ``paper.csv``; this script writes exactly that shape
-from a run's ``*-predictions.jsonl``, so generation and scoring stay two
-separate passes and a scoring change never requires re-running the model.
+``final_report.md`` and ``paper.csv``; this writes exactly that shape from a
+run's ``*-predictions.jsonl``, so generation and scoring stay separate passes
+and a scoring change never requires re-running the model.
 
-``intro.md`` and ``final_report.md`` are both the answer text, byte for byte,
-matching what lit-agents' exporter writes. ``paper.csv`` holds every arXiv
-source the search tool showed the agent -- not only the cited ones -- because
-the contract the scorer checks is that cited IDs are a subset of the CSV.
+``intro.md`` is NOT the raw answer. The benchmark prompt mandates numbered
+inline citations, while ``DeepScholarBaseParser`` credits only markdown links to
+arxiv.org/abs and returns no documents for a query without one, so the answer's
+citations are rewritten by
+:mod:`olmo_eval.evals.tasks.deepscholar_citations`, which mirrors lit-agents'
+``render_intro``. ``final_report.md`` is the same rewritten bytes, matching what
+lit-agents' ``_write_query_folder`` writes.
 
-Publication dates come from the ``Published`` line the search tool renders: day
-precision when Semantic Scholar dated the paper, month precision when only the
-arXiv ID could. The distinction matters because the contract rejects a
-month-precise source dated inside the cutoff's own month, so reporting a known
-day as a month would silently discard citable work.
+``paper.csv`` carries only the sources the rewritten intro actually cites, which
+is what lit-agents exports and what keeps the contract's "cited IDs are a subset
+of paper.csv" check meaningful. Its ``snippet`` column is scored, so abstracts
+are re-fetched in full from Semantic Scholar rather than reused from the
+truncated preview the agent was shown; ``snippet_source`` records which row fell
+back to that preview.
+
+``export_manifest.json``, ``summary.json`` and ``generation_manifest.json``
+mirror lit-agents' own, so the output can be handed to its ``preflight_folder``
+rather than only to the parser.
 
 Usage:
     python -m olmo_eval.evals.tasks.deepscholar_export \\
@@ -26,21 +34,56 @@ from __future__ import annotations
 
 import argparse
 import csv
+import hashlib
 import json
 import logging
+import os
 import sys
+import tempfile
 from collections.abc import Iterator, Mapping, Sequence
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
+
+import httpx
 
 from olmo_eval.common.types.trajectory import AgentTrajectory
-from olmo_eval.evals.tasks.deepscholar_bench import sources_from_trajectory
-from olmo_eval.harness.tools.search import date_from_arxiv_id
+from olmo_eval.evals.tasks.deepscholar_bench import (
+    DEEPSCHOLAR_COMMIT,
+    _first_nonempty,
+    _parse_iso_date,
+    build_deepscholar_prompt,
+    download_deepscholar_dataset,
+    sources_from_trajectory,
+)
+from olmo_eval.evals.tasks.deepscholar_citations import rewrite_intro
+from olmo_eval.harness.tools.search import date_from_arxiv_id, normalize_arxiv_id
 
 logger = logging.getLogger(__name__)
 
-PAPER_CSV_FIELDS = ("id", "title", "snippet", "published_date", "date_precision", "paper_id")
+# The six columns lit-agents' _write_query_folder writes, plus one recording
+# where the snippet came from. The upstream parser reads id/title/snippet by
+# name and ignores the rest, so the extra column is inert to scoring.
+PAPER_CSV_FIELDS = (
+    "id",
+    "title",
+    "snippet",
+    "published_date",
+    "date_precision",
+    "paper_id",
+    "snippet_source",
+)
 EXPORTED_FILES = ("intro.md", "final_report.md", "paper.csv")
+EXPORT_SCHEMA_VERSION = 1
+QUERY_MANIFEST_NAME = "export_manifest.json"
+GENERATION_MANIFEST_NAME = "generation_manifest.json"
+# lit-agents' preflight only accepts systems it knows. This run's shape -- one
+# agent, searching and writing its own numbered reference list -- is
+# single_agent_1's, so that is the name the manifests carry by default.
+DEFAULT_SYSTEM = "single_agent_1"
+
+S2_BATCH_URL = "https://api.semanticscholar.org/graph/v1/paper/batch"
+S2_BATCH_FIELDS = "title,abstract,publicationDate"
+S2_BATCH_MAX_IDS = 500
 
 
 def read_predictions(path: str | Path) -> Iterator[dict[str, Any]]:
@@ -69,105 +112,391 @@ def answer_text(prediction: Mapping[str, Any]) -> str:
     return ""
 
 
-def query_id(prediction: Mapping[str, Any]) -> str:
+def query_id(prediction: Mapping[str, Any]) -> int:
     """The upstream positional query ID this prediction belongs to.
 
-    Folders are named for it, and upstream identifies a query by its row
-    position in the dataset CSV, so a row without one cannot be exported.
+    Upstream identifies a query by its row position in the dataset CSV and the
+    export folders are named for it, so a wrong ID silently scores one paper's
+    answer against another's ground truth. ``doc_id`` is a within-run counter
+    that coincides with the position only when nothing was filtered or limited,
+    so it is not an acceptable substitute and this raises instead.
     """
     native_id = prediction.get("native_id")
     if isinstance(native_id, str) and native_id.isdigit():
-        return native_id
-    doc_id = prediction.get("doc_id")
-    return str(doc_id) if isinstance(doc_id, int) else ""
+        return int(native_id)
+    raise ValueError(
+        f"Prediction has no positional native_id (got {native_id!r}); it cannot be "
+        "matched to a DeepScholar query. Re-run the task so predictions carry "
+        "Instance.metadata['id']."
+    )
 
 
-def build_paper_rows(sources: Sequence[Mapping[str, str]]) -> list[dict[str, str]]:
-    """Build paper.csv rows, dropping sources nothing can date.
+def fetch_full_abstracts(
+    arxiv_ids: Sequence[str],
+    *,
+    client: httpx.Client | None = None,
+) -> dict[str, dict[str, str]]:
+    """Re-fetch title and full abstract for each arXiv ID from Semantic Scholar.
 
-    Dates come from the search tool's Published line, falling back to the month
-    the arXiv ID encodes. A row the upstream contract cannot date is one it
-    would reject, so dropping it here keeps the export self-consistent rather
-    than shipping a row that fails validation later.
+    paper.csv's snippet column is scored, and what the agent saw is truncated to
+    keep its context affordable, so the export asks for the text again rather
+    than shipping a preview as if it were the abstract.
+
+    Failure is survivable by design: an unreachable API, a missing paper or a
+    paper with no abstract simply leaves that ID out of the result, and the
+    caller falls back to the rendered preview and records that it did.
     """
+    if not arxiv_ids:
+        return {}
+
+    headers = {"Content-Type": "application/json"}
+    api_key = os.getenv("S2_API_KEY", "").split(",")[0].strip()
+    if api_key:
+        headers["x-api-key"] = api_key
+
+    owned = client is None
+    http = client or httpx.Client(timeout=60.0)
+    fetched: dict[str, dict[str, str]] = {}
+    try:
+        for start in range(0, len(arxiv_ids), S2_BATCH_MAX_IDS):
+            chunk = list(arxiv_ids[start : start + S2_BATCH_MAX_IDS])
+            try:
+                response = http.post(
+                    S2_BATCH_URL,
+                    params={"fields": S2_BATCH_FIELDS},
+                    json={"ids": [f"ARXIV:{arxiv_id}" for arxiv_id in chunk]},
+                    headers=headers,
+                )
+                response.raise_for_status()
+                payload = response.json()
+            except (httpx.HTTPError, json.JSONDecodeError) as error:
+                logger.warning(
+                    "Semantic Scholar batch lookup failed for %d IDs: %s", len(chunk), error
+                )
+                continue
+            if not isinstance(payload, list):
+                logger.warning(
+                    "Semantic Scholar batch returned %s, not a list", type(payload).__name__
+                )
+                continue
+            for arxiv_id, raw in zip(chunk, payload, strict=False):
+                if not isinstance(raw, Mapping):
+                    continue
+                record = cast("Mapping[str, Any]", raw)
+                abstract = str(record.get("abstract") or "").strip()
+                if not abstract:
+                    continue
+                fetched[arxiv_id] = {
+                    "title": str(record.get("title") or "").strip(),
+                    "abstract": abstract,
+                    "published_date": str(record.get("publicationDate") or "").strip(),
+                }
+    finally:
+        if owned:
+            http.close()
+    return fetched
+
+
+def build_paper_rows(
+    sources: Sequence[Mapping[str, str]],
+    fetched: Mapping[str, Mapping[str, str]] | None = None,
+) -> list[dict[str, str]]:
+    """Build paper.csv rows for the cited sources, dropping any that cannot stand.
+
+    A row needs a non-empty title and snippet and a resolvable date, because
+    those are exactly the conditions the contract checks; shipping a row that
+    fails them turns a scoreable query into a rejected one.
+    """
+    fetched = fetched or {}
     rows: list[dict[str, str]] = []
     for source in sources:
-        arxiv_id = source["arxiv_id"]
-        published = source.get("published_date", "")
-        precision = source.get("date_precision", "")
-        if not published or not precision:
-            # Predictions saved before the tool rendered a Published line still
-            # carry the month their arXiv ID encodes.
-            fallback = date_from_arxiv_id(arxiv_id)
-            if fallback is None:
-                logger.warning("Dropping source %s: it has no resolvable date", arxiv_id)
-                continue
-            published, precision = fallback.isoformat(), "month"
+        arxiv_id = normalize_arxiv_id(str(source.get("arxiv_id") or ""))
+        if not arxiv_id:
+            continue
+        record = fetched.get(arxiv_id) or {}
+
+        if record.get("abstract"):
+            title = record.get("title") or str(source.get("title") or "")
+            snippet = record["abstract"]
+            snippet_source = "s2_batch"
+        else:
+            title = str(source.get("title") or "")
+            snippet = str(source.get("abstract") or "")
+            snippet_source = "tool_output"
+
+        published, precision = _resolve_row_date(source, record, arxiv_id)
+        if not published:
+            logger.warning("Dropping source %s: it has no resolvable date", arxiv_id)
+            continue
+        if not title.strip() or not snippet.strip():
+            logger.warning("Dropping source %s: it has no title or no abstract", arxiv_id)
+            continue
+
         rows.append(
             {
                 "id": arxiv_id,
-                "title": source.get("title", ""),
-                "snippet": source.get("abstract", ""),
+                "title": title.strip(),
+                "snippet": snippet.strip(),
                 "published_date": published,
                 "date_precision": precision,
                 # The rendered tool output carries no Semantic Scholar paper ID,
                 # and the arXiv ID is already the unique key for a source here.
                 "paper_id": arxiv_id,
+                "snippet_source": snippet_source,
             }
         )
     return rows
 
 
-def write_query_folder(folder: Path, answer: str, rows: Sequence[Mapping[str, str]]) -> None:
-    """Write one query's three scorer inputs into ``folder``."""
-    folder.mkdir(parents=True, exist_ok=True)
-    (folder / "intro.md").write_text(answer, encoding="utf-8")
-    (folder / "final_report.md").write_text(answer, encoding="utf-8")
-    with (folder / "paper.csv").open("w", newline="", encoding="utf-8") as stream:
-        writer = csv.DictWriter(stream, fieldnames=list(PAPER_CSV_FIELDS))
-        writer.writeheader()
-        writer.writerows(rows)
+def _resolve_row_date(
+    source: Mapping[str, str],
+    record: Mapping[str, str],
+    arxiv_id: str,
+) -> tuple[str, str]:
+    """Best date available for a row: the batch lookup, the tool's line, the ID."""
+    batch_date = _parse_iso_date(str(record.get("published_date") or ""))
+    if batch_date is not None:
+        return batch_date.isoformat(), "day"
+    published = str(source.get("published_date") or "")
+    precision = str(source.get("date_precision") or "")
+    if published and precision:
+        return published, precision
+    fallback = date_from_arxiv_id(arxiv_id)
+    return ("", "") if fallback is None else (fallback.isoformat(), "month")
 
 
-def export_predictions(predictions_path: str | Path, output_dir: str | Path) -> dict[str, Any]:
-    """Export every exportable prediction, returning a summary of what happened."""
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    digest.update(path.read_bytes())
+    return digest.hexdigest()
+
+
+def _write_json_atomic(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    temporary.write_text(
+        json.dumps(value, indent=2, sort_keys=True, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    os.replace(temporary, path)
+
+
+def query_fingerprint(record: Mapping[str, Any]) -> str:
+    """Fingerprint one query exactly as lit-agents' _query_fingerprint does."""
+    payload = {
+        "idx": record["idx"],
+        "query": record["query"],
+        "cutoff_date": record["cutoff_date"],
+        "arxiv_id": record["arxiv_id"],
+        "title": record["title"],
+        "abstract": record["abstract"],
+    }
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode(
+        "utf-8"
+    )
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def load_query_records(dataset_path: str | Path | None = None) -> dict[int, dict[str, Any]]:
+    """Rebuild the query records the manifests are fingerprinted against.
+
+    Mirrors lit-agents' ``load_queries``: positional IDs, the same cutoff and
+    title fallbacks, and the query text this task actually sent, which is the
+    verbatim template.
+    """
+    path = Path(dataset_path) if dataset_path is not None else download_deepscholar_dataset()
+    with path.open(newline="", encoding="utf-8") as stream:
+        rows = list(csv.DictReader(stream))
+
+    records: dict[int, dict[str, Any]] = {}
+    for index, row in enumerate(rows):
+        cutoff = _parse_iso_date(_first_nonempty(row, "published_date", "cutoff_date"))
+        abstract = _first_nonempty(row, "abstract")
+        if cutoff is None or not abstract:
+            continue
+        records[index] = {
+            "idx": index,
+            "query": build_deepscholar_prompt(cutoff.isoformat(), abstract),
+            "cutoff_date": cutoff.isoformat(),
+            "arxiv_id": normalize_arxiv_id(_first_nonempty(row, "arxiv_id")),
+            "title": _first_nonempty(row, "title") or f"DeepScholar query {index}",
+            "abstract": abstract,
+        }
+    return records
+
+
+def write_query_folder(
+    root: Path,
+    query_id_value: int,
+    intro: str,
+    rows: Sequence[Mapping[str, str]],
+    *,
+    system: str,
+    fingerprint: str,
+) -> None:
+    """Write one query's scorer inputs and its export manifest, atomically.
+
+    Mirrors lit-agents' ``_write_query_folder``: intro.md and final_report.md
+    hold the same bytes, and the manifest checksums all three files so a
+    truncated write cannot pass for a complete export.
+    """
+    target = root / str(query_id_value)
+    if target.exists():
+        raise FileExistsError(f"Query output already exists: {target}")
+    root.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix=f".query-{query_id_value}-", dir=root) as tmp:
+        temporary = Path(tmp)
+        (temporary / "intro.md").write_text(intro, encoding="utf-8")
+        (temporary / "final_report.md").write_text(intro, encoding="utf-8")
+        with (temporary / "paper.csv").open("w", newline="", encoding="utf-8") as stream:
+            writer = csv.DictWriter(stream, fieldnames=list(PAPER_CSV_FIELDS))
+            writer.writeheader()
+            writer.writerows(rows)
+        _write_json_atomic(
+            temporary / QUERY_MANIFEST_NAME,
+            {
+                "schema_version": EXPORT_SCHEMA_VERSION,
+                "system": system,
+                "idx": query_id_value,
+                "query_fingerprint": fingerprint,
+                "num_papers": len(rows),
+                "files": {name: _sha256_file(temporary / name) for name in EXPORTED_FILES},
+            },
+        )
+        os.replace(temporary, target)
+
+
+def export_predictions(
+    predictions_path: str | Path,
+    output_dir: str | Path,
+    *,
+    system: str = DEFAULT_SYSTEM,
+    dataset_path: str | Path | None = None,
+    fetch_abstracts: bool = True,
+    client: httpx.Client | None = None,
+) -> dict[str, Any]:
+    """Export every prediction, returning the summary it also writes to disk."""
     root = Path(output_dir)
     root.mkdir(parents=True, exist_ok=True)
+    records = load_query_records(dataset_path)
 
-    exported: list[str] = []
-    skipped: list[dict[str, str]] = []
+    prepared = []
     for prediction in read_predictions(predictions_path):
         identifier = query_id(prediction)
-        if not identifier:
-            skipped.append({"idx": "", "reason": "no query ID"})
-            continue
-
+        if identifier not in records:
+            raise ValueError(
+                f"Prediction {identifier} is not a query in the pinned dataset at "
+                f"{DEEPSCHOLAR_COMMIT}"
+            )
         answer = answer_text(prediction)
-        if not answer.strip():
-            skipped.append({"idx": identifier, "reason": "no answer text"})
-            continue
-
         raw_trajectory = prediction.get("trajectory")
         trajectory = (
             AgentTrajectory.from_dict(raw_trajectory) if isinstance(raw_trajectory, dict) else None
         )
-        rows = build_paper_rows(sources_from_trajectory(trajectory))
+        sources = sources_from_trajectory(trajectory)
+        intro, cited = rewrite_intro(answer, sources)
+        prepared.append((identifier, answer, sources, intro, cited))
+
+    fetched: dict[str, dict[str, str]] = {}
+    if fetch_abstracts:
+        wanted = list(
+            dict.fromkeys(
+                normalize_arxiv_id(str(source.get("arxiv_id") or ""))
+                for _, _, _, _, cited in prepared
+                for source in cited
+            )
+        )
+        fetched = fetch_full_abstracts([w for w in wanted if w], client=client)
+
+    summary: list[dict[str, Any]] = []
+    exported: list[int] = []
+    for identifier, answer, sources, intro, cited in prepared:
+        record = records[identifier]
+        if not answer.strip():
+            summary.append(
+                {
+                    "idx": identifier,
+                    "arxiv_id": record["arxiv_id"],
+                    "status": "no_answer",
+                    "reason": "the run produced no answer text",
+                    "termination_reason": "empty_response",
+                    "papers_retrieved": len(sources),
+                }
+            )
+            continue
+        rows = build_paper_rows(cited, fetched)
         if not rows:
-            # An empty paper.csv fails the upstream contract, so an unciteable
-            # run is recorded as skipped rather than written out as a folder.
-            skipped.append({"idx": identifier, "reason": "no arXiv sources in trajectory"})
+            summary.append(
+                {
+                    "idx": identifier,
+                    "arxiv_id": record["arxiv_id"],
+                    "status": "no_eligible_source",
+                    "reason": (
+                        "no citation in the answer resolved to a retrieved arXiv source"
+                        if not cited
+                        else "every cited source lacked a title, an abstract or a date"
+                    ),
+                    "sources_considered": len(sources),
+                    "source_rejections": {
+                        "unresolved_citations": len(sources) - len(cited),
+                        "unexportable_rows": len(cited) - len(rows),
+                    },
+                }
+            )
             continue
 
-        write_query_folder(root / identifier, answer, rows)
+        write_query_folder(
+            root,
+            identifier,
+            intro,
+            rows,
+            system=system,
+            fingerprint=query_fingerprint(record),
+        )
         exported.append(identifier)
+        summary.append(
+            {
+                "idx": identifier,
+                "arxiv_id": record["arxiv_id"],
+                "status": "success",
+                "num_papers": len(rows),
+            }
+        )
 
+    summary.sort(key=lambda item: item["idx"])
+    _write_json_atomic(root / "summary.json", summary)
+    _write_json_atomic(
+        root / GENERATION_MANIFEST_NAME,
+        {
+            "schema_version": EXPORT_SCHEMA_VERSION,
+            "system": system,
+            "queries": [
+                {"idx": item["idx"], "fingerprint": query_fingerprint(records[item["idx"]])}
+                for item in summary
+            ],
+        },
+    )
+
+    fallback_rows = sum(
+        1
+        for identifier in exported
+        for row in _read_rows(root / str(identifier) / "paper.csv")
+        if row.get("snippet_source") == "tool_output"
+    )
     return {
         "output_dir": str(root),
+        "system": system,
         "exported_ids": exported,
         "exported_count": len(exported),
-        "skipped": skipped,
-        "skipped_count": len(skipped),
+        "skipped": [item for item in summary if item["status"] != "success"],
+        "skipped_count": sum(1 for item in summary if item["status"] != "success"),
+        "snippet_fallback_rows": fallback_rows,
     }
+
+
+def _read_rows(path: Path) -> list[dict[str, str]]:
+    with path.open(newline="", encoding="utf-8") as stream:
+        return list(csv.DictReader(stream))
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -182,10 +511,28 @@ def main(argv: Sequence[str] | None = None) -> int:
         required=True,
         help="Directory to write the per-query scorer folders into",
     )
+    parser.add_argument(
+        "--system",
+        default=DEFAULT_SYSTEM,
+        help=(
+            "System name recorded in the manifests. lit-agents' preflight only "
+            f"accepts names it knows; default {DEFAULT_SYSTEM}."
+        ),
+    )
+    parser.add_argument(
+        "--no-fetch-abstracts",
+        action="store_true",
+        help="Skip the Semantic Scholar lookup and use the truncated tool snippets",
+    )
     args = parser.parse_args(argv)
 
     logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
-    summary = export_predictions(args.predictions, args.output)
+    summary = export_predictions(
+        args.predictions,
+        args.output,
+        system=args.system,
+        fetch_abstracts=not args.no_fetch_abstracts,
+    )
     print(json.dumps(summary, indent=2, sort_keys=True))
     return 0 if summary["exported_count"] else 1
 

--- a/src/olmo_eval/evals/tasks/researchqa.py
+++ b/src/olmo_eval/evals/tasks/researchqa.py
@@ -67,25 +67,72 @@ RESEARCHQA_LABEL_SCORES = {
     "Completely": 5,
 }
 
-RESEARCHQA_GENERATION_PROMPT = (
-    "You are answering a scholarly research question. Use the available research tools "
-    "to find reliable sources that support your answer.\n\n"
-    "Available tools:\n"
-    "- semantic_scholar_snippet_search\n"
-    "- serper_google_webpage_search\n"
-    "- serper_fetch_webpage_content\n\n"
-    "Format and length requirements:\n"
-    "- Write a well-organized, citation-supported answer in about 250 words.\n"
-    "- Synthesize the evidence directly around the question and cite the sources you use.\n\n"
-    "{date_cutoff}"
-    "Workflow (follow this order):\n"
-    "1. Search for relevant scholarly sources using semantic_scholar_snippet_search and "
-    "serper_google_webpage_search.\n"
-    "2. Fetch and read promising source content using serper_fetch_webpage_content.\n"
-    "3. Only after searching, fetching, and reading, write the answer.\n"
-    "Search first, then fetch and read, and only then answer. Do not answer from memory.\n\n"
-    "Question: "
+# Tool list the prompt falls back to when the harness reports no tools of its own.
+# It is the set the dr_tulu preset exposes, and keeps non-agentic runs byte-identical
+# to the prompt this task shipped with.
+RESEARCHQA_DEFAULT_TOOLS = (
+    "semantic_scholar_snippet_search",
+    "serper_google_webpage_search",
+    "serper_fetch_webpage_content",
 )
+
+# Tools that retrieve a full document; every other tool is described as a search tool.
+RESEARCHQA_FETCH_TOOLS = frozenset({"serper_fetch_webpage_content", "browse_webpage"})
+
+
+def _join_tool_names(names: Sequence[str]) -> str:
+    """Join tool names as prose: "a", "a and b", "a, b and c"."""
+    if len(names) < 3:
+        return " and ".join(names)
+    return f"{', '.join(names[:-1])} and {names[-1]}"
+
+
+def build_generation_prompt(tool_names: Sequence[str] = ()) -> str:
+    """Build the generation prompt template for the tools the harness really exposes.
+
+    Naming a tool the harness does not provide makes the model call it, and the
+    scaffold then aborts the episode with a tool-not-found error before any turn
+    runs, so the prompt has to follow the harness rather than a fixed list.
+    ``tool_names`` is that harness list; empty falls back to
+    ``RESEARCHQA_DEFAULT_TOOLS``. The result still carries the ``{date_cutoff}``
+    placeholder for :meth:`ResearchQA.format_request` to fill in.
+    """
+    tools = tuple(tool_names) or RESEARCHQA_DEFAULT_TOOLS
+    fetch_tools = [name for name in tools if name in RESEARCHQA_FETCH_TOOLS]
+    search_tools = [name for name in tools if name not in RESEARCHQA_FETCH_TOOLS]
+    # A harness with fetch tools only still needs a step 1 to point at.
+    if not search_tools:
+        search_tools, fetch_tools = list(tools), []
+
+    workflow = f"1. Search for relevant scholarly sources using {_join_tool_names(search_tools)}.\n"
+    if fetch_tools:
+        workflow += (
+            f"2. Fetch and read promising source content using {_join_tool_names(fetch_tools)}.\n"
+            "3. Only after searching, fetching, and reading, write the answer.\n"
+            "Search first, then fetch and read, and only then answer. Do not answer from memory."
+        )
+    else:
+        workflow += (
+            "2. Only after searching and reading the search results, write the answer.\n"
+            "Search first, and only then answer. Do not answer from memory."
+        )
+
+    tool_list = "".join(f"- {name}\n" for name in tools)
+    return (
+        "You are answering a scholarly research question. Use the available research tools "
+        "to find reliable sources that support your answer.\n\n"
+        f"Available tools:\n{tool_list}\n"
+        "Format and length requirements:\n"
+        "- Write a well-organized, citation-supported answer in about 250 words.\n"
+        "- Synthesize the evidence directly around the question and cite the sources you use.\n\n"
+        "{date_cutoff}"
+        "Workflow (follow this order):\n"
+        f"{workflow}\n\n"
+        "Question: "
+    )
+
+
+RESEARCHQA_GENERATION_PROMPT = build_generation_prompt()
 
 # Verbatim from ResearchQA's official compute_coverage.py:build_prompt().
 RESEARCHQA_COVERAGE_JUDGE_PROMPT = (
@@ -323,7 +370,9 @@ class ResearchQA(Task):
             if isinstance(date, str) and date
             else ""
         )
-        generation_prompt = RESEARCHQA_GENERATION_PROMPT.format(date_cutoff=date_cutoff)
+        generation_prompt = build_generation_prompt(self.config.harness_tool_names).format(
+            date_cutoff=date_cutoff
+        )
         return LMRequest(
             request_type=RequestType.CHAT,
             messages=(

--- a/src/olmo_eval/harness/presets.py
+++ b/src/olmo_eval/harness/presets.py
@@ -34,6 +34,25 @@ serper_fetch_webpage_content before answering. Quote only text copied from
 fetched page content, and do not invent citations."""
 
 
+# The delimiter contract for deepscholar_bench's single arm. The benchmark's
+# user prompt is run verbatim and cannot be edited, and the 9B run showed why
+# something had to give: 45 of 63 answers reached their Related Works section
+# only after a median 9.8k characters of planning, all of which the scorer read
+# as the report. Banning deliberation would cost quality, so this buys the
+# split instead -- think above the line, deliver below it. Kept in sync with
+# deepscholar_citations.split_final_report by a test that reads the marker back
+# out of this string.
+ARXIV_PAPER_SEARCH_SYSTEM_PROMPT = """\
+You may plan and deliberate freely in your reply. When you are ready to deliver,
+write a line containing exactly:
+
+=== FINAL REPORT ===
+
+Everything after that line is your deliverable: only the Related Works section,
+followed by the numbered reference list. Text before the marker is discarded and
+is never evaluated."""
+
+
 # TODO(undfined): Remove reference to beaker
 def _get_logs_dir() -> str:
     """Get the logs directory based on environment."""
@@ -181,6 +200,13 @@ class HarnessPresets:
     def arxiv_paper_search_agent(name: str) -> HarnessConfig:
         """Agentic harness exposing only arXiv-filtered paper search.
 
+        The system prompt carries a delimiter contract: the model may deliberate
+        in its reply, but its deliverable starts at an exact marker line and
+        everything above that line is discarded before scoring. See
+        ARXIV_PAPER_SEARCH_SYSTEM_PROMPT and
+        deepscholar_citations.split_final_report, which reads the marker back
+        out.
+
         For tasks whose scorer credits arXiv sources alone (e.g.
         deepscholar_bench). Kept separate from `paper_search_agent` rather than
         added to it: which search tools an agent holds changes what it retrieves,
@@ -209,6 +235,7 @@ class HarnessPresets:
                 kwargs={"timeout": 120},
             ),
             tools=(arxiv_paper_search,),
+            system_prompt=ARXIV_PAPER_SEARCH_SYSTEM_PROMPT,
             # Writing a related-works section takes more searching than a
             # single-answer lookup, so this doubles paper_search_agent's turns.
             max_turns=20,

--- a/src/olmo_eval/harness/presets.py
+++ b/src/olmo_eval/harness/presets.py
@@ -178,6 +178,33 @@ class HarnessPresets:
         )
 
     @lazy
+    def arxiv_paper_search_agent(name: str) -> HarnessConfig:
+        """Agentic harness exposing only arXiv-filtered paper search.
+
+        For tasks whose scorer credits arXiv sources alone (e.g.
+        deepscholar_bench). Kept separate from `paper_search_agent` rather than
+        added to it: which search tools an agent holds changes what it retrieves,
+        so sharing a preset would move litsearch and SAGE numbers that were
+        measured against Semantic Scholar search.
+        """
+        from .tools.search import arxiv_paper_search
+
+        return HarnessConfig(
+            name=name,
+            provider=ProviderConfig(
+                kind=ProviderKind.VLLM_SERVER,
+                kwargs={"timeout": 120},
+            ),
+            tools=(arxiv_paper_search,),
+            # Writing a related-works section takes more searching than a
+            # single-answer lookup, so this doubles paper_search_agent's turns.
+            max_turns=20,
+            max_concurrency=4,
+            scaffold="openai_agents",
+            batching=BatchConfig.streaming(),
+        )
+
+    @lazy
     def web_search_agent(name: str) -> HarnessConfig:
         """Agentic harness exposing only web search/fetch tools.
 

--- a/src/olmo_eval/harness/presets.py
+++ b/src/olmo_eval/harness/presets.py
@@ -34,22 +34,28 @@ serper_fetch_webpage_content before answering. Quote only text copied from
 fetched page content, and do not invent citations."""
 
 
-# The delimiter contract for deepscholar_bench's single arm. The benchmark's
-# user prompt is run verbatim and cannot be edited, and the 9B run showed why
-# something had to give: 45 of 63 answers reached their Related Works section
-# only after a median 9.8k characters of planning, all of which the scorer read
-# as the report. Banning deliberation would cost quality, so this buys the
-# split instead -- think above the line, deliver below it. Kept in sync with
-# deepscholar_citations.split_final_report by a test that reads the marker back
-# out of this string.
+# The v3 instrument's whole prompt-side contract, in one string, because the two
+# halves fix two different failures and the agent reads them as one instruction.
 #
-# The wording is emphatic about where the prose goes because the first version
-# was not, and Qwen3.5-9B read it the other way: it wrote the whole Related
-# Works section while deliberating and put only the numbered list below the
-# line, so the split threw its report away. Saying 'your deliverable is what
-# follows' was not enough -- it has to say the section itself must not appear
-# above the marker.
+# The first sentence is the search nudge, measured in W0018: Qwen3.5-9B otherwise
+# skips the tool outright on some queries, answering from memory in a single turn,
+# and every such query is unexportable because nothing it cites was ever
+# retrieved. That sentence took 9B's tool-skips from 6/63 to 0/63 and is
+# reproduced here verbatim -- it is a pre-registered string, not prose to edit.
+#
+# The rest is the delimiter contract. The benchmark's user prompt is run verbatim
+# and cannot be edited, and 9B reached its Related Works section only after a
+# median 9.8k characters of planning, all of which the scorer read as the report.
+# Banning deliberation would cost quality, so this buys the split instead: think
+# above the line, deliver below it. The wording is emphatic about where the prose
+# goes because the first version was not, and 9B read it the other way -- writing
+# the whole section while deliberating and leaving only the numbered list below
+# the line. Kept in sync with deepscholar_citations by a test that reads the
+# marker back out of this string.
 ARXIV_PAPER_SEARCH_SYSTEM_PROMPT = """\
+Search for relevant papers with the tool before writing. Base every citation on \
+sources returned by your searches, never on memory.
+
 You may plan and deliberate freely in your reply. When you are ready to deliver,
 write a line containing exactly:
 

--- a/src/olmo_eval/harness/presets.py
+++ b/src/olmo_eval/harness/presets.py
@@ -186,6 +186,12 @@ class HarnessPresets:
         added to it: which search tools an agent holds changes what it retrieves,
         so sharing a preset would move litsearch and SAGE numbers that were
         measured against Semantic Scholar search.
+
+        No secret is declared, so this runs keyless against the public Semantic
+        Scholar API at its shared ~1 request/second. `required_secrets` is a
+        hard launch gate with no optional form, and declaring one here would
+        make a keyless run impossible; mount a key per run instead with
+        `--secret-env <user>_S2_API_KEY:S2_API_KEY`.
         """
         from .tools.search import arxiv_paper_search
 

--- a/src/olmo_eval/harness/presets.py
+++ b/src/olmo_eval/harness/presets.py
@@ -157,7 +157,10 @@ class HarnessPresets:
         For literature-search tasks (e.g. litsearch). Exposes a single paper-search
         tool and declares no required secrets, so it runs against the public
         Semantic Scholar API keyless (rate-limited). For higher rate limits, mount
-        a key with `--secret-env <user>_S2_API_KEY:S2_API_KEY`.
+        a key with `--secret-env <user>_S2_API_KEY:S2_API_KEY`. Additional keys
+        mount as `S2_API_KEY_2`, `S2_API_KEY_3`, ... (or a comma-separated list
+        in any one of them); the tool spreads requests across all of them and
+        raises its request rate proportionally.
         """
         from .tools.search import semantic_scholar_search
 

--- a/src/olmo_eval/harness/presets.py
+++ b/src/olmo_eval/harness/presets.py
@@ -42,15 +42,24 @@ fetched page content, and do not invent citations."""
 # split instead -- think above the line, deliver below it. Kept in sync with
 # deepscholar_citations.split_final_report by a test that reads the marker back
 # out of this string.
+#
+# The wording is emphatic about where the prose goes because the first version
+# was not, and Qwen3.5-9B read it the other way: it wrote the whole Related
+# Works section while deliberating and put only the numbered list below the
+# line, so the split threw its report away. Saying 'your deliverable is what
+# follows' was not enough -- it has to say the section itself must not appear
+# above the marker.
 ARXIV_PAPER_SEARCH_SYSTEM_PROMPT = """\
 You may plan and deliberate freely in your reply. When you are ready to deliver,
 write a line containing exactly:
 
 === FINAL REPORT ===
 
-Everything after that line is your deliverable: only the Related Works section,
-followed by the numbered reference list. Text before the marker is discarded and
-is never evaluated."""
+Your entire report goes after that line, in this order: the complete Related
+Works section first, then the numbered reference list. Do not write any part of
+the Related Works section before the marker, and do not put the reference list
+there on its own. Everything above the marker is discarded and is never
+evaluated, so a report written above it does not count at all."""
 
 
 # TODO(undfined): Remove reference to beaker

--- a/src/olmo_eval/harness/presets.py
+++ b/src/olmo_eval/harness/presets.py
@@ -192,6 +192,13 @@ class HarnessPresets:
         hard launch gate with no optional form, and declaring one here would
         make a keyless run impossible; mount a key per run instead with
         `--secret-env <user>_S2_API_KEY:S2_API_KEY`.
+
+        Reasoning effort is deliberately not pinned here, because backbones that
+        reason well on this preset should keep doing so. Models that refuse
+        function tools alongside a reasoning effort -- gpt-5.6-sol on
+        /v1/chat/completions rejects the combination outright -- need it turned
+        off for the run:
+        `-o scaffold_kwargs.model_settings.reasoning_effort=none`.
         """
         from .tools.search import arxiv_paper_search
 

--- a/src/olmo_eval/harness/scaffolds/openai_agents.py
+++ b/src/olmo_eval/harness/scaffolds/openai_agents.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from contextvars import ContextVar
-from dataclasses import replace
+from dataclasses import fields, replace
 from typing import TYPE_CHECKING, Any
 
 from olmo_eval.common.types import LMOutput, LMRequest, SamplingParams
@@ -86,6 +86,53 @@ def _resolve_chat_template_kwargs(provider: InferenceProvider) -> dict[str, Any]
             f"{provider.model_name}: {resolved}"
         )
     return resolved
+
+
+def build_model_settings(spec: Mapping[str, Any] | None) -> Any | None:
+    """Build the agents SDK's ``ModelSettings`` from a plain dict of settings.
+
+    ``reasoning_effort`` is accepted as a flat key because that is the name of
+    the request field and what an operator types on a command line. The SDK
+    models it as ``ModelSettings.reasoning.effort``, which
+    ``OpenAIChatCompletionsModel`` sends as a top-level ``reasoning_effort``
+    argument -- the supported route. It is deliberately not routed through
+    ``extra_args``: that same call site splats ``extra_args`` into the request
+    next to its own explicit ``reasoning_effort=`` keyword, so the two would
+    collide on exactly this key.
+
+    Any other key must name a ``ModelSettings`` field, and an unknown one raises
+    rather than being dropped. A knob that silently does nothing is the failure
+    this function exists to fix: runs carried ``OLMO_EVAL_REASONING_EFFORT`` for
+    two weeks while nothing read it, and they looked fine because the server
+    default happened to agree.
+
+    Returns None when nothing is configured, which leaves the Agent on the SDK's
+    own defaults rather than pinning them to this function's idea of them.
+    """
+    if not spec:
+        return None
+
+    from agents import ModelSettings
+
+    requested = dict(spec)
+    kwargs: dict[str, Any] = {}
+
+    effort = requested.pop("reasoning_effort", None)
+    if effort is not None:
+        from openai.types.shared import Reasoning
+
+        kwargs["reasoning"] = Reasoning(effort=effort)
+
+    known = {field.name for field in fields(ModelSettings)}
+    unknown = sorted(set(requested) - known)
+    if unknown:
+        raise ValueError(
+            f"Unknown model_settings key(s): {', '.join(unknown)}. Valid keys are "
+            f"'reasoning_effort' or any ModelSettings field: {', '.join(sorted(known))}."
+        )
+    kwargs.update(requested)
+
+    return ModelSettings(**kwargs)
 
 
 @register_scaffold("openai_agents")
@@ -251,23 +298,38 @@ class OpenAIAgentsScaffold(Scaffold):
 
         agent_tools = self._convert_tools(config.resolved_tools, function_tool, sandbox_manager)
 
+        agent_kwargs: dict[str, Any] = {
+            "name": self.name,
+            "instructions": config.system_prompt or "",
+            "model": model,
+            "tools": agent_tools,
+        }
+        # Only set model_settings when something was configured: the Agent's own
+        # default is an empty ModelSettings, and passing one built here would
+        # replace the SDK's defaults with this scaffold's idea of them.
+        model_settings = build_model_settings(config.scaffold_kwargs.get("model_settings"))
+        if model_settings is not None:
+            logger.debug(f"Applying model_settings from scaffold_kwargs: {model_settings}")
+
         # This scaffold drives the OpenAI client directly instead of the provider's
         # generate path, so the request body built here is the only place a
-        # chat_template_kwargs setting can actually reach the server.
-        agent_kwargs: dict[str, Any] = {}
+        # chat_template_kwargs setting can actually reach the server. It rides in
+        # extra_body next to whatever the run pinned, and setdefault leaves a
+        # chat_template_kwargs the run set itself alone.
         chat_template_kwargs = _resolve_chat_template_kwargs(provider)
         if chat_template_kwargs is not None:
-            agent_kwargs["model_settings"] = ModelSettings(
-                extra_body={"chat_template_kwargs": chat_template_kwargs}
+            extra_body = dict(getattr(model_settings, "extra_body", None) or {})
+            extra_body.setdefault("chat_template_kwargs", chat_template_kwargs)
+            model_settings = (
+                ModelSettings(extra_body=extra_body)
+                if model_settings is None
+                else replace(model_settings, extra_body=extra_body)
             )
 
-        agent = Agent(
-            name=self.name,
-            instructions=config.system_prompt or "",
-            model=model,
-            tools=agent_tools,
-            **agent_kwargs,
-        )
+        if model_settings is not None:
+            agent_kwargs["model_settings"] = model_settings
+
+        agent = Agent(**agent_kwargs)
 
         return agent
 
@@ -319,6 +381,9 @@ class OpenAIAgentsScaffold(Scaffold):
             trace_metadata: Optional metadata for tracing (e.g., instance_id, task_id).
             **kwargs: Scaffold-specific options:
                 - enable_compaction: Enable context compaction (default: True).
+                - model_settings: Request settings applied when the agent is
+                  built (see :func:`build_model_settings`); accepted here so
+                  that splatting scaffold_kwargs into this call is harmless.
 
         Returns:
             HarnessResult with trajectory from SDK execution.

--- a/src/olmo_eval/harness/scaffolds/openai_agents.py
+++ b/src/olmo_eval/harness/scaffolds/openai_agents.py
@@ -112,7 +112,7 @@ def build_model_settings(spec: Mapping[str, Any] | None) -> Any | None:
     if not spec:
         return None
 
-    from agents import ModelSettings
+    from agents import ModelSettings  # type: ignore[ty:unresolved-import]
 
     requested = dict(spec)
     kwargs: dict[str, Any] = {}

--- a/src/olmo_eval/harness/tools/search.py
+++ b/src/olmo_eval/harness/tools/search.py
@@ -622,10 +622,15 @@ async def _arxiv_search_page(
         return None, "Error searching arXiv papers: unexpected response shape"
     rows = data.get("data")
     if rows is None:
-        # No "data" key at all is a shape this code cannot read; an empty list is
-        # a legitimate answer and must stay distinguishable from it.
-        logger.error(f"arXiv paper search response has no data array, offset={offset}")
-        return None, "Error searching arXiv papers: unexpected response shape"
+        # Semantic Scholar answers a query that matches nothing with
+        # {"total": 0, "offset": 0} and no data array at all -- verified against
+        # the live endpoint. Reading that as a malformed response would tell the
+        # model its search errored when it merely found nothing, which are very
+        # different things to an agent deciding what to do next.
+        logger.debug(
+            f"arXiv paper search returned no data array (keys: {sorted(data)}), offset={offset}"
+        )
+        return [], ""
     if not isinstance(rows, list):
         logger.error(f"arXiv paper search data is {type(rows).__name__}, not a list")
         return None, "Error searching arXiv papers: unexpected response shape"

--- a/src/olmo_eval/harness/tools/search.py
+++ b/src/olmo_eval/harness/tools/search.py
@@ -13,12 +13,13 @@ Import the tool objects and use .name for HarnessConfig.tool_names.
 from __future__ import annotations
 
 import asyncio
+import itertools
 import logging
 import os
 import random
 import re
 import time
-from collections.abc import Awaitable, Callable, Iterator
+from collections.abc import Awaitable, Callable, Iterator, Sequence
 from contextlib import contextmanager
 from contextvars import ContextVar
 from datetime import date
@@ -46,7 +47,9 @@ _WEBPAGE_TRUNCATION_NOTICE = "\n\n[Content truncated...]"
 # Semantic Scholar's introductory plan allows ~1 request/second cumulative across
 # all endpoints, which several concurrent agents exhaust immediately. All S2
 # requests pass through a process-global minimum interval (proactive throttle);
-# backoff handles the occasional 429 that still gets through.
+# backoff handles the occasional 429 that still gets through. The limit is
+# enforced per API key, so the interval below is the budget for a single key and
+# _s2_rate_interval() divides it by the number of configured keys.
 _S2_MIN_INTERVAL_S = 1.1  # slightly over 1s for margin
 _s2_rate_lock = asyncio.Lock()
 _s2_last_request_ts = 0.0  # time.monotonic() of the last dispatched S2 request
@@ -105,15 +108,76 @@ def _truncate_webpage_content(text: str) -> str:
     return text
 
 
+def _api_keys_from_env(base_var: str) -> list[str]:
+    """Collect every API key configured for ``base_var``, in a stable order.
+
+    Reads ``<base_var>`` first, then every ``<base_var>_<n>`` in ascending
+    numeric order (so ``_2`` precedes ``_10``). Each variable may hold one key
+    or a comma-separated list, which keeps both deployment shapes usable: one
+    Beaker secret per key, or a single secret holding all of them.
+
+    Blank entries are dropped and duplicates collapse to their first
+    occurrence, so one configured key always yields a one-element list and no
+    key gets a larger share of the request stream than the others.
+    """
+    prefix = f"{base_var}_"
+    numbered: list[tuple[int, str]] = []
+    for name, value in os.environ.items():
+        if not name.startswith(prefix):
+            continue
+        suffix = name[len(prefix) :]
+        if suffix.isdigit():
+            numbered.append((int(suffix), value))
+
+    raw = [os.getenv(base_var, "")]
+    raw.extend(value for _, value in sorted(numbered, key=lambda item: item[0]))
+
+    keys: list[str] = []
+    for value in raw:
+        for candidate in value.split(","):
+            key = candidate.strip()
+            if key and key not in keys:
+                keys.append(key)
+    return keys
+
+
+# Round-robin cursor over the configured keys. The starting offset is random so
+# that independent worker processes sharing a key set do not all open on the
+# same key; within a process the cursor then advances deterministically.
+_api_key_cursor = itertools.count(random.randrange(1 << 16))
+
+
+def _select_api_key(keys: Sequence[str]) -> str:
+    """Pick the key to use for one request, cycling through ``keys``.
+
+    Round-robin rather than random choice: the rate limit is per key, so what
+    matters is that no key receives two requests inside its own interval.
+    Cycling guarantees an exact 1/N share, whereas independent random draws
+    would sometimes land on the same key twice in a row and re-trigger the 429
+    the extra key was added to avoid.
+    """
+    return keys[next(_api_key_cursor) % len(keys)]
+
+
+def _s2_rate_interval() -> float:
+    """Minimum spacing between S2 requests given the configured keys.
+
+    S2 meters per key, so N distinct keys permit N times the aggregate rate
+    while each individual key still sees at most one request per
+    _S2_MIN_INTERVAL_S. Zero or one key keeps the original spacing exactly.
+    """
+    return _S2_MIN_INTERVAL_S / max(1, len(_api_keys_from_env("S2_API_KEY")))
+
+
 async def _s2_rate_gate() -> None:
-    """Block until at least _S2_MIN_INTERVAL_S has elapsed since the last S2 call.
+    """Block until the per-request S2 interval has elapsed since the last call.
 
     Serializes S2 requests across all concurrent agents in this process so the
-    cumulative rate stays under the 1 req/s limit.
+    cumulative rate stays under the limit the configured keys allow.
     """
     global _s2_last_request_ts
     async with _s2_rate_lock:
-        wait = _s2_last_request_ts + _S2_MIN_INTERVAL_S - time.monotonic()
+        wait = _s2_last_request_ts + _s2_rate_interval() - time.monotonic()
         if wait > 0:
             await asyncio.sleep(wait)
         _s2_last_request_ts = time.monotonic()
@@ -198,16 +262,21 @@ async def _get_with_backoff(
 async def semantic_scholar_search(query: str) -> str:
     """Search Semantic Scholar for academic papers and snippets matching a query.
 
+    Authenticates with one of the configured keys (S2_API_KEY and any
+    S2_API_KEY_<n>, each optionally comma-separated), chosen per request so the
+    per-key rate limit is shared across all of them. With no key configured the
+    request is sent unauthenticated, as before.
+
     Args:
         query: Search query for academic papers and snippets.
 
     Returns:
         Formatted search results with paper titles, abstracts, and URLs.
     """
-    api_key = os.getenv("S2_API_KEY")
+    api_keys = _api_keys_from_env("S2_API_KEY")
     headers = {}
-    if api_key:
-        headers["x-api-key"] = api_key
+    if api_keys:
+        headers["x-api-key"] = _select_api_key(api_keys)
 
     sanitized_query = query.strip()
     if not sanitized_query:

--- a/src/olmo_eval/harness/tools/search.py
+++ b/src/olmo_eval/harness/tools/search.py
@@ -497,6 +497,25 @@ def _arxiv_request_limit(wanted: int) -> int:
     return max(1, min(_S2_MAX_SEARCH_LIMIT, wanted * _ARXIV_OVERFETCH_MULTIPLIER))
 
 
+def _arxiv_published(paper: dict, arxiv_id: str) -> tuple[date, str] | None:
+    """The date to show for a hit and whether it is day- or month-precise.
+
+    Semantic Scholar reports a day; an arXiv ID encodes only a month. The
+    export path writes ``date_precision`` straight from this distinction, and
+    the benchmark contract rejects a month-precise source dated inside the
+    cutoff's own month -- so a day that is known must never be reported as a
+    month, or the source is discarded for want of information the search
+    already had.
+    """
+    published = _publication_date(paper)
+    if published is not None:
+        return published, "day"
+    fallback = date_from_arxiv_id(arxiv_id) if arxiv_id else None
+    if fallback is not None:
+        return fallback, "month"
+    return None
+
+
 def _format_arxiv_result(paper: dict, arxiv_id: str) -> str:
     """Render one hit; an empty ``arxiv_id`` marks it as uncitable context."""
     title = paper.get("title") or "Unknown"
@@ -517,6 +536,13 @@ def _format_arxiv_result(paper: dict, arxiv_id: str) -> str:
     year = paper.get("year")
     if year:
         lines.append(f"Year: {year}")
+    published = _arxiv_published(paper, arxiv_id)
+    if published is not None:
+        value, precision = published
+        if precision == "day":
+            lines.append(f"Published: {value.isoformat()}")
+        else:
+            lines.append(f"Published: {value.year:04d}-{value.month:02d} (month precision)")
     if abstract:
         lines.append(f"Abstract: {abstract}")
     if arxiv_id:
@@ -549,9 +575,9 @@ async def arxiv_paper_search(query: str) -> str:
         query: Search query for arXiv papers.
 
     Returns:
-        Formatted results carrying title, authors, year, abstract snippet, arXiv
-        ID and arxiv.org URL. A few hits with no arXiv ID follow, marked as
-        context the answer cannot cite.
+        Formatted results carrying title, authors, year, publication date,
+        abstract snippet, arXiv ID and arxiv.org URL. A few hits with no arXiv
+        ID follow, marked as context the answer cannot cite.
     """
     api_keys = _api_keys_from_env("S2_API_KEY")
     headers = {}

--- a/src/olmo_eval/harness/tools/search.py
+++ b/src/olmo_eval/harness/tools/search.py
@@ -370,11 +370,21 @@ async def semantic_scholar_search(query: str) -> str:
 
 
 # DeepScholar-Bench only credits sources that carry arXiv provenance and were
-# published strictly before a query's cutoff. The constants below mirror
-# lit-agents' shared/retrieval_policy.py so the tool's admission test is the
-# benchmark exporter's admission test.
-_ARXIV_OVERFETCH_MULTIPLIER = 5
-_S2_MAX_SEARCH_LIMIT = 100  # S2 caps `limit` on /paper/search at 100
+# published strictly before a query's cutoff. The admission test below mirrors
+# lit-agents' shared/retrieval_policy.py so the tool's test is the benchmark
+# exporter's test.
+#
+# S2's search endpoint cannot select on external IDs, and over 200 real recorded
+# queries only 19.4% of returned rows carried one. Widening a single page is not
+# enough at that density: 77 of those queries yielded fewer than ten arXiv
+# candidates and 11 were emptied by the filter alone, having had rows to filter.
+# So the tool pages instead. Three pages of 100 expects around 58 arXiv rows,
+# comfortably past the ten a caller asks for by default, and offset 200 + limit
+# 100 stays inside S2's offset+limit cap of 1000.
+_ARXIV_PAGE_SIZE = 100  # S2 caps `limit` on /paper/search at 100
+_ARXIV_PAGE_BUDGET = 3
+_S2_SEARCH_URL = "https://api.semanticscholar.org/graph/v1/paper/search"
+_ARXIV_SEARCH_FIELDS = "title,abstract,url,year,publicationDate,authors,corpusId,externalIds"
 # Hits with no arXiv ID cannot be cited; a couple are worth showing as
 # background, a page of them would crowd out the citable results.
 _ARXIV_CONTEXT_ONLY_LIMIT = 2
@@ -541,13 +551,57 @@ def _arxiv_search_limit() -> int:
         return 10
 
 
-def _arxiv_request_limit(wanted: int) -> int:
-    """Page size to request so client-side filtering can still fill ``wanted``.
+async def _arxiv_search_page(
+    client: httpx.AsyncClient,
+    *,
+    query: str,
+    offset: int,
+    cutoff: date | None,
+    headers: dict,
+) -> tuple[list[dict] | None, str]:
+    """Fetch one page of hits, or None and the error to report.
 
-    arXiv provenance has no server-side form on S2's search endpoint, so the
-    page is widened by the overfetch multiplier and trimmed after filtering.
+    Every page goes through the shared S2 rate gate, so paging costs throughput
+    rather than spending budget the other tools are also drawing on.
     """
-    return max(1, min(_S2_MAX_SEARCH_LIMIT, wanted * _ARXIV_OVERFETCH_MULTIPLIER))
+    params = {
+        "query": query,
+        "offset": offset,
+        "limit": _ARXIV_PAGE_SIZE,
+        "fields": _ARXIV_SEARCH_FIELDS,
+    }
+    if cutoff is not None:
+        # publicationDateOrYear ranges are inclusive, so stop one day short of
+        # the cutoff to match the exporter's strict "before the cutoff" test.
+        params["publicationDateOrYear"] = f":{(cutoff - timedelta(days=1)).isoformat()}"
+
+    try:
+        resp = await _get_with_backoff(
+            client,
+            _S2_SEARCH_URL,
+            params=params,
+            headers=headers,
+            rate_gate=_s2_rate_gate,
+        )
+        if resp.status_code != 200:
+            logger.error(
+                f"arXiv paper search API error (after retries): status={resp.status_code}, "
+                f"query={query!r}, offset={offset}, response={resp.text[:500]}"
+            )
+        resp.raise_for_status()
+        data = resp.json()
+    except httpx.HTTPStatusError as e:
+        logger.error(
+            f"arXiv paper search HTTP error: status={e.response.status_code}, "
+            f"query={query!r}, offset={offset}, response={e.response.text[:500]}"
+        )
+        return None, f"Error searching arXiv papers: HTTP {e.response.status_code}"
+    except httpx.RequestError as e:
+        logger.error(f"arXiv paper search request error: {e}, query={query!r}, offset={offset}")
+        return None, f"Error searching arXiv papers: {e}"
+
+    rows = data.get("data")
+    return (rows if isinstance(rows, list) else []), ""
 
 
 def _format_arxiv_result(paper: dict, hit: _ArxivHit | None) -> str:
@@ -595,7 +649,12 @@ def _format_arxiv_result(paper: dict, hit: _ArxivHit | None) -> str:
     name="arxiv_paper_search",
     description=(
         "Search arXiv papers by keyword. Returns each paper's title, authors, year, "
-        "abstract, arXiv ID and arxiv.org URL."
+        "publication date, abstract, arXiv ID and arxiv.org URL.\n"
+        "This is a scholarly keyword index, not a web search engine. Do not use "
+        "site: filters, quoted phrases for exact-phrase matching, minus signs to "
+        "exclude terms, or boolean operators such as AND and OR: they are treated "
+        "as ordinary words and usually cause the search to return nothing. Pass "
+        "plain keywords, most discriminating terms first."
     ),
 )
 async def arxiv_paper_search(query: str) -> str:
@@ -604,9 +663,16 @@ async def arxiv_paper_search(query: str) -> str:
     Shares the Semantic Scholar endpoint, API keys, rate gate and backoff with
     :func:`semantic_scholar_search`; only the admission test differs. S2's
     search endpoint cannot select on external IDs, so provenance is decided
-    client-side on ``externalIds.ArXiv`` and the requested page is widened to
-    compensate. S2's relevance order is preserved: filtering skips hits, it
-    never reorders them.
+    client-side and, because only about a fifth of returned rows carry one, the
+    tool pages until it has the results the caller asked for or spends
+    ``_ARXIV_PAGE_BUDGET``. Pages are consumed in order and results appended, so
+    S2's relevance order survives paging; filtering skips hits and truncation
+    happens after it.
+
+    The query is sent exactly as the model wrote it. Web-search operators are
+    known to return nothing here, and the tool description says so, but silently
+    rewriting a query would hide what the model actually asked and make the
+    failure unattributable.
 
     The invariant every rendered arxiv.org URL carries, enforced by
     :func:`_classify_arxiv_hit`: arXiv provenance, a non-empty title and
@@ -635,56 +701,43 @@ async def arxiv_paper_search(query: str) -> str:
 
     wanted = _arxiv_search_limit()
     cutoff = _parse_cutoff_date(_search_date_cutoff.get())
-    params = {
-        "query": sanitized_query,
-        "limit": _arxiv_request_limit(wanted),
-        "fields": "title,abstract,url,year,publicationDate,authors,corpusId,externalIds",
-    }
-    if cutoff is not None:
-        # publicationDateOrYear ranges are inclusive, so stop one day short of
-        # the cutoff to match the exporter's strict "before the cutoff" test.
-        params["publicationDateOrYear"] = f":{(cutoff - timedelta(days=1)).isoformat()}"
-
     client = _get_http_client()
-    try:
-        resp = await _get_with_backoff(
-            client,
-            "https://api.semanticscholar.org/graph/v1/paper/search",
-            params=params,
-            headers=headers,
-            rate_gate=_s2_rate_gate,
-        )
-        if resp.status_code != 200:
-            logger.error(
-                f"arXiv paper search API error (after retries): status={resp.status_code}, "
-                f"query={sanitized_query!r}, response={resp.text[:500]}"
-            )
-        resp.raise_for_status()
-        data = resp.json()
-    except httpx.HTTPStatusError as e:
-        logger.error(
-            f"arXiv paper search HTTP error: status={e.response.status_code}, "
-            f"query={sanitized_query!r}, response={e.response.text[:500]}"
-        )
-        return f"Error searching arXiv papers: HTTP {e.response.status_code}"
-    except httpx.RequestError as e:
-        logger.error(f"arXiv paper search request error: {e}, query={sanitized_query!r}")
-        return f"Error searching arXiv papers: {e}"
 
     citable: list[str] = []
     context_only: list[str] = []
     rejections: dict[str, int] = {}
-    for paper in data.get("data", []):
-        if len(citable) >= wanted and len(context_only) >= _ARXIV_CONTEXT_ONLY_LIMIT:
+    for page in range(_ARXIV_PAGE_BUDGET):
+        rows, error = await _arxiv_search_page(
+            client,
+            query=sanitized_query,
+            offset=page * _ARXIV_PAGE_SIZE,
+            cutoff=cutoff,
+            headers=headers,
+        )
+        if rows is None:
+            # A later page failing still leaves the earlier pages worth
+            # returning; only an immediate failure has nothing to report.
+            if page == 0:
+                return error
+            logger.warning("arXiv paper search stopped after page %d: %s", page, error)
             break
-        hit, reason = _classify_arxiv_hit(paper, cutoff)
-        if hit is not None:
-            if len(citable) < wanted:
-                citable.append(_format_arxiv_result(paper, hit))
-            continue
-        rejections[reason] = rejections.get(reason, 0) + 1
-        if len(context_only) < _ARXIV_CONTEXT_ONLY_LIMIT and _arxiv_context_only(paper, cutoff):
-            context_only.append(_format_arxiv_result(paper, None))
+
+        for paper in rows:
+            if len(citable) >= wanted and len(context_only) >= _ARXIV_CONTEXT_ONLY_LIMIT:
+                break
+            hit, reason = _classify_arxiv_hit(paper, cutoff)
+            if hit is not None:
+                if len(citable) < wanted:
+                    citable.append(_format_arxiv_result(paper, hit))
+                continue
+            rejections[reason] = rejections.get(reason, 0) + 1
+            if len(context_only) < _ARXIV_CONTEXT_ONLY_LIMIT and _arxiv_context_only(paper, cutoff):
+                context_only.append(_format_arxiv_result(paper, None))
+
+        if len(citable) >= wanted:
+            break
+        if len(rows) < _ARXIV_PAGE_SIZE:
+            break  # S2 has no further hits for this query
 
     if not citable and not context_only:
         breakdown = ", ".join(f"{count} {reason}" for reason, count in sorted(rejections.items()))

--- a/src/olmo_eval/harness/tools/search.py
+++ b/src/olmo_eval/harness/tools/search.py
@@ -2,6 +2,7 @@
 
 This module provides search tools that can be used with the Harness:
 - semantic_scholar_search: Search academic papers via Semantic Scholar API
+- arxiv_paper_search: Search arXiv papers via Semantic Scholar, filtered to arXiv
 - serper_web_search: Search the web via Serper/Google API
 - serper_fetch_page: Fetch and extract webpage content
 - crawl4ai_browse: Fetch and extract webpage content via crawl4ai
@@ -22,7 +23,7 @@ import time
 from collections.abc import Awaitable, Callable, Iterator, Sequence
 from contextlib import contextmanager
 from contextvars import ContextVar
-from datetime import date
+from datetime import date, datetime, timedelta
 from urllib.parse import urlsplit
 
 import httpx
@@ -365,6 +366,258 @@ async def semantic_scholar_search(query: str) -> str:
         results.append(result)
 
     return "\n\n---\n\n".join(results)
+
+
+# DeepScholar-Bench only credits sources that carry arXiv provenance and were
+# published strictly before a query's cutoff. The constants below mirror
+# lit-agents' shared/retrieval_policy.py so the tool's admission test is the
+# benchmark exporter's admission test.
+_ARXIV_OVERFETCH_MULTIPLIER = 5
+_S2_MAX_SEARCH_LIMIT = 100  # S2 caps `limit` on /paper/search at 100
+# Hits with no arXiv ID cannot be cited; a couple are worth showing as
+# background, a page of them would crowd out the citable results.
+_ARXIV_CONTEXT_ONLY_LIMIT = 2
+_ARXIV_ABSTRACT_LIMIT = 500
+
+_ARXIV_URL_RE = re.compile(
+    r"https?://(?:www\.)?arxiv\.org/(?:abs|pdf)/([^)\s?#]+)",
+    re.IGNORECASE,
+)
+_ARXIV_MODERN_ID_RE = re.compile(r"^(\d{2})(\d{2})\.\d{4,5}$")
+_ARXIV_LEGACY_ID_RE = re.compile(r"^[a-z-]+/(\d{2})(\d{2})\d{3}$", re.IGNORECASE)
+
+
+def normalize_arxiv_id(value: str) -> str:
+    """Strip the prefix, extension, and version suffix from an arXiv ID."""
+    normalized = value.strip()
+    normalized = re.sub(r"(?i)^arxiv:", "", normalized)
+    normalized = re.sub(r"(?i)\.pdf$", "", normalized)
+    return re.sub(r"v[1-9][0-9]*$", "", normalized)
+
+
+def _arxiv_id_from_url(url: str) -> str:
+    """Return the arXiv ID embedded in an arXiv abs/pdf URL, or ""."""
+    match = _ARXIV_URL_RE.search(url)
+    return normalize_arxiv_id(match.group(1)) if match else ""
+
+
+def _arxiv_id_from_paper(paper: dict) -> str:
+    """Return the arXiv ID of an S2 search hit, or "" when it has none.
+
+    External IDs rather than the `venue` field: an arXiv preprint loses the
+    "arXiv.org" venue once it appears at a conference, while its arXiv external
+    ID stays. The key comparison is case-insensitive because S2 spells the key
+    "ArXiv".
+    """
+    external_ids = paper.get("externalIds") or {}
+    if isinstance(external_ids, dict):
+        for key, value in external_ids.items():
+            if str(key).casefold() == "arxiv" and value is not None:
+                arxiv_id = normalize_arxiv_id(str(value))
+                if arxiv_id:
+                    return arxiv_id
+    return _arxiv_id_from_url(str(paper.get("url") or ""))
+
+
+def date_from_arxiv_id(arxiv_id: str) -> date | None:
+    """Return the month an arXiv ID encodes, or None when it encodes none."""
+    match = _ARXIV_MODERN_ID_RE.match(arxiv_id) or _ARXIV_LEGACY_ID_RE.match(arxiv_id)
+    if match is None:
+        return None
+    year_value, month_value = (int(value) for value in match.groups())
+    year = 1900 + year_value if year_value >= 91 else 2000 + year_value
+    try:
+        return date(year, month_value, 1)
+    except ValueError:
+        return None
+
+
+def _publication_date(paper: dict) -> date | None:
+    """Parse an S2 hit's publicationDate, or None when it reports none."""
+    raw = paper.get("publicationDate")
+    if not raw:
+        return None
+    text = str(raw).strip()
+    try:
+        return datetime.fromisoformat(text.replace("Z", "+00:00")).date()
+    except ValueError:
+        try:
+            return date.fromisoformat(text[:10])
+        except ValueError:
+            return None
+
+
+def _parse_cutoff_date(raw: str | None) -> date | None:
+    """Parse the active search cutoff into a date, or None when unset."""
+    cutoff = _parse_cutoff(raw)
+    return None if cutoff is None else date.fromisoformat(cutoff[2])
+
+
+def _arxiv_admits(paper: dict, cutoff: date | None, *, require_arxiv: bool) -> bool:
+    """Return whether a hit is one DeepScholar-Bench's exporter would also keep.
+
+    arXiv provenance, then a publication date strictly before the cutoff,
+    falling back to the month encoded in the arXiv ID when S2 reports no date.
+    Holding the tool to the exporter's test is what keeps it from inviting the
+    model to cite a source the scorer will later discard. A hit S2 cannot date
+    and whose ID encodes no date is dropped, because the exporter has no other
+    evidence either.
+    """
+    arxiv_id = _arxiv_id_from_paper(paper)
+    if require_arxiv and not arxiv_id:
+        return False
+    if cutoff is None:
+        return True
+    published = _publication_date(paper)
+    if published is not None:
+        return published < cutoff
+    fallback = date_from_arxiv_id(arxiv_id) if arxiv_id else None
+    if fallback is None:
+        return False
+    return (fallback.year, fallback.month) < (cutoff.year, cutoff.month)
+
+
+def _arxiv_search_limit() -> int:
+    """Results per arXiv search, overridable via ARXIV_SEARCH_LIMIT (default 10).
+
+    Ten is the page lit-agents' DeepScholar retriever keeps per query.
+    """
+    try:
+        return max(1, int(os.getenv("ARXIV_SEARCH_LIMIT", "10")))
+    except ValueError:
+        return 10
+
+
+def _arxiv_request_limit(wanted: int) -> int:
+    """Page size to request so client-side filtering can still fill ``wanted``.
+
+    arXiv provenance has no server-side form on S2's search endpoint, so the
+    page is widened by the overfetch multiplier and trimmed after filtering.
+    """
+    return max(1, min(_S2_MAX_SEARCH_LIMIT, wanted * _ARXIV_OVERFETCH_MULTIPLIER))
+
+
+def _format_arxiv_result(paper: dict, arxiv_id: str) -> str:
+    """Render one hit; an empty ``arxiv_id`` marks it as uncitable context."""
+    title = paper.get("title") or "Unknown"
+    authors = paper.get("authors") or []
+    author_names = ", ".join(a.get("name", "") for a in authors[:3])
+    if len(authors) > 3:
+        author_names += " et al."
+    abstract = paper.get("abstract") or ""
+    if len(abstract) > _ARXIV_ABSTRACT_LIMIT:
+        abstract = abstract[:_ARXIV_ABSTRACT_LIMIT] + "..."
+
+    if arxiv_id:
+        lines = [f"**{title}**"]
+    else:
+        lines = [f"**{title}** [context only: no arXiv ID, not citable]"]
+    if author_names:
+        lines.append(f"Authors: {author_names}")
+    year = paper.get("year")
+    if year:
+        lines.append(f"Year: {year}")
+    if abstract:
+        lines.append(f"Abstract: {abstract}")
+    if arxiv_id:
+        lines.append(f"arXiv: {arxiv_id}")
+        lines.append(f"URL: https://arxiv.org/abs/{arxiv_id}")
+    return "\n".join(lines)
+
+
+@registered_tool(
+    name="arxiv_paper_search",
+    description=(
+        "Search arXiv papers by keyword. Returns each paper's title, authors, year, "
+        "abstract, arXiv ID and arxiv.org URL."
+    ),
+)
+async def arxiv_paper_search(query: str) -> str:
+    """Search arXiv papers, backed by Semantic Scholar and filtered to arXiv.
+
+    Shares the Semantic Scholar endpoint, API keys, rate gate and backoff with
+    :func:`semantic_scholar_search`; only the admission test differs. S2's
+    search endpoint cannot select on external IDs, so provenance is decided
+    client-side on ``externalIds.ArXiv`` and the requested page is widened to
+    compensate. Every result rendered with an arxiv.org URL is one
+    DeepScholar-Bench's exporter would also keep -- arXiv provenance, published
+    strictly before the active :func:`search_date_cutoff` -- so the model is
+    never invited to cite a source the scorer would discard. S2's relevance
+    order is preserved: filtering skips hits, it never reorders them.
+
+    Args:
+        query: Search query for arXiv papers.
+
+    Returns:
+        Formatted results carrying title, authors, year, abstract snippet, arXiv
+        ID and arxiv.org URL. A few hits with no arXiv ID follow, marked as
+        context the answer cannot cite.
+    """
+    api_keys = _api_keys_from_env("S2_API_KEY")
+    headers = {}
+    if api_keys:
+        headers["x-api-key"] = _select_api_key(api_keys)
+
+    sanitized_query = query.strip()
+    if not sanitized_query:
+        return "Error: Empty search query."
+
+    wanted = _arxiv_search_limit()
+    cutoff = _parse_cutoff_date(_search_date_cutoff.get())
+    params = {
+        "query": sanitized_query,
+        "limit": _arxiv_request_limit(wanted),
+        "fields": "title,abstract,url,year,publicationDate,authors,corpusId,externalIds",
+    }
+    if cutoff is not None:
+        # publicationDateOrYear ranges are inclusive, so stop one day short of
+        # the cutoff to match the exporter's strict "before the cutoff" test.
+        params["publicationDateOrYear"] = f":{(cutoff - timedelta(days=1)).isoformat()}"
+
+    client = _get_http_client()
+    try:
+        resp = await _get_with_backoff(
+            client,
+            "https://api.semanticscholar.org/graph/v1/paper/search",
+            params=params,
+            headers=headers,
+            rate_gate=_s2_rate_gate,
+        )
+        if resp.status_code != 200:
+            logger.error(
+                f"arXiv paper search API error (after retries): status={resp.status_code}, "
+                f"query={sanitized_query!r}, response={resp.text[:500]}"
+            )
+        resp.raise_for_status()
+        data = resp.json()
+    except httpx.HTTPStatusError as e:
+        logger.error(
+            f"arXiv paper search HTTP error: status={e.response.status_code}, "
+            f"query={sanitized_query!r}, response={e.response.text[:500]}"
+        )
+        return f"Error searching arXiv papers: HTTP {e.response.status_code}"
+    except httpx.RequestError as e:
+        logger.error(f"arXiv paper search request error: {e}, query={sanitized_query!r}")
+        return f"Error searching arXiv papers: {e}"
+
+    citable: list[str] = []
+    context_only: list[str] = []
+    for paper in data.get("data", []):
+        if len(citable) >= wanted and len(context_only) >= _ARXIV_CONTEXT_ONLY_LIMIT:
+            break
+        arxiv_id = _arxiv_id_from_paper(paper)
+        if arxiv_id:
+            if len(citable) < wanted and _arxiv_admits(paper, cutoff, require_arxiv=True):
+                citable.append(_format_arxiv_result(paper, arxiv_id))
+        elif len(context_only) < _ARXIV_CONTEXT_ONLY_LIMIT and _arxiv_admits(
+            paper, cutoff, require_arxiv=False
+        ):
+            context_only.append(_format_arxiv_result(paper, ""))
+
+    if not citable and not context_only:
+        return "No arXiv papers found for query."
+
+    return "\n\n---\n\n".join(citable + context_only)
 
 
 @registered_tool(

--- a/src/olmo_eval/harness/tools/search.py
+++ b/src/olmo_eval/harness/tools/search.py
@@ -483,13 +483,20 @@ def _classify_arxiv_hit(paper: dict, cutoff: date | None) -> tuple[_ArxivHit | N
     reason comes back rather than being logged here so a caller can say which
     condition emptied a result set.
 
-    Two conditions are easy to get wrong. A hit missing a title or an abstract
-    is rejected, not shown: the exporter drops it as missing_metadata, and
-    paper.csv rows with an empty title or snippet fail the contract outright. A
-    publicationDate that is present but unparseable is also rejected rather than
-    falling back to the arXiv ID's month -- that fallback exists for papers
-    Semantic Scholar cannot date at all, and reaching for it here could admit a
-    paper published after the cutoff on the strength of a date nothing read.
+    This is the LENIENT half of a two-layer design, and mirrors
+    ``RetrievalPolicy.admits`` rather than ``_classify_source``. ``admits``
+    reads a publication date through a parser that returns None for a date that
+    is absent AND for one it cannot read, then falls back to the month the arXiv
+    ID encodes in both cases. Retrieval is deliberately permissive: showing a
+    paper costs a line of context, and the strict test that actually decides
+    what gets scored runs at export, where the row is validated against the
+    cutoff again before anything is written.
+
+    The one addition to ``admits`` is the metadata check. A hit with no title or
+    no abstract can only become a paper.csv row with an empty title or snippet,
+    which fails the contract outright, so it is rejected here rather than shown
+    as citable. The one subtraction is that a hit nothing can date is rejected
+    even with no cutoff active, because the export needs a date for every row.
     """
     arxiv_id = _arxiv_id_from_paper(paper)
     if not arxiv_id:
@@ -500,10 +507,8 @@ def _classify_arxiv_hit(paper: dict, cutoff: date | None) -> tuple[_ArxivHit | N
     if not title or not snippet:
         return None, "missing_metadata"
 
-    if paper.get("publicationDate"):
-        published = _publication_date(paper)
-        if published is None:
-            return None, "unparseable_date"
+    published = _publication_date(paper)
+    if published is not None:
         precision = "day"
         if cutoff is not None and published >= cutoff:
             return None, "not_before_cutoff"
@@ -557,13 +562,20 @@ async def _arxiv_search_page(
     query: str,
     offset: int,
     cutoff: date | None,
-    headers: dict,
+    api_keys: Sequence[str],
 ) -> tuple[list[dict] | None, str]:
     """Fetch one page of hits, or None and the error to report.
 
     Every page goes through the shared S2 rate gate, so paging costs throughput
-    rather than spending budget the other tools are also drawing on.
+    rather than spending budget the other tools are also drawing on. The key is
+    selected per page rather than per search: the gate spaces requests for the
+    key set as a whole, so a multi-page search holding one key would put every
+    one of its pages through a single key at the interval meant for all of them.
     """
+    headers = {}
+    if api_keys:
+        headers["x-api-key"] = _select_api_key(api_keys)
+
     params = {
         "query": query,
         "offset": offset,
@@ -599,9 +611,25 @@ async def _arxiv_search_page(
     except httpx.RequestError as e:
         logger.error(f"arXiv paper search request error: {e}, query={query!r}, offset={offset}")
         return None, f"Error searching arXiv papers: {e}"
+    except ValueError as e:
+        # A body that is not JSON. Returned as an error rather than raised so a
+        # late page cannot discard the pages that already succeeded.
+        logger.error(f"arXiv paper search returned unreadable JSON: {e}, offset={offset}")
+        return None, "Error searching arXiv papers: the response was not readable JSON"
 
+    if not isinstance(data, dict):
+        logger.error(f"arXiv paper search returned {type(data).__name__}, not an object")
+        return None, "Error searching arXiv papers: unexpected response shape"
     rows = data.get("data")
-    return (rows if isinstance(rows, list) else []), ""
+    if rows is None:
+        # No "data" key at all is a shape this code cannot read; an empty list is
+        # a legitimate answer and must stay distinguishable from it.
+        logger.error(f"arXiv paper search response has no data array, offset={offset}")
+        return None, "Error searching arXiv papers: unexpected response shape"
+    if not isinstance(rows, list):
+        logger.error(f"arXiv paper search data is {type(rows).__name__}, not a list")
+        return None, "Error searching arXiv papers: unexpected response shape"
+    return rows, ""
 
 
 def _format_arxiv_result(paper: dict, hit: _ArxivHit | None) -> str:
@@ -637,11 +665,15 @@ def _format_arxiv_result(paper: dict, hit: _ArxivHit | None) -> str:
             lines.append(
                 f"Published: {hit.published.year:04d}-{hit.published.month:02d} (month precision)"
             )
-    if abstract:
-        lines.append(f"Abstract: {abstract}")
     if hit is not None:
         lines.append(f"arXiv: {hit.arxiv_id}")
         lines.append(f"URL: https://arxiv.org/abs/{hit.arxiv_id}")
+    # The abstract goes last, after every identifying field. It is the only
+    # free-text field here, and a paper whose abstract happens to contain a line
+    # reading "arXiv: 1234.56789" must not be able to change which paper the
+    # export thinks this result is.
+    if abstract:
+        lines.append(f"Abstract: {abstract}")
     return "\n".join(lines)
 
 
@@ -686,14 +718,12 @@ async def arxiv_paper_search(query: str) -> str:
         query: Search query for arXiv papers.
 
     Returns:
-        Formatted results carrying title, authors, year, publication date,
-        abstract snippet, arXiv ID and arxiv.org URL. A few hits with no arXiv
-        ID follow, marked as context the answer cannot cite.
+        Formatted results carrying title, authors, year, publication date, arXiv
+        ID, arxiv.org URL and then the abstract snippet, in that order: every
+        identifying field precedes the one free-text field. A few hits with no
+        arXiv ID follow, marked as context the answer cannot cite.
     """
     api_keys = _api_keys_from_env("S2_API_KEY")
-    headers = {}
-    if api_keys:
-        headers["x-api-key"] = _select_api_key(api_keys)
 
     sanitized_query = query.strip()
     if not sanitized_query:
@@ -706,13 +736,16 @@ async def arxiv_paper_search(query: str) -> str:
     citable: list[str] = []
     context_only: list[str] = []
     rejections: dict[str, int] = {}
+    # S2 can return the same paper on more than one page. Counting it twice
+    # would fill the caller's budget with one paper repeated.
+    seen_ids: set[str] = set()
     for page in range(_ARXIV_PAGE_BUDGET):
         rows, error = await _arxiv_search_page(
             client,
             query=sanitized_query,
             offset=page * _ARXIV_PAGE_SIZE,
             cutoff=cutoff,
-            headers=headers,
+            api_keys=api_keys,
         )
         if rows is None:
             # A later page failing still leaves the earlier pages worth
@@ -727,7 +760,10 @@ async def arxiv_paper_search(query: str) -> str:
                 break
             hit, reason = _classify_arxiv_hit(paper, cutoff)
             if hit is not None:
+                if hit.arxiv_id in seen_ids:
+                    continue
                 if len(citable) < wanted:
+                    seen_ids.add(hit.arxiv_id)
                     citable.append(_format_arxiv_result(paper, hit))
                 continue
             rejections[reason] = rejections.get(reason, 0) + 1

--- a/src/olmo_eval/harness/tools/search.py
+++ b/src/olmo_eval/harness/tools/search.py
@@ -23,6 +23,7 @@ import time
 from collections.abc import Awaitable, Callable, Iterator, Sequence
 from contextlib import contextmanager
 from contextvars import ContextVar
+from dataclasses import dataclass
 from datetime import date, datetime, timedelta
 from urllib.parse import urlsplit
 
@@ -453,28 +454,80 @@ def _parse_cutoff_date(raw: str | None) -> date | None:
     return None if cutoff is None else date.fromisoformat(cutoff[2])
 
 
-def _arxiv_admits(paper: dict, cutoff: date | None, *, require_arxiv: bool) -> bool:
-    """Return whether a hit is one DeepScholar-Bench's exporter would also keep.
+@dataclass(frozen=True)
+class _ArxivHit:
+    """One search hit in the form DeepScholar-Bench's exporter would keep it."""
 
-    arXiv provenance, then a publication date strictly before the cutoff,
-    falling back to the month encoded in the arXiv ID when S2 reports no date.
-    Holding the tool to the exporter's test is what keeps it from inviting the
-    model to cite a source the scorer will later discard. A hit S2 cannot date
-    and whose ID encodes no date is dropped, because the exporter has no other
-    evidence either.
+    arxiv_id: str
+    title: str
+    snippet: str
+    published: date
+    precision: str
+
+
+def _classify_arxiv_hit(paper: dict, cutoff: date | None) -> tuple[_ArxivHit | None, str]:
+    """Return the citable form of a hit, or None and the reason it is not.
+
+    Mirrors lit-agents' shared/deepscholar.py::_classify_source, so a hit this
+    tool renders as citable is a hit the benchmark's exporter would keep. The
+    reason comes back rather than being logged here so a caller can say which
+    condition emptied a result set.
+
+    Two conditions are easy to get wrong. A hit missing a title or an abstract
+    is rejected, not shown: the exporter drops it as missing_metadata, and
+    paper.csv rows with an empty title or snippet fail the contract outright. A
+    publicationDate that is present but unparseable is also rejected rather than
+    falling back to the arXiv ID's month -- that fallback exists for papers
+    Semantic Scholar cannot date at all, and reaching for it here could admit a
+    paper published after the cutoff on the strength of a date nothing read.
     """
     arxiv_id = _arxiv_id_from_paper(paper)
-    if require_arxiv and not arxiv_id:
+    if not arxiv_id:
+        return None, "no_arxiv_provenance"
+
+    title = str(paper.get("title") or "").strip()
+    snippet = str(paper.get("abstract") or "").strip()
+    if not title or not snippet:
+        return None, "missing_metadata"
+
+    if paper.get("publicationDate"):
+        published = _publication_date(paper)
+        if published is None:
+            return None, "unparseable_date"
+        precision = "day"
+        if cutoff is not None and published >= cutoff:
+            return None, "not_before_cutoff"
+    else:
+        published = date_from_arxiv_id(arxiv_id)
+        precision = "month"
+        if published is None:
+            return None, "undated"
+        if cutoff is not None and (published.year, published.month) >= (
+            cutoff.year,
+            cutoff.month,
+        ):
+            return None, "not_before_cutoff"
+
+    return _ArxivHit(arxiv_id, title, snippet, published, precision), "eligible"
+
+
+def _arxiv_context_only(paper: dict, cutoff: date | None) -> bool:
+    """Whether a hit with no arXiv ID is still worth showing as background.
+
+    It has to be readable -- a title and an abstract -- and, under an active
+    cutoff, dated before it. The arXiv-ID month fallback has nothing to fall
+    back to here, which is the point: nothing can cite this hit anyway.
+    """
+    if _arxiv_id_from_paper(paper):
+        return False
+    if not str(paper.get("title") or "").strip():
+        return False
+    if not str(paper.get("abstract") or "").strip():
         return False
     if cutoff is None:
         return True
     published = _publication_date(paper)
-    if published is not None:
-        return published < cutoff
-    fallback = date_from_arxiv_id(arxiv_id) if arxiv_id else None
-    if fallback is None:
-        return False
-    return (fallback.year, fallback.month) < (cutoff.year, cutoff.month)
+    return published is not None and published < cutoff
 
 
 def _arxiv_search_limit() -> int:
@@ -497,37 +550,24 @@ def _arxiv_request_limit(wanted: int) -> int:
     return max(1, min(_S2_MAX_SEARCH_LIMIT, wanted * _ARXIV_OVERFETCH_MULTIPLIER))
 
 
-def _arxiv_published(paper: dict, arxiv_id: str) -> tuple[date, str] | None:
-    """The date to show for a hit and whether it is day- or month-precise.
+def _format_arxiv_result(paper: dict, hit: _ArxivHit | None) -> str:
+    """Render one hit; ``hit is None`` marks it as uncitable context.
 
-    Semantic Scholar reports a day; an arXiv ID encodes only a month. The
-    export path writes ``date_precision`` straight from this distinction, and
-    the benchmark contract rejects a month-precise source dated inside the
-    cutoff's own month -- so a day that is known must never be reported as a
-    month, or the source is discarded for want of information the search
-    already had.
+    The abstract is truncated to keep the agent's context affordable. That makes
+    this snippet a preview rather than the abstract, which is why the export
+    re-fetches full text from Semantic Scholar instead of reusing what was
+    rendered here -- paper.csv's snippet column is scored.
     """
-    published = _publication_date(paper)
-    if published is not None:
-        return published, "day"
-    fallback = date_from_arxiv_id(arxiv_id) if arxiv_id else None
-    if fallback is not None:
-        return fallback, "month"
-    return None
-
-
-def _format_arxiv_result(paper: dict, arxiv_id: str) -> str:
-    """Render one hit; an empty ``arxiv_id`` marks it as uncitable context."""
-    title = paper.get("title") or "Unknown"
+    title = (hit.title if hit is not None else str(paper.get("title") or "")) or "Unknown"
     authors = paper.get("authors") or []
     author_names = ", ".join(a.get("name", "") for a in authors[:3])
     if len(authors) > 3:
         author_names += " et al."
-    abstract = paper.get("abstract") or ""
+    abstract = hit.snippet if hit is not None else str(paper.get("abstract") or "")
     if len(abstract) > _ARXIV_ABSTRACT_LIMIT:
         abstract = abstract[:_ARXIV_ABSTRACT_LIMIT] + "..."
 
-    if arxiv_id:
+    if hit is not None:
         lines = [f"**{title}**"]
     else:
         lines = [f"**{title}** [context only: no arXiv ID, not citable]"]
@@ -536,18 +576,18 @@ def _format_arxiv_result(paper: dict, arxiv_id: str) -> str:
     year = paper.get("year")
     if year:
         lines.append(f"Year: {year}")
-    published = _arxiv_published(paper, arxiv_id)
-    if published is not None:
-        value, precision = published
-        if precision == "day":
-            lines.append(f"Published: {value.isoformat()}")
+    if hit is not None:
+        if hit.precision == "day":
+            lines.append(f"Published: {hit.published.isoformat()}")
         else:
-            lines.append(f"Published: {value.year:04d}-{value.month:02d} (month precision)")
+            lines.append(
+                f"Published: {hit.published.year:04d}-{hit.published.month:02d} (month precision)"
+            )
     if abstract:
         lines.append(f"Abstract: {abstract}")
-    if arxiv_id:
-        lines.append(f"arXiv: {arxiv_id}")
-        lines.append(f"URL: https://arxiv.org/abs/{arxiv_id}")
+    if hit is not None:
+        lines.append(f"arXiv: {hit.arxiv_id}")
+        lines.append(f"URL: https://arxiv.org/abs/{hit.arxiv_id}")
     return "\n".join(lines)
 
 
@@ -565,11 +605,16 @@ async def arxiv_paper_search(query: str) -> str:
     :func:`semantic_scholar_search`; only the admission test differs. S2's
     search endpoint cannot select on external IDs, so provenance is decided
     client-side on ``externalIds.ArXiv`` and the requested page is widened to
-    compensate. Every result rendered with an arxiv.org URL is one
-    DeepScholar-Bench's exporter would also keep -- arXiv provenance, published
-    strictly before the active :func:`search_date_cutoff` -- so the model is
-    never invited to cite a source the scorer would discard. S2's relevance
-    order is preserved: filtering skips hits, it never reorders them.
+    compensate. S2's relevance order is preserved: filtering skips hits, it
+    never reorders them.
+
+    The invariant every rendered arxiv.org URL carries, enforced by
+    :func:`_classify_arxiv_hit`: arXiv provenance, a non-empty title and
+    abstract, and a publication date strictly before the active
+    :func:`search_date_cutoff` -- day-precise when Semantic Scholar supplies
+    one, otherwise the month the arXiv ID encodes. That is
+    DeepScholar-Bench's own admission test, so the model is never invited to
+    cite a source the scorer would discard.
 
     Args:
         query: Search query for arXiv papers.
@@ -628,19 +673,26 @@ async def arxiv_paper_search(query: str) -> str:
 
     citable: list[str] = []
     context_only: list[str] = []
+    rejections: dict[str, int] = {}
     for paper in data.get("data", []):
         if len(citable) >= wanted and len(context_only) >= _ARXIV_CONTEXT_ONLY_LIMIT:
             break
-        arxiv_id = _arxiv_id_from_paper(paper)
-        if arxiv_id:
-            if len(citable) < wanted and _arxiv_admits(paper, cutoff, require_arxiv=True):
-                citable.append(_format_arxiv_result(paper, arxiv_id))
-        elif len(context_only) < _ARXIV_CONTEXT_ONLY_LIMIT and _arxiv_admits(
-            paper, cutoff, require_arxiv=False
-        ):
-            context_only.append(_format_arxiv_result(paper, ""))
+        hit, reason = _classify_arxiv_hit(paper, cutoff)
+        if hit is not None:
+            if len(citable) < wanted:
+                citable.append(_format_arxiv_result(paper, hit))
+            continue
+        rejections[reason] = rejections.get(reason, 0) + 1
+        if len(context_only) < _ARXIV_CONTEXT_ONLY_LIMIT and _arxiv_context_only(paper, cutoff):
+            context_only.append(_format_arxiv_result(paper, None))
 
     if not citable and not context_only:
+        breakdown = ", ".join(f"{count} {reason}" for reason, count in sorted(rejections.items()))
+        logger.info(
+            "arXiv paper search kept nothing for %r: %s",
+            sanitized_query,
+            breakdown or "no hits returned",
+        )
         return "No arXiv papers found for query."
 
     return "\n\n---\n\n".join(citable + context_only)

--- a/src/olmo_eval/inference/__init__.py
+++ b/src/olmo_eval/inference/__init__.py
@@ -136,6 +136,13 @@ def create_provider(
             from .providers.litellm import LiteLLMProvider
 
             return LiteLLMProvider(model_name, **kwargs)
+        case "python":
+            import importlib
+
+            class_path = kwargs.pop("class")
+            module_path, class_name = class_path.rsplit(".", 1)
+            cls = getattr(importlib.import_module(module_path), class_name)
+            return cls(model_name, **kwargs)
         case _:
             raise ValueError(f"Unknown provider kind: {provider_kind}")
 

--- a/src/olmo_eval/inference/__init__.py
+++ b/src/olmo_eval/inference/__init__.py
@@ -19,6 +19,7 @@ __all__ = [
     "VLLMServerProvider",
     "OlmoCoreProvider",
     "LiteLLMProvider",
+    "StoredPredictionsProvider",
     "create_provider",
     # Tokenizer utilities
     "encode_context_and_continuation",
@@ -173,6 +174,10 @@ def __getattr__(name: str):
         from .providers.litellm import LiteLLMProvider
 
         return LiteLLMProvider
+    if name == "StoredPredictionsProvider":
+        from .providers.replay import StoredPredictionsProvider
+
+        return StoredPredictionsProvider
     if name == "metrics":
         from . import metrics
 

--- a/src/olmo_eval/inference/providers/config.py
+++ b/src/olmo_eval/inference/providers/config.py
@@ -116,6 +116,7 @@ class ProviderConfig:
             "max_model_len",
         ),
         "mock": (),
+        "python": (),
     }
 
     def create_provider(self) -> InferenceProvider:

--- a/src/olmo_eval/inference/providers/replay.py
+++ b/src/olmo_eval/inference/providers/replay.py
@@ -1,0 +1,634 @@
+"""Replay provider: serve generations that were already produced and saved to disk.
+
+`olmo-eval run` couples generation and scoring. When the generations already exist
+(they were produced by an earlier run and written to `predictions/` and `requests/`),
+re-running the model would produce *different* text and score that instead. This
+provider closes the gap: it loads the saved requests/predictions pair, joins them,
+and hands the stored text back to the normal scoring path.
+
+Wiring::
+
+    -o provider.kind=python \
+    -o provider.kwargs.class=olmo_eval.inference.providers.replay.StoredPredictionsProvider \
+    -o provider.kwargs.results_dir=/path/to/results
+
+Design rules, in the order they matter:
+
+1. Never answer the wrong instance. `LMRequest` carries no instance identifier, so
+   the lookup keys off request *content* (see `_request_key`). Matching is exact on a
+   structurally canonicalised key -- never fuzzy, never nearest-neighbour. Any key that
+   would resolve to two different stored texts is rejected at load time.
+2. Never silently answer nothing. A stored prediction that *is* the empty string is a
+   real result and is replayed as an empty string. A request with no stored prediction
+   is a bug and raises. The two are represented differently end to end.
+3. Report coverage. Every `generate` call logs matched/missing/empty counts, and a
+   single missing request aborts the run instead of quietly degrading it.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from hashlib import sha256
+from pathlib import Path
+from typing import Any, cast
+
+from olmo_eval.common.logging import get_logger
+from olmo_eval.common.types import LMOutput, LMRequest, SamplingParams
+from olmo_eval.inference.base import InferenceProvider
+from olmo_eval.runners.common.types import PREDICTIONS_SUFFIX, REQUESTS_SUFFIX
+
+logger = get_logger(__name__)
+
+# How many offending examples to name in an error message before truncating.
+_MAX_REPORTED_EXAMPLES = 5
+# How much of a request key preview to keep for diagnostics.
+_KEY_PREVIEW_CHARS = 200
+
+
+class ReplayError(RuntimeError):
+    """Base class for every failure raised by the replay provider."""
+
+
+class ReplayInputError(ReplayError):
+    """Saved artifacts are missing, ambiguous, or internally inconsistent."""
+
+
+class ReplayCoverageError(ReplayError):
+    """One or more live requests had no stored prediction to replay."""
+
+
+@dataclass(frozen=True, slots=True)
+class _StoredPrediction:
+    """A stored prediction joined to the request that produced it."""
+
+    doc_id: Any
+    native_id: Any
+    texts: tuple[str, ...]
+    trajectory: dict[str, Any] | None
+
+
+@dataclass(frozen=True, slots=True)
+class _UnusableEntry:
+    """A saved request whose prediction cannot be replayed, and why.
+
+    Kept separately from the usable index so that a lookup which lands here reports
+    "the instance is known but its prediction is missing" instead of the much weaker
+    "this request is unknown". Conflating those two has cost real debugging time.
+    """
+
+    doc_id: Any
+    native_id: Any
+    reason: str
+
+
+@dataclass
+class ReplayCoverage:
+    """Coverage accounting for everything this provider has been asked to replay."""
+
+    stored_requests: int = 0
+    stored_predictions: int = 0
+    replayable_entries: int = 0
+    unusable_entries: int = 0
+    requested: int = 0
+    matched: int = 0
+    missing: int = 0
+    empty_text_replayed: int = 0
+    used_keys: set[str] = field(default_factory=set)
+
+    @property
+    def unused_entries(self) -> int:
+        """Stored entries that no live request ever asked for."""
+        return max(self.replayable_entries - len(self.used_keys), 0)
+
+    def as_dict(self) -> dict[str, int]:
+        """Return a plain dict, for logging and for assertions in tests."""
+        return {
+            "stored_requests": self.stored_requests,
+            "stored_predictions": self.stored_predictions,
+            "replayable_entries": self.replayable_entries,
+            "unusable_entries": self.unusable_entries,
+            "requested": self.requested,
+            "matched": self.matched,
+            "missing": self.missing,
+            "empty_text_replayed": self.empty_text_replayed,
+            "unused_entries": self.unused_entries,
+        }
+
+
+def _canonical_json(value: Any) -> str:
+    """Serialise `value` so that structurally identical data yields identical text.
+
+    Sorting keys and using compact separators removes formatting differences, and
+    `ensure_ascii=False` keeps both sides of the comparison in the same encoding.
+    Tuples serialise as JSON arrays, which is what makes an in-memory `LMRequest`
+    comparable to the same request after a round trip through JSONL.
+    """
+    return json.dumps(value, sort_keys=True, ensure_ascii=False, separators=(",", ":"))
+
+
+def _hash_key(canonical: str) -> str:
+    """Hash a canonical key so the index stays small regardless of prompt length."""
+    return sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _key_from_context(context: Any) -> tuple[str, str]:
+    """Build the lookup key for one request payload.
+
+    `context` is either the chat message list or the plain-text prompt. The tag in
+    front of the payload keeps the two namespaces apart, so a prompt string can never
+    collide with a chat conversation that happens to serialise the same way.
+
+    Returns:
+        (hashed key, human-readable preview for diagnostics).
+    """
+    if isinstance(context, (list, tuple)):
+        canonical = _canonical_json({"kind": "chat", "messages": list(context)})
+    elif isinstance(context, str):
+        canonical = _canonical_json({"kind": "text", "prompt": context})
+    else:
+        raise ReplayInputError(
+            f"Cannot build a replay key from request context of type {type(context).__name__}; "
+            "expected a chat message list or a prompt string."
+        )
+    return _hash_key(canonical), canonical[:_KEY_PREVIEW_CHARS]
+
+
+def _read_jsonl(path: Path) -> list[dict[str, Any]]:
+    """Read a JSONL file, reporting the offending line number on bad JSON."""
+    rows: list[dict[str, Any]] = []
+    with path.open(encoding="utf-8") as handle:
+        for lineno, line in enumerate(handle, start=1):
+            if not line.strip():
+                continue
+            try:
+                row = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise ReplayInputError(f"{path}:{lineno} is not valid JSON: {exc}") from exc
+            if not isinstance(row, dict):
+                raise ReplayInputError(f"{path}:{lineno} is not a JSON object")
+            rows.append(row)
+    return rows
+
+
+def _resolve_single_file(
+    root: Path,
+    suffix: str,
+    explicit: str | None,
+    task_filter: str | None,
+    label: str,
+    base: Path,
+) -> Path:
+    """Find exactly one artifact file under `root`, or refuse to guess.
+
+    Picking one of several candidates would silently decide which run gets scored, so
+    ambiguity is an error. `task_filter` is the supported way to narrow the choice.
+
+    Args:
+        root: Directory to glob (`<results_dir>/requests` or `<results_dir>/predictions`).
+        suffix: Filename suffix identifying the artifact type.
+        explicit: Caller-supplied path, absolute or relative to `base`.
+        task_filter: Optional substring filter over candidate filenames.
+        label: Human-readable artifact name used in error messages.
+        base: Directory that relative `explicit` paths resolve against.
+    """
+    if explicit is not None:
+        path = Path(explicit).expanduser()
+        if not path.is_absolute():
+            path = base / path
+        if not path.is_file():
+            raise ReplayInputError(f"Explicit {label} file does not exist: {path}")
+        return path
+
+    if not root.is_dir():
+        raise ReplayInputError(f"Expected a '{root.name}' directory at {root}, but it is missing.")
+
+    candidates = sorted(p for p in root.rglob(f"*{suffix}") if p.is_file())
+    if task_filter:
+        candidates = [p for p in candidates if task_filter in p.name]
+
+    if not candidates:
+        hint = f" matching task_filter={task_filter!r}" if task_filter else ""
+        raise ReplayInputError(f"No *{suffix} file found under {root}{hint}.")
+    if len(candidates) > 1:
+        listed = "\n  ".join(str(p) for p in candidates)
+        raise ReplayInputError(
+            f"Ambiguous {label} input: {len(candidates)} files match *{suffix} under {root}. "
+            "Refusing to pick one. Narrow it with provider.kwargs.task_filter=<substring> or "
+            f"name the file with provider.kwargs.{label}_file=<path>. Candidates:\n  {listed}"
+        )
+    return candidates[0]
+
+
+class StoredPredictionsProvider(InferenceProvider):
+    """Replay generations from a saved `predictions/` + `requests/` pair.
+
+    The provider is generation-only. `logprobs` raises rather than returning anything,
+    because a replayed run has no token-level scores and a plausible-looking stand-in
+    would corrupt any metric derived from them.
+
+    Args:
+        model_name: Model identifier. Only used for labelling; nothing is loaded.
+        results_dir: Directory holding `predictions/` and `requests/` subdirectories.
+        task_filter: Optional substring used to disambiguate when the results directory
+            holds artifacts for more than one task or model.
+        predictions_file: Optional explicit path to the predictions JSONL, absolute or
+            relative to `results_dir`. Bypasses globbing.
+        requests_file: Optional explicit path to the requests JSONL, same rules.
+        preserve_trajectory: When True (default), a `trajectory` recorded on the stored
+            prediction is re-attached under `LMOutput.metadata["trajectory"]`, which is
+            where the runner looks when rebuilding `Response.trajectory`.
+    """
+
+    def __init__(
+        self,
+        model_name: str,
+        results_dir: str | None = None,
+        task_filter: str | None = None,
+        predictions_file: str | None = None,
+        requests_file: str | None = None,
+        preserve_trajectory: bool = True,
+    ) -> None:
+        super().__init__(model_name)
+
+        if results_dir is None and (predictions_file is None or requests_file is None):
+            raise ReplayInputError(
+                "StoredPredictionsProvider needs provider.kwargs.results_dir (a directory "
+                "containing predictions/ and requests/), or both predictions_file and "
+                "requests_file."
+            )
+
+        self.results_dir = Path(results_dir).expanduser() if results_dir else Path()
+        self.preserve_trajectory = preserve_trajectory
+
+        self.requests_path = _resolve_single_file(
+            self.results_dir / "requests",
+            REQUESTS_SUFFIX,
+            requests_file,
+            task_filter,
+            "requests",
+            self.results_dir,
+        )
+        self.predictions_path = _resolve_single_file(
+            self.results_dir / "predictions",
+            PREDICTIONS_SUFFIX,
+            predictions_file,
+            task_filter,
+            "predictions",
+            self.results_dir,
+        )
+
+        self.coverage = ReplayCoverage()
+        self._entries: dict[str, _StoredPrediction] = {}
+        self._unusable: dict[str, _UnusableEntry] = {}
+        self._load()
+
+    # ─────────────────────────────────────────────────────────
+    # Loading and joining
+    # ─────────────────────────────────────────────────────────
+
+    def _load(self) -> None:
+        """Join the saved requests to the saved predictions and index them by key."""
+        request_rows = _read_jsonl(self.requests_path)
+        prediction_rows = _read_jsonl(self.predictions_path)
+        self.coverage.stored_requests = len(request_rows)
+        self.coverage.stored_predictions = len(prediction_rows)
+
+        predictions_by_doc_id = self._index_predictions(prediction_rows)
+
+        for lineno, row in enumerate(request_rows, start=1):
+            if "doc_id" not in row:
+                raise ReplayInputError(f"{self.requests_path}:{lineno} has no 'doc_id' field.")
+            doc_id = row["doc_id"]
+            native_id = row.get("native_id")
+
+            request_payload = row.get("request")
+            if not isinstance(request_payload, dict) or "context" not in request_payload:
+                raise ReplayInputError(
+                    f"{self.requests_path}:{lineno} (doc_id={doc_id!r}) has no request.context; "
+                    "this file cannot be used for replay."
+                )
+            key, _ = _key_from_context(request_payload["context"])
+
+            prediction = predictions_by_doc_id.get(doc_id)
+            if prediction is None:
+                self._record_unusable(
+                    key, doc_id, native_id, f"no prediction row with doc_id={doc_id!r}"
+                )
+                continue
+
+            self._check_native_id(doc_id, native_id, prediction.get("native_id"))
+
+            texts, reason = _extract_texts(prediction)
+            if texts is None:
+                self._record_unusable(key, doc_id, native_id, reason)
+                continue
+
+            entry = _StoredPrediction(
+                doc_id=doc_id,
+                native_id=native_id,
+                texts=texts,
+                trajectory=_trajectory_of(prediction) if self.preserve_trajectory else None,
+            )
+            self._register(key, entry)
+
+        self.coverage.replayable_entries = len(self._entries)
+        self.coverage.unusable_entries = len(self._unusable)
+        self._log_load_summary()
+
+    def _index_predictions(self, rows: list[dict[str, Any]]) -> dict[Any, dict[str, Any]]:
+        """Index prediction rows by doc_id, refusing duplicates."""
+        by_doc_id: dict[Any, dict[str, Any]] = {}
+        for lineno, row in enumerate(rows, start=1):
+            if "doc_id" not in row:
+                raise ReplayInputError(f"{self.predictions_path}:{lineno} has no 'doc_id' field.")
+            doc_id = row["doc_id"]
+            if doc_id in by_doc_id:
+                raise ReplayInputError(
+                    f"{self.predictions_path}:{lineno} repeats doc_id={doc_id!r}. Refusing to "
+                    "choose between duplicate predictions for the same instance."
+                )
+            by_doc_id[doc_id] = row
+        return by_doc_id
+
+    def _check_native_id(self, doc_id: Any, request_native: Any, prediction_native: Any) -> None:
+        """Fail if the two files disagree about which instance a doc_id refers to.
+
+        The join runs on doc_id; native_id is the independent witness that the two
+        files describe the same run. If they disagree, the files are misaligned and
+        every replayed answer would be attached to the wrong instance.
+        """
+        if request_native is None or prediction_native is None:
+            return
+        if request_native != prediction_native:
+            raise ReplayInputError(
+                f"doc_id={doc_id!r} has native_id={request_native!r} in {self.requests_path} but "
+                f"native_id={prediction_native!r} in {self.predictions_path}. The two files do "
+                "not describe the same run; replaying them would answer the wrong instances."
+            )
+
+    def _register(self, key: str, entry: _StoredPrediction) -> None:
+        """Add an entry to the index, rejecting conflicting duplicates."""
+        existing = self._entries.get(key)
+        if existing is not None and existing.texts != entry.texts:
+            raise ReplayInputError(
+                f"Two stored instances share an identical request but have different stored "
+                f"text (doc_id={existing.doc_id!r} and doc_id={entry.doc_id!r}). The request "
+                "content cannot identify which one to replay; refusing to guess."
+            )
+        self._entries[key] = entry
+        # A usable entry wins over any earlier unusable record for the same key.
+        self._unusable.pop(key, None)
+
+    def _record_unusable(self, key: str, doc_id: Any, native_id: Any, reason: str) -> None:
+        """Remember why a saved request has nothing replayable behind it."""
+        if key in self._entries:
+            return
+        self._unusable[key] = _UnusableEntry(doc_id=doc_id, native_id=native_id, reason=reason)
+
+    def _log_load_summary(self) -> None:
+        logger.info(
+            "Replay index built from %s and %s: %d saved requests, %d saved predictions, "
+            "%d replayable, %d unusable.",
+            self.requests_path,
+            self.predictions_path,
+            self.coverage.stored_requests,
+            self.coverage.stored_predictions,
+            self.coverage.replayable_entries,
+            self.coverage.unusable_entries,
+        )
+        if self._unusable:
+            examples = list(self._unusable.values())[:_MAX_REPORTED_EXAMPLES]
+            detail = "; ".join(
+                f"doc_id={e.doc_id!r} native_id={e.native_id!r}: {e.reason}" for e in examples
+            )
+            logger.warning(
+                "%d saved request(s) have no replayable prediction. Asking for any of them "
+                "will fail rather than return an empty answer. Examples: %s",
+                len(self._unusable),
+                detail,
+            )
+
+    # ─────────────────────────────────────────────────────────
+    # Lookup
+    # ─────────────────────────────────────────────────────────
+
+    def _request_key(self, request: LMRequest) -> tuple[str, str]:
+        """Derive the lookup key for a live request.
+
+        Chat messages take precedence over `prompt` because a chat request stores its
+        payload in `messages`, and that is exactly what the saved `request.context`
+        holds for chat requests. Tools, sampling parameters and stop sequences are
+        deliberately excluded: they describe *how* to generate, not *which instance*
+        this is, and including them would make replay fail whenever the scoring run
+        configures generation slightly differently.
+        """
+        if request.messages:
+            return _key_from_context([dict(message) for message in request.messages])
+        return _key_from_context(request.prompt)
+
+    def has_stored_prediction(self, request: LMRequest) -> bool:
+        """Whether `request` can be replayed. Useful for a dry run before scoring."""
+        key, _ = self._request_key(request)
+        return key in self._entries
+
+    # ─────────────────────────────────────────────────────────
+    # InferenceProvider interface
+    # ─────────────────────────────────────────────────────────
+
+    def generate(
+        self,
+        requests: list[LMRequest],
+        sampling_params: SamplingParams | None = None,
+    ) -> list[list[LMOutput]]:
+        """Replay the stored generations for `requests`.
+
+        Raises:
+            ReplayCoverageError: If any request has no stored prediction. Partial runs
+                are never returned, because a missing instance that quietly scores as
+                an empty answer is indistinguishable from a genuinely empty answer.
+        """
+        params = self._default_sampling_params(sampling_params)
+        num_samples = max(int(params.num_samples or 1), 1)
+
+        results: list[list[LMOutput]] = []
+        missing: list[str] = []
+
+        for index, request in enumerate(requests):
+            self.coverage.requested += 1
+            key, preview = self._request_key(request)
+            entry = self._entries.get(key)
+
+            if entry is None:
+                self.coverage.missing += 1
+                missing.append(self._describe_miss(index, key, preview))
+                results.append([])
+                continue
+
+            if num_samples > len(entry.texts):
+                raise ReplayCoverageError(
+                    f"Request {index} (doc_id={entry.doc_id!r}, native_id={entry.native_id!r}) "
+                    f"asks for {num_samples} sample(s) but only {len(entry.texts)} stored "
+                    "generation(s) exist. Replay never fabricates additional samples."
+                )
+            if num_samples < len(entry.texts):
+                logger.warning(
+                    "doc_id=%r has %d stored generations but only %d sample(s) were requested; "
+                    "replaying the first %d.",
+                    entry.doc_id,
+                    len(entry.texts),
+                    num_samples,
+                    num_samples,
+                )
+
+            self.coverage.matched += 1
+            self.coverage.used_keys.add(key)
+            outputs = [self._build_output(entry, sample) for sample in range(num_samples)]
+            # An empty stored generation is a real result, not a miss. Count it so the
+            # run log shows how many empties were replayed on purpose.
+            if any(output.text == "" for output in outputs):
+                self.coverage.empty_text_replayed += 1
+            results.append(outputs)
+
+        self._log_batch_coverage(len(requests), len(missing))
+
+        if missing:
+            shown = missing[:_MAX_REPORTED_EXAMPLES]
+            suffix = (
+                f"\n  ... and {len(missing) - len(shown)} more" if len(missing) > len(shown) else ""
+            )
+            raise ReplayCoverageError(
+                f"{len(missing)} of {len(requests)} request(s) have no stored prediction to "
+                f"replay from {self.predictions_path}. Refusing to return a partial batch, "
+                "because an unanswered instance must not look like an empty answer.\n  "
+                + "\n  ".join(shown)
+                + suffix
+            )
+
+        return results
+
+    async def agenerate(
+        self,
+        requests: list[LMRequest],
+        sampling_params: SamplingParams | None = None,
+    ) -> list[list[LMOutput]]:
+        """Async generate. Replay is a dictionary lookup, so it just calls generate."""
+        return self.generate(requests, sampling_params)
+
+    def logprobs(
+        self,
+        requests: list[LMRequest],
+        sampling_params: SamplingParams | None = None,
+    ) -> list[list[LMOutput]]:
+        """Always raises: saved predictions carry no token-level scores.
+
+        Returning zeros or recomputed values here would silently produce a wrong
+        likelihood metric, which is worse than not running at all.
+        """
+        raise NotImplementedError(
+            "StoredPredictionsProvider replays saved generations and has no logprobs. "
+            "Saved predictions do not carry token-level scores, so any value returned here "
+            "would be fabricated. Score loglikelihood tasks with a real provider."
+        )
+
+    async def alogprobs(
+        self,
+        requests: list[LMRequest],
+        sampling_params: SamplingParams | None = None,
+    ) -> list[list[LMOutput]]:
+        """Always raises, for the same reason as `logprobs`."""
+        return self.logprobs(requests, sampling_params)
+
+    # ─────────────────────────────────────────────────────────
+    # Reporting helpers
+    # ─────────────────────────────────────────────────────────
+
+    def _build_output(self, entry: _StoredPrediction, sample_index: int) -> LMOutput:
+        """Build the LMOutput handed back to the scoring path.
+
+        `extracted_answer` is deliberately left unset: the task recomputes it from
+        `text` during scoring, so replaying a stored value would be dead weight at
+        best and stale at worst. Logprob-derived metadata (`sum_logits`, `num_tokens`,
+        ...) is deliberately absent -- downstream code treats its absence as
+        "unavailable" and its presence as a real measurement.
+        """
+        metadata: dict[str, Any] = {
+            "replay_source": {
+                "predictions_file": str(self.predictions_path),
+                "requests_file": str(self.requests_path),
+                "doc_id": entry.doc_id,
+                "native_id": entry.native_id,
+                "sample_index": sample_index,
+            }
+        }
+        # The runner rebuilds Response.trajectory from metadata["trajectory"], and
+        # tasks such as litsearch/expertqa/sage score against that trajectory. Keeping
+        # it means a replayed run reproduces those tasks too, and keeps the trajectory
+        # column in the re-written predictions file. DeepResearch Bench itself scores
+        # only the text, so this is preservation rather than a requirement for DRB.
+        if sample_index == 0 and entry.trajectory is not None:
+            metadata["trajectory"] = entry.trajectory
+        return LMOutput(text=entry.texts[sample_index], metadata=metadata)
+
+    def _describe_miss(self, index: int, key: str, preview: str) -> str:
+        """Explain one lookup failure as precisely as the saved data allows."""
+        known = self._unusable.get(key)
+        if known is not None:
+            return (
+                f"request {index}: matches saved doc_id={known.doc_id!r} "
+                f"native_id={known.native_id!r} but {known.reason}"
+            )
+        return f"request {index}: no saved request matches this content. key={key[:12]} {preview!r}"
+
+    def _log_batch_coverage(self, batch_size: int, missing: int) -> None:
+        logger.info(
+            "Replay coverage: %d/%d matched in this batch (%d missing); cumulative "
+            "%d requested, %d matched, %d missing, %d empty-but-present, %d stored entries "
+            "never requested.",
+            batch_size - missing,
+            batch_size,
+            missing,
+            self.coverage.requested,
+            self.coverage.matched,
+            self.coverage.missing,
+            self.coverage.empty_text_replayed,
+            self.coverage.unused_entries,
+        )
+
+    def coverage_report(self) -> dict[str, int]:
+        """Return the cumulative coverage counters."""
+        return self.coverage.as_dict()
+
+
+def _extract_texts(prediction: dict[str, Any]) -> tuple[tuple[str, ...] | None, str]:
+    """Pull the generated text(s) out of a stored prediction row.
+
+    Returns:
+        (texts, reason). `texts` is None when nothing replayable is present, and
+        `reason` then explains what was wrong. An empty string inside `texts` is a
+        real, replayable result and never becomes None.
+    """
+    model_output = prediction.get("model_output")
+    if not isinstance(model_output, list) or not model_output:
+        return None, "prediction row has an empty or missing 'model_output' list"
+
+    texts: list[str] = []
+    for position, raw_output in enumerate(model_output):
+        if not isinstance(raw_output, dict):
+            return None, f"model_output[{position}] is not an object"
+        output = cast("dict[str, Any]", raw_output)
+        if "text" not in output:
+            return None, f"model_output[{position}] has no 'text' field"
+        text = output["text"]
+        if text is None:
+            return None, f"model_output[{position}]['text'] is null (no generation recorded)"
+        if not isinstance(text, str):
+            return None, f"model_output[{position}]['text'] is {type(text).__name__}, not a string"
+        texts.append(text)
+    return tuple(texts), ""
+
+
+def _trajectory_of(prediction: dict[str, Any]) -> dict[str, Any] | None:
+    """Return the stored trajectory dict, if the prediction row carries one."""
+    trajectory = prediction.get("trajectory")
+    return trajectory if isinstance(trajectory, dict) else None

--- a/src/olmo_eval/inference/providers/vllm_server_utils.py
+++ b/src/olmo_eval/inference/providers/vllm_server_utils.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import atexit
 import logging
 import os
+import shutil
 import signal
 import socket
 import subprocess
@@ -224,6 +225,38 @@ def _get_vllm_python() -> str:
         Path to Python interpreter.
     """
     return os.environ.get("VLLM_PYTHON", sys.executable)
+
+
+def _prepend_interpreter_bin_to_path(env: dict[str, str], python_executable: str) -> str:
+    """Put the vLLM interpreter's bin directory at the front of PATH.
+
+    When vLLM runs from an isolated virtualenv (see VLLM_PYTHON), only the main
+    app venv is on PATH, because that is what the image exports. Console scripts
+    installed next to vLLM are therefore invisible to the server process and to
+    anything it shells out to. Runtime kernel compilation depends on exactly
+    that: flashinfer's JIT runs a bare "ninja", which execvp resolves through
+    PATH. A model whose kernels are compiled on the first forward pass (Mamba /
+    GDN linear attention, for example) then kills the engine with
+    "FileNotFoundError: ninja" after the server has already passed its readiness
+    probe, so every request fails while the job still looks healthy.
+
+    The directory is prepended, never substituted, so the harness keeps every
+    entry it already relies on and the main venv stays reachable as a fallback.
+
+    Args:
+        env: Environment mapping for the child process, mutated in place.
+        python_executable: Interpreter the vLLM server will be launched with.
+
+    Returns:
+        The resulting PATH value.
+    """
+    directory = os.path.dirname(python_executable)
+    if directory:
+        bin_dir = os.path.abspath(directory)
+        entries = [entry for entry in env.get("PATH", "").split(os.pathsep) if entry]
+        if bin_dir not in entries:
+            env["PATH"] = os.pathsep.join([bin_dir, *entries])
+    return env.get("PATH", "")
 
 
 def _get_olmo3_tool_template_path() -> str:
@@ -503,6 +536,20 @@ class VLLMServerProcess:
         # itself does not need to see it, and forwarding it triggers a warning
         # because vLLM treats unknown VLLM_* variables as suspicious.
         env.pop("VLLM_PYTHON", None)
+        # vLLM may run from an isolated venv whose bin directory is not on PATH.
+        # Console scripts installed alongside it - notably "ninja", which
+        # flashinfer's JIT shells out to when it compiles a kernel on the first
+        # forward pass - must stay resolvable, otherwise the engine dies on the
+        # first real request even though startup succeeded.
+        search_path = _prepend_interpreter_bin_to_path(env, cmd[0])
+        if shutil.which("ninja", path=search_path) is None:
+            self._log(
+                logging.WARNING,
+                "ninja was not found on the vLLM server's PATH. Models that "
+                "JIT-compile kernels at inference time (e.g. Mamba/GDN linear "
+                "attention) will fail on their first request. Install ninja into "
+                f"the environment of {cmd[0]}.",
+            )
         # vLLM uses VLLM_PORT as the starting point for internal port
         # selection, including torch distributed rendezvous. Give each managed
         # server a low base port so concurrent cold starts do not collide in

--- a/src/olmo_eval/inference/providers/vllm_server_utils.py
+++ b/src/olmo_eval/inference/providers/vllm_server_utils.py
@@ -531,15 +531,6 @@ class VLLMServerProcess:
 
         # Build environment for subprocess (child only, don't mutate parent)
         env = os.environ.copy()
-        # VLLM_PYTHON can point at an isolated environment whose console tools
-        # (for example ninja, used by FlashInfer JIT compilation) are installed
-        # beside its Python executable. Make those tools visible to the child
-        # without changing the launcher's environment.
-        python_bin_dir = os.path.dirname(cmd[0])
-        if python_bin_dir:
-            python_bin_dir = os.path.abspath(python_bin_dir)
-        inherited_path = env.get("PATH")
-        env["PATH"] = os.pathsep.join(part for part in (python_bin_dir, inherited_path) if part)
         # VLLM_PYTHON is our own steering variable for selecting which Python
         # interpreter launches the server. Once the command is built, vLLM
         # itself does not need to see it, and forwarding it triggers a warning

--- a/src/olmo_eval/launch/beaker/launcher.py
+++ b/src/olmo_eval/launch/beaker/launcher.py
@@ -954,26 +954,39 @@ class BeakerLauncher:
 
         # Install provider-specific dependencies
         if provider_packages:
-            # Rewrite github.com HTTPS URLs to embed the token so uv's git subprocess
-            # inherits credentials without relying on gh's credential helper.
-            steps.append(
-                'if [ -n "$GITHUB_TOKEN" ]; then '
-                "export GIT_CONFIG_COUNT=1; "
-                "export GIT_CONFIG_KEY_0=credential.helper; "
-                "export GIT_CONFIG_VALUE_0="
-                "'!f() { echo username=x-access-token; "
-                "echo password=$GITHUB_TOKEN; }; f'; "
-                "fi"
-            )
-            for pkg in provider_packages:
-                steps.append(
-                    build_install_command(
-                        provider_package_spec(pkg),
-                        constraints,
-                        venv_path=vllm_venv if use_isolated_vllm_venv else None,
-                        force_reinstall=True,
-                    )
+            for i, pkg in enumerate(provider_packages):
+                github_match = re.search(
+                    r"github\.com[:/]([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+?)(?:\.git)?(?:@[^\s]+)?$",
+                    pkg,
                 )
+                if github_match:
+                    # Clone directly so we control the git invocation and can
+                    # inject GITHUB_TOKEN into the URL without relying on
+                    # git config or credential helpers reaching uv's subprocess.
+                    gh_path = github_match.group(1)
+                    clone_dir = f"/tmp/provider-src-{i}"
+                    steps.append(
+                        f"git clone --quiet --depth=1 "
+                        f'"https://${{GITHUB_TOKEN:-}}@github.com/{gh_path}" '
+                        f"{clone_dir}"
+                    )
+                    steps.append(
+                        build_install_command(
+                            provider_package_spec(clone_dir),
+                            constraints,
+                            venv_path=vllm_venv if use_isolated_vllm_venv else None,
+                            force_reinstall=True,
+                        )
+                    )
+                else:
+                    steps.append(
+                        build_install_command(
+                            provider_package_spec(pkg),
+                            constraints,
+                            venv_path=vllm_venv if use_isolated_vllm_venv else None,
+                            force_reinstall=True,
+                        )
+                    )
 
         # Install task-specific dependencies
         if task_packages:

--- a/src/olmo_eval/launch/beaker/launcher.py
+++ b/src/olmo_eval/launch/beaker/launcher.py
@@ -1066,6 +1066,12 @@ class BeakerLauncher:
         if not any(name == "BEAKER_TOKEN" for name, _ in env_secrets):
             env_secrets.append(("BEAKER_TOKEN", f"{self.beaker.user_name}_BEAKER_TOKEN"))
 
+        # Inject GITHUB_TOKEN so provider package installs can clone private repos.
+        # Gantry only mounts this automatically for private olmo-eval repos; since
+        # olmo-eval is public, we must add it explicitly.
+        if not any(name == "GITHUB_TOKEN" for name, _ in env_secrets):
+            env_secrets.append(("GITHUB_TOKEN", self._default_github_token_secret()))
+
         # Inject AWS credentials if requested
         if config.inject_aws_credentials:
             from olmo_eval.launch.beaker.aws import ensure_aws_secrets

--- a/src/olmo_eval/launch/beaker/launcher.py
+++ b/src/olmo_eval/launch/beaker/launcher.py
@@ -958,8 +958,9 @@ class BeakerLauncher:
             # inherits credentials without relying on gh's credential helper.
             steps.append(
                 'if [ -n "$GITHUB_TOKEN" ]; then '
-                "git config --global "
-                'url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"; '
+                "export GIT_CONFIG_COUNT=1; "
+                'export GIT_CONFIG_KEY_0="url.https://${GITHUB_TOKEN}@github.com/.insteadOf"; '
+                'export GIT_CONFIG_VALUE_0="https://github.com/"; '
                 "fi"
             )
             for pkg in provider_packages:

--- a/src/olmo_eval/launch/beaker/launcher.py
+++ b/src/olmo_eval/launch/beaker/launcher.py
@@ -28,6 +28,7 @@ from typing import TYPE_CHECKING, Any
 from urllib.parse import urlsplit
 
 from rich.console import Console
+from rich.markup import escape as rich_escape
 from rich.panel import Panel
 from rich.syntax import Syntax
 from rich.text import Text
@@ -692,7 +693,9 @@ def describe_code_version(git_ref: str | None = None) -> str:
         repo = Repo(".")
         head = str(repo.commit())
         branch = "detached HEAD" if repo.head.is_detached else repo.active_branch.name
-        dirty = " [dirty]" if repo.is_dirty() else ""
+        # Gantry clones the committed SHA, so uncommitted edits never reach
+        # the job. Say so plainly rather than with a marker that is easy to miss.
+        dirty = " (uncommitted changes are NOT deployed)" if repo.is_dirty() else ""
         return f"{head} ({branch}){dirty} from cwd {cwd}"
     except Exception as exc:  # noqa: BLE001 - diagnostics must never block a launch
         return f"unresolved from cwd {cwd} ({exc})"
@@ -1163,7 +1166,9 @@ class BeakerLauncher:
         # olmo-eval setting. Launching from a second checkout of this repo
         # therefore silently runs that checkout's HEAD instead of the branch you
         # think you are on. Report what will actually be cloned.
-        _console.print(f"[bold blue]Code version:[/] {describe_code_version(config.git_ref)}")
+        _console.print(
+            f"[bold blue]Code version:[/] {rich_escape(describe_code_version(config.git_ref))}"
+        )
 
         # Launch the experiment (or show spec if dry_run)
         workload = launch_experiment(

--- a/src/olmo_eval/launch/beaker/launcher.py
+++ b/src/olmo_eval/launch/beaker/launcher.py
@@ -963,12 +963,19 @@ class BeakerLauncher:
                     # Clone directly so we control the git invocation and can
                     # inject GITHUB_TOKEN into the URL without relying on
                     # git config or credential helpers reaching uv's subprocess.
+                    # GitHub token auth requires user:token format (token as password).
                     gh_path = github_match.group(1)
                     clone_dir = f"/tmp/provider-src-{i}"
                     steps.append(
+                        f'if [ -n "$GITHUB_TOKEN" ]; then '
                         f"git clone --quiet --depth=1 "
-                        f'"https://${{GITHUB_TOKEN:-}}@github.com/{gh_path}" '
-                        f"{clone_dir}"
+                        f'"https://x-access-token:${{GITHUB_TOKEN}}@github.com/{gh_path}" '
+                        f"{clone_dir}; "
+                        f"else "
+                        f"git clone --quiet --depth=1 "
+                        f'"https://github.com/{gh_path}" '
+                        f"{clone_dir}; "
+                        f"fi"
                     )
                     steps.append(
                         build_install_command(

--- a/src/olmo_eval/launch/beaker/launcher.py
+++ b/src/olmo_eval/launch/beaker/launcher.py
@@ -965,6 +965,7 @@ class BeakerLauncher:
                     # git config or credential helpers reaching uv's subprocess.
                     # GitHub token auth requires user:token format (token as password).
                     gh_path = github_match.group(1)
+                    repo_name = gh_path.split("/")[-1]
                     clone_dir = f"/tmp/provider-src-{i}"
                     steps.append(
                         f'if [ -n "$GITHUB_TOKEN" ]; then '
@@ -979,7 +980,7 @@ class BeakerLauncher:
                     )
                     steps.append(
                         build_install_command(
-                            provider_package_spec(clone_dir),
+                            provider_package_spec(f"{repo_name} @ {clone_dir}"),
                             constraints,
                             venv_path=vllm_venv if use_isolated_vllm_venv else None,
                             force_reinstall=True,

--- a/src/olmo_eval/launch/beaker/launcher.py
+++ b/src/olmo_eval/launch/beaker/launcher.py
@@ -1163,7 +1163,7 @@ class BeakerLauncher:
         # olmo-eval setting. Launching from a second checkout of this repo
         # therefore silently runs that checkout's HEAD instead of the branch you
         # think you are on. Report what will actually be cloned.
-        log.info(f"Code version: {describe_code_version(config.git_ref)}")
+        _console.print(f"[bold blue]Code version:[/] {describe_code_version(config.git_ref)}")
 
         # Launch the experiment (or show spec if dry_run)
         workload = launch_experiment(

--- a/src/olmo_eval/launch/beaker/launcher.py
+++ b/src/olmo_eval/launch/beaker/launcher.py
@@ -1050,6 +1050,18 @@ class BeakerLauncher:
                         )
                     )
 
+        # Prebuilt FlashInfer kernels. The runtime image has no nvcc, so any
+        # kernel FlashInfer decides to JIT at inference time kills the engine
+        # mid-run. Runs last so it reads the flashinfer version that provider
+        # overrides actually left behind.
+        if use_isolated_vllm_venv:
+            script = (
+                "/gantry-runtime/src/olmo_eval/launch/beaker/scripts/install_flashinfer_jit_cache"
+            )
+            # Executed, not sourced: the script sets its own shell options
+            # and must not impose them on the remaining install steps.
+            steps.append(f"bash {script} {vllm_venv}/bin/python")
+
         # Install task-specific dependencies
         if task_packages:
             for pkg in task_packages:

--- a/src/olmo_eval/launch/beaker/launcher.py
+++ b/src/olmo_eval/launch/beaker/launcher.py
@@ -348,6 +348,8 @@ class BeakerJobConfig:
         timeout: Job timeout (e.g., "24h", "30m").
         retries: Number of retries on failure.
         beaker_image: Container image to use.
+        git_ref: Commit SHA of this repo to run. When None, gantry uses the
+            HEAD of the git repository rooted at the current working directory.
         description: Optional job description.
         weka_buckets: Weka storage mounts.
         nfs: Whether to mount NFS.
@@ -375,6 +377,7 @@ class BeakerJobConfig:
 
     # Beaker settings
     beaker_image: str = BEAKER_DEFAULT_IMAGE
+    git_ref: str | None = None
     description: str | None = None
 
     # Storage - defaults include common eval buckets
@@ -659,6 +662,40 @@ def is_direct_source_package(package: str) -> bool:
         or "://" in normalized
         or normalized.startswith("/")
     )
+
+
+def describe_code_version(git_ref: str | None = None) -> str:
+    """Describe the commit gantry will clone for a job, and where it came from.
+
+    Gantry derives the job's code version from the git repository rooted at the
+    launching process's working directory, not from any olmo-eval option, so the
+    same command run from two checkouts of this repo launches two different
+    commits with no other visible difference. This renders that decision so it
+    can be checked before a job starts.
+
+    Args:
+        git_ref: Explicit commit passed through to gantry, if any.
+
+    Returns:
+        A human-readable description; never raises, since this is diagnostics.
+    """
+    import os
+
+    if git_ref is not None:
+        return f"{git_ref} (pinned via git_ref)"
+
+    cwd = os.getcwd()
+    try:
+        from git.repo import Repo
+
+        # The same lookup gantry performs in GitRepoState.from_env().
+        repo = Repo(".")
+        head = str(repo.commit())
+        branch = "detached HEAD" if repo.head.is_detached else repo.active_branch.name
+        dirty = " [dirty]" if repo.is_dirty() else ""
+        return f"{head} ({branch}){dirty} from cwd {cwd}"
+    except Exception as exc:  # noqa: BLE001 - diagnostics must never block a launch
+        return f"unresolved from cwd {cwd} ({exc})"
 
 
 def build_install_command(
@@ -1121,6 +1158,13 @@ class BeakerLauncher:
         if dry_run:
             self._print_dry_run_config(config, clusters)
 
+        # Gantry resolves the code version from the CURRENT WORKING DIRECTORY
+        # (gantry.git_utils.GitRepoState.from_env -> Repo(".")), not from any
+        # olmo-eval setting. Launching from a second checkout of this repo
+        # therefore silently runs that checkout's HEAD instead of the branch you
+        # think you are on. Report what will actually be cloned.
+        log.info(f"Code version: {describe_code_version(config.git_ref)}")
+
         # Launch the experiment (or show spec if dry_run)
         workload = launch_experiment(
             args=config.command,
@@ -1137,6 +1181,7 @@ class BeakerLauncher:
             retries=config.retries,
             budget=config.budget,
             beaker_image=config.beaker_image,
+            ref=config.git_ref,
             weka=weka_mounts if weka_mounts else None,
             gh_token_secret=self._default_github_token_secret(),
             env_vars=env_vars if env_vars else None,

--- a/src/olmo_eval/launch/beaker/launcher.py
+++ b/src/olmo_eval/launch/beaker/launcher.py
@@ -905,6 +905,12 @@ class BeakerLauncher:
         if use_isolated_vllm_venv:
             vllm_venv = "/opt/vllm-venv"
             steps.append(f"uv venv {vllm_venv}")
+            # flashinfer compiles some kernels on the first forward pass and
+            # shells out to a bare "ninja", resolved through PATH from the
+            # process vLLM runs in. Install it explicitly so the isolated venv
+            # owns a copy instead of relying on a transitive dependency of
+            # whichever vLLM build (or fork) lands here.
+            steps.append(f"uv pip install --python {vllm_venv}/bin/python ninja")
             # Symlink torch and nvidia packages from main venv (already installed)
             steps.append(
                 f"for pkg in /opt/venv/lib/python*/site-packages/torch* "

--- a/src/olmo_eval/launch/beaker/launcher.py
+++ b/src/olmo_eval/launch/beaker/launcher.py
@@ -959,8 +959,10 @@ class BeakerLauncher:
             steps.append(
                 'if [ -n "$GITHUB_TOKEN" ]; then '
                 "export GIT_CONFIG_COUNT=1; "
-                'export GIT_CONFIG_KEY_0="url.https://${GITHUB_TOKEN}@github.com/.insteadOf"; '
-                'export GIT_CONFIG_VALUE_0="https://github.com/"; '
+                "export GIT_CONFIG_KEY_0=credential.helper; "
+                "export GIT_CONFIG_VALUE_0="
+                "'!f() { echo username=x-access-token; "
+                "echo password=$GITHUB_TOKEN; }; f'; "
                 "fi"
             )
             for pkg in provider_packages:

--- a/src/olmo_eval/launch/beaker/launcher.py
+++ b/src/olmo_eval/launch/beaker/launcher.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import json
 import logging
 import re
+import shlex
 from dataclasses import dataclass, field
 from datetime import UTC
 from typing import TYPE_CHECKING, Any
@@ -956,7 +957,7 @@ class BeakerLauncher:
         if provider_packages:
             for i, pkg in enumerate(provider_packages):
                 github_match = re.search(
-                    r"github\.com[:/]([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+?)(?:\.git)?(?:@[^\s]+)?$",
+                    r"github\.com[:/]([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+?)(?:\.git)?(?:@([^\s]+))?$",
                     pkg,
                 )
                 if github_match:
@@ -965,6 +966,7 @@ class BeakerLauncher:
                     # git config or credential helpers reaching uv's subprocess.
                     # GitHub token auth requires user:token format (token as password).
                     gh_path = github_match.group(1)
+                    revision = github_match.group(2)
                     repo_name = gh_path.split("/")[-1]
                     clone_dir = f"/tmp/provider-src-{i}"
                     steps.append(
@@ -978,6 +980,12 @@ class BeakerLauncher:
                         f"{clone_dir}; "
                         f"fi"
                     )
+                    if revision:
+                        steps.append(
+                            f"git -C {clone_dir} fetch --quiet --depth=1 origin "
+                            f"{shlex.quote(revision)} && "
+                            f"git -C {clone_dir} checkout --quiet --detach FETCH_HEAD"
+                        )
                     steps.append(
                         build_install_command(
                             provider_package_spec(f"{repo_name} @ {clone_dir}"),

--- a/src/olmo_eval/launch/beaker/launcher.py
+++ b/src/olmo_eval/launch/beaker/launcher.py
@@ -954,6 +954,14 @@ class BeakerLauncher:
 
         # Install provider-specific dependencies
         if provider_packages:
+            # Rewrite github.com HTTPS URLs to embed the token so uv's git subprocess
+            # inherits credentials without relying on gh's credential helper.
+            steps.append(
+                'if [ -n "$GITHUB_TOKEN" ]; then '
+                "git config --global "
+                'url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"; '
+                "fi"
+            )
             for pkg in provider_packages:
                 steps.append(
                     build_install_command(

--- a/src/olmo_eval/launch/beaker/scripts/install_flashinfer_jit_cache
+++ b/src/olmo_eval/launch/beaker/scripts/install_flashinfer_jit_cache
@@ -1,0 +1,76 @@
+#!/bin/bash
+# Install FlashInfer's prebuilt kernel cache into the isolated vLLM venv.
+#
+# FlashInfer JIT-compiles some kernels on first use and shells out to nvcc. Our
+# base image is a CUDA *runtime* image, which ships no compiler, so that path can
+# never succeed: it dies with "/usr/local/cuda/bin/nvcc: not found" mid-run, long
+# after the server reported ready. The flashinfer-jit-cache package ships those
+# kernels prebuilt; when it is installed, JitSpec.is_aot is true and
+# build_and_load() loads the .so directly without invoking ninja or nvcc.
+#
+# The version must match the installed flashinfer exactly. flashinfer's
+# jit/env.py raises at import when flashinfer_jit_cache.__version__ does not
+# start with the flashinfer version, which would break every model rather than
+# just the ones that JIT. This script therefore derives the version instead of
+# pinning one, and removes the package again if the pair does not match.
+#
+# Never fatal: a missing wheel leaves the job exactly as it was before.
+#
+# Usage: install_flashinfer_jit_cache [VENV_PYTHON]
+
+set -uo pipefail  # deliberately not -e: this must never abort a job
+
+VENV_PYTHON="${1:-${VLLM_PYTHON:-/opt/vllm-venv/bin/python}}"
+
+log() { echo "[flashinfer-jit-cache] $*"; }
+
+if [ ! -x "$VENV_PYTHON" ]; then
+    log "no vLLM interpreter at $VENV_PYTHON, skipping"
+    return 0 2>/dev/null || exit 0
+fi
+
+FI_VERSION=$("$VENV_PYTHON" -c \
+    'from importlib.metadata import version; print(version("flashinfer-python"))' 2>/dev/null)
+if [ -z "$FI_VERSION" ]; then
+    log "flashinfer-python is not installed, nothing to prebuild"
+    return 0 2>/dev/null || exit 0
+fi
+
+# Wheels are published per CUDA minor version, tagged cu128, cu129, ...
+CU_TAG=$("$VENV_PYTHON" -c \
+    'import torch; v=torch.version.cuda or ""; print("cu"+v.replace(".","") if v else "")' 2>/dev/null)
+if [ -z "$CU_TAG" ]; then
+    log "could not determine the CUDA version from torch, skipping"
+    return 0 2>/dev/null || exit 0
+fi
+
+log "flashinfer-python==$FI_VERSION, CUDA $CU_TAG; installing matching kernel cache"
+uv pip install --python "$VENV_PYTHON" \
+    "flashinfer-jit-cache==${FI_VERSION}+${CU_TAG}" \
+    --extra-index-url "https://flashinfer.ai/whl/${CU_TAG}/" \
+    --index-strategy unsafe-best-match
+
+# Verify the pair agrees, because a mismatch is worse than an absence: it makes
+# flashinfer raise at import time for every model, not only ones that JIT.
+CACHE_VERSION=$("$VENV_PYTHON" -c \
+    'from importlib.metadata import version; print(version("flashinfer-jit-cache"))' 2>/dev/null)
+if [ -z "$CACHE_VERSION" ]; then
+    log "WARNING: no prebuilt kernel cache for ${FI_VERSION}+${CU_TAG}."
+    log "WARNING: kernels that are not prebuilt will try to compile and fail on"
+    log "WARNING: this image. Pass gdn_prefill_backend=triton to avoid the GDN one."
+    return 0 2>/dev/null || exit 0
+fi
+
+case "$CACHE_VERSION" in
+    "$FI_VERSION"*)
+        log "installed flashinfer-jit-cache==$CACHE_VERSION"
+        ;;
+    *)
+        log "WARNING: flashinfer-jit-cache==$CACHE_VERSION does not match"
+        log "WARNING: flashinfer-python==$FI_VERSION; removing it, since flashinfer"
+        log "WARNING: refuses to import when the two disagree."
+        uv pip uninstall --python "$VENV_PYTHON" flashinfer-jit-cache
+        ;;
+esac
+
+return 0 2>/dev/null || exit 0

--- a/src/olmo_eval/runners/asynq/preparation.py
+++ b/src/olmo_eval/runners/asynq/preparation.py
@@ -23,6 +23,7 @@ def prepare_task_items(
     model_name: str,
     overrides: dict[str, Any] | None,
     sampling_overrides: dict[str, Any] | None = None,
+    harness_tool_names: Sequence[str] = (),
 ) -> tuple[Task, list[QueueItem]]:
     """Prepare a task and its queue items.
 
@@ -31,6 +32,8 @@ def prepare_task_items(
         model_name: Model name this task is for
         overrides: Optional config overrides (num_fewshot, limit, fewshot_seed)
         sampling_overrides: Optional overrides for sampling params (temperature, max_tokens, etc.)
+        harness_tool_names: Tool names the harness exposes, so a task that names
+            tools in its prompt can describe the ones that really exist.
 
     Returns:
         Tuple of (Task instance for scoring, list of QueueItems)
@@ -40,6 +43,9 @@ def prepare_task_items(
 
     if overrides:
         task.config = replace(task.config, **overrides)
+
+    if harness_tool_names:
+        task.config = replace(task.config, harness_tool_names=tuple(harness_tool_names))
 
     # Build sampling params from overrides
     existing_params = task.config.sampling_params or SamplingParams()

--- a/src/olmo_eval/runners/asynq/runner.py
+++ b/src/olmo_eval/runners/asynq/runner.py
@@ -927,6 +927,7 @@ class AsyncEvalRunner(RunnerResultsMixin, BaseEvalRunner):
                     self.model_name,
                     overrides or None,
                     sampling_overrides=sampling_overrides or None,
+                    harness_tool_names=self.harness_config.tool_names,
                 )
                 tracker = TaskTracker(
                     model_name=self.model_name,

--- a/tests/cli/beaker/test_launch.py
+++ b/tests/cli/beaker/test_launch.py
@@ -8,6 +8,15 @@ from olmo_eval.common.constants.infrastructure import BEAKER_UV_CACHE_DIR
 from olmo_eval.inference.providers.config import ProviderConfig
 
 
+def test_secret_env_override_satisfies_required_secret():
+    from olmo_eval.cli.beaker.launch import _unsatisfied_required_secrets
+
+    required = {"OPENAI_API_KEY", "S2_API_KEY"}
+    overrides = {"openai_api_key": "OPENAI_API_KEY"}
+
+    assert _unsatisfied_required_secrets(required, overrides) == {"S2_API_KEY"}
+
+
 class TestProviderConfigDependenciesValidation:
     """Tests for ProviderConfig.from_dict dependencies validation."""
 

--- a/tests/cli/test_run_exit_code.py
+++ b/tests/cli/test_run_exit_code.py
@@ -1,0 +1,51 @@
+"""Tests for the run command's all-instances-failed exit gate."""
+
+import pytest
+
+from olmo_eval.cli.run import _scored_nothing
+
+
+class TestScoredNothing:
+    """A run that scored no instances must not be reported as a success.
+
+    ``aggregate_results`` writes ``num_instances`` only for tasks that produced
+    results; a task whose instances all failed carries an ``error`` key instead.
+    """
+
+    @pytest.mark.parametrize(
+        ("label", "results"),
+        [
+            ("task errored outright", {"tasks": {"t": {"error": "597 instances failed"}}}),
+            ("explicit zero instances", {"tasks": {"t": {"num_instances": 0}}}),
+            ("every task errored", {"tasks": {"a": {"error": "x"}, "b": {"error": "y"}}}),
+        ],
+    )
+    def test_detects_a_run_with_nothing_scored(self, label, results):
+        assert _scored_nothing(results) is True, label
+
+    @pytest.mark.parametrize(
+        ("label", "results"),
+        [
+            ("all instances scored", {"tasks": {"t": {"num_instances": 100}}}),
+            (
+                "partial failure still has data",
+                {"tasks": {"a": {"error": "x"}, "b": {"num_instances": 10}}},
+            ),
+        ],
+    )
+    def test_leaves_runs_that_produced_data_alone(self, label, results):
+        assert _scored_nothing(results) is False, label
+
+    @pytest.mark.parametrize(
+        ("label", "results"),
+        [
+            ("no tasks ran at all", {"tasks": {}}),
+            ("no tasks key", {}),
+            ("runner returned nothing", None),
+            ("unexpected shape", "surprise"),
+        ],
+    )
+    def test_never_fails_a_run_on_an_unexpected_shape(self, label, results):
+        # This gates the process exit code, so anything unrecognised must be
+        # treated as "cannot tell", never as failure.
+        assert _scored_nothing(results) is False, label

--- a/tests/evals/tasks/fixtures/__init__.py
+++ b/tests/evals/tasks/fixtures/__init__.py
@@ -1,0 +1,1 @@
+"""Test fixtures for the DeepScholar-Bench task."""

--- a/tests/evals/tasks/fixtures/deepscholar_c95413b/__init__.py
+++ b/tests/evals/tasks/fixtures/deepscholar_c95413b/__init__.py
@@ -1,0 +1,16 @@
+"""The DeepScholar-Bench scorer, pinned, so its contract is tested and not assumed.
+
+Verbatim copy of the parser package from
+github.com/guestrin-lab/deepscholar at commit
+c95413b3b2f3255b461b90d0ce650f685ae2d1ff (``eval/parsers/``), by way of
+``ai2-multi-agent/integrated/tests/fixtures/deepscholar_c95413b`` which
+reformatted the imports without changing behaviour.
+
+It is here because the export writes for this parser and nothing else: it
+credits a citation only as a markdown link whose URL matches arxiv.org/abs, and
+returns no documents for a query that has none. Asserting that against a
+hand-written imitation would only prove the imitation self-consistent, so the
+end-to-end test runs the real thing.
+
+Do not edit. Re-copy from the pinned commit if the benchmark is ever re-pinned.
+"""

--- a/tests/evals/tasks/fixtures/deepscholar_c95413b/eval/__init__.py
+++ b/tests/evals/tasks/fixtures/deepscholar_c95413b/eval/__init__.py
@@ -1,0 +1,1 @@
+"""Pinned DeepScholar parser fixture package."""

--- a/tests/evals/tasks/fixtures/deepscholar_c95413b/eval/parsers/__init__.py
+++ b/tests/evals/tasks/fixtures/deepscholar_c95413b/eval/parsers/__init__.py
@@ -1,0 +1,5 @@
+from .deepscholar_base import DeepScholarBaseParser
+from .parser import Parser
+from .parser_type import ParserType
+
+__all__ = ["DeepScholarBaseParser", "Parser", "ParserType"]

--- a/tests/evals/tasks/fixtures/deepscholar_c95413b/eval/parsers/deepscholar_base.py
+++ b/tests/evals/tasks/fixtures/deepscholar_c95413b/eval/parsers/deepscholar_base.py
@@ -1,0 +1,71 @@
+from collections import OrderedDict
+import csv
+import re
+
+from .parser import Parser
+from .parser_type import ParserType
+
+
+class DeepScholarBaseParser(Parser):
+    parser_type = ParserType.DEEPSCHOLAR_BASE
+
+    def _get_file_path(self):
+        return self.folder_path + "/intro.md"
+
+    @property
+    def citation_pattern(self):
+        return re.compile(r"\[([^\]]+?)\]\((https?://[^\)]+)\)")
+
+    def _load_file(self):
+        self.file_path = self._get_file_path()
+        self.raw_generated_text = open(
+            self.file_path,
+            "r",
+            encoding="utf-8",
+        ).read()
+        reference_map = self._reference_parsing(self.folder_path + "/paper.csv")
+        self.clean_text, self.docs = self._to_autoais(
+            self.raw_generated_text,
+            reference_map,
+        )
+        self.citations_for_cite_quality = [
+            (doc.get("title", ""), doc.get("sent", "")) for doc in self.docs
+        ]
+
+    def _to_autoais(self, updated_text: str, reference_map: dict):
+        link2id: OrderedDict[str, int] = OrderedDict()
+        docs = []
+
+        def extract_arxiv_id(url: str) -> str | None:
+            match = re.search(r"arxiv\.org/abs/([^)\s]+)", url)
+            return match.group(1) if match else None
+
+        def repl(match: re.Match) -> str:
+            visible, url = match.groups()
+            arxiv_id = extract_arxiv_id(url)
+            if arxiv_id is None:
+                return visible
+            if arxiv_id not in link2id:
+                link2id[arxiv_id] = len(link2id) + 1
+                info = reference_map.get(arxiv_id, {})
+                docs.append(
+                    {
+                        "title": info.get("title", ""),
+                        "sent": info.get("abstract", ""),
+                    }
+                )
+            return f"[{link2id[arxiv_id]}]"
+
+        clean_text = self.citation_pattern.sub(repl, updated_text).strip()
+        return clean_text, docs
+
+    def _reference_parsing(self, file_path):
+        result = {}
+        with open(file_path, newline="", encoding="utf-8") as stream:
+            reader = csv.DictReader(stream)
+            for row in reader:
+                paper_id = row["id"].strip()
+                title = row["title"].strip()
+                abstract = row["snippet"].strip()
+                result[paper_id] = {"title": title, "abstract": abstract}
+        return result

--- a/tests/evals/tasks/fixtures/deepscholar_c95413b/eval/parsers/parser.py
+++ b/tests/evals/tasks/fixtures/deepscholar_c95413b/eval/parsers/parser.py
@@ -1,0 +1,52 @@
+from abc import ABC, abstractmethod
+
+import pandas as pd
+
+from .parser_type import ParserType
+
+
+class Parser(ABC):
+    parser_type: ParserType
+
+    def __init__(self, folder_path: str, config: dict):
+        self.config = config
+        self.folder_path = folder_path
+        self.file_id = (
+            self.config["file_id"]
+            if "file_id" in self.config
+            else self.folder_path.split("/")[-1]
+        )
+        self.use_local_reference_map = self.config.get(
+            "use_local_reference_map",
+            True,
+        )
+        self.raw_generated_text: str | None = None
+        self.clean_text: str | None = None
+        self.docs: list[dict[str, str]] | None = None
+        self.citations_for_cite_quality: list[tuple[str, str]] | None = None
+        self._load_dataset()
+        self._load_file()
+
+    def _load_dataset(self):
+        if "s_map_groundtruth" in self.config:
+            self.s_map_groundtruth = self.config["s_map_groundtruth"]
+        else:
+            if "dataset" in self.config:
+                dataset = self.config["dataset"]
+            else:
+                dataset = pd.read_csv(self.config["dataset_path"])
+            row = dataset.iloc[int(self.file_id)]
+            self.s_map_groundtruth = {
+                "title": row["title"],
+                "abstract": row["abstract"],
+                "arxiv_link": row["arxiv_link"],
+                "related_works_section": row.get(
+                    "clean_latex_related_works",
+                    "",
+                ),
+                "arxiv_id": row["arxiv_id"],
+            }
+
+    @abstractmethod
+    def _load_file(self):
+        pass

--- a/tests/evals/tasks/fixtures/deepscholar_c95413b/eval/parsers/parser_type.py
+++ b/tests/evals/tasks/fixtures/deepscholar_c95413b/eval/parsers/parser_type.py
@@ -1,0 +1,11 @@
+import enum
+
+
+class ParserType(enum.Enum):
+    SEARCH_AI = "SearchAI"
+    OPENSCHOLAR = "openscholar"
+    DEEPRESEARCHER = "deepresearcher"
+    DEEPSCHOLAR_BASE = "deepscholar_base"
+    GROUNDTRUTH = "groundtruth"
+    STORM = "storm"
+    OPENAI_DEEPRESEARCH = "openai_deepresearch"

--- a/tests/evals/tasks/fixtures/litagents_c95413b/__init__.py
+++ b/tests/evals/tasks/fixtures/litagents_c95413b/__init__.py
@@ -1,0 +1,19 @@
+"""Reference export-contract validators, re-exported under readable names."""
+
+from .deepscholar import (
+    DeepScholarContractError,
+    QueryRecord,
+    _query_fingerprint as query_fingerprint,
+    _read_paper_csv as read_paper_csv,
+    _validate_query_export as validate_query_export,
+    _validate_source_rows as validate_source_rows,
+)
+
+__all__ = [
+    "DeepScholarContractError",
+    "QueryRecord",
+    "query_fingerprint",
+    "read_paper_csv",
+    "validate_query_export",
+    "validate_source_rows",
+]

--- a/tests/evals/tasks/fixtures/litagents_c95413b/deepscholar.py
+++ b/tests/evals/tasks/fixtures/litagents_c95413b/deepscholar.py
@@ -1,0 +1,288 @@
+"""The DeepScholar-Bench export contract, as lit-agents implements it.
+
+Verbatim excerpt of shared/deepscholar.py from ai2-multi-agent/integrated, which targets
+github.com/guestrin-lab/deepscholar at commit
+c95413b3b2f3255b461b90d0ce650f685ae2d1ff. Only the definitions the export tests
+need are copied; nothing has been reworded.
+
+It is here because the export is written to satisfy these functions, and a test
+suite that only exercises our own reimplementation of them proves nothing about
+whether the real ones would accept the output.
+
+Do not edit. Re-extract from the reference if the benchmark is re-pinned.
+"""
+
+from __future__ import annotations
+
+import csv
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from datetime import date, datetime
+from pathlib import Path
+from typing import Any, Mapping
+
+from .retrieval_policy import (
+    arxiv_id_from_url as _arxiv_id_from_url,
+    normalize_arxiv_id as _normalize_arxiv_id,
+)
+
+
+EXPORT_SCHEMA_VERSION = 1
+
+
+QUERY_MANIFEST_NAME = "export_manifest.json"
+
+
+_EXPORTED_FILES = ("intro.md", "final_report.md", "paper.csv")
+
+
+_ARXIV_URL_RE = re.compile(
+    r"https?://(?:www\.)?arxiv\.org/(?:abs|pdf)/([^)\s?#]+)",
+    re.IGNORECASE,
+)
+
+
+class DeepScholarContractError(RuntimeError):
+    """Raised when generated output cannot satisfy the benchmark contract."""
+
+
+@dataclass(frozen=True)
+class QueryRecord:
+    """One DeepScholar query and its source-policy cutoff."""
+
+    query_id: int
+    query: str
+    cutoff_date: date
+    arxiv_id: str
+    title: str
+    abstract: str
+
+    @property
+    def groundtruth(self) -> dict[str, str]:
+        return {
+            "title": self.title,
+            "abstract": self.abstract,
+            "arxiv_link": (
+                f"https://arxiv.org/abs/{self.arxiv_id}"
+                if self.arxiv_id
+                else ""
+            ),
+            "related_works_section": "",
+            "arxiv_id": self.arxiv_id,
+        }
+
+
+def _query_fingerprint(record: QueryRecord) -> str:
+    payload = {
+        "idx": record.query_id,
+        "query": record.query,
+        "cutoff_date": record.cutoff_date.isoformat(),
+        "arxiv_id": record.arxiv_id,
+        "title": record.title,
+        "abstract": record.abstract,
+    }
+    encoded = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _validate_query_export(
+    folder: Path,
+    record: QueryRecord,
+    system_name: str,
+) -> dict[str, Any]:
+    query_id = record.query_id
+    if not folder.is_dir():
+        raise DeepScholarContractError(
+            f"Query {query_id} output folder is missing: {folder}"
+        )
+    manifest_path = folder / QUERY_MANIFEST_NAME
+    manifest = _read_json_mapping(
+        manifest_path,
+        f"query {query_id} export manifest",
+    )
+    required_keys = {
+        "schema_version",
+        "system",
+        "idx",
+        "query_fingerprint",
+        "num_papers",
+        "files",
+    }
+    if set(manifest) != required_keys:
+        raise DeepScholarContractError(
+            f"Query {query_id} {QUERY_MANIFEST_NAME} has unexpected fields"
+        )
+    expected_values = {
+        "schema_version": EXPORT_SCHEMA_VERSION,
+        "system": system_name,
+        "idx": query_id,
+        "query_fingerprint": _query_fingerprint(record),
+    }
+    for field, expected_value in expected_values.items():
+        if manifest.get(field) != expected_value:
+            raise DeepScholarContractError(
+                f"Query {query_id} {QUERY_MANIFEST_NAME} has {field} "
+                f"{manifest.get(field)!r}; expected {expected_value!r}"
+            )
+    files = manifest.get("files")
+    if not isinstance(files, Mapping) or set(files) != set(_EXPORTED_FILES):
+        raise DeepScholarContractError(
+            f"Query {query_id} {QUERY_MANIFEST_NAME} must checksum "
+            f"{', '.join(_EXPORTED_FILES)}"
+        )
+    for name in _EXPORTED_FILES:
+        path = folder / name
+        if not path.is_file():
+            raise DeepScholarContractError(
+                f"Query {query_id} is missing required file {name}"
+            )
+        actual_checksum = _sha256_file(path)
+        if files.get(name) != actual_checksum:
+            raise DeepScholarContractError(
+                f"Query {query_id} {name} checksum does not match "
+                f"{QUERY_MANIFEST_NAME}"
+            )
+
+    intro_text = (folder / "intro.md").read_text(encoding="utf-8")
+    final_report = (folder / "final_report.md").read_text(encoding="utf-8")
+    if intro_text != final_report:
+        raise DeepScholarContractError(
+            f"Query {query_id} intro.md and final_report.md differ"
+        )
+    rows = _read_paper_csv(folder / "paper.csv")
+    _validate_source_rows(rows, record.cutoff_date, query_id)
+    num_papers = manifest.get("num_papers")
+    if type(num_papers) is not int or num_papers != len(rows):
+        raise DeepScholarContractError(
+            f"Query {query_id} {QUERY_MANIFEST_NAME} reports "
+            f"{num_papers!r} papers but paper.csv has {len(rows)} rows"
+        )
+
+    cited_arxiv_ids = _arxiv_ids_from_report(intro_text)
+    if not cited_arxiv_ids:
+        raise DeepScholarContractError(
+            f"Query {query_id} has no arXiv citation URLs"
+        )
+    citation_urls = re.findall(
+        r"\]\((https?://[^)\s]+)\)",
+        intro_text,
+    )
+    non_arxiv_urls = [
+        url for url in citation_urls if _arxiv_id_from_url(url) is None
+    ]
+    if non_arxiv_urls:
+        raise DeepScholarContractError(
+            f"Query {query_id} contains non-arXiv citation URLs: "
+            + ", ".join(non_arxiv_urls)
+        )
+    known_ids = {
+        _normalize_arxiv_id(str(row.get("id") or ""))
+        for row in rows
+    }
+    unknown = sorted(set(cited_arxiv_ids) - known_ids)
+    if unknown:
+        raise DeepScholarContractError(
+            f"Query {query_id} cites arXiv IDs absent from paper.csv: "
+            + ", ".join(unknown)
+        )
+    return dict(manifest)
+
+
+def _read_json_mapping(path: Path, label: str) -> Mapping[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as error:
+        raise DeepScholarContractError(f"Missing {label}: {path}") from error
+    except (OSError, json.JSONDecodeError) as error:
+        raise DeepScholarContractError(
+            f"Cannot read {label} {path}: {error}"
+        ) from error
+    if not isinstance(value, Mapping):
+        raise DeepScholarContractError(f"{label} must contain a mapping")
+    return value
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _validate_source_rows(
+    rows: Sequence[Mapping[str, str]],
+    cutoff_date: date,
+    query_id: int,
+) -> None:
+    if not rows:
+        raise DeepScholarContractError(f"Query {query_id} paper.csv is empty")
+    for row_number, row in enumerate(rows, start=2):
+        arxiv_id = _normalize_arxiv_id(row.get("id", ""))
+        if not arxiv_id:
+            raise DeepScholarContractError(
+                f"Query {query_id} paper.csv row {row_number} has no arXiv ID"
+            )
+        if not str(row.get("title") or "").strip():
+            raise DeepScholarContractError(
+                f"Query {query_id} paper.csv row {row_number} has an empty title"
+            )
+        if not str(row.get("snippet") or "").strip():
+            raise DeepScholarContractError(
+                f"Query {query_id} paper.csv row {row_number} has an empty snippet"
+            )
+        published = _parse_date(
+            str(row.get("published_date") or ""),
+            label=f"query {query_id} paper.csv row {row_number}",
+        )
+        precision = str(row.get("date_precision") or "day")
+        if precision == "month":
+            valid = (published.year, published.month) < (
+                cutoff_date.year,
+                cutoff_date.month,
+            )
+        elif precision == "day":
+            valid = published < cutoff_date
+        else:
+            raise DeepScholarContractError(
+                f"Query {query_id} paper.csv row {row_number} has invalid "
+                f"date_precision {precision!r}"
+            )
+        if not valid:
+            raise DeepScholarContractError(
+                f"Query {query_id} source {arxiv_id} does not precede "
+                f"the cutoff {cutoff_date.isoformat()}"
+            )
+
+
+def _read_paper_csv(path: Path) -> list[dict[str, str]]:
+    with path.open(newline="", encoding="utf-8") as stream:
+        return list(csv.DictReader(stream))
+
+
+def _arxiv_ids_from_report(report: str) -> list[str]:
+    return [
+        _normalize_arxiv_id(match.group(1))
+        for match in _ARXIV_URL_RE.finditer(report)
+    ]
+
+
+def _parse_date(value: str, *, label: str) -> date:
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError(f"{label} is empty")
+    try:
+        return datetime.fromisoformat(normalized.replace("Z", "+00:00")).date()
+    except ValueError:
+        try:
+            return date.fromisoformat(normalized[:10])
+        except ValueError as error:
+            raise ValueError(f"{label} is not an ISO date: {value!r}") from error
+

--- a/tests/evals/tasks/fixtures/litagents_c95413b/retrieval_policy.py
+++ b/tests/evals/tasks/fixtures/litagents_c95413b/retrieval_policy.py
@@ -1,0 +1,41 @@
+"""The DeepScholar-Bench export contract, as lit-agents implements it.
+
+Verbatim excerpt of shared/retrieval_policy.py from ai2-multi-agent/integrated, which targets
+github.com/guestrin-lab/deepscholar at commit
+c95413b3b2f3255b461b90d0ce650f685ae2d1ff. Only the definitions the export tests
+need are copied; nothing has been reworded.
+
+It is here because the export is written to satisfy these functions, and a test
+suite that only exercises our own reimplementation of them proves nothing about
+whether the real ones would accept the output.
+
+Do not edit. Re-extract from the reference if the benchmark is re-pinned.
+"""
+
+from __future__ import annotations
+
+import re
+
+
+_ARXIV_URL_RE = re.compile(
+    r"https?://(?:www\.)?arxiv\.org/(?:abs|pdf)/([^)\s?#]+)",
+    re.IGNORECASE,
+)
+
+
+def normalize_arxiv_id(value: str) -> str:
+    """Strip the prefix, extension, and version suffix from an arXiv ID."""
+
+    normalized = value.strip()
+    normalized = re.sub(r"(?i)^arxiv:", "", normalized)
+    normalized = re.sub(r"(?i)\.pdf$", "", normalized)
+    normalized = re.sub(r"v[1-9][0-9]*$", "", normalized)
+    return normalized
+
+
+def arxiv_id_from_url(url: str) -> str | None:
+    """Return the arXiv ID embedded in an arXiv abs/pdf URL, if any."""
+
+    match = _ARXIV_URL_RE.search(url)
+    return normalize_arxiv_id(match.group(1)) if match else None
+

--- a/tests/evals/tasks/test_deepresearch_bench.py
+++ b/tests/evals/tasks/test_deepresearch_bench.py
@@ -828,8 +828,8 @@ class TestPromptsAndJudges:
     @pytest.mark.parametrize(
         ("env_spec", "expected_models", "expected_efforts"),
         [
-            (None, ["gpt-5.5", "gpt-5.4-mini"], [None, None]),
-            ("judge-override", ["judge-override", "judge-override"], [None, None]),
+            (None, ["gpt-5.5", "gpt-5.4-mini"], ["medium", "low"]),
+            ("judge-override", ["judge-override", "judge-override"], ["medium", "low"]),
             ("gpt-5.5:high", ["gpt-5.5", "gpt-5.5"], ["high", "high"]),
         ],
     )

--- a/tests/evals/tasks/test_deepresearch_bench.py
+++ b/tests/evals/tasks/test_deepresearch_bench.py
@@ -689,6 +689,37 @@ class TestFactHelpersAndMetrics:
             {"idx": 1, "result": "unknown"},
         ]
 
+    @pytest.mark.parametrize("missing_key", ["result", "idx"])
+    @pytest.mark.anyio
+    async def test_validation_missing_required_key_retries_then_returns_all_unknown(
+        self, task, monkeypatch, missing_key
+    ):
+        calls = 0
+        delays = []
+
+        async def judge(_prompt):
+            nonlocal calls
+            calls += 1
+            items = [
+                {"idx": 1, "result": "supported"},
+                {"idx": 2, "result": "unsupported"},
+            ]
+            del items[1][missing_key]
+            return json.dumps(items)
+
+        async def sleep(delay):
+            delays.append(delay)
+
+        monkeypatch.setattr(deepresearch_bench.asyncio, "sleep", sleep)
+        results = await task._validate_facts(["first", "second"], "valid page", "en", judge)
+
+        assert calls == 3
+        assert delays == [1, 2]
+        assert results == [
+            {"idx": 0, "result": "unknown"},
+            {"idx": 1, "result": "unknown"},
+        ]
+
     @pytest.mark.anyio
     async def test_validation_blindly_decrements_idx_and_accepts_arbitrary_label(self, task):
         async def judge(_prompt):
@@ -900,6 +931,57 @@ async def test_score_responses_runs_race_and_fact_without_network(task, monkeypa
             "result": "supported",
         }
     ]
+
+
+@pytest.mark.anyio
+async def test_unexpected_fact_failure_preserves_race_scores(task, monkeypatch, caplog):
+    instance = task.process_doc(_en_doc())
+    assert instance is not None
+    response = _response(instance, "A complete research report.")
+    race_payload = {
+        dimension: [
+            {
+                "criterion": _criteria()["criterions"][dimension][0]["criterion"],
+                "article_1_score": 8,
+                "article_2_score": 2,
+            }
+        ]
+        for dimension in DEEPRESEARCH_DIMENSIONS
+    }
+
+    async def race_judge(_prompt):
+        return json.dumps(race_payload)
+
+    async def unused_fact_judge(_prompt):
+        return "[]"
+
+    async def fail_fact(*_args):
+        raise RuntimeError("unexpected FACT failure")
+
+    monkeypatch.setattr(deepresearch_bench, "build_deepresearch_race_judge_fn", lambda: race_judge)
+    monkeypatch.setattr(
+        deepresearch_bench, "build_deepresearch_fact_judge_fn", lambda: unused_fact_judge
+    )
+    monkeypatch.setattr(task, "_score_fact", fail_fact)
+
+    scored = await task.score_responses([response])
+
+    assert scored == [response]
+    assert response.scores["race_overall"] == pytest.approx(0.8)
+    for dimension in DEEPRESEARCH_DIMENSIONS:
+        assert response.scores[f"race_{dimension}"] == pytest.approx(0.8)
+    assert {
+        metric: response.scores[metric]
+        for metric in (
+            "fact_citation_accuracy",
+            "fact_avg_effective_citations",
+            "fact_avg_citations",
+            "fact_has_citations",
+        )
+    } == task._zero_fact_scores()
+    assert response.outputs[0].metadata["deepresearch_fact"] == []
+    assert "FACT scoring failed for id 51" in caplog.text
+    assert "FACT scoring failed for 1 instance(s)" in caplog.text
 
 
 @pytest.mark.anyio

--- a/tests/evals/tasks/test_deepresearch_bench.py
+++ b/tests/evals/tasks/test_deepresearch_bench.py
@@ -1,0 +1,725 @@
+"""Tests for the DeepResearch Bench RACE + FACT task."""
+
+import builtins
+import hashlib
+import json
+
+import pytest
+
+from olmo_eval.common.types import Instance, LMOutput, LMRequest, RequestType, Response
+from olmo_eval.evals.tasks import deepresearch_bench
+from olmo_eval.evals.tasks.common import get_task, task_exists
+from olmo_eval.evals.tasks.deepresearch_bench import (
+    DEEPRESEARCH_DIMENSIONS,
+    FACT_DEDUPLICATION_PROMPT_EN,
+    FACT_DEDUPLICATION_PROMPT_ZH,
+    FACT_EXTRACTION_PROMPT_EN,
+    FACT_EXTRACTION_PROMPT_ZH,
+    FACT_VALIDATION_PROMPT_EN,
+    FACT_VALIDATION_PROMPT_ZH,
+    RACE_SCORE_PROMPT_EN,
+    RACE_SCORE_PROMPT_ZH,
+    build_deepresearch_fact_judge_fn,
+    build_deepresearch_race_judge_fn,
+    calculate_fact_statistics,
+    calculate_weighted_scores,
+    clean_citation_url,
+    clean_urls,
+    fetch_crawl4ai_page,
+    format_criteria_list,
+    group_citations_by_url,
+    normalize_comparative_score,
+    normalize_weighted_scores,
+    parse_dedup_indices,
+    remove_urls,
+    scrape_failure_unknown_results,
+)
+
+
+def _criterion(text, explanation, weight):
+    return {"criterion": text, "explanation": explanation, "weight": weight}
+
+
+def _criteria():
+    return {
+        "dimension_weight": {
+            "comprehensiveness": 0.4,
+            "insight": 0.3,
+            "instruction_following": 0.2,
+            "readability": 0.1,
+        },
+        "criterions": {
+            "comprehensiveness": [
+                _criterion("Population projections", "Covers 2020 through 2050.", 0.25),
+                _criterion("Market segmentation", "Covers all requested sectors.", 0.75),
+            ],
+            "insight": [_criterion("Deep synthesis", "Explains non-obvious drivers.", 1.0)],
+            "instruction_following": [
+                _criterion("Answers the question", "Directly responds.", 0.2),
+                _criterion("Uses the timeframe", "Uses the requested years.", 0.8),
+            ],
+            "readability": [_criterion("Clear structure", "Uses navigable sections.", 1.0)],
+        },
+    }
+
+
+def _en_doc():
+    # Trimmed from official query id 51, with the audited joined-row shape.
+    return {
+        "id": 51,
+        "language": "en",
+        "topic": "Finance & Business",
+        "prompt": (
+            "From 2020 to 2050, how many elderly people will there be in Japan? "
+            "What is their consumption potential across clothing, food, housing, and "
+            "transportation?"
+        ),
+        "criteria": _criteria(),
+        "reference_article": (
+            "# Japan's Silver Tsunami\n\nOfficial projections show a sustained aging trend."
+        ),
+    }
+
+
+def _zh_doc():
+    # Trimmed from official query id 1.
+    return {
+        "id": 1,
+        "language": "zh",
+        "topic": "Finance & Business",
+        "prompt": "收集整理目前中国9阶层实际收入和财务状况，特别研究中国中产的特点和人数。",
+        "criteria": _criteria(),
+        "reference_article": "# 当代中国社会阶层结构\n\n本报告分析收入、财富与中产阶层。",
+    }
+
+
+def _response(instance: Instance, text: str) -> Response:
+    return Response(
+        instance=instance,
+        request=LMRequest(request_type=RequestType.CHAT, messages=()),
+        outputs=[LMOutput(text=text)],
+        scores={},
+    )
+
+
+@pytest.fixture
+def task():
+    return get_task("deepresearch_bench")
+
+
+class TestRegistrationAndDocs:
+    def test_registration_and_metrics(self):
+        assert task_exists("deepresearch_bench")
+        assert task_exists("deepresearch_bench:en")
+        task = get_task("deepresearch_bench")
+        assert task.config.data_source.path == "allenai/deepresearch-bench"
+        assert task.config.data_source.subset == "default"
+        assert task.config.data_source.split == "test"
+        assert not hasattr(task.config, "language")
+        assert task.config.sampling_params.temperature == 0.0
+        assert task.config.sampling_params.max_tokens == 16_384
+        assert task.config.get_primary_metric().name == "race_overall"
+        assert {metric.name for metric in task.config.metrics} == {
+            "race_overall",
+            "race_comprehensiveness",
+            "race_insight",
+            "race_instruction_following",
+            "race_readability",
+            "fact_citation_accuracy",
+            "fact_avg_effective_citations",
+            "fact_avg_citations",
+        }
+
+    @pytest.mark.parametrize("doc", [_en_doc(), _zh_doc()])
+    def test_process_doc_preserves_official_fields_and_appends_instruction(self, task, doc):
+        instance = task.process_doc(doc, index=7)
+
+        assert instance is not None
+        assert instance.question.startswith(doc["prompt"] + "\n\n")
+        assert "[source title](url)" in instance.question or "[来源标题](url)" in instance.question
+        assert instance.metadata["id"] == doc["id"]
+        assert instance.metadata["language"] == doc["language"]
+        assert instance.metadata["topic"] == doc["topic"]
+        assert instance.metadata["prompt"] == doc["prompt"]
+        assert instance.metadata["criteria"] == doc["criteria"]
+        assert instance.metadata["reference_article"] == doc["reference_article"]
+        assert instance.metadata["index"] == 7
+
+        request = task.format_request(instance)
+        assert request.request_type == RequestType.CHAT
+        assert request.messages == ({"role": "user", "content": instance.question},)
+
+    def test_english_variant_uses_hub_subset(self):
+        task = get_task("deepresearch_bench:en")
+        assert task.config.data_source.path == "allenai/deepresearch-bench"
+        assert task.config.data_source.subset == "en"
+        assert task.config.data_source.split == "test"
+        assert task.process_doc(_en_doc()) is not None
+
+    def test_think_strip_matches_researchqa_pattern(self, task):
+        output = LMOutput(text="<think>private reasoning</think>\n\nFinal report.")
+        assert task.extract_answer(output) == "Final report."
+
+
+class TestRaceScoring:
+    def test_format_criteria_hides_all_weights(self):
+        rendered = format_criteria_list(_criteria())
+        parsed = json.loads(rendered)
+
+        assert "dimension_weight" not in parsed
+        assert parsed["comprehensiveness"][0] == {
+            "criterion": "Population projections",
+            "explanation": "Covers 2020 through 2050.",
+        }
+        assert "weight" not in rendered
+
+    def test_weighted_math_exact_case_substring_fallback_and_single_score(self):
+        judge_output = {
+            "comprehensiveness": [
+                {
+                    "criterion": "Population projections",
+                    "article_1_score": 8,
+                    "article_2_score": 4,
+                },
+                {
+                    "criterion": "MARKET SEGMENTATION",
+                    "article_1_score": 6,
+                    "article_2_score": 2,
+                },
+            ],
+            "insight": [
+                {
+                    "criterion": "Deep synthesis plus",
+                    "article_1_score": 9,
+                    "article_2_score": 3,
+                }
+            ],
+            "instruction_following": [
+                {
+                    "criterion": "Answers the question",
+                    "article_1_score": 3,
+                    "article_2_score": 1,
+                },
+                {
+                    "criterion": "A criterion the generator paraphrased beyond matching",
+                    "article_1_score": 7,
+                    "article_2_score": 5,
+                },
+            ],
+            "readability": [
+                {
+                    "criterion": "Clear structure",
+                    "target_score": 4,
+                }
+            ],
+        }
+
+        weighted = calculate_weighted_scores(judge_output, _criteria())
+
+        assert weighted["target"]["dims"] == pytest.approx(
+            {
+                "comprehensiveness_weighted_avg": 6.5,
+                "insight_weighted_avg": 9.0,
+                "instruction_following_weighted_avg": 41 / 7,
+                "readability_weighted_avg": 4.0,
+            }
+        )
+        assert weighted["reference"]["dims"] == pytest.approx(
+            {
+                "comprehensiveness_weighted_avg": 2.5,
+                "insight_weighted_avg": 3.0,
+                "instruction_following_weighted_avg": 27 / 7,
+                "readability_weighted_avg": 0.0,
+            }
+        )
+        assert weighted["target"]["total"] == pytest.approx(481 / 70)
+        assert weighted["reference"]["total"] == pytest.approx(187 / 70)
+
+        normalized = normalize_weighted_scores(weighted)
+        assert normalized == pytest.approx(
+            {
+                "race_overall": 481 / 668,
+                "race_comprehensiveness": 6.5 / 9,
+                "race_insight": 0.75,
+                "race_instruction_following": 41 / 68,
+                "race_readability": 1.0,
+            }
+        )
+
+    def test_normalization_zero_guard(self):
+        assert normalize_comparative_score(3.0, 1.0) == 0.75
+        assert normalize_comparative_score(0.0, 0.0) == 0.0
+
+
+class TestFactHelpersAndMetrics:
+    def test_url_cleaning_and_fact_url_removal(self):
+        url = "https://example.test/page#:~:text=quoted%20passage"
+        report = f"A claim [Example]({url}) follows."
+
+        assert clean_citation_url(url) == "https://example.test/page"
+        assert clean_urls(report) == "A claim [Example](https://example.test/page) follows."
+        assert remove_urls(report) == "A claim [Example] follows."
+
+    def test_grouping_uses_cleaned_url(self):
+        citations = [
+            {
+                "fact": "First claim",
+                "ref_idx": 0,
+                "url": "https://example.test/page#:~:text=first",
+            },
+            {"fact": "Second claim", "ref_idx": 0, "url": "https://example.test/page"},
+            {"fact": "Other", "ref_idx": 0, "url": "https://other.test"},
+        ]
+
+        groups = group_citations_by_url(citations)
+
+        assert list(groups) == ["https://example.test/page", "https://other.test"]
+        assert [item["fact"] for item in groups["https://example.test/page"]] == [
+            "First claim",
+            "Second claim",
+        ]
+
+    def test_dedup_index_parsing_and_official_fallback(self):
+        assert parse_dedup_indices("```json\n[1, 3]\n```", 3) == [1, 3]
+        assert parse_dedup_indices("[-1]", 3) == [-1]
+        assert parse_dedup_indices("[0, 2]", 3) == [1, 2, 3]
+        assert parse_dedup_indices("[4]", 3) == [1, 2, 3]
+        assert parse_dedup_indices("[-3]", 3) == [1, 2, 3]
+        assert parse_dedup_indices("not json", 2) == [1, 2]
+
+    @pytest.mark.anyio
+    @pytest.mark.parametrize(
+        ("judge_result", "expected"),
+        [
+            ("[-1]", ["second"]),
+            ("[]", ["first", "second", "third"]),
+            ("[0, 2]", ["first", "second", "third"]),
+            ("[4]", ["first", "second", "third"]),
+        ],
+    )
+    async def test_dedup_success_uses_official_guard_without_retry(
+        self, task, judge_result, expected
+    ):
+        calls = 0
+
+        async def judge(_prompt):
+            nonlocal calls
+            calls += 1
+            return judge_result
+
+        facts = ["first", "second", "third"]
+        assert await task._deduplicate_facts(facts, "en", judge) == expected
+        assert calls == 1
+
+    @pytest.mark.anyio
+    async def test_dedup_retries_only_json_parse_failure(self, task, monkeypatch):
+        judge_results = iter(["not json", "still not json", "[-1]"])
+        delays = []
+
+        async def judge(_prompt):
+            return next(judge_results)
+
+        async def sleep(delay):
+            delays.append(delay)
+
+        monkeypatch.setattr(deepresearch_bench.asyncio, "sleep", sleep)
+        facts = ["first", "second", "third"]
+        assert await task._deduplicate_facts(facts, "en", judge) == ["second"]
+        assert delays == [1, 2]
+
+    @pytest.mark.anyio
+    async def test_dedup_judge_failure_returns_all_facts(self, task, monkeypatch):
+        calls = 0
+        delays = []
+
+        async def judge(_prompt):
+            nonlocal calls
+            calls += 1
+            raise RuntimeError("transient judge failure")
+
+        async def sleep(delay):
+            delays.append(delay)
+
+        monkeypatch.setattr(deepresearch_bench.asyncio, "sleep", sleep)
+        facts = ["first", "second", "third"]
+
+        assert await task._deduplicate_facts(facts, "en", judge) == facts
+        assert calls == 3
+        assert delays == [1, 2]
+
+    def test_stat_semantics_exclude_unknown_and_skip_no_citation_tasks(self):
+        statistics = calculate_fact_statistics(
+            [
+                "supported",
+                "unknown",
+                "unsupported",
+                "supported",
+                "unknown",
+                "supported",
+                "arbitrary-label",
+            ],
+            n_tasks=2,
+        )
+        assert statistics == {
+            "fact_citation_accuracy": 0.6,
+            "fact_avg_effective_citations": 1.5,
+            "fact_avg_citations": 2.5,
+        }
+
+    def test_metric_averages_use_only_citation_bearing_responses(self, task):
+        responses = [
+            _response(Instance(question="one"), ""),
+            _response(Instance(question="two"), ""),
+        ]
+        responses[0].scores.update(
+            {
+                "fact_avg_effective_citations": 2.0,
+                "fact_avg_citations": 3.0,
+                "fact_citation_accuracy": 2 / 3,
+                "fact_has_citations": 1.0,
+            }
+        )
+        responses[1].scores.update(
+            {
+                "fact_avg_effective_citations": 0.0,
+                "fact_avg_citations": 0.0,
+                "fact_citation_accuracy": 0.0,
+                "fact_has_citations": 0.0,
+            }
+        )
+        metrics = {metric.name: metric.compute(responses) for metric in task.config.metrics}
+        assert metrics["fact_citation_accuracy"] == 2 / 3
+        assert metrics["fact_avg_effective_citations"] == 2.0
+        assert metrics["fact_avg_citations"] == 3.0
+
+        responses[0].scores["fact_has_citations"] = 0.0
+        fact_metrics = {metric.name: metric for metric in task.config.metrics}
+        assert fact_metrics["fact_avg_effective_citations"].compute(responses) == 0.0
+        assert fact_metrics["fact_avg_citations"].compute(responses) == 0.0
+
+    def test_scrape_failure_short_circuits_to_unknown(self):
+        assert scrape_failure_unknown_results("Error fetching webpage: timeout", 2) == [
+            {"idx": 0, "result": "unknown"},
+            {"idx": 1, "result": "unknown"},
+        ]
+        assert scrape_failure_unknown_results("A valid source page", 2) is None
+
+    @pytest.mark.anyio
+    async def test_scrape_cache_fetches_each_url_once(self, task, monkeypatch):
+        calls = []
+
+        async def fetch_page(url):
+            calls.append(url)
+            return "A valid source page"
+
+        monkeypatch.setattr(deepresearch_bench, "fetch_crawl4ai_page", fetch_page)
+        assert await task._fetch_page("https://example.test/page") == "A valid source page"
+        assert await task._fetch_page("https://example.test/page") == "A valid source page"
+        assert calls == ["https://example.test/page"]
+
+    @pytest.mark.anyio
+    async def test_crawl4ai_import_error_names_install_extra(self, monkeypatch):
+        real_import = builtins.__import__
+
+        def import_without_crawl4ai(name, *args, **kwargs):
+            if name == "crawl4ai":
+                raise ImportError
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", import_without_crawl4ai)
+        with pytest.raises(
+            RuntimeError,
+            match=r"pip install 'olmo-eval\[crawl4ai\]'",
+        ):
+            await fetch_crawl4ai_page("https://example.test/page")
+
+    @pytest.mark.anyio
+    async def test_validation_failure_returns_all_unknown(self, task, monkeypatch):
+        calls = 0
+        delays = []
+
+        async def judge(_prompt):
+            nonlocal calls
+            calls += 1
+            return "not json"
+
+        async def sleep(delay):
+            delays.append(delay)
+
+        monkeypatch.setattr(deepresearch_bench.asyncio, "sleep", sleep)
+        results = await task._validate_facts(["first", "second"], "valid page", "en", judge)
+
+        assert calls == 3
+        assert delays == [1, 2]
+        assert results == [
+            {"idx": 0, "result": "unknown"},
+            {"idx": 1, "result": "unknown"},
+        ]
+
+    @pytest.mark.anyio
+    async def test_validation_blindly_decrements_idx_and_accepts_arbitrary_label(self, task):
+        async def judge(_prompt):
+            return json.dumps([{"idx": -7, "result": "arbitrary-label"}])
+
+        assert await task._validate_facts(["fact"], "valid page", "en", judge) == [
+            {"idx": -8, "result": "arbitrary-label"}
+        ]
+
+    @pytest.mark.anyio
+    async def test_fact_metadata_pairs_by_returned_idx_then_position(self, task, monkeypatch):
+        citations = [
+            {"fact": "first", "url": "https://example.test"},
+            {"fact": "second", "url": "https://example.test"},
+            {"fact": "third", "url": "https://example.test"},
+        ]
+
+        async def extract(*_args):
+            return citations
+
+        async def deduplicate(facts, *_args):
+            return facts
+
+        async def fetch(_url):
+            return "valid page"
+
+        async def validate(*_args):
+            return [
+                {"idx": 2, "result": "supported"},
+                {"idx": 99, "result": "arbitrary-label"},
+                {"idx": 0, "result": "unknown"},
+            ]
+
+        async def unused_judge(_prompt):
+            return ""
+
+        monkeypatch.setattr(task, "_extract_citations", extract)
+        monkeypatch.setattr(task, "_deduplicate_facts", deduplicate)
+        monkeypatch.setattr(task, "_fetch_page", fetch)
+        monkeypatch.setattr(task, "_validate_facts", validate)
+        instance = task.process_doc(_en_doc())
+        assert instance is not None
+
+        scores, details = await task._score_fact(instance, "report", unused_judge)
+
+        assert [detail["fact"] for detail in details] == ["third", "second", "first"]
+        assert scores == {
+            "fact_citation_accuracy": 0.5,
+            "fact_avg_effective_citations": 1.0,
+            "fact_avg_citations": 2.0,
+            "fact_has_citations": 1.0,
+        }
+
+
+class TestPromptsAndJudges:
+    @pytest.mark.parametrize(
+        ("prompt", "digest"),
+        [
+            (
+                RACE_SCORE_PROMPT_EN,
+                "29c0dc8365d047b293c6e6dce80c840402003aa5171c47e2a6f19a064ca77a1f",
+            ),
+            (
+                RACE_SCORE_PROMPT_ZH,
+                "d324077bbe7218ad1df5c49cf3d0207f66416526c73063be883203d7e80610c4",
+            ),
+            (
+                FACT_EXTRACTION_PROMPT_EN,
+                "3f78bbd60b6a78147bed7c51b5f056e2ba990d299c1064318ef63349009e6e8e",
+            ),
+            (
+                FACT_EXTRACTION_PROMPT_ZH,
+                "2b3ce39d315d8f0637601bbe0262887a0f0e2909bd39b7b5e8fb4b3222f56bcd",
+            ),
+            (
+                FACT_DEDUPLICATION_PROMPT_EN,
+                "7c7965e51c48189f49267b6681efce5dcd6f4638cb331a2e63b937d317c2e93b",
+            ),
+            (
+                FACT_DEDUPLICATION_PROMPT_ZH,
+                "e12080068b5fe54893ee896cdf3d9efe8a0fb221a725d3551f8c8c6b3ed4509c",
+            ),
+            (
+                FACT_VALIDATION_PROMPT_EN,
+                "3d8f531bbad26b004faf2284ccd58ce561bf827d117cae3d2475c9a61e5cb71c",
+            ),
+            (
+                FACT_VALIDATION_PROMPT_ZH,
+                "81358173e19cdee1f560e1445048d800d6d455616782f14574eb4dc0920307d4",
+            ),
+        ],
+    )
+    def test_official_prompt_sha256(self, prompt, digest):
+        assert hashlib.sha256(prompt.encode()).hexdigest() == digest
+
+    def test_official_prompt_distinctive_substrings(self):
+        assert 'Start with "Standard 1"' in RACE_SCORE_PROMPT_EN
+        assert '从"标准1"开始' in RACE_SCORE_PROMPT_ZH
+        assert "A segment of text + [number†" in FACT_EXTRACTION_PROMPT_EN
+        assert "一段文字+[（一个或多个)数字†" in FACT_EXTRACTION_PROMPT_ZH
+        assert "*exactly the same thing*" in FACT_DEDUPLICATION_PROMPT_EN
+        assert "只有表达完全一致的事情时" in FACT_DEDUPLICATION_PROMPT_ZH
+        assert "such as a 'page not found' message" in FACT_VALIDATION_PROMPT_EN
+        assert '如"page not found"页面' in FACT_VALIDATION_PROMPT_ZH
+
+    @pytest.mark.parametrize(
+        ("env_spec", "expected_models", "expected_efforts"),
+        [
+            (None, ["gpt-5.5", "gpt-5.4-mini"], [None, None]),
+            ("judge-override", ["judge-override", "judge-override"], [None, None]),
+            ("gpt-5.5:high", ["gpt-5.5", "gpt-5.5"], ["high", "high"]),
+        ],
+    )
+    def test_single_override_applies_to_both_judges(
+        self, monkeypatch, env_spec, expected_models, expected_efforts
+    ):
+        captured = []
+
+        async def sentinel(_prompt):
+            return ""
+
+        def fake_builder(**kwargs):
+            captured.append(kwargs)
+            return sentinel
+
+        if env_spec is None:
+            monkeypatch.delenv("OLMO_EVAL_JUDGE", raising=False)
+        else:
+            monkeypatch.setenv("OLMO_EVAL_JUDGE", env_spec)
+        monkeypatch.setattr(deepresearch_bench, "build_openai_judge_fn", fake_builder)
+
+        assert build_deepresearch_race_judge_fn() is sentinel
+        assert build_deepresearch_fact_judge_fn() is sentinel
+        assert [call["model"] for call in captured] == expected_models
+        assert [call["reasoning_effort"] for call in captured] == expected_efforts
+        assert [call["scorer_name"] for call in captured] == [
+            "DeepResearchBenchRACE",
+            "DeepResearchBenchFACT",
+        ]
+        assert all(call["temperature"] == 0.0 for call in captured)
+        assert all(call["max_tokens"] == 64_000 for call in captured)
+
+
+@pytest.mark.anyio
+async def test_score_responses_runs_race_and_fact_without_network(task, monkeypatch):
+    instance = task.process_doc(_en_doc())
+    assert instance is not None
+    response = _response(
+        instance,
+        "<think>research plan</think>A supported fact [Source](https://example.test/page).",
+    )
+    race_calls = []
+    fact_calls = []
+
+    race_payload = {
+        dimension: [
+            {
+                "criterion": _criteria()["criterions"][dimension][0]["criterion"],
+                "article_1_score": 8,
+                "article_2_score": 2,
+            }
+        ]
+        for dimension in DEEPRESEARCH_DIMENSIONS
+    }
+
+    async def race_judge(prompt):
+        race_calls.append(prompt)
+        return f"```json\n{json.dumps(race_payload)}\n```"
+
+    async def fact_judge(prompt):
+        fact_calls.append(prompt)
+        if "Here is the main text" in prompt:
+            return json.dumps(
+                [
+                    {
+                        "fact": "A supported fact [Source](https://example.test/page).",
+                        "ref_idx": 0,
+                        "url": "https://example.test/page",
+                    }
+                ]
+            )
+        assert "A valid source page" in prompt
+        return json.dumps([{"idx": 1, "result": "supported"}])
+
+    async def fetch_page(url):
+        assert url == "https://example.test/page"
+        return "A valid source page containing the supported fact."
+
+    monkeypatch.setattr(deepresearch_bench, "build_deepresearch_race_judge_fn", lambda: race_judge)
+    monkeypatch.setattr(deepresearch_bench, "build_deepresearch_fact_judge_fn", lambda: fact_judge)
+    monkeypatch.setattr(deepresearch_bench, "fetch_crawl4ai_page", fetch_page)
+
+    await task.score_responses([response])
+
+    assert len(race_calls) == 1
+    assert len(fact_calls) == 2
+    assert response.scores["race_overall"] == pytest.approx(0.8)
+    for dimension in DEEPRESEARCH_DIMENSIONS:
+        assert response.scores[f"race_{dimension}"] == pytest.approx(0.8)
+    assert response.scores["fact_citation_accuracy"] == 1.0
+    assert response.scores["fact_avg_effective_citations"] == 1.0
+    assert response.scores["fact_avg_citations"] == 1.0
+    assert response.scores["fact_has_citations"] == 1.0
+    assert response.outputs[0].extracted_answer.startswith("A supported fact")
+    assert response.outputs[0].metadata["deepresearch_fact"] == [
+        {
+            "url": "https://example.test/page",
+            "fact": "A supported fact [Source].",
+            "result": "supported",
+        }
+    ]
+
+
+@pytest.mark.anyio
+async def test_empty_answer_sets_fact_has_citations_to_zero(task, monkeypatch):
+    instance = task.process_doc(_en_doc())
+    assert instance is not None
+    response = _response(instance, "<think>research plan only</think>")
+    judge_calls = 0
+
+    async def judge(_prompt):
+        nonlocal judge_calls
+        judge_calls += 1
+        return ""
+
+    monkeypatch.setattr(deepresearch_bench, "build_deepresearch_race_judge_fn", lambda: judge)
+    monkeypatch.setattr(deepresearch_bench, "build_deepresearch_fact_judge_fn", lambda: judge)
+
+    await task.score_responses([response])
+
+    assert judge_calls == 0
+    assert response.scores["fact_has_citations"] == 0.0
+    assert response.scores["fact_avg_effective_citations"] == 0.0
+    assert response.scores["fact_avg_citations"] == 0.0
+
+
+@pytest.mark.anyio
+async def test_race_parse_failure_retries_and_keeps_zero_instance(task, monkeypatch):
+    instance = task.process_doc(_en_doc())
+    assert instance is not None
+    response = _response(instance, "A report without citations.")
+    race_calls = 0
+    delays = []
+
+    async def race_judge(_prompt):
+        nonlocal race_calls
+        race_calls += 1
+        return "malformed"
+
+    async def fact_judge(_prompt):
+        return "[]"
+
+    async def sleep(delay):
+        delays.append(delay)
+
+    monkeypatch.setattr(deepresearch_bench, "build_deepresearch_race_judge_fn", lambda: race_judge)
+    monkeypatch.setattr(deepresearch_bench, "build_deepresearch_fact_judge_fn", lambda: fact_judge)
+    monkeypatch.setattr(deepresearch_bench.asyncio, "sleep", sleep)
+
+    scored = await task.score_responses([response])
+
+    assert scored == [response]
+    assert race_calls == 3
+    assert delays == [1, 2]
+    assert response.scores["race_overall"] == 0.0
+    assert response.scores["fact_has_citations"] == 0.0
+    assert task.config.get_primary_metric().compute(scored) == 0.0

--- a/tests/evals/tasks/test_deepresearch_bench.py
+++ b/tests/evals/tasks/test_deepresearch_bench.py
@@ -3,6 +3,7 @@
 import builtins
 import hashlib
 import json
+import re
 
 import pytest
 
@@ -11,6 +12,7 @@ from olmo_eval.evals.tasks import deepresearch_bench
 from olmo_eval.evals.tasks.common import get_task, task_exists
 from olmo_eval.evals.tasks.deepresearch_bench import (
     DEEPRESEARCH_DIMENSIONS,
+    DEEPRESEARCH_GENERATION_INSTRUCTIONS,
     FACT_DEDUPLICATION_PROMPT_EN,
     FACT_DEDUPLICATION_PROMPT_ZH,
     FACT_EXTRACTION_PROMPT_EN,
@@ -136,7 +138,7 @@ class TestRegistrationAndDocs:
 
         assert instance is not None
         assert instance.question.startswith(doc["prompt"] + "\n\n")
-        assert "[source title](url)" in instance.question or "[来源标题](url)" in instance.question
+        assert instance.question.endswith(DEEPRESEARCH_GENERATION_INSTRUCTIONS[doc["language"]])
         assert instance.metadata["id"] == doc["id"]
         assert instance.metadata["language"] == doc["language"]
         assert instance.metadata["topic"] == doc["topic"]
@@ -159,6 +161,230 @@ class TestRegistrationAndDocs:
     def test_think_strip_matches_researchqa_pattern(self, task):
         output = LMOutput(text="<think>private reasoning</think>\n\nFinal report.")
         assert task.extract_answer(output) == "Final report."
+
+    @pytest.mark.parametrize(
+        (
+            "language",
+            "bare_placeholder",
+            "citation_format",
+            "inline_citation",
+            "replacement_clause",
+        ),
+        [
+            (
+                "en",
+                "[source title]",
+                "[<the source's actual title>](<the source's actual URL>)",
+                "inline Markdown citation",
+                "Replace both placeholders with the real page title and URL",
+            ),
+            (
+                "zh",
+                "[来源标题]",
+                "[<来源的真实标题>](<来源的真实链接>)",
+                "行内 Markdown 引用",
+                "请将两个占位符替换为真实网页标题和链接",
+            ),
+        ],
+    )
+    def test_generation_instruction_uses_noncopyable_citation_placeholders(
+        self,
+        language,
+        bare_placeholder,
+        citation_format,
+        inline_citation,
+        replacement_clause,
+    ):
+        instruction = DEEPRESEARCH_GENERATION_INSTRUCTIONS[language]
+
+        assert instruction
+        assert bare_placeholder not in instruction
+        assert citation_format in instruction
+        assert inline_citation in instruction
+        assert replacement_clause in instruction
+        assert "](<" in instruction
+        assert re.search(r"https?://", instruction, flags=re.IGNORECASE) is None
+
+
+class TestGeneratedReportCleaning:
+    def test_dangling_nid_76_closing_tags_are_removed_and_report_survives(self, task):
+        report = (
+            "# Findings\n\nThe evidence supports the conclusion.\n"
+            "The final sources were MDPI and Healthline."
+        )
+        generated = f"{report}\n</parameter>\n</function>\n</tool_call>"
+
+        cleaned = task.extract_answer(LMOutput(text=generated))
+
+        assert cleaned == report
+        assert cleaned.endswith("The final sources were MDPI and Healthline.")
+        assert "<" not in cleaned
+
+    def test_channel_and_harmony_markers_are_removed_on_production_path(self, task):
+        report = "# Findings\n\nA legitimate report sentence."
+        generated = f"<|channel>thought\n<channel|>{report}<|im_end|>"
+
+        assert task.extract_answer(LMOutput(text=generated)) == report
+
+    def test_pure_gemma_channel_and_tool_call_scaffold_becomes_empty(self, task):
+        generated = "<|channel>thought<tool_call|>"
+
+        assert task.extract_answer(LMOutput(text=generated)) == ""
+
+    def test_complete_tool_call_wrapper_loses_markup_but_keeps_prose(self, task):
+        generated = '<tool_call name="write_report">\nA legitimate report sentence.\n</tool_call>'
+
+        assert task.extract_answer(LMOutput(text=generated)) == "A legitimate report sentence."
+
+    def test_complete_tool_response_wrapper_loses_markup_but_keeps_prose(self, task):
+        generated = "<tool_response>\nA sourced report sentence.\n</tool_response>"
+
+        assert task.extract_answer(LMOutput(text=generated)) == "A sourced report sentence."
+
+    @pytest.mark.parametrize("family", ["tool_call", "tool_response", "function", "parameter"])
+    @pytest.mark.parametrize("quote", ['"', "'"])
+    @pytest.mark.parametrize("value", ["write=report", "write report"])
+    def test_quoted_scaffold_attributes_accept_spaces_and_equals_on_production_path(
+        self, task, family, quote, value
+    ):
+        generated = f"<{family} name={quote}{value}{quote}>Final report.</{family}>"
+
+        assert task.extract_answer(LMOutput(text=generated)) == "Final report."
+
+    @pytest.mark.parametrize("value", ["write=report", "write report"])
+    def test_unquoted_scaffold_attributes_remain_identifier_shaped(self, task, value):
+        generated = f"<tool_call name={value}>Final report."
+
+        assert task.extract_answer(LMOutput(text=generated)) == generated
+
+    @pytest.mark.parametrize(
+        "generated",
+        [
+            '<tool_call name="write report>Visible prose > remains visible.',
+            "<tool_call name='write report>Visible prose > remains visible.",
+            '<tool_call name="write report\nVisible prose > remains visible.',
+            "<tool_call name='write report\nVisible prose > remains visible.",
+        ],
+    )
+    def test_unterminated_quoted_opener_cannot_cross_angle_or_newline(self, task, generated):
+        assert task.extract_answer(LMOutput(text=generated)) == generated
+
+    def test_double_quoted_scaffold_attribute_cannot_consume_quoted_prose(self, task):
+        generated = '<function name="a" and "b" > tail.'
+
+        assert task.extract_answer(LMOutput(text=generated)) == generated
+
+    def test_single_quoted_scaffold_attribute_cannot_consume_apostrophe_prose(self, task):
+        generated = "<function name='x' the model's output '> tail."
+
+        assert task.extract_answer(LMOutput(text=generated)) == generated
+
+    def test_function_opener_with_double_quoted_spaced_value_is_stripped(self, task):
+        generated = '<function name="write report">Final report.'
+
+        assert task.extract_answer(LMOutput(text=generated)) == "Final report."
+
+    def test_tool_call_opener_with_multiple_quoted_attributes_is_stripped(self, task):
+        generated = '<tool_call name="a b" id="c d">Final report.'
+
+        assert task.extract_answer(LMOutput(text=generated)) == "Final report."
+
+    @pytest.mark.parametrize(
+        "generated",
+        [
+            (
+                "<|start|>assistant<|channel|>analysis<|message|>Private reasoning."
+                "<|end|><|start|>assistant<|channel|>final<|message|>Final report."
+                "<|return|>"
+            ),
+            (
+                "<start|>assistant<|channel>thought<message|>Private reasoning."
+                "<end|><start|>assistant<|channel>final<message|>Final report.<return|>"
+            ),
+        ],
+    )
+    def test_reasoning_channel_content_is_dropped_when_final_channel_exists(self, task, generated):
+        assert task.extract_answer(LMOutput(text=generated)) == "Final report."
+
+    def test_report_content_before_first_channel_is_retained_with_final_content(self, task):
+        generated = (
+            "Report body comes first."
+            "<|channel|>analysis<|message|>Private reasoning."
+            "<|channel|>final<|message|>Final report."
+        )
+
+        assert task.extract_answer(LMOutput(text=generated)) == (
+            "Report body comes first. Final report."
+        )
+
+    def test_special_token_removal_separates_adjacent_words(self, task):
+        generated = "First<|im_end|>second"
+
+        assert task.extract_answer(LMOutput(text=generated)) == "First second"
+
+    def test_think_block_is_removed_before_scaffold_tags(self):
+        generated = (
+            "<think>private reasoning with <tool_call></think>\n"
+            "<tool_call><function=write_report><parameter=report>"
+            "Final report sentence.</parameter></function></tool_call>"
+        )
+
+        assert deepresearch_bench._clean_generated_report(generated) == ("Final report sentence.")
+
+    def test_text_without_tags_is_unchanged_modulo_strip(self):
+        report = "A plain report with no scaffold markup."
+
+        assert deepresearch_bench._clean_generated_report(f" \n{report}\n ") == report
+
+    def test_unpaired_bare_function_keyword_in_prose_is_preserved(self):
+        report = "C++ does not use the `<function>` keyword for function declarations."
+
+        assert deepresearch_bench._clean_generated_report(report) == report
+
+    @pytest.mark.parametrize(
+        "code",
+        [
+            "`<function>example</function>`",
+            '```xml\n<tool_call name="example">\n</tool_call>\n```',
+        ],
+    )
+    def test_scaffold_examples_in_markdown_code_are_preserved(self, code):
+        report = f"The documentation shows {code} as an example."
+
+        assert deepresearch_bench._clean_generated_report(report) == report
+
+    def test_paired_bare_function_tags_in_prose_lose_markup_but_keep_content(self):
+        report = "The prose uses <function>call</function> to discuss the wrapper."
+
+        assert deepresearch_bench._clean_generated_report(report) == (
+            "The prose uses call to discuss the wrapper."
+        )
+
+    def test_bare_parameter_pairing_crosses_preserved_inline_code_on_production_path(self, task):
+        generated = "<parameter>A report cites `x = <parameter>` verbatim.</parameter>"
+
+        assert task.extract_answer(LMOutput(text=generated)) == (
+            "A report cites `x = <parameter>` verbatim."
+        )
+
+    def test_malformed_opener_is_preserved_on_production_path(self, task):
+        generated = '<function name="write_report"\n# Findings\n\nThe report starts here.'
+
+        assert task.extract_answer(LMOutput(text=generated)) == generated
+
+    def test_malformed_opener_cannot_consume_prose_at_bare_greater_than(self, task):
+        generated = (
+            '<parameter name="report"\n'
+            "# Findings\n\nGlobal spending > 100 trillion dollars.\n"
+            "The result was not significant (p > 0.05)."
+        )
+
+        assert task.extract_answer(LMOutput(text=generated)) == generated
+
+    def test_large_bare_tag_sequence_is_cleaned_without_pairwise_lookahead(self):
+        generated = "<function>" * 10_000 + "report" + "</function>" * 10_000
+
+        assert deepresearch_bench._clean_generated_report(generated) == "report"
 
 
 class TestRaceScoring:
@@ -259,6 +485,13 @@ class TestFactHelpersAndMetrics:
         assert clean_citation_url(url) == "https://example.test/page"
         assert clean_urls(report) == "A claim [Example](https://example.test/page) follows."
         assert remove_urls(report) == "A claim [Example] follows."
+
+    def test_url_cleaning_removes_commonmark_autolink_brackets(self):
+        url = " <https://example.test/page#:~:text=quoted%20passage> "
+        report = f"A claim [Example]({url}) follows."
+
+        assert clean_citation_url(url) == "https://example.test/page"
+        assert clean_urls(report) == "A claim [Example](https://example.test/page) follows."
 
     def test_grouping_uses_cleaned_url(self):
         citations = [

--- a/tests/evals/tasks/test_deepscholar_bench.py
+++ b/tests/evals/tasks/test_deepscholar_bench.py
@@ -1,9 +1,11 @@
 """Tests for the DeepScholar-Bench task and its export adapter.
 
 The prompt is pinned against a golden copy of lit-agents'
-``shared/deepscholar.py::QUERY_TEMPLATE``: the whole point of this task is to be
-comparable with the systems prompted that way, and a reworded prompt would
-break that silently rather than loudly.
+``shared/deepscholar.py::QUERY_TEMPLATE``: the point of this task is to be
+comparable with the systems prompted that way, and a reworded prompt would break
+that silently. The export is pinned against the real upstream parser, copied in
+under ``fixtures/deepscholar_c95413b``, because an imitation would only prove
+itself self-consistent.
 """
 
 import csv
@@ -19,6 +21,7 @@ from olmo_eval.evals.tasks.deepscholar_bench import (
     DEEPSCHOLAR_COMMIT,
     DEEPSCHOLAR_QUERY_TEMPLATE,
     SEARCH_TOOL_NAME,
+    download_deepscholar_dataset,
     parse_arxiv_tool_results,
     sources_from_trajectory,
 )
@@ -26,8 +29,13 @@ from olmo_eval.evals.tasks.deepscholar_export import (
     PAPER_CSV_FIELDS,
     build_paper_rows,
     export_predictions,
+    query_id,
 )
-from olmo_eval.harness.tools.search import _format_arxiv_result
+from olmo_eval.harness.tools.search import _classify_arxiv_hit, _format_arxiv_result
+from tests.evals.tasks.fixtures.deepscholar_c95413b.eval.parsers import (
+    DeepScholarBaseParser,
+    ParserType,
+)
 
 # Golden copy of lit-agents' shared/deepscholar.py::QUERY_TEMPLATE.
 GOLDEN_QUERY_TEMPLATE = """Your task is to write a Related Works section for an academic paper given the paper's abstract. Your response should provide the Related Works section and references. Only include references from arXiv that are published before {cutoff_date}. Mention them in a separate, numbered reference list at the end and use the reference numbers to provide in-line citations in the Related Works section for all claims referring to a source (e.g., description of source [3]. Further details [6][7][8][9][10].) Each in-line citation must consist of a single reference number within a pair of brackets. Do not use any other citation format. Do not exceed 600 words for the related works section. Here is the paper abstract: {abstract}"""
@@ -37,7 +45,22 @@ CSV_ROW = {
     "title": "TaxAgent: How Large Language Model Designs Fiscal Policy",
     "abstract": "  Economic inequality is a global challenge.  ",
     "published_date": "2025-06-03T13:06:19+00:00",
+    "arxiv_link": "http://arxiv.org/abs/2506.02838v1",
 }
+
+# The shape the prompt actually mandates: numbered inline citations plus a
+# numbered reference list, and not one markdown link anywhere.
+NUMBERED_ANSWER = """## Related Works
+
+Early systems retrieved passages [1]. Later work scaled the index [2], and
+recent agents ground each claim [3]. Several combine the two [2][3].
+
+## References
+
+[1] A. Author. First Retrieval System. arXiv:2401.00001
+[2] B. Author. Scaling The Index. arXiv:2401.00002
+[3] C. Author. Grounding Each Claim. arXiv:2401.00003
+"""
 
 
 @pytest.fixture(autouse=True)
@@ -48,15 +71,6 @@ def _setup_registry():
 @pytest.fixture
 def task():
     return get_task("deepscholar_bench")
-
-
-def _tool_output(*papers: dict) -> str:
-    """Render results the way the search tool does, so the parser is tested
-    against the real formatter rather than a hand-written imitation."""
-    return "\n\n---\n\n".join(
-        _format_arxiv_result(paper, paper.get("externalIds", {}).get("ArXiv", ""))
-        for paper in papers
-    )
 
 
 def _paper(
@@ -78,18 +92,42 @@ def _paper(
     return paper
 
 
-def _trajectory(*result_contents: str) -> AgentTrajectory:
+def _tool_output(*papers: dict) -> str:
+    """Render results the way the search tool does, so the parser is tested
+    against the real formatter rather than a hand-written imitation."""
+    rendered = []
+    for paper in papers:
+        hit, reason = _classify_arxiv_hit(paper, None)
+        assert hit is not None, f"fixture paper is not citable: {reason}"
+        rendered.append(_format_arxiv_result(paper, hit))
+    return "\n\n---\n\n".join(rendered)
+
+
+def _trajectory(*result_contents: str, tool_name: str = SEARCH_TOOL_NAME) -> AgentTrajectory:
     turns = []
     for index, content in enumerate(result_contents):
         call = ToolCall(
             id=f"c{index}",
-            function=Function(name=SEARCH_TOOL_NAME, arguments='{"query": "q"}'),
+            function=Function(name=tool_name, arguments='{"query": "q"}'),
         )
         turns.append(AgentTurn.assistant(tool_calls=[call]))
         turns.append(
             AgentTurn.tool(results=[ToolResult(tool_call_id=f"c{index}", content=content)])
         )
     return AgentTrajectory(turns=tuple(turns))
+
+
+def _dataset_csv(tmp_path, *indices: int):
+    """A dataset CSV whose rows sit at the given positions."""
+    path = tmp_path / "papers.csv"
+    with path.open("w", newline="", encoding="utf-8") as stream:
+        writer = csv.DictWriter(stream, fieldnames=list(CSV_ROW))
+        writer.writeheader()
+        for position in range(max(indices) + 1):
+            row = dict(CSV_ROW)
+            row["arxiv_id"] = f"2506.0{position:04d}"
+            writer.writerow(row)
+    return path
 
 
 class TestRegistration:
@@ -99,7 +137,7 @@ class TestRegistration:
     def test_metrics(self, task):
         assert {m.name for m in task.config.metrics} == {
             "exportable_rate",
-            "arxiv_citation_rate",
+            "citation_resolution_rate",
         }
         assert task.config.get_primary_metric().name == "exportable_rate"
 
@@ -146,9 +184,24 @@ class TestProcessDoc:
         assert task.process_doc(row, index=0) is None
 
     def test_unparseable_cutoff_is_dropped(self, task):
-        row = dict(CSV_ROW, published_date="not a date")
+        assert task.process_doc(dict(CSV_ROW, published_date="not a date"), index=0) is None
 
-        assert task.process_doc(row, index=0) is None
+
+class TestDataset:
+    def test_the_pinned_dataset_yields_63_queries(self, task):
+        # Reads the cached CSV; the download only happens on a cold cache.
+        download_deepscholar_dataset()
+        instances = list(task.instances)
+
+        assert len(instances) == 63
+        assert [item.metadata["id"] for item in instances] == [str(i) for i in range(63)]
+
+    def test_positional_ids_do_not_renumber_when_a_row_is_dropped(self, task):
+        rows = [dict(CSV_ROW), dict(CSV_ROW, abstract=""), dict(CSV_ROW)]
+
+        kept = [task.process_doc(row, index=index) for index, row in enumerate(rows)]
+
+        assert [item.metadata["id"] for item in kept if item is not None] == ["0", "2"]
 
 
 class TestResultParsing:
@@ -160,7 +213,6 @@ class TestResultParsing:
         assert [item["arxiv_id"] for item in parsed] == ["2401.00001", "2401.00002"]
         assert parsed[0]["title"] == "First"
         assert parsed[0]["abstract"] == "An abstract."
-        assert parsed[0]["url"] == "https://arxiv.org/abs/2401.00001"
         # No S2 date, so the ID's month is all the tool could claim.
         assert parsed[0]["published_date"] == "2024-01-01"
         assert parsed[0]["date_precision"] == "month"
@@ -179,11 +231,13 @@ class TestResultParsing:
         assert parse_arxiv_tool_results(content)[0]["abstract"] == "Line one.\nLine two."
 
     def test_context_only_results_are_skipped(self):
-        content = _format_arxiv_result({"title": "Journal", "abstract": "x"}, "")
+        content = _format_arxiv_result({"title": "Journal", "abstract": "x"}, None)
 
         assert parse_arxiv_tool_results(content) == []
 
-    def test_trajectory_sources_are_deduplicated_first_mention_winning(self):
+
+class TestTrajectorySources:
+    def test_deduplicated_first_mention_winning(self):
         trajectory = _trajectory(
             _tool_output(_paper("First", "2401.00001")),
             _tool_output(_paper("First again", "2401.00001"), _paper("Second", "2401.00002")),
@@ -197,6 +251,35 @@ class TestResultParsing:
     def test_no_trajectory_yields_no_sources(self):
         assert sources_from_trajectory(None) == []
 
+    def test_only_the_search_tools_results_are_read(self):
+        # Another tool naming an arXiv ID was never shown to the agent as a
+        # citable search result, so it must not become citable.
+        trajectory = _trajectory(
+            _tool_output(_paper("Fetched", "2401.00009")), tool_name="browse_webpage"
+        )
+
+        assert sources_from_trajectory(trajectory) == []
+
+    @pytest.mark.parametrize(
+        "abstract",
+        [
+            "Contains the block separator\n\n---\n\nmid-abstract.",
+            "A continuation line that starts URL: https://example.com/x",
+            "A continuation that starts Abstract: again, and arXiv: 9999.99999 too.",
+        ],
+    )
+    def test_adversarial_abstracts_still_yield_the_id(self, abstract):
+        # The ID is read from its own line, so a block the field parser cannot
+        # make sense of still contributes the one field the export needs.
+        trajectory = _trajectory(_tool_output(_paper("Tricky", "2401.00007", abstract=abstract)))
+
+        assert [item["arxiv_id"] for item in sources_from_trajectory(trajectory)] == ["2401.00007"]
+
+    def test_a_newline_in_a_title_still_yields_the_id(self):
+        trajectory = _trajectory(_tool_output(_paper("Broken\nTitle", "2401.00008")))
+
+        assert [item["arxiv_id"] for item in sources_from_trajectory(trajectory)] == ["2401.00008"]
+
 
 class TestScoring:
     def _response(self, answer: str, trajectory: AgentTrajectory | None) -> Response:
@@ -209,32 +292,58 @@ class TestScoring:
         )
 
     @pytest.mark.anyio
-    async def test_exportable_response_scores_one(self, task):
-        response = self._response(
-            "Related work [Paper](https://arxiv.org/abs/2401.00001).",
-            _trajectory(_tool_output(_paper("First", "2401.00001"))),
+    async def test_a_prompt_compliant_answer_is_exportable(self, task):
+        # No markdown link anywhere in the answer: it scores 1.0 because the
+        # bridge resolves its numbered citations, not because a URL is present.
+        trajectory = _trajectory(
+            _tool_output(
+                _paper("First Retrieval System", "2401.00001"),
+                _paper("Scaling The Index", "2401.00002"),
+                _paper("Grounding Each Claim", "2401.00003"),
+            )
         )
+        assert "](http" not in NUMBERED_ANSWER
 
-        (scored,) = await task.score_responses([response])
+        (scored,) = await task.score_responses([self._response(NUMBERED_ANSWER, trajectory)])
 
         assert scored.scores["exportable_rate"] == 1.0
-        assert scored.scores["arxiv_citation_rate"] == 1.0
-        assert scored.outputs[0].metadata["deepscholar_num_searches"] == 1
+        assert scored.scores["citation_resolution_rate"] == 1.0
+        assert scored.outputs[0].metadata["score:exportable_rate"] == 1.0
+
+    @pytest.mark.anyio
+    async def test_citing_only_unretrieved_papers_is_not_exportable(self, task):
+        trajectory = _trajectory(_tool_output(_paper("Unrelated", "2401.09999")))
+
+        (scored,) = await task.score_responses([self._response(NUMBERED_ANSWER, trajectory)])
+
+        assert scored.scores["exportable_rate"] == 0.0
+        assert scored.scores["citation_resolution_rate"] == 0.0
+
+    @pytest.mark.anyio
+    async def test_a_bare_url_in_prose_is_not_a_citation(self, task):
+        # The old metric counted any arxiv.org URL anywhere in the text; the
+        # parser counts only markdown links, so this must score zero.
+        answer = "See https://arxiv.org/abs/2401.00001 for details."
+        trajectory = _trajectory(_tool_output(_paper("First", "2401.00001")))
+
+        (scored,) = await task.score_responses([self._response(answer, trajectory)])
+
+        assert scored.scores["exportable_rate"] == 0.0
 
     @pytest.mark.anyio
     async def test_response_without_a_trajectory_is_not_exportable(self, task):
-        (scored,) = await task.score_responses([self._response("Some text.", None)])
+        (scored,) = await task.score_responses([self._response(NUMBERED_ANSWER, None)])
 
         assert scored.scores["exportable_rate"] == 0.0
-        assert scored.scores["arxiv_citation_rate"] == 0.0
 
 
 class TestExportAdapter:
-    def _prediction(self, native_id: str = "7", answer: str = "Related work.") -> dict:
+    def _prediction(self, native_id: str = "7", answer: str = NUMBERED_ANSWER) -> dict:
         trajectory = _trajectory(
             _tool_output(
-                _paper("First", "2401.00001", published="2024-01-15"),
-                _paper("Second", "cs/0501001"),
+                _paper("First Retrieval System", "2401.00001", published="2024-01-15"),
+                _paper("Scaling The Index", "2401.00002"),
+                _paper("Grounding Each Claim", "cs/0501001"),
             )
         )
         return {
@@ -253,100 +362,223 @@ class TestExportAdapter:
         )
         return path
 
+    def _export(self, tmp_path, *predictions: dict, **kwargs):
+        return export_predictions(
+            self._write(tmp_path, *predictions),
+            tmp_path / "export",
+            dataset_path=_dataset_csv(tmp_path, 7),
+            fetch_abstracts=False,
+            **kwargs,
+        )
+
     def test_writes_one_folder_per_query(self, tmp_path):
-        predictions = self._write(tmp_path, self._prediction())
-        output = tmp_path / "export"
+        summary = self._export(tmp_path, self._prediction())
 
-        summary = export_predictions(predictions, output)
-
-        assert summary["exported_ids"] == ["7"]
-        assert sorted(p.name for p in (output / "7").iterdir()) == [
+        assert summary["exported_ids"] == [7]
+        assert sorted(p.name for p in (tmp_path / "export" / "7").iterdir()) == [
+            "export_manifest.json",
             "final_report.md",
             "intro.md",
             "paper.csv",
         ]
 
-    def test_intro_and_final_report_are_the_answer(self, tmp_path):
-        predictions = self._write(tmp_path, self._prediction(answer="The section."))
-        output = tmp_path / "export"
+    def test_intro_is_the_rewritten_answer_and_final_report_matches(self, tmp_path):
+        self._export(tmp_path, self._prediction())
+        folder = tmp_path / "export" / "7"
 
-        export_predictions(predictions, output)
+        intro = (folder / "intro.md").read_text(encoding="utf-8")
 
-        intro = (output / "7" / "intro.md").read_text(encoding="utf-8")
-        assert intro == "The section."
-        assert (output / "7" / "final_report.md").read_text(encoding="utf-8") == intro
+        # The raw answer has no markdown link; the exported intro must, or the
+        # upstream parser finds no documents at all.
+        assert "[First Retrieval System](https://arxiv.org/abs/2401.00001)" in intro
+        assert "## References" not in intro
+        assert intro != NUMBERED_ANSWER
+        assert (folder / "final_report.md").read_text(encoding="utf-8") == intro
 
-    def test_paper_csv_columns_and_rows(self, tmp_path):
-        predictions = self._write(tmp_path, self._prediction())
-        output = tmp_path / "export"
+    def test_the_real_upstream_parser_finds_documents(self, tmp_path):
+        self._export(tmp_path, self._prediction())
+        folder = tmp_path / "export" / "7"
 
-        export_predictions(predictions, output)
-
-        with (output / "7" / "paper.csv").open(newline="", encoding="utf-8") as stream:
-            reader = csv.DictReader(stream)
-            assert reader.fieldnames == list(PAPER_CSV_FIELDS)
-            rows = list(reader)
-
-        assert [row["id"] for row in rows] == ["2401.00001", "cs/0501001"]
-        assert rows[0]["title"] == "First"
-        assert rows[0]["snippet"] == "An abstract."
-        # S2 dated the first source, so the day survives into the CSV.
-        assert rows[0]["published_date"] == "2024-01-15"
-        assert rows[0]["date_precision"] == "day"
-        assert rows[0]["paper_id"] == "2401.00001"
-        # The second was undated, so only its ID's month can be claimed.
-        assert rows[1]["published_date"] == "2005-01-01"
-        assert rows[1]["date_precision"] == "month"
-
-    def test_predictions_without_sources_are_skipped(self, tmp_path):
-        prediction = self._prediction()
-        prediction["trajectory"] = AgentTrajectory().to_dict()
-        predictions = self._write(tmp_path, prediction)
-        output = tmp_path / "export"
-
-        summary = export_predictions(predictions, output)
-
-        assert summary["exported_count"] == 0
-        assert summary["skipped"] == [{"idx": "7", "reason": "no arXiv sources in trajectory"}]
-        assert not (output / "7").exists()
-
-    def test_predictions_without_an_answer_are_skipped(self, tmp_path):
-        prediction = self._prediction(answer="   ")
-        predictions = self._write(tmp_path, prediction)
-
-        summary = export_predictions(predictions, tmp_path / "export")
-
-        assert summary["skipped"] == [{"idx": "7", "reason": "no answer text"}]
-
-    def test_undatable_sources_are_dropped(self):
-        rows = build_paper_rows(
-            [
-                {"arxiv_id": "2401.00001", "title": "Datable", "abstract": "a"},
-                {"arxiv_id": "not-an-id", "title": "Undatable", "abstract": "b"},
-            ]
+        parser = DeepScholarBaseParser(
+            str(folder),
+            {
+                "mode": ParserType.DEEPSCHOLAR_BASE,
+                "file_id": "7",
+                "s_map_groundtruth": {
+                    "title": "T",
+                    "abstract": "A",
+                    "arxiv_link": "https://arxiv.org/abs/2506.02838",
+                    "related_works_section": "",
+                    "arxiv_id": "2506.02838",
+                },
+            },
         )
 
-        assert [row["id"] for row in rows] == ["2401.00001"]
+        assert parser.docs, "the pinned parser found no documents in the export"
+        assert all(doc["title"].strip() for doc in parser.docs)
+        assert all(doc["sent"].strip() for doc in parser.docs)
+        # Every citation the parser renumbered points at a row it resolved.
+        assert "[1]" in parser.clean_text
+
+    def test_paper_csv_holds_only_the_cited_sources(self, tmp_path):
+        prediction = self._prediction()
+        # A retrieved paper the answer never cites must not appear.
+        trajectory = AgentTrajectory.from_dict(prediction["trajectory"])
+        extra = _tool_output(_paper("Never Cited", "2401.05555"))
+        prediction["trajectory"] = _trajectory(
+            *[r.content for r in trajectory.tool_result_sequence], extra
+        ).to_dict()
+
+        self._export(tmp_path, prediction)
+
+        rows = self._rows(tmp_path / "export" / "7" / "paper.csv")
+        assert "2401.05555" not in {row["id"] for row in rows}
+        assert {row["id"] for row in rows} == {"2401.00001", "2401.00002", "cs/0501001"}
+
+    def test_paper_csv_columns_and_dates(self, tmp_path):
+        self._export(tmp_path, self._prediction())
+
+        rows = self._rows(tmp_path / "export" / "7" / "paper.csv")
+        by_id = {row["id"]: row for row in rows}
+
+        assert list(by_id["2401.00001"]) == list(PAPER_CSV_FIELDS)
+        # S2 dated the first source, so the day survives into the CSV.
+        assert by_id["2401.00001"]["published_date"] == "2024-01-15"
+        assert by_id["2401.00001"]["date_precision"] == "day"
+        # The others were undated, so only their ID's month can be claimed.
+        assert by_id["2401.00002"]["published_date"] == "2024-01-01"
+        assert by_id["cs/0501001"]["date_precision"] == "month"
+
+    def test_export_manifest_checksums_every_scored_file(self, tmp_path):
+        import hashlib
+
+        self._export(tmp_path, self._prediction())
+        folder = tmp_path / "export" / "7"
+
+        manifest = json.loads((folder / "export_manifest.json").read_text(encoding="utf-8"))
+
+        assert set(manifest) == {
+            "schema_version",
+            "system",
+            "idx",
+            "query_fingerprint",
+            "num_papers",
+            "files",
+        }
+        assert manifest["idx"] == 7
+        assert manifest["num_papers"] == 3
+        for name, checksum in manifest["files"].items():
+            assert checksum == hashlib.sha256((folder / name).read_bytes()).hexdigest()
+
+    def test_summary_and_generation_manifest_are_written(self, tmp_path):
+        self._export(tmp_path, self._prediction())
+        root = tmp_path / "export"
+
+        summary = json.loads((root / "summary.json").read_text(encoding="utf-8"))
+        generation = json.loads((root / "generation_manifest.json").read_text(encoding="utf-8"))
+
+        assert summary == [
+            {"idx": 7, "arxiv_id": "2506.00007", "status": "success", "num_papers": 3}
+        ]
+        assert generation["system"] == "single_agent_1"
+        assert [item["idx"] for item in generation["queries"]] == [7]
+
+    def test_an_answer_citing_nothing_retrieved_is_recorded_not_written(self, tmp_path):
+        answer = "Body [1].\n\nReferences\n[1] Someone. Never Retrieved. arXiv:2999.99999\n"
+
+        summary = self._export(tmp_path, self._prediction(answer=answer))
+
+        assert summary["exported_count"] == 0
+        assert summary["skipped"][0]["status"] == "no_eligible_source"
+        assert not (tmp_path / "export" / "7").exists()
+
+    def test_an_answer_whose_only_url_is_bare_prose_is_not_exported(self, tmp_path):
+        # The parser reads markdown links only, so this answer would yield no
+        # documents; writing a folder for it would manufacture a scoreable query.
+        answer = "See https://arxiv.org/abs/2401.00001 for details."
+
+        summary = self._export(tmp_path, self._prediction(answer=answer))
+
+        assert summary["exported_count"] == 0
+        assert summary["skipped"][0]["status"] == "no_eligible_source"
+
+    def test_predictions_without_an_answer_are_recorded_as_no_answer(self, tmp_path):
+        summary = self._export(tmp_path, self._prediction(answer="   "))
+
+        assert summary["skipped"][0]["status"] == "no_answer"
+
+    @pytest.mark.parametrize("native_id", [None, "abc", ""])
+    def test_a_prediction_without_a_positional_id_fails_loudly(self, native_id):
+        # doc_id is a within-run counter, so falling back to it would score one
+        # paper's answer against another paper's ground truth.
+        prediction = {"doc_id": 3}
+        if native_id is not None:
+            prediction["native_id"] = native_id
+
+        with pytest.raises(ValueError, match="positional native_id"):
+            query_id(prediction)
+
+    @staticmethod
+    def _rows(path):
+        with path.open(newline="", encoding="utf-8") as stream:
+            return list(csv.DictReader(stream))
+
+
+class TestPaperRows:
+    SOURCE = {
+        "arxiv_id": "2401.00001",
+        "title": "Truncated Title",
+        "abstract": "A truncated preview...",
+        "published_date": "2024-01-01",
+        "date_precision": "month",
+    }
+
+    def test_snippet_is_the_full_refetched_abstract(self):
+        full = "A full abstract. " * 60
+        fetched = {"2401.00001": {"title": "Full Title", "abstract": full}}
+
+        (row,) = build_paper_rows([self.SOURCE], fetched)
+
+        assert row["snippet"] == full.strip()
+        assert len(row["snippet"]) > 500
+        assert row["title"] == "Full Title"
+        assert row["snippet_source"] == "s2_batch"
+
+    def test_a_failed_lookup_falls_back_to_the_preview_and_says_so(self):
+        (row,) = build_paper_rows([self.SOURCE], {})
+
+        assert row["snippet"] == "A truncated preview..."
+        assert row["snippet_source"] == "tool_output"
+
+    def test_a_refetched_publication_date_wins(self):
+        fetched = {
+            "2401.00001": {
+                "title": "T",
+                "abstract": "A",
+                "published_date": "2024-01-22",
+            }
+        }
+
+        (row,) = build_paper_rows([self.SOURCE], fetched)
+
+        assert row["published_date"] == "2024-01-22"
+        assert row["date_precision"] == "day"
+
+    def test_undatable_sources_are_dropped(self):
+        rows = build_paper_rows([dict(self.SOURCE, arxiv_id="not-an-id", published_date="")], {})
+
+        assert rows == []
+
+    @pytest.mark.parametrize("field", ["title", "abstract"])
+    def test_sources_without_a_title_or_snippet_are_dropped(self, field):
+        # These rows fail the contract's own validation, so shipping them turns
+        # a scoreable query into a rejected one.
+        assert build_paper_rows([dict(self.SOURCE, **{field: "  "})], {}) == []
 
     def test_sources_without_a_published_line_fall_back_to_the_id_month(self):
-        # Predictions saved before the tool rendered a Published line.
-        (row,) = build_paper_rows([{"arxiv_id": "2401.00001", "title": "Legacy", "abstract": "a"}])
+        source = {"arxiv_id": "2401.00001", "title": "T", "abstract": "A"}
+
+        (row,) = build_paper_rows([source], {})
 
         assert row["published_date"] == "2024-01-01"
         assert row["date_precision"] == "month"
-
-    def test_a_parsed_day_is_written_unchanged(self):
-        (row,) = build_paper_rows(
-            [
-                {
-                    "arxiv_id": "2401.00001",
-                    "title": "Dated",
-                    "abstract": "a",
-                    "published_date": "2024-01-15",
-                    "date_precision": "day",
-                }
-            ]
-        )
-
-        assert row["published_date"] == "2024-01-15"
-        assert row["date_precision"] == "day"

--- a/tests/evals/tasks/test_deepscholar_bench.py
+++ b/tests/evals/tasks/test_deepscholar_bench.py
@@ -1,0 +1,304 @@
+"""Tests for the DeepScholar-Bench task and its export adapter.
+
+The prompt is pinned against a golden copy of lit-agents'
+``shared/deepscholar.py::QUERY_TEMPLATE``: the whole point of this task is to be
+comparable with the systems prompted that way, and a reworded prompt would
+break that silently rather than loudly.
+"""
+
+import csv
+import json
+
+import pytest
+
+from olmo_eval.common.types import Instance, LMOutput, LMRequest, RequestType, Response
+from olmo_eval.common.types.tools import Function, ToolCall, ToolResult
+from olmo_eval.common.types.trajectory import AgentTrajectory, AgentTurn
+from olmo_eval.evals.tasks.common import get_task, list_tasks
+from olmo_eval.evals.tasks.deepscholar_bench import (
+    DEEPSCHOLAR_COMMIT,
+    DEEPSCHOLAR_QUERY_TEMPLATE,
+    SEARCH_TOOL_NAME,
+    parse_arxiv_tool_results,
+    sources_from_trajectory,
+)
+from olmo_eval.evals.tasks.deepscholar_export import (
+    PAPER_CSV_FIELDS,
+    build_paper_rows,
+    export_predictions,
+)
+from olmo_eval.harness.tools.search import _format_arxiv_result
+
+# Golden copy of lit-agents' shared/deepscholar.py::QUERY_TEMPLATE.
+GOLDEN_QUERY_TEMPLATE = """Your task is to write a Related Works section for an academic paper given the paper's abstract. Your response should provide the Related Works section and references. Only include references from arXiv that are published before {cutoff_date}. Mention them in a separate, numbered reference list at the end and use the reference numbers to provide in-line citations in the Related Works section for all claims referring to a source (e.g., description of source [3]. Further details [6][7][8][9][10].) Each in-line citation must consist of a single reference number within a pair of brackets. Do not use any other citation format. Do not exceed 600 words for the related works section. Here is the paper abstract: {abstract}"""
+
+CSV_ROW = {
+    "arxiv_id": "2506.02838v1",
+    "title": "TaxAgent: How Large Language Model Designs Fiscal Policy",
+    "abstract": "  Economic inequality is a global challenge.  ",
+    "published_date": "2025-06-03T13:06:19+00:00",
+}
+
+
+@pytest.fixture(autouse=True)
+def _setup_registry():
+    import olmo_eval.evals.tasks  # noqa: F401
+
+
+@pytest.fixture
+def task():
+    return get_task("deepscholar_bench")
+
+
+def _tool_output(*papers: dict) -> str:
+    """Render results the way the search tool does, so the parser is tested
+    against the real formatter rather than a hand-written imitation."""
+    return "\n\n---\n\n".join(
+        _format_arxiv_result(paper, paper.get("externalIds", {}).get("ArXiv", ""))
+        for paper in papers
+    )
+
+
+def _paper(title: str, arxiv_id: str, *, abstract: str = "An abstract.") -> dict:
+    return {
+        "title": title,
+        "abstract": abstract,
+        "year": 2024,
+        "authors": [{"name": "A. Author"}],
+        "externalIds": {"ArXiv": arxiv_id},
+    }
+
+
+def _trajectory(*result_contents: str) -> AgentTrajectory:
+    turns = []
+    for index, content in enumerate(result_contents):
+        call = ToolCall(
+            id=f"c{index}",
+            function=Function(name=SEARCH_TOOL_NAME, arguments='{"query": "q"}'),
+        )
+        turns.append(AgentTurn.assistant(tool_calls=[call]))
+        turns.append(
+            AgentTurn.tool(results=[ToolResult(tool_call_id=f"c{index}", content=content)])
+        )
+    return AgentTrajectory(turns=tuple(turns))
+
+
+class TestRegistration:
+    def test_registered(self):
+        assert "deepscholar_bench" in list_tasks()
+
+    def test_metrics(self, task):
+        assert {m.name for m in task.config.metrics} == {
+            "exportable_rate",
+            "arxiv_citation_rate",
+        }
+        assert task.config.get_primary_metric().name == "exportable_rate"
+
+    def test_dataset_is_pinned_to_a_commit(self):
+        from olmo_eval.evals.tasks.deepscholar_bench import DEEPSCHOLAR_DATASET_URL
+
+        assert DEEPSCHOLAR_COMMIT in DEEPSCHOLAR_DATASET_URL
+        assert DEEPSCHOLAR_DATASET_URL.endswith("dataset/papers_with_related_works.csv")
+
+
+class TestPrompt:
+    def test_template_is_verbatim(self):
+        assert DEEPSCHOLAR_QUERY_TEMPLATE == GOLDEN_QUERY_TEMPLATE
+
+    def test_request_interpolates_the_cutoff_and_abstract(self, task):
+        instance = task.process_doc(dict(CSV_ROW), index=7)
+        request = task.format_request(instance)
+
+        assert request.request_type is RequestType.CHAT
+        assert request.messages[0]["content"] == GOLDEN_QUERY_TEMPLATE.format(
+            cutoff_date="2025-06-03",
+            abstract="Economic inequality is a global challenge.",
+        )
+
+
+class TestProcessDoc:
+    def test_carries_the_cutoff_to_the_search_tools(self, task):
+        instance = task.process_doc(dict(CSV_ROW), index=7)
+
+        assert instance.metadata["retrieval_date_cutoff"] == "2025-06-03"
+        assert instance.metadata["cutoff_date"] == "2025-06-03"
+
+    def test_keeps_the_upstream_positional_id(self, task):
+        instance = task.process_doc(dict(CSV_ROW), index=7)
+
+        assert instance.metadata["id"] == "7"
+        assert instance.metadata["arxiv_id"] == "2506.02838"
+
+    @pytest.mark.parametrize("field", ["abstract", "published_date"])
+    def test_rows_missing_a_required_field_are_dropped(self, task, field):
+        row = dict(CSV_ROW)
+        row[field] = ""
+
+        assert task.process_doc(row, index=0) is None
+
+    def test_unparseable_cutoff_is_dropped(self, task):
+        row = dict(CSV_ROW, published_date="not a date")
+
+        assert task.process_doc(row, index=0) is None
+
+
+class TestResultParsing:
+    def test_round_trips_the_tools_rendering(self):
+        content = _tool_output(_paper("First", "2401.00001"), _paper("Second", "2401.00002"))
+
+        parsed = parse_arxiv_tool_results(content)
+
+        assert [item["arxiv_id"] for item in parsed] == ["2401.00001", "2401.00002"]
+        assert parsed[0]["title"] == "First"
+        assert parsed[0]["abstract"] == "An abstract."
+        assert parsed[0]["url"] == "https://arxiv.org/abs/2401.00001"
+
+    def test_multiline_abstracts_survive(self):
+        content = _tool_output(_paper("Wrapped", "2401.00003", abstract="Line one.\nLine two."))
+
+        assert parse_arxiv_tool_results(content)[0]["abstract"] == "Line one.\nLine two."
+
+    def test_context_only_results_are_skipped(self):
+        content = _format_arxiv_result({"title": "Journal", "abstract": "x"}, "")
+
+        assert parse_arxiv_tool_results(content) == []
+
+    def test_trajectory_sources_are_deduplicated_first_mention_winning(self):
+        trajectory = _trajectory(
+            _tool_output(_paper("First", "2401.00001")),
+            _tool_output(_paper("First again", "2401.00001"), _paper("Second", "2401.00002")),
+        )
+
+        sources = sources_from_trajectory(trajectory)
+
+        assert [item["arxiv_id"] for item in sources] == ["2401.00001", "2401.00002"]
+        assert sources[0]["title"] == "First"
+
+    def test_no_trajectory_yields_no_sources(self):
+        assert sources_from_trajectory(None) == []
+
+
+class TestScoring:
+    def _response(self, answer: str, trajectory: AgentTrajectory | None) -> Response:
+        return Response(
+            instance=Instance(question="abstract", metadata={"id": "0"}),
+            request=LMRequest(request_type=RequestType.CHAT, messages=()),
+            outputs=[LMOutput(text=answer)],
+            scores={},
+            trajectory=trajectory,
+        )
+
+    @pytest.mark.anyio
+    async def test_exportable_response_scores_one(self, task):
+        response = self._response(
+            "Related work [Paper](https://arxiv.org/abs/2401.00001).",
+            _trajectory(_tool_output(_paper("First", "2401.00001"))),
+        )
+
+        (scored,) = await task.score_responses([response])
+
+        assert scored.scores["exportable_rate"] == 1.0
+        assert scored.scores["arxiv_citation_rate"] == 1.0
+        assert scored.outputs[0].metadata["deepscholar_num_searches"] == 1
+
+    @pytest.mark.anyio
+    async def test_response_without_a_trajectory_is_not_exportable(self, task):
+        (scored,) = await task.score_responses([self._response("Some text.", None)])
+
+        assert scored.scores["exportable_rate"] == 0.0
+        assert scored.scores["arxiv_citation_rate"] == 0.0
+
+
+class TestExportAdapter:
+    def _prediction(self, native_id: str = "7", answer: str = "Related work.") -> dict:
+        trajectory = _trajectory(
+            _tool_output(_paper("First", "2401.00001"), _paper("Second", "cs/0501001"))
+        )
+        return {
+            "doc_id": 0,
+            "native_id": native_id,
+            "final_output": answer,
+            "model_output": [{"text": answer}],
+            "trajectory": trajectory.to_dict(),
+        }
+
+    def _write(self, tmp_path, *predictions: dict):
+        path = tmp_path / "deepscholar_bench-predictions.jsonl"
+        path.write_text(
+            "".join(json.dumps(prediction) + "\n" for prediction in predictions),
+            encoding="utf-8",
+        )
+        return path
+
+    def test_writes_one_folder_per_query(self, tmp_path):
+        predictions = self._write(tmp_path, self._prediction())
+        output = tmp_path / "export"
+
+        summary = export_predictions(predictions, output)
+
+        assert summary["exported_ids"] == ["7"]
+        assert sorted(p.name for p in (output / "7").iterdir()) == [
+            "final_report.md",
+            "intro.md",
+            "paper.csv",
+        ]
+
+    def test_intro_and_final_report_are_the_answer(self, tmp_path):
+        predictions = self._write(tmp_path, self._prediction(answer="The section."))
+        output = tmp_path / "export"
+
+        export_predictions(predictions, output)
+
+        intro = (output / "7" / "intro.md").read_text(encoding="utf-8")
+        assert intro == "The section."
+        assert (output / "7" / "final_report.md").read_text(encoding="utf-8") == intro
+
+    def test_paper_csv_columns_and_rows(self, tmp_path):
+        predictions = self._write(tmp_path, self._prediction())
+        output = tmp_path / "export"
+
+        export_predictions(predictions, output)
+
+        with (output / "7" / "paper.csv").open(newline="", encoding="utf-8") as stream:
+            reader = csv.DictReader(stream)
+            assert reader.fieldnames == list(PAPER_CSV_FIELDS)
+            rows = list(reader)
+
+        assert [row["id"] for row in rows] == ["2401.00001", "cs/0501001"]
+        assert rows[0]["title"] == "First"
+        assert rows[0]["snippet"] == "An abstract."
+        # The rendered tool output carries a month, not a day.
+        assert rows[0]["published_date"] == "2024-01-01"
+        assert rows[0]["date_precision"] == "month"
+        assert rows[0]["paper_id"] == "2401.00001"
+        assert rows[1]["published_date"] == "2005-01-01"
+
+    def test_predictions_without_sources_are_skipped(self, tmp_path):
+        prediction = self._prediction()
+        prediction["trajectory"] = AgentTrajectory().to_dict()
+        predictions = self._write(tmp_path, prediction)
+        output = tmp_path / "export"
+
+        summary = export_predictions(predictions, output)
+
+        assert summary["exported_count"] == 0
+        assert summary["skipped"] == [{"idx": "7", "reason": "no arXiv sources in trajectory"}]
+        assert not (output / "7").exists()
+
+    def test_predictions_without_an_answer_are_skipped(self, tmp_path):
+        prediction = self._prediction(answer="   ")
+        predictions = self._write(tmp_path, prediction)
+
+        summary = export_predictions(predictions, tmp_path / "export")
+
+        assert summary["skipped"] == [{"idx": "7", "reason": "no answer text"}]
+
+    def test_undatable_sources_are_dropped(self):
+        rows = build_paper_rows(
+            [
+                {"arxiv_id": "2401.00001", "title": "Datable", "abstract": "a"},
+                {"arxiv_id": "not-an-id", "title": "Undatable", "abstract": "b"},
+            ]
+        )
+
+        assert [row["id"] for row in rows] == ["2401.00001"]

--- a/tests/evals/tasks/test_deepscholar_bench.py
+++ b/tests/evals/tasks/test_deepscholar_bench.py
@@ -152,6 +152,7 @@ class TestRegistration:
             "citation_resolution_rate",
             "unresolved_citation_forms",
             "marker_compliance_rate",
+            "marker_misuse_rate",
         }
         assert task.config.get_primary_metric().name == "exportable_rate"
 
@@ -500,6 +501,7 @@ class TestExportAdapter:
                 # Every row carries the flag, so the compliance rate stays
                 # recomputable from the export on disk.
                 "marker_found": False,
+                "marker_misused": False,
             }
         ]
         assert generation["system"] == "single_agent_1"
@@ -996,3 +998,148 @@ class TestFinalReportMarkerExport:
         assert "deliberate" in prompt
         assert "exactly" in prompt
         assert "discarded" in prompt
+
+
+class TestMarkerMisuseFuse:
+    """A marker honoured but misplaced must not cost the query its export.
+
+    Qwen3.5-9B wrote its Related Works section above the line and only the
+    numbered list below it. On the first smoke that took query idx=1 from
+    exportable to unscoreable, which is an instrument regression rather than a
+    model one, so the export now falls back to the full text and records why.
+    """
+
+    def _prediction(self, answer: str, native_id: str = "7") -> dict:
+        trajectory = _trajectory(
+            _tool_output(
+                _paper("First Retrieval System", "2401.00001", published="2024-01-15"),
+                _paper("Scaling The Index", "2401.00002"),
+                _paper("Grounding Each Claim", "cs/0501001"),
+            )
+        )
+        return {
+            "doc_id": 0,
+            "native_id": native_id,
+            "final_output": answer,
+            "model_output": [{"text": answer}],
+            "trajectory": trajectory.to_dict(),
+        }
+
+    def _export(self, tmp_path, answer: str, name: str = "export"):
+        path = tmp_path / (name + "-predictions.jsonl")
+        path.write_text(json.dumps(self._prediction(answer)) + "\n", encoding="utf-8")
+        summary = export_predictions(
+            path,
+            tmp_path / name,
+            dataset_path=_dataset_csv(tmp_path, 7),
+            fetch_abstracts=False,
+        )
+        return summary, tmp_path / name
+
+    # The 9B shape: report above the marker, bare numbered list below it.
+    def _misused(self) -> str:
+        return (
+            NUMBERED_ANSWER
+            + "\n=== FINAL REPORT ===\n\n"
+            + "1. A. Author. First Retrieval System. arXiv:2401.00001\n"
+            + "2. B. Author. Scaling The Index. arXiv:2401.00002\n"
+        )
+
+    def test_a_misplaced_report_still_exports(self, tmp_path):
+        summary, root = self._export(tmp_path, self._misused())
+
+        assert summary["exported_ids"] == [7]
+        intro = (root / "7" / "intro.md").read_text(encoding="utf-8")
+        assert "[First Retrieval System](https://arxiv.org/abs/2401.00001)" in intro
+
+    def test_the_misuse_is_counted_without_costing_compliance(self, tmp_path):
+        summary, root = self._export(tmp_path, self._misused())
+
+        # The instruction WAS followed -- the marker is there.
+        assert summary["marker_compliance_rate"] == 1.0
+        # And it was followed wrongly, which is a different fact.
+        assert summary["marker_misuse_rate"] == 1.0
+        assert summary["markers_misused"] == 1
+        row = json.loads((root / "summary.json").read_text(encoding="utf-8"))[0]
+        assert row["marker_found"] is True
+        assert row["marker_misused"] is True
+
+    def test_the_fuse_matches_the_no_marker_export_byte_for_byte(self, tmp_path):
+        # "Falls back to the full text" has to mean exactly the marker-absent
+        # path, or the fuse is its own third behaviour.
+        fused, fused_root = self._export(tmp_path, self._misused(), name="fused")
+        plain, plain_root = self._export(tmp_path, NUMBERED_ANSWER, name="plain")
+
+        assert fused["exported_ids"] == plain["exported_ids"] == [7]
+        assert (fused_root / "7" / "paper.csv").read_text(encoding="utf-8") == (
+            plain_root / "7" / "paper.csv"
+        ).read_text(encoding="utf-8")
+
+    def test_a_well_placed_report_is_not_misuse(self, tmp_path):
+        answer = "Planning first.\n\n=== FINAL REPORT ===\n\n" + NUMBERED_ANSWER
+
+        summary, _ = self._export(tmp_path, answer)
+
+        assert summary["marker_compliance_rate"] == 1.0
+        assert summary["marker_misuse_rate"] == 0.0
+        assert summary["exported_ids"] == [7]
+
+    def test_splitting_never_exports_less_than_not_splitting(self, tmp_path):
+        # The gate the researcher set, as a unit test.
+        for index, answer in enumerate(
+            (
+                "Planning.\n\n=== FINAL REPORT ===\n\n" + NUMBERED_ANSWER,
+                self._misused(),
+                NUMBERED_ANSWER,
+            )
+        ):
+            split, _ = self._export(tmp_path, answer, name=f"split-{index}")
+            stripped, _ = self._export(
+                tmp_path,
+                answer.replace("=== FINAL REPORT ===", ""),
+                name=f"nosplit-{index}",
+            )
+
+            assert split["exported_count"] >= stripped["exported_count"], answer
+
+
+class TestHardenedContractWording:
+    """The prompt has to say where the prose goes, not only where it ends up."""
+
+    def _prompt(self) -> str:
+        from olmo_eval.harness.presets import get_harness_preset
+
+        prompt = get_harness_preset("arxiv_paper_search_agent").system_prompt
+        assert prompt is not None
+        return prompt
+
+    def _flat(self) -> str:
+        """The prompt as one lowercase line; it wraps, the sentences do not."""
+        return " ".join(self._prompt().lower().split())
+
+    def test_the_three_original_elements_survive(self):
+        prompt = self._prompt().lower()
+
+        assert "deliberate" in prompt
+        assert "exactly" in prompt
+        assert "discarded" in prompt
+
+    def test_it_forbids_writing_the_section_above_the_line(self):
+        # The exact ambiguity 9B took the other way.
+        prompt = self._flat()
+
+        assert "do not write any part of the related works section before the marker" in prompt
+
+    def test_it_puts_the_whole_report_after_the_marker(self):
+        prompt = self._flat()
+
+        assert "entire report goes after that line" in prompt
+        assert "reference list" in prompt
+
+    def test_the_marker_still_round_trips_through_the_splitter(self):
+        mandated = [line for line in self._prompt().splitlines() if line.strip().startswith("===")]
+
+        assert mandated == [FINAL_REPORT_MARKER]
+        body, found = split_final_report("Planning.\n" + mandated[0] + "\nThe report.\n")
+        assert found is True
+        assert body == "The report.\n"

--- a/tests/evals/tasks/test_deepscholar_bench.py
+++ b/tests/evals/tasks/test_deepscholar_bench.py
@@ -27,6 +27,10 @@ from olmo_eval.evals.tasks.deepscholar_bench import (
     parse_arxiv_tool_results,
     sources_from_trajectory,
 )
+from olmo_eval.evals.tasks.deepscholar_citations import (
+    FINAL_REPORT_MARKER,
+    split_final_report,
+)
 from olmo_eval.evals.tasks.deepscholar_export import (
     PAPER_CSV_FIELDS,
     build_paper_rows,
@@ -147,6 +151,7 @@ class TestRegistration:
             "exportable_rate",
             "citation_resolution_rate",
             "unresolved_citation_forms",
+            "marker_compliance_rate",
         }
         assert task.config.get_primary_metric().name == "exportable_rate"
 
@@ -487,7 +492,15 @@ class TestExportAdapter:
         generation = json.loads((root / "generation_manifest.json").read_text(encoding="utf-8"))
 
         assert summary == [
-            {"idx": 7, "arxiv_id": "2506.00007", "status": "success", "num_papers": 3}
+            {
+                "idx": 7,
+                "arxiv_id": "2506.00007",
+                "status": "success",
+                "num_papers": 3,
+                # Every row carries the flag, so the compliance rate stays
+                # recomputable from the export on disk.
+                "marker_found": False,
+            }
         ]
         assert generation["system"] == "single_agent_1"
         assert [item["idx"] for item in generation["queries"]] == [7]
@@ -799,3 +812,187 @@ class TestExportRefusals:
 
         assert not (output / "99").exists()
         assert (output / "summary.json").is_file()
+
+
+class TestFinalReportMarkerExport:
+    """The delimiter contract as the export applies it.
+
+    The 9B run put a median 9.8k characters of planning above its Related Works
+    heading and the scorer read all of it as the report. The preset's system
+    prompt now asks for a marker line instead of banning the planning; these pin
+    what the export does with an answer that honours it and with one that does
+    not.
+    """
+
+    DELIBERATION = "First I will search for retrieval papers, then for scaling.\n"
+
+    def _prediction(self, answer: str, native_id: str = "7") -> dict:
+        trajectory = _trajectory(
+            _tool_output(
+                _paper("First Retrieval System", "2401.00001", published="2024-01-15"),
+                _paper("Scaling The Index", "2401.00002"),
+                _paper("Grounding Each Claim", "cs/0501001"),
+            )
+        )
+        return {
+            "doc_id": 0,
+            "native_id": native_id,
+            "final_output": answer,
+            "model_output": [{"text": answer}],
+            "trajectory": trajectory.to_dict(),
+        }
+
+    def _export(self, tmp_path, answer: str, name: str = "export"):
+        path = tmp_path / (name + "-predictions.jsonl")
+        path.write_text(json.dumps(self._prediction(answer)) + "\n", encoding="utf-8")
+        summary = export_predictions(
+            path,
+            tmp_path / name,
+            dataset_path=_dataset_csv(tmp_path, 7),
+            fetch_abstracts=False,
+        )
+        return summary, tmp_path / name
+
+    def _summary_rows(self, root):
+        return json.loads((root / "summary.json").read_text(encoding="utf-8"))
+
+    def test_the_marker_splits_the_deliberation_out_of_intro_md(self, tmp_path):
+        answer = self.DELIBERATION + "\n" + FINAL_REPORT_MARKER + "\n\n" + NUMBERED_ANSWER
+
+        summary, root = self._export(tmp_path, answer)
+
+        assert summary["exported_ids"] == [7]
+        intro = (root / "7" / "intro.md").read_text(encoding="utf-8")
+        assert "First I will search" not in intro
+        # No residue of the delimiter itself in the scored bytes.
+        assert "FINAL REPORT" not in intro
+        assert "===" not in intro
+        # And the bridge still ran on what was kept.
+        assert "[First Retrieval System](https://arxiv.org/abs/2401.00001)" in intro
+
+    def test_a_compliant_answer_scores_its_marker_compliance(self, tmp_path):
+        answer = self.DELIBERATION + "\n" + FINAL_REPORT_MARKER + "\n\n" + NUMBERED_ANSWER
+
+        summary, root = self._export(tmp_path, answer)
+
+        assert summary["marker_compliance_rate"] == 1.0
+        assert summary["markers_found"] == 1
+        assert summary["answers_with_text"] == 1
+        assert self._summary_rows(root)[0]["marker_found"] is True
+
+    def test_an_answer_without_the_marker_is_kept_whole_and_counted(self, tmp_path):
+        # The fallback must not cost the answer its export -- only its place in
+        # the compliance rate.
+        answer = self.DELIBERATION + NUMBERED_ANSWER
+
+        summary, root = self._export(tmp_path, answer)
+
+        assert summary["exported_ids"] == [7]
+        assert summary["marker_compliance_rate"] == 0.0
+        assert summary["markers_found"] == 0
+        assert self._summary_rows(root)[0]["marker_found"] is False
+        assert "First I will search" in (root / "7" / "intro.md").read_text(encoding="utf-8")
+
+    def test_the_last_marker_wins_in_the_export(self, tmp_path):
+        answer = (
+            FINAL_REPORT_MARKER
+            + "\n## Related Works\n\nAn abandoned draft citing nothing.\n\n"
+            + FINAL_REPORT_MARKER
+            + "\n"
+            + NUMBERED_ANSWER
+        )
+
+        summary, root = self._export(tmp_path, answer)
+
+        intro = (root / "7" / "intro.md").read_text(encoding="utf-8")
+        assert summary["marker_compliance_rate"] == 1.0
+        assert "abandoned draft" not in intro
+        assert "[First Retrieval System](https://arxiv.org/abs/2401.00001)" in intro
+
+    def test_the_sentinel_in_prose_does_not_split_the_export(self, tmp_path):
+        answer = "I will write " + FINAL_REPORT_MARKER + " when ready.\n\n" + NUMBERED_ANSWER
+
+        summary, root = self._export(tmp_path, answer)
+
+        assert summary["marker_compliance_rate"] == 0.0
+        assert "I will write" in (root / "7" / "intro.md").read_text(encoding="utf-8")
+
+    def test_a_marker_with_nothing_above_it_changes_nothing(self, tmp_path):
+        with_marker, marked_root = self._export(
+            tmp_path, FINAL_REPORT_MARKER + "\n" + NUMBERED_ANSWER, name="marked"
+        )
+        without, plain_root = self._export(tmp_path, NUMBERED_ANSWER, name="plain")
+
+        assert with_marker["exported_ids"] == without["exported_ids"] == [7]
+        assert (marked_root / "7" / "intro.md").read_text(encoding="utf-8") == (
+            plain_root / "7" / "intro.md"
+        ).read_text(encoding="utf-8")
+        # Same bytes, different bookkeeping: one followed the instruction.
+        assert with_marker["marker_compliance_rate"] == 1.0
+        assert without["marker_compliance_rate"] == 0.0
+
+    def test_a_reference_list_with_no_prose_is_unscoreable_but_still_flagged(self, tmp_path):
+        # Nothing cites anything once the reference tail is stripped, so there is
+        # no document for the upstream parser to find. That is a real result, not
+        # a marker failure, and the two must stay distinguishable.
+        answer = (
+            self.DELIBERATION
+            + "\n"
+            + FINAL_REPORT_MARKER
+            + "\n\n## References\n\n[1] A. Author. First Retrieval System. arXiv:2401.00001\n"
+        )
+
+        summary, root = self._export(tmp_path, answer)
+
+        assert summary["exported_ids"] == []
+        (row,) = self._summary_rows(root)
+        assert row["status"] == "no_eligible_source"
+        assert row["marker_found"] is True
+        assert summary["marker_compliance_rate"] == 1.0
+
+    def test_a_marker_followed_by_nothing_is_named_for_what_it_is(self, tmp_path):
+        # An empty tail is compliance without a deliverable; reporting it as "the
+        # run produced no answer text" would blame the wrong thing.
+        summary, root = self._export(tmp_path, self.DELIBERATION + FINAL_REPORT_MARKER + "\n")
+
+        (row,) = self._summary_rows(root)
+        assert row["status"] == "no_answer"
+        assert "marker was followed by no text" in row["reason"]
+        assert row["marker_found"] is True
+
+    def test_an_empty_answer_stays_out_of_the_compliance_denominator(self, tmp_path):
+        # A query that generated nothing can neither honour the contract nor
+        # break it; counting it as non-compliant would blame the prompt.
+        summary, root = self._export(tmp_path, "")
+
+        assert summary["answers_with_text"] == 0
+        assert summary["marker_compliance_rate"] == 0.0
+        assert self._summary_rows(root)[0]["reason"] == "the run produced no answer text"
+
+    def test_the_preset_prompt_and_the_export_agree_on_the_marker(self):
+        # The contract lives in two places -- the sentence the model reads and
+        # the regex the export applies -- and a silent drift between them would
+        # discard every report. So the marker is read back out of the prompt and
+        # run through the splitter.
+        from olmo_eval.harness.presets import get_harness_preset
+
+        prompt = get_harness_preset("arxiv_paper_search_agent").system_prompt
+        assert prompt is not None
+        mandated = [line for line in prompt.splitlines() if line.strip().startswith("===")]
+
+        assert mandated == [FINAL_REPORT_MARKER]
+        body, found = split_final_report("Planning.\n" + mandated[0] + "\nThe report.\n")
+        assert found is True
+        assert body == "The report.\n"
+
+    def test_the_preset_prompt_still_states_the_whole_contract(self):
+        # Three parts, all load-bearing: deliberation is allowed, the marker is
+        # exact, and what comes before it is thrown away. Dropping any one of
+        # them changes what the model does.
+        from olmo_eval.harness.presets import get_harness_preset
+
+        prompt = (get_harness_preset("arxiv_paper_search_agent").system_prompt or "").lower()
+
+        assert "deliberate" in prompt
+        assert "exactly" in prompt
+        assert "discarded" in prompt

--- a/tests/evals/tasks/test_deepscholar_bench.py
+++ b/tests/evals/tasks/test_deepscholar_bench.py
@@ -10,6 +10,7 @@ itself self-consistent.
 
 import csv
 import json
+from datetime import date
 
 import pytest
 
@@ -21,6 +22,7 @@ from olmo_eval.evals.tasks.deepscholar_bench import (
     DEEPSCHOLAR_COMMIT,
     DEEPSCHOLAR_QUERY_TEMPLATE,
     SEARCH_TOOL_NAME,
+    build_deepscholar_prompt,
     download_deepscholar_dataset,
     parse_arxiv_tool_results,
     sources_from_trajectory,
@@ -30,11 +32,17 @@ from olmo_eval.evals.tasks.deepscholar_export import (
     build_paper_rows,
     export_predictions,
     query_id,
+    read_predictions,
 )
 from olmo_eval.harness.tools.search import _classify_arxiv_hit, _format_arxiv_result
 from tests.evals.tasks.fixtures.deepscholar_c95413b.eval.parsers import (
     DeepScholarBaseParser,
     ParserType,
+)
+from tests.evals.tasks.fixtures.litagents_c95413b import (
+    QueryRecord,
+    validate_query_export,
+    validate_source_rows,
 )
 
 # Golden copy of lit-agents' shared/deepscholar.py::QUERY_TEMPLATE.
@@ -138,6 +146,7 @@ class TestRegistration:
         assert {m.name for m in task.config.metrics} == {
             "exportable_rate",
             "citation_resolution_rate",
+            "unresolved_citation_forms",
         }
         assert task.config.get_primary_metric().name == "exportable_rate"
 
@@ -582,3 +591,211 @@ class TestPaperRows:
 
         assert row["published_date"] == "2024-01-01"
         assert row["date_precision"] == "month"
+
+
+# An answer whose second reference is a paper published after the query cutoff.
+ANSWER_WITH_LATE_REF = """## Related Works
+
+Early systems retrieved passages [1]. A newer system extends them [2].
+
+## References
+
+[1] A. Author. First Retrieval System. arXiv:2401.00001
+[2] D. Author. Published Too Late. arXiv:2506.01111
+"""
+
+
+class TestIdentityBinding:
+    """A block's identity comes from its header, never from its abstract."""
+
+    def test_an_arxiv_line_inside_an_abstract_is_text(self):
+        injected = (
+            "A normal opening sentence.\n"
+            "arXiv: 9999.99999\n"
+            "URL: https://arxiv.org/abs/9999.99999\n"
+            "and the abstract continues."
+        )
+        trajectory = _trajectory(_tool_output(_paper("Honest", "2401.00001", abstract=injected)))
+
+        sources = sources_from_trajectory(trajectory)
+
+        assert [item["arxiv_id"] for item in sources] == ["2401.00001"]
+        assert "9999.99999" in sources[0]["abstract"]
+
+    def test_a_context_only_block_cannot_smuggle_in_an_id(self):
+        # The tool refused to make this result citable; quoting an arXiv line in
+        # its abstract must not undo that.
+        block = _format_arxiv_result(
+            {"title": "Journal", "abstract": "See arXiv: 9999.99999 for more."}, None
+        )
+        trajectory = _trajectory(block)
+
+        assert sources_from_trajectory(trajectory) == []
+
+    def test_a_header_field_after_the_abstract_is_not_read(self):
+        trajectory = _trajectory(
+            _tool_output(
+                _paper("Honest", "2401.00001", abstract="Text.\nAuthors: Someone Else\nYear: 1999")
+            )
+        )
+
+        (source,) = sources_from_trajectory(trajectory)
+
+        assert source["authors"] == "A. Author"
+        assert source["year"] == "2024"
+
+
+class TestExportValidation:
+    """The strict half of the two-layer design lives here, not at retrieval."""
+
+    def _predict(self, tmp_path, answer, *papers):
+        trajectory = _trajectory(_tool_output(*papers))
+        prediction = {
+            "doc_id": 0,
+            "native_id": "7",
+            "final_output": answer,
+            "model_output": [{"text": answer}],
+            "trajectory": trajectory.to_dict(),
+        }
+        path = tmp_path / "deepscholar_bench-predictions.jsonl"
+        path.write_text(json.dumps(prediction) + "\n", encoding="utf-8")
+        return path
+
+    def _run(self, tmp_path, answer, *papers, **kwargs):
+        return export_predictions(
+            self._predict(tmp_path, answer, *papers),
+            tmp_path / "export",
+            dataset_path=_dataset_csv(tmp_path, 7),
+            fetch_abstracts=False,
+            **kwargs,
+        )
+
+    def test_a_post_cutoff_source_is_not_exported(self, tmp_path):
+        # Retrieval admitted it on its arXiv-ID month; the real date is after
+        # the query's cutoff, and only the export test catches that.
+        summary = self._run(
+            tmp_path,
+            ANSWER_WITH_LATE_REF,
+            _paper("First Retrieval System", "2401.00001"),
+            _paper("Published Too Late", "2506.01111", published="2025-07-01"),
+        )
+
+        rows = self._rows(tmp_path / "export" / "7" / "paper.csv")
+        assert summary["exported_ids"] == [7]
+        assert [row["id"] for row in rows] == ["2401.00001"]
+
+    def test_a_dropped_source_loses_its_citation_too(self, tmp_path):
+        # intro.md and paper.csv must never disagree: the contract checks that
+        # every cited ID has a row, and the parser would render an empty one.
+        self._run(
+            tmp_path,
+            ANSWER_WITH_LATE_REF,
+            _paper("First Retrieval System", "2401.00001"),
+            _paper("Published Too Late", "2506.01111", published="2025-07-01"),
+        )
+
+        intro = (tmp_path / "export" / "7" / "intro.md").read_text(encoding="utf-8")
+
+        assert "2506.01111" not in intro
+        assert "Published Too Late" not in intro
+        assert "2401.00001" in intro
+
+    def test_an_answer_whose_every_source_fails_is_recorded_not_written(self, tmp_path):
+        answer = "Only this [1].\n\n## References\n[1] D. Published Too Late. arXiv:2506.01111\n"
+
+        summary = self._run(
+            tmp_path, answer, _paper("Published Too Late", "2506.01111", published="2025-07-01")
+        )
+
+        assert summary["exported_count"] == 0
+        assert summary["skipped"][0]["status"] == "no_eligible_source"
+        assert not (tmp_path / "export" / "7").exists()
+
+    def test_the_reference_validators_accept_the_export(self, tmp_path):
+        # The export is written to satisfy these functions; testing it against
+        # our own reimplementation of them would prove nothing.
+        self._run(
+            tmp_path,
+            NUMBERED_ANSWER,
+            _paper("First Retrieval System", "2401.00001"),
+            _paper("Scaling The Index", "2401.00002"),
+            _paper("Grounding Each Claim", "2401.00003"),
+        )
+
+        record = QueryRecord(
+            query_id=7,
+            query=build_deepscholar_prompt(
+                "2025-06-03", "Economic inequality is a global challenge."
+            ),
+            cutoff_date=date(2025, 6, 3),
+            arxiv_id="2506.00007",
+            title=CSV_ROW["title"],
+            abstract="Economic inequality is a global challenge.",
+        )
+
+        manifest = validate_query_export(tmp_path / "export" / "7", record, "single_agent_1")
+
+        assert manifest["num_papers"] == 3
+
+    def test_the_reference_row_validator_accepts_paper_csv(self, tmp_path):
+        self._run(
+            tmp_path,
+            NUMBERED_ANSWER,
+            _paper("First Retrieval System", "2401.00001"),
+            _paper("Scaling The Index", "2401.00002"),
+            _paper("Grounding Each Claim", "2401.00003"),
+        )
+
+        rows = self._rows(tmp_path / "export" / "7" / "paper.csv")
+
+        # Raises DeepScholarContractError if any row fails.
+        validate_source_rows(rows, date(2025, 6, 3), 7)
+
+    @staticmethod
+    def _rows(path):
+        with path.open(newline="", encoding="utf-8") as stream:
+            return list(csv.DictReader(stream))
+
+
+class TestExportRefusals:
+    def _predictions(self, tmp_path, text):
+        path = tmp_path / "deepscholar_bench-predictions.jsonl"
+        path.write_text(text, encoding="utf-8")
+        return path
+
+    def test_an_unreadable_prediction_row_stops_the_export(self, tmp_path):
+        # Skipping it would shrink the export and the manifests built from it,
+        # so a truncated run would produce a folder that looks complete.
+        path = self._predictions(
+            tmp_path, json.dumps({"native_id": "7"}) + '\n{"native_id": "8", trunc\n'
+        )
+
+        with pytest.raises(ValueError, match="line\\(s\\) 2"):
+            read_predictions(path)
+
+    def test_blank_lines_are_not_unreadable(self, tmp_path):
+        path = self._predictions(tmp_path, json.dumps({"native_id": "7"}) + "\n\n")
+
+        assert len(read_predictions(path)) == 1
+
+    def test_a_non_empty_output_directory_is_refused(self, tmp_path):
+        # A stale numeric folder survives into the new run and breaks preflight
+        # with an error naming the run that is not at fault.
+        output = tmp_path / "export"
+        (output / "99").mkdir(parents=True)
+        path = self._predictions(tmp_path, "")
+
+        with pytest.raises(FileExistsError, match="already holds"):
+            export_predictions(path, output, dataset_path=_dataset_csv(tmp_path, 7))
+
+    def test_force_replaces_a_previous_run(self, tmp_path):
+        output = tmp_path / "export"
+        (output / "99").mkdir(parents=True)
+        path = self._predictions(tmp_path, "")
+
+        export_predictions(
+            path, output, dataset_path=_dataset_csv(tmp_path, 7), fetch_abstracts=False, force=True
+        )
+
+        assert not (output / "99").exists()
+        assert (output / "summary.json").is_file()

--- a/tests/evals/tasks/test_deepscholar_bench.py
+++ b/tests/evals/tasks/test_deepscholar_bench.py
@@ -153,6 +153,7 @@ class TestRegistration:
             "unresolved_citation_forms",
             "marker_compliance_rate",
             "marker_misuse_rate",
+            "split_coverage_rate",
         }
         assert task.config.get_primary_metric().name == "exportable_rate"
 
@@ -502,6 +503,7 @@ class TestExportAdapter:
                 # recomputable from the export on disk.
                 "marker_found": False,
                 "marker_misused": False,
+                "split_tier": "heading",
             }
         ]
         assert generation["system"] == "single_agent_1"
@@ -882,18 +884,19 @@ class TestFinalReportMarkerExport:
         assert summary["answers_with_text"] == 1
         assert self._summary_rows(root)[0]["marker_found"] is True
 
-    def test_an_answer_without_the_marker_is_kept_whole_and_counted(self, tmp_path):
-        # The fallback must not cost the answer its export -- only its place in
-        # the compliance rate.
+    def test_an_answer_without_the_marker_falls_through_to_the_heading(self, tmp_path):
+        # Non-compliance still costs the answer nothing, and since v3 it no
+        # longer costs it a clean intro either: the heading tier trims the
+        # deliberation the marker would have trimmed.
         answer = self.DELIBERATION + NUMBERED_ANSWER
 
         summary, root = self._export(tmp_path, answer)
 
         assert summary["exported_ids"] == [7]
         assert summary["marker_compliance_rate"] == 0.0
-        assert summary["markers_found"] == 0
         assert self._summary_rows(root)[0]["marker_found"] is False
-        assert "First I will search" in (root / "7" / "intro.md").read_text(encoding="utf-8")
+        assert self._summary_rows(root)[0]["split_tier"] == "heading"
+        assert "First I will search" not in (root / "7" / "intro.md").read_text(encoding="utf-8")
 
     def test_the_last_marker_wins_in_the_export(self, tmp_path):
         answer = (
@@ -911,13 +914,17 @@ class TestFinalReportMarkerExport:
         assert "abandoned draft" not in intro
         assert "[First Retrieval System](https://arxiv.org/abs/2401.00001)" in intro
 
-    def test_the_sentinel_in_prose_does_not_split_the_export(self, tmp_path):
+    def test_the_sentinel_in_prose_does_not_count_as_compliance(self, tmp_path):
+        # The sentinel tier still refuses a mid-sentence mention. The heading tier
+        # then does the trimming, which is a different tier reporting a different
+        # fact -- compliance stays 0.
         answer = "I will write " + FINAL_REPORT_MARKER + " when ready.\n\n" + NUMBERED_ANSWER
 
         summary, root = self._export(tmp_path, answer)
 
         assert summary["marker_compliance_rate"] == 0.0
-        assert "I will write" in (root / "7" / "intro.md").read_text(encoding="utf-8")
+        assert self._summary_rows(root)[0]["split_tier"] == "heading"
+        assert "I will write" not in (root / "7" / "intro.md").read_text(encoding="utf-8")
 
     def test_a_marker_with_nothing_above_it_changes_nothing(self, tmp_path):
         with_marker, marked_root = self._export(
@@ -1143,3 +1150,51 @@ class TestHardenedContractWording:
         body, found = split_final_report("Planning.\n" + mandated[0] + "\nThe report.\n")
         assert found is True
         assert body == "The report.\n"
+
+
+class TestSplitTierBookkeeping:
+    """The export reports which rule recovered each report."""
+
+    def _prediction(self, answer: str) -> dict:
+        trajectory = _trajectory(
+            _tool_output(
+                _paper("First Retrieval System", "2401.00001", published="2024-01-15"),
+                _paper("Scaling The Index", "2401.00002"),
+                _paper("Grounding Each Claim", "cs/0501001"),
+            )
+        )
+        return {
+            "doc_id": 0,
+            "native_id": "7",
+            "final_output": answer,
+            "model_output": [{"text": answer}],
+            "trajectory": trajectory.to_dict(),
+        }
+
+    def _export(self, tmp_path, answer: str, name: str = "export"):
+        path = tmp_path / (name + "-predictions.jsonl")
+        path.write_text(json.dumps(self._prediction(answer)) + "\n", encoding="utf-8")
+        summary = export_predictions(
+            path,
+            tmp_path / name,
+            dataset_path=_dataset_csv(tmp_path, 7),
+            fetch_abstracts=False,
+        )
+        return summary, tmp_path / name
+
+    def test_the_sentinel_tier_is_reported(self, tmp_path):
+        answer = "Planning.\n\n" + FINAL_REPORT_MARKER + "\n\n" + NUMBERED_ANSWER
+
+        summary, root = self._export(tmp_path, answer)
+
+        assert summary["split_tier_counts"]["sentinel"] == 1
+        assert summary["split_coverage_rate"] == 1.0
+        rows = json.loads((root / "summary.json").read_text(encoding="utf-8"))
+        assert rows[0]["split_tier"] == "sentinel"
+
+    def test_an_unrecoverable_answer_is_reported_as_none(self, tmp_path):
+        # No marker, no heading, no citation-bearing paragraph.
+        summary, _ = self._export(tmp_path, "I could not find anything useful.\n")
+
+        assert summary["split_tier_counts"]["none"] == 1
+        assert summary["split_coverage_rate"] == 0.0

--- a/tests/evals/tasks/test_deepscholar_bench.py
+++ b/tests/evals/tasks/test_deepscholar_bench.py
@@ -59,14 +59,23 @@ def _tool_output(*papers: dict) -> str:
     )
 
 
-def _paper(title: str, arxiv_id: str, *, abstract: str = "An abstract.") -> dict:
-    return {
+def _paper(
+    title: str,
+    arxiv_id: str,
+    *,
+    abstract: str = "An abstract.",
+    published: str | None = None,
+) -> dict:
+    paper = {
         "title": title,
         "abstract": abstract,
         "year": 2024,
         "authors": [{"name": "A. Author"}],
         "externalIds": {"ArXiv": arxiv_id},
     }
+    if published is not None:
+        paper["publicationDate"] = published
+    return paper
 
 
 def _trajectory(*result_contents: str) -> AgentTrajectory:
@@ -152,6 +161,17 @@ class TestResultParsing:
         assert parsed[0]["title"] == "First"
         assert parsed[0]["abstract"] == "An abstract."
         assert parsed[0]["url"] == "https://arxiv.org/abs/2401.00001"
+        # No S2 date, so the ID's month is all the tool could claim.
+        assert parsed[0]["published_date"] == "2024-01-01"
+        assert parsed[0]["date_precision"] == "month"
+
+    def test_a_day_precise_date_round_trips(self):
+        content = _tool_output(_paper("Dated", "2401.00001", published="2024-01-15"))
+
+        (parsed,) = parse_arxiv_tool_results(content)
+
+        assert parsed["published_date"] == "2024-01-15"
+        assert parsed["date_precision"] == "day"
 
     def test_multiline_abstracts_survive(self):
         content = _tool_output(_paper("Wrapped", "2401.00003", abstract="Line one.\nLine two."))
@@ -212,7 +232,10 @@ class TestScoring:
 class TestExportAdapter:
     def _prediction(self, native_id: str = "7", answer: str = "Related work.") -> dict:
         trajectory = _trajectory(
-            _tool_output(_paper("First", "2401.00001"), _paper("Second", "cs/0501001"))
+            _tool_output(
+                _paper("First", "2401.00001", published="2024-01-15"),
+                _paper("Second", "cs/0501001"),
+            )
         )
         return {
             "doc_id": 0,
@@ -267,11 +290,13 @@ class TestExportAdapter:
         assert [row["id"] for row in rows] == ["2401.00001", "cs/0501001"]
         assert rows[0]["title"] == "First"
         assert rows[0]["snippet"] == "An abstract."
-        # The rendered tool output carries a month, not a day.
-        assert rows[0]["published_date"] == "2024-01-01"
-        assert rows[0]["date_precision"] == "month"
+        # S2 dated the first source, so the day survives into the CSV.
+        assert rows[0]["published_date"] == "2024-01-15"
+        assert rows[0]["date_precision"] == "day"
         assert rows[0]["paper_id"] == "2401.00001"
+        # The second was undated, so only its ID's month can be claimed.
         assert rows[1]["published_date"] == "2005-01-01"
+        assert rows[1]["date_precision"] == "month"
 
     def test_predictions_without_sources_are_skipped(self, tmp_path):
         prediction = self._prediction()
@@ -302,3 +327,26 @@ class TestExportAdapter:
         )
 
         assert [row["id"] for row in rows] == ["2401.00001"]
+
+    def test_sources_without_a_published_line_fall_back_to_the_id_month(self):
+        # Predictions saved before the tool rendered a Published line.
+        (row,) = build_paper_rows([{"arxiv_id": "2401.00001", "title": "Legacy", "abstract": "a"}])
+
+        assert row["published_date"] == "2024-01-01"
+        assert row["date_precision"] == "month"
+
+    def test_a_parsed_day_is_written_unchanged(self):
+        (row,) = build_paper_rows(
+            [
+                {
+                    "arxiv_id": "2401.00001",
+                    "title": "Dated",
+                    "abstract": "a",
+                    "published_date": "2024-01-15",
+                    "date_precision": "day",
+                }
+            ]
+        )
+
+        assert row["published_date"] == "2024-01-15"
+        assert row["date_precision"] == "day"

--- a/tests/evals/tasks/test_deepscholar_citations.py
+++ b/tests/evals/tasks/test_deepscholar_citations.py
@@ -9,10 +9,12 @@ paper.
 import pytest
 
 from olmo_eval.evals.tasks.deepscholar_citations import (
+    FINAL_REPORT_MARKER,
     abs_url,
     reference_list,
     resolve_numbering,
     rewrite_intro,
+    split_final_report,
     strip_references,
     unresolved_citation_forms,
 )
@@ -289,3 +291,107 @@ class TestCitationForms:
         intro, _ = rewrite_intro(NUMBERED_ANSWER, SOURCES)
 
         assert unresolved_citation_forms(intro) == 0
+
+
+class TestSplitFinalReport:
+    """The delimiter contract: deliberate above the line, deliver below it.
+
+    The preset's system prompt buys the scorer a clean report out of an answer
+    the model is otherwise free to think out loud in. These pin both directions
+    of that bargain -- what counts as the line, and what does not.
+    """
+
+    REPORT = (
+        "## Related Works\n\nEarly systems retrieved passages [1].\n\n"
+        "## References\n\n[1] A. Author. First Retrieval System. arXiv:2401.00001\n"
+    )
+    DELIBERATION = "Let me search for retrieval papers first, then scaling work.\n"
+
+    def test_the_marker_drops_the_deliberation_above_it(self):
+        body, found = split_final_report(
+            self.DELIBERATION + "\n" + FINAL_REPORT_MARKER + "\n\n" + self.REPORT
+        )
+
+        assert found is True
+        assert body == self.REPORT
+        assert "Let me search" not in body
+        # The marker line is a delimiter, not content; leaving it in would put a
+        # row of "=" at the top of every scored intro.
+        assert "FINAL REPORT" not in body
+
+    def test_an_answer_without_the_marker_survives_whole(self):
+        # The fallback is today's behaviour exactly: non-compliance is measured,
+        # never punished by throwing the answer away.
+        body, found = split_final_report(self.DELIBERATION + self.REPORT)
+
+        assert found is False
+        assert body == self.DELIBERATION + self.REPORT
+
+    def test_the_last_marker_wins(self):
+        answer = (
+            FINAL_REPORT_MARKER
+            + "\nA draft I abandoned.\n\nOn reflection that was wrong.\n\n"
+            + FINAL_REPORT_MARKER
+            + "\n"
+            + self.REPORT
+        )
+
+        body, found = split_final_report(answer)
+
+        assert found is True
+        assert body == self.REPORT
+        assert "abandoned" not in body
+
+    def test_the_sentinel_named_inside_a_sentence_is_not_a_marker(self):
+        # A model explaining the instruction back to itself must not thereby
+        # throw its own report away.
+        answer = "I will write " + FINAL_REPORT_MARKER + " when I am ready.\n\n" + self.REPORT
+
+        body, found = split_final_report(answer)
+
+        assert found is False
+        assert body == answer
+
+    def test_trailing_prose_on_the_marker_line_is_not_a_marker(self):
+        answer = FINAL_REPORT_MARKER + " starts here\n" + self.REPORT
+
+        _, found = split_final_report(answer)
+
+        assert found is False
+
+    def test_a_marker_with_nothing_above_it_is_a_no_op(self):
+        body, found = split_final_report(FINAL_REPORT_MARKER + "\n" + self.REPORT)
+
+        assert found is True
+        assert body == self.REPORT
+
+    def test_a_padded_rule_still_means_the_marker(self):
+        body, found = split_final_report(
+            self.DELIBERATION + "\n===== FINAL REPORT =====\n" + self.REPORT
+        )
+
+        assert found is True
+        assert body == self.REPORT
+
+    def test_an_indented_marker_line_still_splits(self):
+        body, found = split_final_report(
+            self.DELIBERATION + "\n   " + FINAL_REPORT_MARKER + "   \n" + self.REPORT
+        )
+
+        assert found is True
+        assert body == self.REPORT
+
+    def test_the_reference_list_under_the_marker_is_the_one_that_is_read(self):
+        # The point of the split: a numbered list drafted while deliberating
+        # must not be mistaken for the reference list the answer published.
+        answer = (
+            "Draft list:\n\n## References\n\n[1] Something I later dropped.\n\n"
+            + FINAL_REPORT_MARKER
+            + "\n"
+            + self.REPORT
+        )
+
+        body, found = split_final_report(answer)
+
+        assert found is True
+        assert reference_list(body) == {"1": "A. Author. First Retrieval System. arXiv:2401.00001"}

--- a/tests/evals/tasks/test_deepscholar_citations.py
+++ b/tests/evals/tasks/test_deepscholar_citations.py
@@ -14,6 +14,7 @@ from olmo_eval.evals.tasks.deepscholar_citations import (
     resolve_numbering,
     rewrite_intro,
     strip_references,
+    unresolved_citation_forms,
 )
 
 SOURCES = [
@@ -164,3 +165,127 @@ class TestRewriteIntro:
 
     def test_no_sources_yields_nothing(self):
         assert rewrite_intro(NUMBERED_ANSWER, []) == ("", [])
+
+
+class TestAlternateReferenceHeadings:
+    """lit-agents strips only "References"; models write three other things."""
+
+    @pytest.mark.parametrize(
+        "heading",
+        ["References", "## Bibliography", "Works Cited", "### SOURCES", "references:"],
+    )
+    def test_the_tail_is_stripped(self, heading):
+        report = (
+            f"Grounded work [1].\n\n{heading}\n"
+            "[1] A. Author. Agentic Citation Grounding. arXiv:2401.00003\n"
+        )
+
+        intro, cited = rewrite_intro(report, SOURCES)
+
+        assert "A. Author" not in intro
+        assert [source["arxiv_id"] for source in cited] == ["2401.00003"]
+
+    def test_an_unstripped_bibliography_would_fabricate_citations(self):
+        # The failure this guards: entries left in the prose have their own
+        # "[1]" markers, and every one becomes an inline citation.
+        report = (
+            "Body with no citations at all.\n\n## Bibliography\n"
+            "[1] A. Author. Agentic Citation Grounding. arXiv:2401.00003\n"
+        )
+
+        intro, cited = rewrite_intro(report, SOURCES)
+
+        assert cited == []
+        assert intro == ""
+
+    def test_a_non_reference_heading_is_logged(self, caplog):
+        report = (
+            "Body [1].\n\n## Bibliography\n[1] A. Agentic Citation Grounding. arXiv:2401.00003\n"
+        )
+
+        with caplog.at_level("WARNING"):
+            strip_references(report)
+
+        assert "Bibliography" in caplog.text
+
+    def test_the_canonical_heading_is_not_logged(self, caplog):
+        with caplog.at_level("WARNING"):
+            strip_references(NUMBERED_ANSWER)
+
+        assert caplog.text == ""
+
+
+class TestExistingLinksAreNotReprocessed:
+    def test_a_rendered_link_is_not_wrapped_again(self):
+        # The link pass emits "[Title](url)"; the bracket pass would match its
+        # "[Title]" -- titles are aliases -- and produce "[Title](url)(url)".
+        report = "See [Agentic Citation Grounding](https://arxiv.org/abs/2401.00003) here."
+
+        intro, _ = rewrite_intro(report, SOURCES)
+
+        assert intro.strip() == (
+            "See [Agentic Citation Grounding](https://arxiv.org/abs/2401.00003) here."
+        )
+        assert ")(" not in intro
+
+    def test_a_title_written_as_a_bare_bracket_still_resolves(self):
+        report = "See [Agentic Citation Grounding] here."
+
+        intro, _ = rewrite_intro(report, SOURCES)
+
+        assert f"[Agentic Citation Grounding]({abs_url('2401.00003')})" in intro
+        assert ")(" not in intro
+
+
+class TestCitationForms:
+    def test_numeric_ranges_expand(self):
+        report = "Several systems [1-3] agree.\n\n## References\n" + (
+            "[1] A. First Retrieval System. arXiv:2401.00001\n"
+            "[2] B. Scaling. arXiv:2401.00002\n"
+            "[3] C. Grounding. arXiv:2401.00003\n"
+        )
+
+        intro, cited = rewrite_intro(report, SOURCES)
+
+        assert {source["arxiv_id"] for source in cited} == {
+            "2401.00001",
+            "2401.00002",
+            "2401.00003",
+        }
+        assert "[1-3]" not in intro
+
+    def test_a_reversed_range_is_left_alone(self):
+        # At that width it is a page range, not a citation, and expanding it
+        # would invent 300 citation markers out of one bracket.
+        report = "Pages [300-1] here [1].\n\n## References\n[1] A. Grounding. arXiv:2401.00003\n"
+
+        intro, cited = rewrite_intro(report, SOURCES)
+
+        assert [source["arxiv_id"] for source in cited] == ["2401.00003"]
+        assert "[300-1]" in intro
+
+    def test_footnote_markers_resolve_like_plain_numbers(self):
+        report = "Grounded [^1].\n\n## References\n[1] A. Grounding. arXiv:2401.00003\n"
+
+        intro, cited = rewrite_intro(report, SOURCES)
+
+        assert [source["arxiv_id"] for source in cited] == ["2401.00003"]
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            "Superscript citation<sup>1</sup> here.",
+            "Unicode superscript\u00b9 here.",
+            "Author-year style [Smith, 2023] here.",
+            "A footnote the list never defined [^7] here.",
+        ],
+    )
+    def test_unhandled_forms_are_counted_not_ignored(self, body):
+        # An answer that cited carefully in a style this bridge cannot read
+        # scores zero, and without this count it looks like one that never cited.
+        assert unresolved_citation_forms(body) >= 1
+
+    def test_a_clean_intro_counts_zero(self):
+        intro, _ = rewrite_intro(NUMBERED_ANSWER, SOURCES)
+
+        assert unresolved_citation_forms(intro) == 0

--- a/tests/evals/tasks/test_deepscholar_citations.py
+++ b/tests/evals/tasks/test_deepscholar_citations.py
@@ -321,8 +321,8 @@ class TestSplitFinalReport:
         assert "FINAL REPORT" not in body
 
     def test_an_answer_without_the_marker_survives_whole(self):
-        # The fallback is today's behaviour exactly: non-compliance is measured,
-        # never punished by throwing the answer away.
+        # split_final_report itself is still sentinel-only; the heading tier
+        # lives above it in select_scored_text, not inside it.
         body, found = split_final_report(self.DELIBERATION + self.REPORT)
 
         assert found is False
@@ -422,7 +422,7 @@ class TestSelectScoredText:
     def test_a_marker_that_keeps_the_report_splits(self):
         answer = "Planning.\n\n=== FINAL REPORT ===\n\n" + self.PROSE
 
-        text, found, misused = select_scored_text(answer, SOURCES)
+        text, tier, found, misused = select_scored_text(answer, SOURCES)
 
         assert (found, misused) == (True, False)
         assert text == self.PROSE
@@ -431,7 +431,7 @@ class TestSelectScoredText:
         # The whole point: the prose is above the line, only the list is below.
         answer = self.PROSE + "\n=== FINAL REPORT ===\n\n" + self.BARE_LIST
 
-        text, found, misused = select_scored_text(answer, SOURCES)
+        text, tier, found, misused = select_scored_text(answer, SOURCES)
 
         assert (found, misused) == (True, True)
         assert text == answer
@@ -439,8 +439,8 @@ class TestSelectScoredText:
     def test_the_fallback_is_exactly_the_marker_absent_path(self):
         answer = self.PROSE + "\n=== FINAL REPORT ===\n\n" + self.BARE_LIST
 
-        fused, _, _ = select_scored_text(answer, SOURCES)
-        unmarked, _, _ = select_scored_text(answer.replace("=== FINAL REPORT ===", ""), SOURCES)
+        fused, _, _, _ = select_scored_text(answer, SOURCES)
+        unmarked, _, _, _ = select_scored_text(answer.replace("=== FINAL REPORT ===", ""), SOURCES)
 
         # Same citations survive either way; the marker costs the answer nothing.
         assert rewrite_intro(fused, SOURCES)[1] == rewrite_intro(unmarked, SOURCES)[1]
@@ -453,14 +453,14 @@ class TestSelectScoredText:
             self.PROSE,
             "=== FINAL REPORT ===\n",
         ):
-            chosen, _, _ = select_scored_text(answer, SOURCES)
+            chosen, _, _, _ = select_scored_text(answer, SOURCES)
 
             assert len(rewrite_intro(chosen, SOURCES)[1]) >= len(
                 rewrite_intro(answer, SOURCES)[1]
             ), answer
 
     def test_no_marker_is_not_misuse(self):
-        text, found, misused = select_scored_text(self.PROSE, SOURCES)
+        text, tier, found, misused = select_scored_text(self.PROSE, SOURCES)
 
         assert (found, misused) == (False, False)
         assert text == self.PROSE
@@ -469,7 +469,7 @@ class TestSelectScoredText:
         # There is no export to save, so there is nothing to report.
         answer = "Thinking.\n\n=== FINAL REPORT ===\n\nNo citations here at all.\n"
 
-        text, found, misused = select_scored_text(answer, SOURCES)
+        text, tier, found, misused = select_scored_text(answer, SOURCES)
 
         assert (found, misused) == (True, False)
         assert text == "No citations here at all.\n"
@@ -479,3 +479,114 @@ class TestSelectScoredText:
         # strip_references": a numbered list with no References heading is not
         # stripped, so the emptiness test would never fire on the real failure.
         assert strip_references(self.BARE_LIST).strip() != ""
+
+
+class TestTierStack:
+    """The three tiers, and the corpora findings that chose their rules.
+
+    Fixtures here are the shapes actually seen in the W0020 study across 223
+    archived answers, not invented ones.
+    """
+
+    REPORT = (
+        "## Related Works\n\nRetrieval augmentation is well studied [1].\n\n"
+        "## References\n\n[1] A. Author. Retrieval Augmented Generation for Science. "
+        "arXiv:2401.00001\n"
+    )
+
+    def test_a_heading_recovers_a_report_with_no_marker(self):
+        answer = "Let me plan my search strategy first.\n\n" + self.REPORT
+
+        text, tier, found, misused = select_scored_text(answer, SOURCES)
+
+        assert tier == "heading"
+        assert (found, misused) == (False, False)
+        assert "Let me plan" not in text
+        assert text.startswith("## Related Works")
+
+    def test_the_first_heading_wins_not_the_last(self):
+        # The U0009 finding, and the reason this rule differs from the sentinel's.
+        # 27B writes a real report and then a late skeleton draft; last-wins picked
+        # the skeleton, whose tail resolves nothing, and burned the split.
+        skeleton = (
+            "\n\nRelated Works\n...\n\nReferences\n1. ...\n\n"
+            "Need maybe reference list not counted? fine. Let's final.\n"
+        )
+        answer = "Planning.\n\n" + self.REPORT + skeleton
+
+        text, tier, _, _ = select_scored_text(answer, SOURCES)
+
+        assert tier == "heading"
+        assert text.startswith("## Related Works")
+        assert "Let's final" in text, "first-wins keeps everything after the real heading"
+        assert "Planning." not in text
+
+    def test_the_prose_tier_catches_an_answer_with_no_heading_at_all(self):
+        answer = (
+            "I will search for retrieval papers and then summarise them.\n\n"
+            "Retrieval augmentation is a well studied approach to grounding "
+            "generation in documents, and a substantial literature has grown around "
+            "it over the past several years covering indexing, ranking and "
+            "attribution of individual claims to their sources [1].\n\n"
+            "## References\n\n[1] A. Author. Retrieval Augmented Generation for "
+            "Science. arXiv:2401.00001\n"
+        )
+
+        text, tier, _, _ = select_scored_text(answer, SOURCES)
+
+        assert tier == "prose"
+        assert "I will search for retrieval papers" not in text
+        assert text.startswith("Retrieval augmentation is a well studied")
+
+    def test_a_short_citation_bearing_line_is_not_a_report_opening(self):
+        # MIN_PROSE_WORDS: a fragment carrying a bracket is not the section.
+        answer = (
+            "Found [1].\n\n"
+            "## References\n\n[1] A. Author. Retrieval Augmented Generation for "
+            "Science. arXiv:2401.00001\n"
+        )
+
+        _, tier, _, _ = select_scored_text(answer, SOURCES)
+
+        assert tier == "none"
+
+    def test_every_tier_is_fused_so_nothing_is_ever_lost(self):
+        # The query-24 shape: report above, bare numbered list below the marker.
+        bare_list = (
+            "1. A. Author. Retrieval Augmented Generation for Science. arXiv:2401.00001\n"
+            "2. B. Author. Scaling Laws for Literature Search. arXiv:2401.00002\n"
+        )
+        answer = self.REPORT + "\n=== FINAL REPORT ===\n\n" + bare_list
+
+        text, _, found, misused = select_scored_text(answer, SOURCES)
+
+        assert (found, misused) == (True, True)
+        _, cited_chosen = rewrite_intro(text, SOURCES)
+        _, cited_full = rewrite_intro(answer, SOURCES)
+        assert len(cited_chosen) >= len(cited_full)
+
+    def test_the_stack_never_exports_less_than_keeping_everything(self):
+        # The losslessness invariant, over every shape above.
+        bare_list = "1. A. Author. Retrieval Augmented Generation. arXiv:2401.00001\n"
+        for answer in (
+            "Planning.\n\n=== FINAL REPORT ===\n\n" + self.REPORT,
+            "Planning.\n\n" + self.REPORT,
+            self.REPORT + "\n=== FINAL REPORT ===\n\n" + bare_list,
+            "Nothing citable at all here.\n\nStill nothing.\n",
+            self.REPORT,
+        ):
+            chosen, _, _, _ = select_scored_text(answer, SOURCES)
+
+            assert len(rewrite_intro(chosen, SOURCES)[1]) >= len(
+                rewrite_intro(answer, SOURCES)[1]
+            ), answer
+
+    def test_a_heading_inside_the_reference_tail_is_not_a_split_point(self):
+        answer = (
+            "Planning without citations.\n\n## References\n\n"
+            "[1] A. Author. Related Works. arXiv:2401.00001\n"
+        )
+
+        _, tier, _, _ = select_scored_text(answer, SOURCES)
+
+        assert tier == "none"

--- a/tests/evals/tasks/test_deepscholar_citations.py
+++ b/tests/evals/tasks/test_deepscholar_citations.py
@@ -1,0 +1,166 @@
+"""Tests for the citation bridge between the prompt's form and the scorer's.
+
+The prompt mandates "[3]"-style citations; the upstream parser credits only
+markdown links to arxiv.org/abs. These pin the translation, including the cases
+where it must refuse to translate rather than point a citation at the wrong
+paper.
+"""
+
+import pytest
+
+from olmo_eval.evals.tasks.deepscholar_citations import (
+    abs_url,
+    reference_list,
+    resolve_numbering,
+    rewrite_intro,
+    strip_references,
+)
+
+SOURCES = [
+    {"arxiv_id": "2401.00001", "title": "Retrieval Augmented Generation for Science"},
+    {"arxiv_id": "2401.00002", "title": "Scaling Laws for Literature Search"},
+    {"arxiv_id": "2401.00003", "title": "Agentic Citation Grounding"},
+]
+
+NUMBERED_ANSWER = """## Related Works
+
+Retrieval augmentation is well studied [1]. Later work scaled it [2] and grounded
+citations directly [3]. Some combine both [2, 3].
+
+## References
+
+[1] A. Author. Retrieval Augmented Generation for Science. arXiv:2401.00001
+[2] B. Author. Scaling Laws for Literature Search. arXiv:2401.00002v2
+[3] C. Author. Agentic Citation Grounding. https://arxiv.org/abs/2401.00003
+"""
+
+
+class TestReferenceList:
+    def test_bracket_numbering(self):
+        assert set(reference_list(NUMBERED_ANSWER)) == {"1", "2", "3"}
+
+    def test_dotted_and_parenthesised_numbering(self):
+        report = (
+            "Body [1].\n\nReferences\n1. First entry arXiv:2401.00001\n2) Second arXiv:2401.00002\n"
+        )
+
+        assert set(reference_list(report)) == {"1", "2"}
+
+    def test_wrapped_entries_stay_whole(self):
+        report = (
+            "Body [1].\n\nReferences\n[1] A. Author. A Very Long Title That\n"
+            "wraps onto another line. arXiv:2401.00001\n"
+        )
+
+        assert "wraps onto another line" in reference_list(report)["1"]
+
+    def test_no_reference_section_yields_nothing_numbered(self):
+        assert reference_list("Just prose with no list.") == {}
+
+
+class TestStripReferences:
+    def test_reference_section_is_removed(self):
+        assert "arXiv:2401.00001" not in strip_references(NUMBERED_ANSWER)
+        assert "Retrieval augmentation is well studied" in strip_references(NUMBERED_ANSWER)
+
+
+class TestResolveNumbering:
+    def test_numbers_resolve_by_arxiv_id(self):
+        resolved = resolve_numbering(NUMBERED_ANSWER, SOURCES)
+
+        assert {number: source["arxiv_id"] for number, source in resolved.items()} == {
+            "1": "2401.00001",
+            "2": "2401.00002",
+            "3": "2401.00003",
+        }
+
+    def test_version_suffixes_in_the_reference_list_still_match(self):
+        # Entry [2] is written "arXiv:2401.00002v2" while the source is normalised.
+        assert resolve_numbering(NUMBERED_ANSWER, SOURCES)["2"]["arxiv_id"] == "2401.00002"
+
+    def test_numbers_resolve_by_title_when_no_id_is_given(self):
+        report = (
+            "Body [1].\n\nReferences\n[1] A. Author. Agentic Citation Grounding. In Proc. 2024.\n"
+        )
+
+        assert resolve_numbering(report, SOURCES)["1"]["arxiv_id"] == "2401.00003"
+
+    def test_an_entry_naming_no_retrieved_paper_stays_unresolved(self):
+        report = "Body [1].\n\nReferences\n[1] Someone. A Paper Never Retrieved. arXiv:2999.99999\n"
+
+        assert resolve_numbering(report, SOURCES) == {}
+
+
+class TestRewriteIntro:
+    def test_numbered_citations_become_arxiv_links(self):
+        intro, cited = rewrite_intro(NUMBERED_ANSWER, SOURCES)
+
+        assert f"[Retrieval Augmented Generation for Science]({abs_url('2401.00001')})" in intro
+        assert f"[Agentic Citation Grounding]({abs_url('2401.00003')})" in intro
+        assert {source["arxiv_id"] for source in cited} == {
+            "2401.00001",
+            "2401.00002",
+            "2401.00003",
+        }
+
+    def test_the_reference_list_is_not_carried_into_the_intro(self):
+        intro, _ = rewrite_intro(NUMBERED_ANSWER, SOURCES)
+
+        assert "## References" not in intro
+        assert "B. Author" not in intro
+
+    def test_grouped_citations_expand_to_one_link_each(self):
+        intro, _ = rewrite_intro(NUMBERED_ANSWER, SOURCES)
+
+        # "[2, 3]" is two citations, not one label.
+        assert intro.count(abs_url("2401.00002")) == 2
+        assert intro.count(abs_url("2401.00003")) == 2
+
+    def test_generated_urls_carry_no_version_suffix(self):
+        # The upstream parser keys its reference map on the raw URL text, so a
+        # "v2" here would never match the normalised paper.csv row.
+        intro, _ = rewrite_intro(NUMBERED_ANSWER, SOURCES)
+
+        assert "v2)" not in intro
+        assert abs_url("2401.00002") in intro
+
+    def test_unresolvable_numbers_are_deleted_not_left_behind(self):
+        report = (
+            "Grounded work [1]. Invented work [7].\n\n"
+            "References\n[1] A. Author. Agentic Citation Grounding. arXiv:2401.00003\n"
+        )
+
+        intro, cited = rewrite_intro(report, SOURCES)
+
+        # Leaving "[7]" would make the parser number a document that has no row.
+        assert "[7]" not in intro
+        assert len(cited) == 1
+
+    def test_an_answer_citing_only_unretrieved_papers_yields_nothing(self):
+        report = "Body [1].\n\nReferences\n[1] Someone. Never Retrieved. arXiv:2999.99999\n"
+
+        assert rewrite_intro(report, SOURCES) == ("", [])
+
+    def test_existing_markdown_links_are_normalised(self):
+        report = "See [this paper](https://arxiv.org/abs/2401.00002v3) for details."
+
+        intro, cited = rewrite_intro(report, SOURCES)
+
+        assert f"[Scaling Laws for Literature Search]({abs_url('2401.00002')})" in intro
+        assert [source["arxiv_id"] for source in cited] == ["2401.00002"]
+
+    def test_a_link_to_an_unretrieved_paper_keeps_its_prose_label(self):
+        report = "See [some other work](https://arxiv.org/abs/2999.99999) and [1].\n\n"
+        report += "References\n[1] A. Author. Agentic Citation Grounding. arXiv:2401.00003\n"
+
+        intro, _ = rewrite_intro(report, SOURCES)
+
+        assert "some other work" in intro
+        assert "2999.99999" not in intro
+
+    @pytest.mark.parametrize("report", ["", "   \n\n"])
+    def test_an_empty_answer_yields_nothing(self, report):
+        assert rewrite_intro(report, SOURCES) == ("", [])
+
+    def test_no_sources_yields_nothing(self):
+        assert rewrite_intro(NUMBERED_ANSWER, []) == ("", [])

--- a/tests/evals/tasks/test_deepscholar_citations.py
+++ b/tests/evals/tasks/test_deepscholar_citations.py
@@ -14,6 +14,7 @@ from olmo_eval.evals.tasks.deepscholar_citations import (
     reference_list,
     resolve_numbering,
     rewrite_intro,
+    select_scored_text,
     split_final_report,
     strip_references,
     unresolved_citation_forms,
@@ -395,3 +396,86 @@ class TestSplitFinalReport:
 
         assert found is True
         assert reference_list(body) == {"1": "A. Author. First Retrieval System. arXiv:2401.00001"}
+
+
+class TestSelectScoredText:
+    """The fuse: the split is kept only where it leaves something scoreable.
+
+    Qwen3.5-9B honoured the marker and put its whole Related Works section above
+    it, leaving a bare numbered list below. Trusting the split there turned an
+    exportable answer into an unscoreable one, so the split now has to earn its
+    keep.
+    """
+
+    PROSE = (
+        "## Related Works\n\nRetrieval augmentation is well studied [1].\n\n"
+        "## References\n\n[1] A. Author. Retrieval Augmented Generation for Science. "
+        "arXiv:2401.00001\n"
+    )
+    # What 9B actually emitted below the line: a numbered list with no heading,
+    # so strip_references never touches it and nothing cites into it.
+    BARE_LIST = (
+        "1. Arora, R. Retrieval Augmented Generation for Science. arXiv:2401.00001\n"
+        "2. Choudhary, A. Scaling Laws for Literature Search. arXiv:2401.00002\n"
+    )
+
+    def test_a_marker_that_keeps_the_report_splits(self):
+        answer = "Planning.\n\n=== FINAL REPORT ===\n\n" + self.PROSE
+
+        text, found, misused = select_scored_text(answer, SOURCES)
+
+        assert (found, misused) == (True, False)
+        assert text == self.PROSE
+
+    def test_a_marker_that_would_throw_the_report_away_falls_back(self):
+        # The whole point: the prose is above the line, only the list is below.
+        answer = self.PROSE + "\n=== FINAL REPORT ===\n\n" + self.BARE_LIST
+
+        text, found, misused = select_scored_text(answer, SOURCES)
+
+        assert (found, misused) == (True, True)
+        assert text == answer
+
+    def test_the_fallback_is_exactly_the_marker_absent_path(self):
+        answer = self.PROSE + "\n=== FINAL REPORT ===\n\n" + self.BARE_LIST
+
+        fused, _, _ = select_scored_text(answer, SOURCES)
+        unmarked, _, _ = select_scored_text(answer.replace("=== FINAL REPORT ===", ""), SOURCES)
+
+        # Same citations survive either way; the marker costs the answer nothing.
+        assert rewrite_intro(fused, SOURCES)[1] == rewrite_intro(unmarked, SOURCES)[1]
+
+    def test_the_split_never_lowers_what_can_be_cited(self):
+        # The losslessness property, stated directly.
+        for answer in (
+            "Planning.\n\n=== FINAL REPORT ===\n\n" + self.PROSE,
+            self.PROSE + "\n=== FINAL REPORT ===\n\n" + self.BARE_LIST,
+            self.PROSE,
+            "=== FINAL REPORT ===\n",
+        ):
+            chosen, _, _ = select_scored_text(answer, SOURCES)
+
+            assert len(rewrite_intro(chosen, SOURCES)[1]) >= len(
+                rewrite_intro(answer, SOURCES)[1]
+            ), answer
+
+    def test_no_marker_is_not_misuse(self):
+        text, found, misused = select_scored_text(self.PROSE, SOURCES)
+
+        assert (found, misused) == (False, False)
+        assert text == self.PROSE
+
+    def test_nothing_scoreable_either_way_is_not_misuse(self):
+        # There is no export to save, so there is nothing to report.
+        answer = "Thinking.\n\n=== FINAL REPORT ===\n\nNo citations here at all.\n"
+
+        text, found, misused = select_scored_text(answer, SOURCES)
+
+        assert (found, misused) == (True, False)
+        assert text == "No citations here at all.\n"
+
+    def test_a_bare_list_is_not_caught_by_the_emptiness_test(self):
+        # Why the fuse tests "resolves no citation" rather than "empty after
+        # strip_references": a numbered list with no References heading is not
+        # stripped, so the emptiness test would never fire on the real failure.
+        assert strip_references(self.BARE_LIST).strip() != ""

--- a/tests/evals/tasks/test_researchqa.py
+++ b/tests/evals/tasks/test_researchqa.py
@@ -9,13 +9,16 @@ from olmo_eval.common.types import Instance, LMOutput, LMRequest, RequestType, R
 from olmo_eval.evals.tasks import researchqa
 from olmo_eval.evals.tasks.common import get_task, task_exists
 from olmo_eval.evals.tasks.researchqa import (
+    RESEARCHQA_DEFAULT_TOOLS,
     RESEARCHQA_GENERATION_PROMPT,
     RESEARCHQA_LABEL_SCORES,
     build_coverage_judge_prompt,
+    build_generation_prompt,
     build_researchqa_judge_fn,
     normalize_coverage_label,
     parse_coverage_labels,
 )
+from olmo_eval.harness import get_harness_preset
 
 
 @pytest.fixture
@@ -174,6 +177,37 @@ class TestPrompts:
             "Workflow (follow this order)"
         )
         assert RESEARCHQA_GENERATION_PROMPT.endswith("Question: ")
+
+    def test_prompt_names_only_the_tools_the_harness_exposes(self, task):
+        """The prompt has to follow the harness: naming an absent tool makes the model
+        call it, and the scaffold then fails the episode before any turn runs."""
+        task.config.harness_tool_names = get_harness_preset("paper_search_agent").tool_names
+        instance = task.process_doc(_doc())
+        assert instance is not None
+        content = task.format_request(instance).messages[0]["content"]
+
+        assert "semantic_scholar_snippet_search" in content
+        assert "serper" not in content
+        assert "browse_webpage" not in content
+        assert "Search first, and only then answer" in content
+        assert "fetch" not in content.lower()
+
+    def test_prompt_is_unchanged_for_the_default_and_dr_tulu_tool_sets(self):
+        """dr_tulu exposes exactly the tools this prompt used to hardcode, and a
+        harness with no tools falls back to that list, so both must stay untouched."""
+        assert build_generation_prompt() == RESEARCHQA_GENERATION_PROMPT
+        assert build_generation_prompt(RESEARCHQA_DEFAULT_TOOLS) == RESEARCHQA_GENERATION_PROMPT
+        dr_tulu_tools = get_harness_preset("dr_tulu").tool_names
+        assert dr_tulu_tools == RESEARCHQA_DEFAULT_TOOLS
+        assert build_generation_prompt(dr_tulu_tools) == RESEARCHQA_GENERATION_PROMPT
+
+    def test_prompt_routes_an_alternative_fetch_tool_into_the_fetch_step(self):
+        content = build_generation_prompt(
+            ("semantic_scholar_snippet_search", "serper_google_webpage_search", "browse_webpage")
+        )
+        assert "- browse_webpage\n" in content
+        assert "Fetch and read promising source content using browse_webpage." in content
+        assert "serper_fetch_webpage_content" not in content
 
     def test_generation_prompt_omits_cutoff_when_date_is_missing(self, task):
         doc = _doc()

--- a/tests/harness/test_model_settings.py
+++ b/tests/harness/test_model_settings.py
@@ -17,6 +17,8 @@ from olmo_eval.harness.scaffolds.openai_agents import (
     build_model_settings,
 )
 
+pytest.importorskip("agents")
+
 
 class _ProviderStub:
     """Just enough provider for agent construction; makes no network calls."""

--- a/tests/harness/test_model_settings.py
+++ b/tests/harness/test_model_settings.py
@@ -1,0 +1,145 @@
+"""Tests for pinning request-level model settings on a harness run.
+
+gpt-5.6-sol rejects function tools and a reasoning effort together on
+/v1/chat/completions, so a run with tools has to be able to turn reasoning off.
+Nothing on the branch could express that: an env var carried by two weeks of
+recorded runs read nothing, and worked only because the server default agreed.
+These pin the mechanism that replaced it, end to end -- the dict an operator
+types, the ModelSettings it becomes, and the Agent it reaches.
+"""
+
+import pytest
+
+from olmo_eval.harness.config import HarnessConfig
+from olmo_eval.harness.presets import get_harness_preset
+from olmo_eval.harness.scaffolds.openai_agents import (
+    OpenAIAgentsScaffold,
+    build_model_settings,
+)
+
+
+class _ProviderStub:
+    """Just enough provider for agent construction; makes no network calls."""
+
+    model_name = "gpt-5.6-sol"
+
+    def get_openai_client(self):
+        from openai import AsyncOpenAI
+
+        return AsyncOpenAI(api_key="test-key", base_url="http://localhost:1/v1")
+
+
+def _agent_for(scaffold_kwargs: dict) -> object:
+    config = HarnessConfig(
+        name="test",
+        scaffold="openai_agents",
+        scaffold_kwargs=scaffold_kwargs,
+    )
+    return OpenAIAgentsScaffold()._create_agent(_ProviderStub(), config)
+
+
+class TestScaffoldRegistration:
+    def test_the_scaffold_is_still_what_openai_agents_resolves_to(self):
+        # Adding a module-level helper immediately above the class put it
+        # between @register_scaffold and the class it decorates, so the registry
+        # returned the helper and every worker died calling it with no
+        # arguments. Direct imports of both names still worked, which is why
+        # only a real run caught it.
+        from olmo_eval.harness.scaffolds import get_scaffold
+
+        assert isinstance(get_scaffold("openai_agents"), OpenAIAgentsScaffold)
+
+
+class TestBuildModelSettings:
+    @pytest.mark.parametrize("spec", [None, {}])
+    def test_nothing_configured_yields_nothing(self, spec):
+        # Returning an empty ModelSettings would replace the SDK's defaults with
+        # this function's idea of them.
+        assert build_model_settings(spec) is None
+
+    def test_reasoning_effort_becomes_the_sdk_reasoning_object(self):
+        settings = build_model_settings({"reasoning_effort": "none"})
+
+        assert settings.reasoning.effort == "none"
+
+    def test_reasoning_effort_does_not_go_through_extra_args(self):
+        # OpenAIChatCompletionsModel splats extra_args into the same call that
+        # already passes reasoning_effort= explicitly; the two would collide.
+        settings = build_model_settings({"reasoning_effort": "none"})
+
+        assert not settings.extra_args
+        assert not settings.extra_body
+
+    def test_other_model_settings_fields_pass_through(self):
+        settings = build_model_settings({"temperature": 0.0, "max_tokens": 512})
+
+        assert settings.temperature == 0.0
+        assert settings.max_tokens == 512
+
+    def test_an_unknown_key_raises_rather_than_being_dropped(self):
+        # The failure this whole mechanism replaced was a knob that read nothing.
+        with pytest.raises(ValueError, match="Unknown model_settings key"):
+            build_model_settings({"reasoning_efort": "none"})
+
+    def test_the_error_names_the_valid_keys(self):
+        with pytest.raises(ValueError, match="reasoning_effort"):
+            build_model_settings({"nonsense": 1})
+
+
+class TestAgentConstruction:
+    def test_the_setting_reaches_the_agent(self):
+        agent = _agent_for({"model_settings": {"reasoning_effort": "none"}})
+
+        assert agent.model_settings.reasoning.effort == "none"
+
+    def test_absent_setting_leaves_the_sdk_defaults(self):
+        agent = _agent_for({})
+
+        assert agent.model_settings.reasoning is None
+
+    def test_an_unrelated_scaffold_kwarg_is_not_treated_as_settings(self):
+        agent = _agent_for({"enable_compaction": False})
+
+        assert agent.model_settings.reasoning is None
+
+
+class TestOverridePath:
+    """The -o syntax an operator actually types has to reach scaffold_kwargs."""
+
+    def _apply(self, overrides: list[str]) -> HarnessConfig:
+        from olmo_eval.cli.beaker.launch import _apply_harness_overrides
+
+        return _apply_harness_overrides(get_harness_preset("arxiv_paper_search_agent"), overrides)
+
+    def test_nested_override_reaches_scaffold_kwargs(self):
+        config = self._apply(["scaffold_kwargs.model_settings.reasoning_effort=none"])
+
+        assert config.scaffold_kwargs["model_settings"] == {"reasoning_effort": "none"}
+
+    def test_the_literal_none_stays_a_string(self):
+        # "none" is a valid reasoning effort; coercing it to Python None would
+        # silently mean "unset" and put the run straight back into the 400.
+        config = self._apply(["scaffold_kwargs.model_settings.reasoning_effort=none"])
+
+        assert config.scaffold_kwargs["model_settings"]["reasoning_effort"] == "none"
+
+    def test_the_override_survives_into_a_usable_setting(self):
+        config = self._apply(["scaffold_kwargs.model_settings.reasoning_effort=none"])
+
+        settings = build_model_settings(config.scaffold_kwargs["model_settings"])
+
+        assert settings.reasoning.effort == "none"
+
+    def test_the_preset_does_not_pin_reasoning_itself(self):
+        # Other backbones on this preset must keep their reasoning.
+        preset = get_harness_preset("arxiv_paper_search_agent")
+
+        assert "model_settings" not in preset.scaffold_kwargs
+
+    def test_the_preset_documents_the_flag(self):
+        docstring = get_harness_preset.__doc__ or ""
+        from olmo_eval.harness.presets import HarnessPresets
+
+        preset_doc = HarnessPresets.__dict__["arxiv_paper_search_agent"]._factory.__doc__ or ""
+
+        assert "scaffold_kwargs.model_settings.reasoning_effort=none" in preset_doc + docstring

--- a/tests/harness/tools/test_arxiv_paper_search.py
+++ b/tests/harness/tools/test_arxiv_paper_search.py
@@ -1,0 +1,256 @@
+"""Tests for the arXiv-filtered paper search tool.
+
+The tool is held to DeepScholar-Bench's admission test -- arXiv provenance,
+published strictly before the query's cutoff -- so these cover the client-side
+filter, the widened page that filter needs, the cutoff on both sides of the
+request, and the rendering the export pass later parses back. Nothing here
+touches the live API.
+"""
+
+import types
+from typing import Any
+
+import pytest
+
+from olmo_eval.harness.tools import search
+
+
+class _ResponseStub:
+    text = ""
+
+    def __init__(
+        self,
+        data: dict[str, Any],
+        status_code: int = 200,
+        headers: dict[str, str] | None = None,
+    ) -> None:
+        self._data = data
+        self.status_code = status_code
+        self.headers = headers or {}
+
+    def raise_for_status(self) -> None:
+        pass
+
+    def json(self) -> dict[str, Any]:
+        return self._data
+
+
+def _paper(
+    title: str,
+    *,
+    arxiv: str | None = None,
+    published: str | None = None,
+    year: int | None = 2020,
+) -> dict[str, Any]:
+    paper: dict[str, Any] = {
+        "title": title,
+        "abstract": f"Abstract of {title}.",
+        "year": year,
+        "url": "",
+        "authors": [{"name": "A. Author"}],
+        "externalIds": {"DOI": "10.1/x"},
+    }
+    if arxiv is not None:
+        paper["externalIds"]["ArXiv"] = arxiv
+    if published is not None:
+        paper["publicationDate"] = published
+    return paper
+
+
+def _stub_search(monkeypatch, papers: list[dict[str, Any]]) -> dict[str, Any]:
+    """Answer any S2 search with ``papers``; returns the captured query params."""
+    captured: dict[str, Any] = {}
+
+    class ClientStub:
+        async def get(self, url: str, *, params: dict, headers: dict) -> _ResponseStub:
+            captured.update(params)
+            return _ResponseStub({"data": papers})
+
+    async def no_rate_gate() -> None:
+        pass
+
+    monkeypatch.setattr(search, "_get_http_client", lambda: ClientStub())
+    monkeypatch.setattr(search, "_s2_rate_gate", no_rate_gate)
+    return captured
+
+
+@pytest.mark.anyio
+async def test_requests_external_ids_and_widens_the_page(monkeypatch) -> None:
+    monkeypatch.setenv("ARXIV_SEARCH_LIMIT", "10")
+    captured = _stub_search(monkeypatch, [])
+
+    await search.arxiv_paper_search(query="retrieval augmented generation")
+
+    assert "externalIds" in captured["fields"]
+    assert captured["limit"] == 10 * search._ARXIV_OVERFETCH_MULTIPLIER
+    # arXiv provenance is decided on external IDs; the venue is not stable.
+    assert "venue" not in captured
+
+
+@pytest.mark.anyio
+async def test_page_widening_is_capped_at_the_s2_maximum(monkeypatch) -> None:
+    monkeypatch.setenv("ARXIV_SEARCH_LIMIT", "50")
+    captured = _stub_search(monkeypatch, [])
+
+    await search.arxiv_paper_search(query="q")
+
+    assert captured["limit"] == search._S2_MAX_SEARCH_LIMIT
+
+
+@pytest.mark.anyio
+async def test_arxiv_hits_are_rendered_with_id_and_abs_url(monkeypatch) -> None:
+    _stub_search(monkeypatch, [_paper("Preprint", arxiv="2401.01234v2")])
+
+    result = await search.arxiv_paper_search(query="q")
+
+    assert "**Preprint**" in result
+    assert "Authors: A. Author" in result
+    assert "Year: 2020" in result
+    assert "Abstract: Abstract of Preprint." in result
+    # The version suffix is stripped, and the abs URL is what the benchmark's
+    # citation parser credits.
+    assert "arXiv: 2401.01234" in result
+    assert "URL: https://arxiv.org/abs/2401.01234" in result
+
+
+@pytest.mark.anyio
+async def test_hits_without_an_arxiv_id_are_marked_context_only_and_capped(monkeypatch) -> None:
+    monkeypatch.setenv("ARXIV_SEARCH_LIMIT", "5")
+    _stub_search(
+        monkeypatch,
+        [_paper(f"Journal {index}") for index in range(5)]
+        + [_paper("Preprint", arxiv="2401.01234")],
+    )
+
+    result = await search.arxiv_paper_search(query="q")
+
+    assert result.count("[context only: no arXiv ID, not citable]") == (
+        search._ARXIV_CONTEXT_ONLY_LIMIT
+    )
+    # Nothing without an arXiv ID is offered an arxiv.org URL to cite.
+    assert result.count("URL: https://arxiv.org/abs/") == 1
+
+
+@pytest.mark.anyio
+async def test_relevance_order_is_preserved_and_truncated_after_filtering(monkeypatch) -> None:
+    monkeypatch.setenv("ARXIV_SEARCH_LIMIT", "2")
+    _stub_search(
+        monkeypatch,
+        [
+            _paper("Journal", published="2020-01-01"),
+            _paper("First", arxiv="2401.00001"),
+            _paper("Second", arxiv="2401.00002"),
+            _paper("Third", arxiv="2401.00003"),
+        ],
+    )
+
+    result = await search.arxiv_paper_search(query="q")
+
+    assert result.index("**First**") < result.index("**Second**")
+    assert "**Third**" not in result
+
+
+@pytest.mark.anyio
+async def test_cutoff_is_pushed_one_day_short_server_side(monkeypatch) -> None:
+    captured = _stub_search(monkeypatch, [])
+
+    with search.search_date_cutoff("2024-06-01 13:06:19+00:00"):
+        await search.arxiv_paper_search(query="q")
+
+    # The exporter's test is strictly-before and S2's range is inclusive.
+    assert captured["publicationDateOrYear"] == ":2024-05-31"
+
+
+@pytest.mark.anyio
+async def test_cutoff_is_enforced_client_side(monkeypatch) -> None:
+    _stub_search(
+        monkeypatch,
+        [
+            _paper("Before", arxiv="2405.00001", published="2024-05-31"),
+            _paper("OnCutoff", arxiv="2406.00001", published="2024-06-01"),
+            _paper("After", arxiv="2407.00001", published="2024-07-01"),
+        ],
+    )
+
+    with search.search_date_cutoff("2024-06-01"):
+        result = await search.arxiv_paper_search(query="q")
+
+    assert "**Before**" in result
+    assert "**OnCutoff**" not in result
+    assert "**After**" not in result
+
+
+@pytest.mark.anyio
+async def test_undated_hits_fall_back_to_the_arxiv_id_month(monkeypatch) -> None:
+    _stub_search(
+        monkeypatch,
+        [
+            _paper("EarlierMonth", arxiv="2405.00001"),
+            _paper("CutoffMonth", arxiv="2406.00001"),
+            _paper("Legacy", arxiv="cs/0501001"),
+            _paper("Undatable", arxiv="not-an-id"),
+        ],
+    )
+
+    with search.search_date_cutoff("2024-06-01"):
+        result = await search.arxiv_paper_search(query="q")
+
+    assert "**EarlierMonth**" in result
+    assert "**Legacy**" in result
+    # Same month as the cutoff cannot be shown to precede it, and an ID that
+    # encodes no date is evidence the exporter would not have either.
+    assert "**CutoffMonth**" not in result
+    assert "**Undatable**" not in result
+
+
+@pytest.mark.anyio
+async def test_empty_result_set_reports_no_papers(monkeypatch) -> None:
+    _stub_search(monkeypatch, [_paper("Journal")])
+
+    with search.search_date_cutoff("2024-06-01"):
+        result = await search.arxiv_paper_search(query="q")
+
+    assert result == "No arXiv papers found for query."
+
+
+@pytest.mark.anyio
+async def test_empty_query_is_rejected_without_a_request(monkeypatch) -> None:
+    def fail() -> None:
+        raise AssertionError("no request should be made for an empty query")
+
+    monkeypatch.setattr(search, "_get_http_client", lambda: fail())
+
+    assert await search.arxiv_paper_search(query="   ") == "Error: Empty search query."
+
+
+@pytest.mark.anyio
+async def test_rate_limited_requests_are_retried_after_the_servers_delay(monkeypatch) -> None:
+    slept: list[float] = []
+    attempts: list[dict[str, Any]] = []
+    responses = [
+        _ResponseStub({}, status_code=429, headers={"Retry-After": "30"}),
+        _ResponseStub({"data": [_paper("Preprint", arxiv="2401.01234")]}),
+    ]
+
+    async def record_sleep(seconds: float) -> None:
+        slept.append(seconds)
+
+    class ClientStub:
+        async def get(self, url: str, *, params: dict, headers: dict) -> _ResponseStub:
+            attempts.append(params)
+            return responses.pop(0)
+
+    async def no_rate_gate() -> None:
+        pass
+
+    monkeypatch.setattr(search, "_get_http_client", lambda: ClientStub())
+    monkeypatch.setattr(search, "_s2_rate_gate", no_rate_gate)
+    monkeypatch.setattr(search, "asyncio", types.SimpleNamespace(sleep=record_sleep))
+
+    result = await search.arxiv_paper_search(query="q")
+
+    assert len(attempts) == 2
+    assert "arXiv: 2401.01234" in result
+    # Retry-After wins over the exponential schedule, clamped to the module's
+    # ceiling: a server asking for longer than _MAX_BACKOFF_S is under-waited.
+    assert slept == [min(30.0, search._MAX_BACKOFF_S)]

--- a/tests/harness/tools/test_arxiv_paper_search.py
+++ b/tests/harness/tools/test_arxiv_paper_search.py
@@ -106,11 +106,35 @@ async def test_arxiv_hits_are_rendered_with_id_and_abs_url(monkeypatch) -> None:
     assert "**Preprint**" in result
     assert "Authors: A. Author" in result
     assert "Year: 2020" in result
+    # S2 reported no date, so only the month the ID encodes can be claimed.
+    assert "Published: 2024-01 (month precision)" in result
     assert "Abstract: Abstract of Preprint." in result
     # The version suffix is stripped, and the abs URL is what the benchmark's
     # citation parser credits.
     assert "arXiv: 2401.01234" in result
     assert "URL: https://arxiv.org/abs/2401.01234" in result
+
+
+@pytest.mark.anyio
+async def test_a_dated_hit_is_published_to_the_day(monkeypatch) -> None:
+    _stub_search(monkeypatch, [_paper("Dated", arxiv="2401.01234", published="2024-01-15")])
+
+    result = await search.arxiv_paper_search(query="q")
+
+    # A day S2 knows must not be downgraded to a month: the benchmark contract
+    # rejects a month-precise source dated inside the cutoff's own month.
+    assert "Published: 2024-01-15" in result
+    assert "month precision" not in result
+
+
+@pytest.mark.anyio
+async def test_a_hit_with_no_date_anywhere_shows_none(monkeypatch) -> None:
+    _stub_search(monkeypatch, [_paper("Undatable", arxiv="not-an-id")])
+
+    result = await search.arxiv_paper_search(query="q")
+
+    assert "**Undatable**" in result
+    assert "Published:" not in result
 
 
 @pytest.mark.anyio

--- a/tests/harness/tools/test_arxiv_paper_search.py
+++ b/tests/harness/tools/test_arxiv_paper_search.py
@@ -61,6 +61,8 @@ def _paper(
 
 BAD_JSON = "<body that is not json>"
 BAD_SHAPE = "<a list where an object belongs>"
+BAD_DATA = "<a data field that is not a list>"
+NO_RESULTS = "<S2's real no-results body: total and offset, no data>"
 
 
 def _stub_pages(
@@ -102,6 +104,10 @@ def _stub_pages(
                 return _BadJson()
             if page is BAD_SHAPE:
                 return _ResponseStub(["not", "an", "object"])
+            if page is BAD_DATA:
+                return _ResponseStub({"total": 1, "data": "not a list"})
+            if page is NO_RESULTS:
+                return _ResponseStub({"total": 0, "offset": 0})
             return _ResponseStub({"data": page})
 
     async def no_rate_gate() -> None:
@@ -574,3 +580,26 @@ async def test_an_empty_data_array_is_not_an_error(monkeypatch) -> None:
     result = await search.arxiv_paper_search(query="q")
 
     assert result == "No arXiv papers found for query."
+
+
+@pytest.mark.anyio
+async def test_s2s_no_results_body_is_not_an_error(monkeypatch) -> None:
+    # Verified against the live endpoint: a query matching nothing comes back as
+    # {"total": 0, "offset": 0} with no data array. Calling that malformed would
+    # tell the model its search broke when it merely found nothing.
+    calls = _stub_pages(monkeypatch, NO_RESULTS)
+
+    result = await search.arxiv_paper_search(query="zzzqqq nonexistent xyzzy")
+
+    assert result == "No arXiv papers found for query."
+    # And it is a complete page, so there is no next one to ask for.
+    assert len(calls) == 1
+
+
+@pytest.mark.anyio
+async def test_a_data_field_that_is_not_a_list_is_still_an_error(monkeypatch) -> None:
+    _stub_pages(monkeypatch, BAD_DATA)
+
+    result = await search.arxiv_paper_search(query="q")
+
+    assert result.startswith("Error searching arXiv papers")

--- a/tests/harness/tools/test_arxiv_paper_search.py
+++ b/tests/harness/tools/test_arxiv_paper_search.py
@@ -10,6 +10,7 @@ touches the live API.
 import types
 from typing import Any
 
+import httpx
 import pytest
 
 from olmo_eval.harness.tools import search
@@ -58,44 +59,161 @@ def _paper(
     return paper
 
 
-def _stub_search(monkeypatch, papers: list[dict[str, Any]]) -> dict[str, Any]:
-    """Answer any S2 search with ``papers``; returns the captured query params."""
-    captured: dict[str, Any] = {}
+def _stub_pages(
+    monkeypatch,
+    *pages: list[dict[str, Any]],
+    error_after: int | None = None,
+) -> list[dict[str, Any]]:
+    """Answer successive S2 searches with ``pages``; returns the params of each.
+
+    ``error_after`` makes every request past that many succeed-then-fail, which
+    is how a page failing mid-pagination is exercised without a live API.
+    """
+    calls: list[dict[str, Any]] = []
+    remaining = list(pages)
 
     class ClientStub:
         async def get(self, url: str, *, params: dict, headers: dict) -> _ResponseStub:
-            captured.update(params)
-            return _ResponseStub({"data": papers})
+            calls.append(dict(params))
+            if error_after is not None and len(calls) > error_after:
+                raise httpx.ConnectError("stubbed transport failure")
+            return _ResponseStub({"data": remaining.pop(0) if remaining else []})
 
     async def no_rate_gate() -> None:
         pass
 
     monkeypatch.setattr(search, "_get_http_client", lambda: ClientStub())
     monkeypatch.setattr(search, "_s2_rate_gate", no_rate_gate)
-    return captured
+    return calls
+
+
+def _stub_search(monkeypatch, papers: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Answer one S2 search with ``papers``; returns the params of each request."""
+    return _stub_pages(monkeypatch, papers)
+
+
+def _filler(count: int) -> list[dict[str, Any]]:
+    """Rows with no arXiv ID -- about four fifths of what S2 really returns."""
+    return [_paper(f"Journal {index}") for index in range(count)]
+
+
+def _no_backoff_sleep(monkeypatch) -> None:
+    """Skip the retry waits so a failure test does not sleep through backoff."""
+
+    async def record_sleep(seconds: float) -> None:
+        pass
+
+    monkeypatch.setattr(search, "asyncio", types.SimpleNamespace(sleep=record_sleep))
 
 
 @pytest.mark.anyio
-async def test_requests_external_ids_and_widens_the_page(monkeypatch) -> None:
+async def test_requests_external_ids_and_a_full_first_page(monkeypatch) -> None:
     monkeypatch.setenv("ARXIV_SEARCH_LIMIT", "10")
-    captured = _stub_search(monkeypatch, [])
+    calls = _stub_search(monkeypatch, [])
 
     await search.arxiv_paper_search(query="retrieval augmented generation")
 
-    assert "externalIds" in captured["fields"]
-    assert captured["limit"] == 10 * search._ARXIV_OVERFETCH_MULTIPLIER
+    assert "externalIds" in calls[0]["fields"]
+    assert calls[0]["limit"] == search._ARXIV_PAGE_SIZE
+    assert calls[0]["offset"] == 0
     # arXiv provenance is decided on external IDs; the venue is not stable.
-    assert "venue" not in captured
+    assert "venue" not in calls[0]
 
 
 @pytest.mark.anyio
-async def test_page_widening_is_capped_at_the_s2_maximum(monkeypatch) -> None:
-    monkeypatch.setenv("ARXIV_SEARCH_LIMIT", "50")
-    captured = _stub_search(monkeypatch, [])
+async def test_pagination_continues_until_the_wanted_count_is_reached(monkeypatch) -> None:
+    # Only about a fifth of S2 rows carry an arXiv ID, so a sparse first page is
+    # the normal case rather than the exception.
+    monkeypatch.setenv("ARXIV_SEARCH_LIMIT", "3")
+    calls = _stub_pages(
+        monkeypatch,
+        _filler(99) + [_paper("First", arxiv="2401.00001")],
+        _filler(98) + [_paper("Second", arxiv="2401.00002"), _paper("Third", arxiv="2401.00003")],
+    )
 
-    await search.arxiv_paper_search(query="q")
+    result = await search.arxiv_paper_search(query="q")
 
-    assert captured["limit"] == search._S2_MAX_SEARCH_LIMIT
+    assert [call["offset"] for call in calls] == [0, search._ARXIV_PAGE_SIZE]
+    assert "**First**" in result
+    assert "**Third**" in result
+    # Relevance order survives paging: page one's hit precedes page two's.
+    assert result.index("**First**") < result.index("**Second**") < result.index("**Third**")
+
+
+@pytest.mark.anyio
+async def test_pagination_stops_at_the_page_budget_without_erroring(monkeypatch) -> None:
+    monkeypatch.setenv("ARXIV_SEARCH_LIMIT", "10")
+    calls = _stub_pages(
+        monkeypatch,
+        *[_filler(99) + [_paper(f"Sparse {n}", arxiv=f"2401.0000{n}")] for n in range(5)],
+    )
+
+    result = await search.arxiv_paper_search(query="q")
+
+    # Three pages, then stop: returning fewer than wanted is a result, not an error.
+    assert [call["offset"] for call in calls] == [0, 100, 200]
+    assert result.count("URL: https://arxiv.org/abs/") == 3
+    assert not result.startswith("Error")
+
+
+@pytest.mark.anyio
+async def test_pagination_stops_when_s2_runs_out_of_hits(monkeypatch) -> None:
+    monkeypatch.setenv("ARXIV_SEARCH_LIMIT", "10")
+    calls = _stub_pages(monkeypatch, _filler(4) + [_paper("Only", arxiv="2401.00001")])
+
+    result = await search.arxiv_paper_search(query="q")
+
+    # A short page means there is no next one; asking for it would waste the gate.
+    assert len(calls) == 1
+    assert "**Only**" in result
+
+
+@pytest.mark.anyio
+async def test_a_page_failing_late_keeps_the_earlier_pages_results(monkeypatch) -> None:
+    monkeypatch.setenv("ARXIV_SEARCH_LIMIT", "10")
+    _no_backoff_sleep(monkeypatch)
+    _stub_pages(
+        monkeypatch,
+        _filler(99) + [_paper("Survivor", arxiv="2401.00001")],
+        error_after=1,
+    )
+
+    result = await search.arxiv_paper_search(query="q")
+
+    assert "**Survivor**" in result
+    assert not result.startswith("Error")
+
+
+@pytest.mark.anyio
+async def test_a_first_page_failure_is_reported(monkeypatch) -> None:
+    _no_backoff_sleep(monkeypatch)
+    _stub_pages(monkeypatch, error_after=0)
+
+    result = await search.arxiv_paper_search(query="q")
+
+    assert result.startswith("Error searching arXiv papers")
+
+
+def test_the_description_tells_the_model_what_the_backend_is() -> None:
+    # 8 of the 12 operator-bearing queries in a 200-query sample returned zero
+    # rows: the model was treating this as a web search engine.
+    description = search.arxiv_paper_search.description
+
+    assert "not a web search engine" in description
+    assert "site:" in description
+    assert "boolean" in description.casefold()
+
+
+@pytest.mark.anyio
+async def test_web_search_operators_are_passed_through_unmodified(monkeypatch) -> None:
+    # The description is the fix. Rewriting the query in code would hide what
+    # the model actually asked and make the empty result unattributable.
+    calls = _stub_pages(monkeypatch, [])
+    query = 'site:arxiv.org "retrieval augmented generation" -survey'
+
+    await search.arxiv_paper_search(query=query)
+
+    assert calls[0]["query"] == query
 
 
 @pytest.mark.anyio
@@ -220,13 +338,13 @@ async def test_relevance_order_is_preserved_and_truncated_after_filtering(monkey
 
 @pytest.mark.anyio
 async def test_cutoff_is_pushed_one_day_short_server_side(monkeypatch) -> None:
-    captured = _stub_search(monkeypatch, [])
+    calls = _stub_search(monkeypatch, [])
 
     with search.search_date_cutoff("2024-06-01 13:06:19+00:00"):
         await search.arxiv_paper_search(query="q")
 
     # The exporter's test is strictly-before and S2's range is inclusive.
-    assert captured["publicationDateOrYear"] == ":2024-05-31"
+    assert calls[0]["publicationDateOrYear"] == ":2024-05-31"
 
 
 @pytest.mark.anyio

--- a/tests/harness/tools/test_arxiv_paper_search.py
+++ b/tests/harness/tools/test_arxiv_paper_search.py
@@ -21,7 +21,7 @@ class _ResponseStub:
 
     def __init__(
         self,
-        data: dict[str, Any],
+        data: Any,
         status_code: int = 200,
         headers: dict[str, str] | None = None,
     ) -> None:
@@ -59,25 +59,50 @@ def _paper(
     return paper
 
 
+BAD_JSON = "<body that is not json>"
+BAD_SHAPE = "<a list where an object belongs>"
+
+
 def _stub_pages(
     monkeypatch,
-    *pages: list[dict[str, Any]],
+    *pages,
     error_after: int | None = None,
+    headers_out: list[dict[str, str]] | None = None,
 ) -> list[dict[str, Any]]:
     """Answer successive S2 searches with ``pages``; returns the params of each.
 
-    ``error_after`` makes every request past that many succeed-then-fail, which
-    is how a page failing mid-pagination is exercised without a live API.
+    A page may be a row list, or one of the BAD_* sentinels standing for a
+    response body S2 should never send but sometimes does. ``error_after`` makes
+    every request past that many fail at the transport, which is how a page
+    failing mid-pagination is exercised without a live API.
     """
     calls: list[dict[str, Any]] = []
     remaining = list(pages)
 
+    class _BadJson:
+        status_code = 200
+        text = ""
+        headers: dict[str, str] = {}
+
+        def raise_for_status(self) -> None:
+            pass
+
+        def json(self) -> Any:
+            raise ValueError("Expecting value: line 1 column 1 (char 0)")
+
     class ClientStub:
-        async def get(self, url: str, *, params: dict, headers: dict) -> _ResponseStub:
+        async def get(self, url: str, *, params: dict, headers: dict) -> Any:
             calls.append(dict(params))
+            if headers_out is not None:
+                headers_out.append(dict(headers))
             if error_after is not None and len(calls) > error_after:
                 raise httpx.ConnectError("stubbed transport failure")
-            return _ResponseStub({"data": remaining.pop(0) if remaining else []})
+            page = remaining.pop(0) if remaining else []
+            if page is BAD_JSON:
+                return _BadJson()
+            if page is BAD_SHAPE:
+                return _ResponseStub(["not", "an", "object"])
+            return _ResponseStub({"data": page})
 
     async def no_rate_gate() -> None:
         pass
@@ -279,10 +304,23 @@ async def test_hits_missing_a_title_or_abstract_are_rejected(monkeypatch, field,
 
 
 @pytest.mark.anyio
-async def test_a_malformed_publication_date_is_rejected_not_downgraded(monkeypatch) -> None:
-    # Falling back to the ID's month here would admit the paper on the strength
-    # of a date nothing could read -- and 2405 precedes the cutoff, so it would.
+async def test_a_malformed_publication_date_falls_back_to_the_id_month(monkeypatch) -> None:
+    # Mirrors RetrievalPolicy.admits, whose date parser returns None for a date
+    # it cannot read just as it does for one that is absent, and falls back to
+    # the arXiv ID's month in both cases. Retrieval is the lenient layer; the
+    # strict cutoff test that decides what is scored runs at export.
     _stub_search(monkeypatch, [_paper("Garbled", arxiv="2405.00001", published="not a date")])
+
+    with search.search_date_cutoff("2024-06-01"):
+        result = await search.arxiv_paper_search(query="q")
+
+    assert "**Garbled**" in result
+    assert "Published: 2024-05 (month precision)" in result
+
+
+@pytest.mark.anyio
+async def test_a_malformed_date_whose_id_month_is_too_late_is_still_rejected(monkeypatch) -> None:
+    _stub_search(monkeypatch, [_paper("Garbled", arxiv="2406.00001", published="not a date")])
 
     with search.search_date_cutoff("2024-06-01"):
         result = await search.arxiv_paper_search(query="q")
@@ -440,3 +478,99 @@ async def test_rate_limited_requests_are_retried_after_the_servers_delay(monkeyp
     # Retry-After wins over the exponential schedule, clamped to the module's
     # ceiling: a server asking for longer than _MAX_BACKOFF_S is under-waited.
     assert slept == [min(30.0, search._MAX_BACKOFF_S)]
+
+
+@pytest.mark.anyio
+async def test_identity_fields_precede_the_abstract(monkeypatch) -> None:
+    # The abstract is the one field a paper controls the text of, so every
+    # identifying field is rendered before it can start.
+    _stub_search(monkeypatch, [_paper("Ordered", arxiv="2401.00001", published="2024-01-05")])
+
+    result = await search.arxiv_paper_search(query="q")
+
+    assert result.index("arXiv: 2401.00001") < result.index("Abstract:")
+    assert result.index("URL: ") < result.index("Abstract:")
+    assert result.index("Published: ") < result.index("Abstract:")
+
+
+@pytest.mark.anyio
+async def test_a_paper_repeated_across_pages_counts_once(monkeypatch) -> None:
+    # S2 can return the same paper on more than one page; counting it twice
+    # would fill the caller's budget with one paper.
+    monkeypatch.setenv("ARXIV_SEARCH_LIMIT", "3")
+    duplicate = _paper("Repeated", arxiv="2401.00001")
+    calls = _stub_pages(
+        monkeypatch,
+        _filler(99) + [duplicate],
+        _filler(98) + [_paper("Repeated again", arxiv="2401.00001v2"), duplicate],
+        _filler(99) + [_paper("Distinct", arxiv="2401.00002")],
+    )
+
+    result = await search.arxiv_paper_search(query="q")
+
+    assert len(calls) == 3
+    assert result.count("arXiv: 2401.00001") == 1
+    assert "**Repeated again**" not in result
+    assert "**Distinct**" in result
+
+
+@pytest.mark.anyio
+async def test_each_page_rotates_through_the_configured_keys(monkeypatch) -> None:
+    # The rate gate spaces requests for the key set as a whole, so a multi-page
+    # search holding one key would hammer it at the interval meant for three.
+    monkeypatch.setenv("S2_API_KEY", "key-a,key-b,key-c")
+    monkeypatch.setenv("ARXIV_SEARCH_LIMIT", "99")
+    headers: list[dict[str, str]] = []
+    _stub_pages(
+        monkeypatch,
+        *[_filler(99) + [_paper(f"One {n}", arxiv=f"2401.0000{n}")] for n in range(3)],
+        headers_out=headers,
+    )
+
+    await search.arxiv_paper_search(query="q")
+
+    assert len(headers) == 3
+    assert len({header["x-api-key"] for header in headers}) == 3
+
+
+@pytest.mark.anyio
+async def test_a_late_page_of_unreadable_json_keeps_earlier_results(monkeypatch) -> None:
+    monkeypatch.setenv("ARXIV_SEARCH_LIMIT", "10")
+    _stub_pages(monkeypatch, _filler(99) + [_paper("Survivor", arxiv="2401.00001")], BAD_JSON)
+
+    result = await search.arxiv_paper_search(query="q")
+
+    assert "**Survivor**" in result
+    assert not result.startswith("Error")
+
+
+@pytest.mark.anyio
+async def test_a_late_page_of_unexpected_shape_keeps_earlier_results(monkeypatch) -> None:
+    monkeypatch.setenv("ARXIV_SEARCH_LIMIT", "10")
+    _stub_pages(monkeypatch, _filler(99) + [_paper("Survivor", arxiv="2401.00001")], BAD_SHAPE)
+
+    result = await search.arxiv_paper_search(query="q")
+
+    assert "**Survivor**" in result
+    assert not result.startswith("Error")
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("payload", [BAD_JSON, BAD_SHAPE])
+async def test_a_first_page_of_garbage_is_reported(monkeypatch, payload) -> None:
+    _stub_pages(monkeypatch, payload)
+
+    result = await search.arxiv_paper_search(query="q")
+
+    assert result.startswith("Error searching arXiv papers")
+
+
+@pytest.mark.anyio
+async def test_an_empty_data_array_is_not_an_error(monkeypatch) -> None:
+    # An empty page is a legitimate answer and must stay distinguishable from a
+    # response this code could not read.
+    _stub_pages(monkeypatch, [])
+
+    result = await search.arxiv_paper_search(query="q")
+
+    assert result == "No arXiv papers found for query."

--- a/tests/harness/tools/test_arxiv_paper_search.py
+++ b/tests/harness/tools/test_arxiv_paper_search.py
@@ -36,15 +36,16 @@ class _ResponseStub:
 
 
 def _paper(
-    title: str,
+    title: str | None,
     *,
     arxiv: str | None = None,
     published: str | None = None,
     year: int | None = 2020,
+    abstract: str | None = "",
 ) -> dict[str, Any]:
     paper: dict[str, Any] = {
         "title": title,
-        "abstract": f"Abstract of {title}.",
+        "abstract": f"Abstract of {title}." if abstract == "" else abstract,
         "year": year,
         "url": "",
         "authors": [{"name": "A. Author"}],
@@ -128,13 +129,56 @@ async def test_a_dated_hit_is_published_to_the_day(monkeypatch) -> None:
 
 
 @pytest.mark.anyio
-async def test_a_hit_with_no_date_anywhere_shows_none(monkeypatch) -> None:
+async def test_a_hit_nothing_can_date_is_rejected(monkeypatch) -> None:
+    # lit-agents' _classify_source calls this "undated" and drops it; the
+    # exporter has no other evidence either.
     _stub_search(monkeypatch, [_paper("Undatable", arxiv="not-an-id")])
 
     result = await search.arxiv_paper_search(query="q")
 
-    assert "**Undatable**" in result
-    assert "Published:" not in result
+    assert result == "No arXiv papers found for query."
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [("title", None), ("title", "   "), ("abstract", None), ("abstract", "  ")],
+)
+async def test_hits_missing_a_title_or_abstract_are_rejected(monkeypatch, field, value) -> None:
+    # paper.csv rows with an empty title or snippet fail the contract, so a hit
+    # that would produce one is never offered as citable.
+    kwargs = {"arxiv": "2401.01234", "published": "2024-01-15"}
+    if field == "abstract":
+        kwargs["abstract"] = value
+        paper = _paper("Titled", **kwargs)
+    else:
+        paper = _paper(value, **kwargs)
+    _stub_search(monkeypatch, [paper])
+
+    result = await search.arxiv_paper_search(query="q")
+
+    assert result == "No arXiv papers found for query."
+
+
+@pytest.mark.anyio
+async def test_a_malformed_publication_date_is_rejected_not_downgraded(monkeypatch) -> None:
+    # Falling back to the ID's month here would admit the paper on the strength
+    # of a date nothing could read -- and 2405 precedes the cutoff, so it would.
+    _stub_search(monkeypatch, [_paper("Garbled", arxiv="2405.00001", published="not a date")])
+
+    with search.search_date_cutoff("2024-06-01"):
+        result = await search.arxiv_paper_search(query="q")
+
+    assert result == "No arXiv papers found for query."
+
+
+@pytest.mark.anyio
+async def test_context_only_hits_need_a_title_and_an_abstract(monkeypatch) -> None:
+    _stub_search(monkeypatch, [_paper("Untitled", abstract=None), _paper(None)])
+
+    result = await search.arxiv_paper_search(query="q")
+
+    assert result == "No arXiv papers found for query."
 
 
 @pytest.mark.anyio

--- a/tests/harness/tools/test_search_api_keys.py
+++ b/tests/harness/tools/test_search_api_keys.py
@@ -213,9 +213,10 @@ def test_key_helpers_are_plain_functions_not_registered_tools() -> None:
     assert isinstance(search._api_keys_from_env("OLMO_EVAL_NO_SUCH_VAR"), list)
 
     # The decorator still binds to the real tool function, not to a helper: the
-    # only Tool objects in the module are the four intended tools.
+    # only Tool objects in the module are the five intended tools.
     assert {name for name, value in vars(search).items() if isinstance(value, Tool)} == {
         "semantic_scholar_search",
+        "arxiv_paper_search",
         "serper_web_search",
         "serper_fetch_page",
         "crawl4ai_browse",

--- a/tests/harness/tools/test_search_api_keys.py
+++ b/tests/harness/tools/test_search_api_keys.py
@@ -1,0 +1,223 @@
+"""Tests for multi-key Semantic Scholar authentication.
+
+Covers key discovery (zero / one / several / duplicates), that selection
+actually rotates, and that the module-level helpers are plain functions rather
+than tools accidentally captured by a nearby @registered_tool decorator.
+"""
+
+import inspect
+from typing import Any
+
+import pytest
+
+from olmo_eval.harness.tools import search
+from olmo_eval.harness.tools.tool import Tool
+
+S2_BASE_VAR = "S2_API_KEY"
+
+
+class _ResponseStub:
+    status_code = 200
+    text = ""
+    headers: dict[str, str] = {}
+
+    def __init__(self, data: dict[str, Any]) -> None:
+        self._data = data
+
+    def raise_for_status(self) -> None:
+        pass
+
+    def json(self) -> dict[str, Any]:
+        return self._data
+
+
+@pytest.fixture
+def clean_s2_env(monkeypatch):
+    """Remove every S2 key variable so each test starts from a known state."""
+    import os
+
+    for name in list(os.environ):
+        if name == S2_BASE_VAR or (
+            name.startswith(f"{S2_BASE_VAR}_") and name[len(S2_BASE_VAR) + 1 :].isdigit()
+        ):
+            monkeypatch.delenv(name, raising=False)
+    return monkeypatch
+
+
+def _capture_request_headers(monkeypatch) -> list[dict[str, str]]:
+    """Stub the HTTP client and rate gate, returning the list of sent headers."""
+    sent_headers: list[dict[str, str]] = []
+
+    class ClientStub:
+        async def get(self, url: str, *, params: dict, headers: dict) -> _ResponseStub:
+            sent_headers.append(dict(headers))
+            return _ResponseStub({"data": [{"title": "Paper", "year": 2020}]})
+
+    async def no_rate_gate() -> None:
+        pass
+
+    monkeypatch.setattr(search, "_get_http_client", lambda: ClientStub())
+    monkeypatch.setattr(search, "_s2_rate_gate", no_rate_gate)
+    return sent_headers
+
+
+def test_no_keys_configured(clean_s2_env) -> None:
+    assert search._api_keys_from_env(S2_BASE_VAR) == []
+    assert search._s2_rate_interval() == search._S2_MIN_INTERVAL_S
+
+
+def test_single_key_is_used_unchanged(clean_s2_env) -> None:
+    clean_s2_env.setenv(S2_BASE_VAR, "solo-key")
+
+    assert search._api_keys_from_env(S2_BASE_VAR) == ["solo-key"]
+    # Every request keeps using the only key, and the pacing is untouched.
+    keys = search._api_keys_from_env(S2_BASE_VAR)
+    assert {search._select_api_key(keys) for _ in range(10)} == {"solo-key"}
+    assert search._s2_rate_interval() == search._S2_MIN_INTERVAL_S
+
+
+def test_numbered_variables_are_discovered_in_numeric_order(clean_s2_env) -> None:
+    clean_s2_env.setenv(S2_BASE_VAR, "first")
+    clean_s2_env.setenv(f"{S2_BASE_VAR}_2", "second")
+    clean_s2_env.setenv(f"{S2_BASE_VAR}_10", "tenth")
+    clean_s2_env.setenv(f"{S2_BASE_VAR}_3", "third")
+
+    # _10 sorts after _3 numerically, not lexicographically.
+    assert search._api_keys_from_env(S2_BASE_VAR) == ["first", "second", "third", "tenth"]
+
+
+def test_comma_separated_variable_is_split(clean_s2_env) -> None:
+    clean_s2_env.setenv(S2_BASE_VAR, "one, two ,three")
+
+    assert search._api_keys_from_env(S2_BASE_VAR) == ["one", "two", "three"]
+
+
+def test_numbered_and_comma_forms_combine(clean_s2_env) -> None:
+    clean_s2_env.setenv(S2_BASE_VAR, "a")
+    clean_s2_env.setenv(f"{S2_BASE_VAR}_2", "b,c")
+
+    assert search._api_keys_from_env(S2_BASE_VAR) == ["a", "b", "c"]
+
+
+def test_blank_and_whitespace_values_are_ignored(clean_s2_env) -> None:
+    clean_s2_env.setenv(S2_BASE_VAR, "")
+    clean_s2_env.setenv(f"{S2_BASE_VAR}_2", "   ")
+    clean_s2_env.setenv(f"{S2_BASE_VAR}_3", "real,,")
+
+    assert search._api_keys_from_env(S2_BASE_VAR) == ["real"]
+
+
+def test_unrelated_suffixes_are_not_treated_as_keys(clean_s2_env) -> None:
+    clean_s2_env.setenv(S2_BASE_VAR, "real")
+    clean_s2_env.setenv(f"{S2_BASE_VAR}_BACKUP", "not-a-key")
+    clean_s2_env.setenv("S2_SEARCH_LIMIT", "20")
+
+    assert search._api_keys_from_env(S2_BASE_VAR) == ["real"]
+
+
+def test_duplicate_keys_collapse(clean_s2_env) -> None:
+    clean_s2_env.setenv(S2_BASE_VAR, "dup")
+    clean_s2_env.setenv(f"{S2_BASE_VAR}_2", " dup ")
+    clean_s2_env.setenv(f"{S2_BASE_VAR}_3", "dup,other")
+
+    assert search._api_keys_from_env(S2_BASE_VAR) == ["dup", "other"]
+
+
+def test_duplicate_only_config_keeps_single_key_pacing(clean_s2_env) -> None:
+    clean_s2_env.setenv(S2_BASE_VAR, "dup")
+    clean_s2_env.setenv(f"{S2_BASE_VAR}_2", "dup")
+
+    # The same key twice is still one key: it must not double the request rate.
+    assert search._api_keys_from_env(S2_BASE_VAR) == ["dup"]
+    assert search._s2_rate_interval() == search._S2_MIN_INTERVAL_S
+
+
+def test_rate_interval_scales_with_distinct_key_count(clean_s2_env) -> None:
+    clean_s2_env.setenv(S2_BASE_VAR, "a")
+    clean_s2_env.setenv(f"{S2_BASE_VAR}_2", "b")
+
+    assert search._s2_rate_interval() == pytest.approx(search._S2_MIN_INTERVAL_S / 2)
+
+    clean_s2_env.setenv(f"{S2_BASE_VAR}_3", "c,d")
+    assert search._s2_rate_interval() == pytest.approx(search._S2_MIN_INTERVAL_S / 4)
+
+
+def test_selection_rotates_evenly_over_all_keys() -> None:
+    keys = ["k1", "k2", "k3"]
+    picks = [search._select_api_key(keys) for _ in range(30)]
+
+    assert set(picks) == set(keys)
+    # Round-robin: perfectly even shares and never the same key twice running.
+    assert {key: picks.count(key) for key in keys} == {"k1": 10, "k2": 10, "k3": 10}
+    assert all(earlier != later for earlier, later in zip(picks, picks[1:], strict=False))
+
+
+def test_selection_cursor_is_shared_across_call_sites() -> None:
+    # Two callers rotating over the same key set must not both get the same key.
+    keys = ["k1", "k2"]
+    assert search._select_api_key(keys) != search._select_api_key(keys)
+
+
+@pytest.mark.anyio
+async def test_semantic_scholar_sends_no_auth_header_without_keys(clean_s2_env) -> None:
+    sent_headers = _capture_request_headers(clean_s2_env)
+
+    await search.semantic_scholar_search(query="test query")
+
+    assert sent_headers == [{}]
+
+
+@pytest.mark.anyio
+async def test_semantic_scholar_reuses_the_only_key(clean_s2_env) -> None:
+    clean_s2_env.setenv(S2_BASE_VAR, "solo-key")
+    sent_headers = _capture_request_headers(clean_s2_env)
+
+    for _ in range(3):
+        await search.semantic_scholar_search(query="test query")
+
+    assert [headers["x-api-key"] for headers in sent_headers] == ["solo-key"] * 3
+
+
+@pytest.mark.anyio
+async def test_semantic_scholar_spreads_requests_over_keys(clean_s2_env) -> None:
+    clean_s2_env.setenv(S2_BASE_VAR, "key-a")
+    clean_s2_env.setenv(f"{S2_BASE_VAR}_2", "key-b")
+    sent_headers = _capture_request_headers(clean_s2_env)
+
+    for _ in range(4):
+        await search.semantic_scholar_search(query="test query")
+
+    used = [headers["x-api-key"] for headers in sent_headers]
+    assert set(used) == {"key-a", "key-b"}
+    assert used[0] != used[1]
+    assert used[0] == used[2] and used[1] == used[3]
+
+
+def test_key_helpers_are_plain_functions_not_registered_tools() -> None:
+    """Guard against the helpers landing inside a @registered_tool sandwich.
+
+    A helper defined between a decorator and its function would come back as a
+    Tool (and calling it would yield a coroutine), so assert the module
+    attributes are ordinary functions and that only real tools are registered.
+    """
+    helpers = (
+        search._api_keys_from_env,
+        search._select_api_key,
+        search._s2_rate_interval,
+    )
+    for helper in helpers:
+        assert inspect.isfunction(helper), helper
+        assert not inspect.iscoroutinefunction(helper), helper
+        assert not isinstance(helper, Tool), helper
+
+    assert isinstance(search._api_keys_from_env("OLMO_EVAL_NO_SUCH_VAR"), list)
+
+    # The decorator still binds to the real tool function, not to a helper: the
+    # only Tool objects in the module are the four intended tools.
+    assert {name for name, value in vars(search).items() if isinstance(value, Tool)} == {
+        "semantic_scholar_search",
+        "serper_web_search",
+        "serper_fetch_page",
+        "crawl4ai_browse",
+    }
+    assert search.semantic_scholar_search.name == "semantic_scholar_snippet_search"

--- a/tests/launch/test_beaker.py
+++ b/tests/launch/test_beaker.py
@@ -695,6 +695,12 @@ class TestBuildCommandWithTaskPackages:
 
         assert "uv venv /opt/vllm-venv" in install_cmd
         assert "export VLLM_PYTHON=/opt/vllm-venv/bin/python" in install_cmd
+        # The runtime image ships no nvcc, so FlashInfer's JIT path can never
+        # succeed; the prebuilt kernel cache is what keeps it off that path.
+        assert (
+            "bash /gantry-runtime/src/olmo_eval/launch/beaker/scripts/"
+            "install_flashinfer_jit_cache /opt/vllm-venv/bin/python"
+        ) in install_cmd
         # flashinfer's runtime JIT shells out to a bare "ninja" from the venv
         # vLLM runs in, so the isolated venv must own the binary itself.
         assert "uv pip install --python /opt/vllm-venv/bin/python ninja" in install_cmd
@@ -722,6 +728,7 @@ class TestBuildCommandWithTaskPackages:
 
         assert "uv pip install -e '.[olmo_core,beaker]' -c /tmp/cuda-constraints.txt" in install_cmd
         assert "flash-attn" not in install_cmd
+        assert "install_flashinfer_jit_cache" not in install_cmd
         assert "--no-build-isolation-package" not in install_cmd
 
 

--- a/tests/launch/test_beaker.py
+++ b/tests/launch/test_beaker.py
@@ -695,6 +695,9 @@ class TestBuildCommandWithTaskPackages:
 
         assert "uv venv /opt/vllm-venv" in install_cmd
         assert "export VLLM_PYTHON=/opt/vllm-venv/bin/python" in install_cmd
+        # flashinfer's runtime JIT shells out to a bare "ninja" from the venv
+        # vLLM runs in, so the isolated venv must own the binary itself.
+        assert "uv pip install --python /opt/vllm-venv/bin/python ninja" in install_cmd
         assert (
             "cd /gantry-runtime && uv pip install "
             "--python /opt/vllm-venv/bin/python "

--- a/tests/launch/test_beaker.py
+++ b/tests/launch/test_beaker.py
@@ -583,6 +583,22 @@ class TestBuildCommandWithTaskPackages:
         ) in install_cmd
         assert "grep -E '^(torch|nvidia-)' > /tmp/cuda-constraints.txt" not in install_cmd
 
+    def test_provider_package_checks_out_git_revision(self):
+        from olmo_eval.launch import BeakerLauncher
+
+        launcher = BeakerLauncher()
+        revision = "8b86284be6d18bcb71c7e64032d91fe73a714229"
+        install_cmd = launcher._build_install_cmd(
+            extras=[],
+            env_exports=None,
+            provider_packages=[f"git+https://github.com/allenai/lit-agents.git@{revision}"],
+        )
+
+        assert (
+            f"git -C /tmp/provider-src-0 fetch --quiet --depth=1 origin {revision}" in install_cmd
+        )
+        assert "git -C /tmp/provider-src-0 checkout --quiet --detach FETCH_HEAD" in install_cmd
+
     def test_no_task_packages_if_none(self):
         """Test that no extra install steps if task_packages is None."""
         from olmo_eval.launch import BeakerLauncher

--- a/tests/launch/test_beaker.py
+++ b/tests/launch/test_beaker.py
@@ -649,10 +649,12 @@ class TestBuildCommandWithTaskPackages:
             "> /tmp/vllm-lock-constraints.txt"
         ) in install_cmd
         assert "-c /tmp/vllm-lock-constraints.txt -e '.[vllm]'" in install_cmd
+        # A git provider package is cloned to a local checkout first, so the
+        # install names that path rather than the URL it came from.
         assert (
             "uv --no-config --no-cache pip install --python /opt/vllm-venv/bin/python "
             "--refresh --refresh-package repo --reinstall-package repo "
-            "'repo @ git+https://github.com/user/repo@v1.0' -c /tmp/cuda-constraints.txt"
+            "'repo @ /tmp/provider-src-0' -c /tmp/cuda-constraints.txt"
         ) in install_cmd
         assert "[isolated-vllm-check]" not in install_cmd
 
@@ -712,7 +714,7 @@ class TestBuildCommandWithTaskPackages:
         assert (
             "uv --no-config --no-cache pip install --python /opt/vllm-venv/bin/python "
             "--refresh --refresh-package vllm --reinstall-package vllm "
-            "'vllm @ git+https://github.com/user/vllm@custom' -c /tmp/cuda-constraints.txt"
+            "'vllm @ /tmp/provider-src-0' -c /tmp/cuda-constraints.txt"
         ) in install_cmd
         assert "[isolated-vllm-check]" not in install_cmd
 

--- a/tests/providers/test_replay_provider.py
+++ b/tests/providers/test_replay_provider.py
@@ -1,0 +1,665 @@
+"""Tests for the replay provider that serves generations already saved to disk."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from olmo_eval.common.types import LMRequest, RequestType, SamplingParams
+from olmo_eval.inference.providers.replay import (
+    ReplayCoverageError,
+    ReplayInputError,
+    StoredPredictionsProvider,
+)
+
+MODEL_DIR = "test-model"
+TASK = "demo_task"
+
+
+def chat_request(content: str) -> LMRequest:
+    """Build the chat request a task would hand to the provider."""
+    return LMRequest(
+        request_type=RequestType.CHAT,
+        messages=({"role": "user", "content": content},),
+    )
+
+
+def write_results_dir(
+    root: Path,
+    rows: list[tuple[Any, Any, Any, Any]],
+    *,
+    task: str = TASK,
+    model_dir: str = MODEL_DIR,
+    include_prediction: bool = True,
+) -> Path:
+    """Write a minimal results directory.
+
+    Args:
+        root: Directory that will hold `requests/` and `predictions/`.
+        rows: (doc_id, native_id, request_context, model_output) tuples. A
+            `model_output` of None omits the prediction row entirely.
+        task: Task name used in the filenames.
+        model_dir: Model subdirectory name.
+        include_prediction: When False, no predictions file is written at all.
+    """
+    req_dir = root / "requests" / model_dir
+    pred_dir = root / "predictions" / model_dir
+    req_dir.mkdir(parents=True, exist_ok=True)
+    pred_dir.mkdir(parents=True, exist_ok=True)
+
+    request_lines = []
+    prediction_lines = []
+    for doc_id, native_id, context, model_output in rows:
+        request_lines.append(
+            json.dumps(
+                {
+                    "request_type": "generate_until",
+                    "doc": {"query": "q"},
+                    "request": {"context": context, "stop_sequences": [], "generation_kwargs": {}},
+                    "idx": 0,
+                    "task_name": task,
+                    "doc_id": doc_id,
+                    "native_id": native_id,
+                    "label": None,
+                }
+            )
+        )
+        if model_output is None:
+            continue
+        prediction_lines.append(
+            json.dumps(
+                {
+                    "doc_id": doc_id,
+                    "native_id": native_id,
+                    "model_output": model_output,
+                    "instance_metrics": {},
+                    "label": None,
+                }
+            )
+        )
+
+    (req_dir / f"{task}-requests.jsonl").write_text("\n".join(request_lines) + "\n")
+    if include_prediction:
+        text = "\n".join(prediction_lines)
+        (pred_dir / f"{task}-predictions.jsonl").write_text(text + "\n" if text else "")
+    return root
+
+
+def simple_rows() -> list[tuple[Any, Any, Any, Any]]:
+    """Three chat instances with distinct prompts and distinct answers."""
+    return [
+        (
+            i,
+            i + 1,
+            [{"role": "user", "content": f"question {i}"}],
+            [{"text": f"answer {i}", "extracted_answer": f"answer {i}", "num_chars": 8}],
+        )
+        for i in range(3)
+    ]
+
+
+class TestExactMatch:
+    def test_replays_stored_text_for_every_request(self, tmp_path: Path) -> None:
+        write_results_dir(tmp_path, simple_rows())
+        provider = StoredPredictionsProvider("stored", results_dir=str(tmp_path))
+
+        requests = [chat_request(f"question {i}") for i in range(3)]
+        outputs = provider.generate(requests)
+
+        assert [out[0].text for out in outputs] == ["answer 0", "answer 1", "answer 2"]
+        assert all(len(out) == 1 for out in outputs)
+
+    def test_out_of_order_requests_get_their_own_answer(self, tmp_path: Path) -> None:
+        write_results_dir(tmp_path, simple_rows())
+        provider = StoredPredictionsProvider("stored", results_dir=str(tmp_path))
+
+        outputs = provider.generate([chat_request("question 2"), chat_request("question 0")])
+
+        assert [out[0].text for out in outputs] == ["answer 2", "answer 0"]
+
+    def test_key_ignores_tools_and_sampling_params(self, tmp_path: Path) -> None:
+        """Tools and generation settings describe how to generate, not which instance."""
+        write_results_dir(tmp_path, simple_rows())
+        provider = StoredPredictionsProvider("stored", results_dir=str(tmp_path))
+
+        request = LMRequest(
+            request_type=RequestType.CHAT,
+            messages=({"role": "user", "content": "question 1"},),
+            max_length=4096,
+        )
+        outputs = provider.generate([request], SamplingParams(temperature=0.7, max_tokens=99))
+
+        assert outputs[0][0].text == "answer 1"
+
+    def test_message_key_is_order_and_content_sensitive(self, tmp_path: Path) -> None:
+        write_results_dir(tmp_path, simple_rows())
+        provider = StoredPredictionsProvider("stored", results_dir=str(tmp_path))
+
+        with pytest.raises(ReplayCoverageError):
+            provider.generate([chat_request("question 1 ")])  # trailing space
+
+    def test_completion_style_prompt_round_trips(self, tmp_path: Path) -> None:
+        write_results_dir(
+            tmp_path,
+            [(0, 1, "raw prompt text", [{"text": "raw answer"}])],
+        )
+        provider = StoredPredictionsProvider("stored", results_dir=str(tmp_path))
+
+        request = LMRequest(request_type=RequestType.COMPLETION, prompt="raw prompt text")
+        assert provider.generate([request])[0][0].text == "raw answer"
+
+    def test_prompt_key_does_not_collide_with_chat_key(self, tmp_path: Path) -> None:
+        """A prompt string must never match a chat conversation."""
+        write_results_dir(tmp_path, [(0, 1, "hello", [{"text": "text answer"}])])
+        provider = StoredPredictionsProvider("stored", results_dir=str(tmp_path))
+
+        with pytest.raises(ReplayCoverageError):
+            provider.generate([chat_request("hello")])
+
+    def test_metadata_carries_provenance_and_no_logprob_fields(self, tmp_path: Path) -> None:
+        write_results_dir(tmp_path, simple_rows())
+        provider = StoredPredictionsProvider("stored", results_dir=str(tmp_path))
+
+        output = provider.generate([chat_request("question 1")])[0][0]
+
+        assert output.metadata["replay_source"]["doc_id"] == 1
+        assert output.metadata["replay_source"]["native_id"] == 2
+        assert output.logprobs is None
+        # Absent, not zero: downstream treats missing logprob fields as "unavailable".
+        assert "sum_logits" not in output.metadata
+        assert "num_tokens" not in output.metadata
+        # The task recomputes extracted_answer during scoring.
+        assert output.extracted_answer is None
+
+
+class TestMissingEntry:
+    def test_unknown_request_raises(self, tmp_path: Path) -> None:
+        write_results_dir(tmp_path, simple_rows())
+        provider = StoredPredictionsProvider("stored", results_dir=str(tmp_path))
+
+        with pytest.raises(ReplayCoverageError) as excinfo:
+            provider.generate([chat_request("question 0"), chat_request("never generated")])
+
+        message = str(excinfo.value)
+        assert "1 of 2" in message
+        assert "no saved request matches this content" in message
+
+    def test_saved_request_without_prediction_is_named(self, tmp_path: Path) -> None:
+        """A known instance with no prediction reports its identity, not just 'unknown'."""
+        rows = simple_rows()
+        rows[1] = (1, 2, [{"role": "user", "content": "question 1"}], None)
+        write_results_dir(tmp_path, rows)
+        provider = StoredPredictionsProvider("stored", results_dir=str(tmp_path))
+
+        with pytest.raises(ReplayCoverageError) as excinfo:
+            provider.generate([chat_request("question 1")])
+
+        message = str(excinfo.value)
+        assert "doc_id=1" in message
+        assert "no prediction row with doc_id=1" in message
+
+    def test_null_text_is_missing_not_empty(self, tmp_path: Path) -> None:
+        rows = simple_rows()
+        rows[1] = (1, 2, [{"role": "user", "content": "question 1"}], [{"text": None}])
+        write_results_dir(tmp_path, rows)
+        provider = StoredPredictionsProvider("stored", results_dir=str(tmp_path))
+
+        with pytest.raises(ReplayCoverageError) as excinfo:
+            provider.generate([chat_request("question 1")])
+
+        assert "is null (no generation recorded)" in str(excinfo.value)
+
+    def test_empty_model_output_list_is_missing(self, tmp_path: Path) -> None:
+        rows = simple_rows()
+        rows[1] = (1, 2, [{"role": "user", "content": "question 1"}], [])
+        write_results_dir(tmp_path, rows)
+        provider = StoredPredictionsProvider("stored", results_dir=str(tmp_path))
+
+        with pytest.raises(ReplayCoverageError) as excinfo:
+            provider.generate([chat_request("question 1")])
+
+        assert "empty or missing 'model_output' list" in str(excinfo.value)
+
+    def test_missing_request_does_not_poison_the_others(self, tmp_path: Path) -> None:
+        """The whole batch fails; no partial result is handed back."""
+        write_results_dir(tmp_path, simple_rows())
+        provider = StoredPredictionsProvider("stored", results_dir=str(tmp_path))
+
+        with pytest.raises(ReplayCoverageError):
+            provider.generate([chat_request("question 0"), chat_request("missing")])
+
+        assert provider.coverage_report()["missing"] == 1
+        assert provider.coverage_report()["matched"] == 1
+
+
+class TestEmptyButPresent:
+    def test_empty_string_prediction_is_replayed_as_empty(self, tmp_path: Path) -> None:
+        rows = simple_rows()
+        rows[1] = (1, 2, [{"role": "user", "content": "question 1"}], [{"text": ""}])
+        write_results_dir(tmp_path, rows)
+        provider = StoredPredictionsProvider("stored", results_dir=str(tmp_path))
+
+        outputs = provider.generate([chat_request("question 1")])
+
+        assert outputs[0][0].text == ""
+        assert provider.coverage_report()["missing"] == 0
+        assert provider.coverage_report()["matched"] == 1
+        assert provider.coverage_report()["empty_text_replayed"] == 1
+
+    def test_empty_and_missing_are_reported_differently(self, tmp_path: Path) -> None:
+        rows = [
+            (0, 1, [{"role": "user", "content": "empty one"}], [{"text": ""}]),
+            (1, 2, [{"role": "user", "content": "absent one"}], None),
+        ]
+        write_results_dir(tmp_path, rows)
+        provider = StoredPredictionsProvider("stored", results_dir=str(tmp_path))
+
+        assert provider.generate([chat_request("empty one")])[0][0].text == ""
+        with pytest.raises(ReplayCoverageError):
+            provider.generate([chat_request("absent one")])
+
+
+class TestAmbiguousInput:
+    def test_two_prediction_files_raise(self, tmp_path: Path) -> None:
+        write_results_dir(tmp_path, simple_rows())
+        extra = tmp_path / "predictions" / MODEL_DIR / "other_task-predictions.jsonl"
+        extra.write_text("")
+
+        with pytest.raises(ReplayInputError) as excinfo:
+            StoredPredictionsProvider("stored", results_dir=str(tmp_path))
+
+        assert "Ambiguous predictions input" in str(excinfo.value)
+        assert "other_task-predictions.jsonl" in str(excinfo.value)
+
+    def test_two_request_files_raise(self, tmp_path: Path) -> None:
+        write_results_dir(tmp_path, simple_rows())
+        extra = tmp_path / "requests" / "another-model" / f"{TASK}-requests.jsonl"
+        extra.parent.mkdir(parents=True, exist_ok=True)
+        extra.write_text("")
+
+        with pytest.raises(ReplayInputError) as excinfo:
+            StoredPredictionsProvider("stored", results_dir=str(tmp_path))
+
+        assert "Ambiguous requests input" in str(excinfo.value)
+
+    def test_task_filter_disambiguates(self, tmp_path: Path) -> None:
+        write_results_dir(tmp_path, simple_rows())
+        write_results_dir(
+            tmp_path,
+            [(0, 1, [{"role": "user", "content": "other"}], [{"text": "other answer"}])],
+            task="other_task",
+        )
+
+        provider = StoredPredictionsProvider(
+            "stored", results_dir=str(tmp_path), task_filter="other_task"
+        )
+        assert provider.generate([chat_request("other")])[0][0].text == "other answer"
+
+    def test_explicit_files_bypass_globbing(self, tmp_path: Path) -> None:
+        write_results_dir(tmp_path, simple_rows())
+        write_results_dir(tmp_path, simple_rows(), task="other_task")
+
+        provider = StoredPredictionsProvider(
+            "stored",
+            results_dir=str(tmp_path),
+            requests_file=f"requests/{MODEL_DIR}/{TASK}-requests.jsonl",
+            predictions_file=f"predictions/{MODEL_DIR}/{TASK}-predictions.jsonl",
+        )
+        assert provider.generate([chat_request("question 0")])[0][0].text == "answer 0"
+
+    def test_no_matching_file_raises(self, tmp_path: Path) -> None:
+        (tmp_path / "requests").mkdir()
+        (tmp_path / "predictions").mkdir()
+
+        with pytest.raises(ReplayInputError) as excinfo:
+            StoredPredictionsProvider("stored", results_dir=str(tmp_path))
+
+        assert "No *-requests.jsonl file found" in str(excinfo.value)
+
+    def test_missing_results_dir_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(ReplayInputError):
+            StoredPredictionsProvider("stored", results_dir=str(tmp_path / "nope"))
+
+    def test_duplicate_doc_id_in_predictions_raises(self, tmp_path: Path) -> None:
+        write_results_dir(tmp_path, simple_rows())
+        path = tmp_path / "predictions" / MODEL_DIR / f"{TASK}-predictions.jsonl"
+        lines = path.read_text().splitlines()
+        path.write_text("\n".join([*lines, lines[0]]) + "\n")
+
+        with pytest.raises(ReplayInputError) as excinfo:
+            StoredPredictionsProvider("stored", results_dir=str(tmp_path))
+
+        assert "repeats doc_id=0" in str(excinfo.value)
+
+    def test_identical_requests_with_different_text_raise(self, tmp_path: Path) -> None:
+        """Two instances that look identical cannot be told apart; refuse to guess."""
+        rows = [
+            (0, 1, [{"role": "user", "content": "same"}], [{"text": "answer A"}]),
+            (1, 2, [{"role": "user", "content": "same"}], [{"text": "answer B"}]),
+        ]
+        write_results_dir(tmp_path, rows)
+
+        with pytest.raises(ReplayInputError) as excinfo:
+            StoredPredictionsProvider("stored", results_dir=str(tmp_path))
+
+        assert "different stored" in str(excinfo.value)
+
+    def test_identical_requests_with_identical_text_are_accepted(self, tmp_path: Path) -> None:
+        rows = [
+            (0, 1, [{"role": "user", "content": "same"}], [{"text": "one answer"}]),
+            (1, 2, [{"role": "user", "content": "same"}], [{"text": "one answer"}]),
+        ]
+        write_results_dir(tmp_path, rows)
+        provider = StoredPredictionsProvider("stored", results_dir=str(tmp_path))
+
+        assert provider.generate([chat_request("same")])[0][0].text == "one answer"
+
+    def test_native_id_disagreement_raises(self, tmp_path: Path) -> None:
+        """doc_id joins the files; native_id is the witness that they match."""
+        write_results_dir(tmp_path, simple_rows())
+        path = tmp_path / "predictions" / MODEL_DIR / f"{TASK}-predictions.jsonl"
+        rows = [json.loads(line) for line in path.read_text().splitlines()]
+        rows[1]["native_id"] = 999
+        path.write_text("\n".join(json.dumps(r) for r in rows) + "\n")
+
+        with pytest.raises(ReplayInputError) as excinfo:
+            StoredPredictionsProvider("stored", results_dir=str(tmp_path))
+
+        assert "do not describe the same run" in str(excinfo.value)
+
+    def test_request_without_context_raises(self, tmp_path: Path) -> None:
+        write_results_dir(tmp_path, simple_rows())
+        path = tmp_path / "requests" / MODEL_DIR / f"{TASK}-requests.jsonl"
+        rows = [json.loads(line) for line in path.read_text().splitlines()]
+        del rows[0]["request"]["context"]
+        path.write_text("\n".join(json.dumps(r) for r in rows) + "\n")
+
+        with pytest.raises(ReplayInputError) as excinfo:
+            StoredPredictionsProvider("stored", results_dir=str(tmp_path))
+
+        assert "has no request.context" in str(excinfo.value)
+
+
+class TestCoverageReporting:
+    def test_load_time_counts(self, tmp_path: Path) -> None:
+        rows = simple_rows()
+        rows[2] = (2, 3, [{"role": "user", "content": "question 2"}], None)
+        write_results_dir(tmp_path, rows)
+        provider = StoredPredictionsProvider("stored", results_dir=str(tmp_path))
+
+        report = provider.coverage_report()
+        assert report["stored_requests"] == 3
+        assert report["stored_predictions"] == 2
+        assert report["replayable_entries"] == 2
+        assert report["unusable_entries"] == 1
+        assert report["requested"] == 0
+
+    def test_counts_accumulate_across_calls(self, tmp_path: Path) -> None:
+        write_results_dir(tmp_path, simple_rows())
+        provider = StoredPredictionsProvider("stored", results_dir=str(tmp_path))
+
+        provider.generate([chat_request("question 0")])
+        provider.generate([chat_request("question 1"), chat_request("question 2")])
+
+        report = provider.coverage_report()
+        assert report["requested"] == 3
+        assert report["matched"] == 3
+        assert report["missing"] == 0
+        assert report["unused_entries"] == 0
+
+    def test_has_stored_prediction_probes_without_raising(self, tmp_path: Path) -> None:
+        write_results_dir(tmp_path, simple_rows())
+        provider = StoredPredictionsProvider("stored", results_dir=str(tmp_path))
+
+        assert provider.has_stored_prediction(chat_request("question 0"))
+        assert not provider.has_stored_prediction(chat_request("never generated"))
+
+    def test_unused_entries_are_visible(self, tmp_path: Path) -> None:
+        write_results_dir(tmp_path, simple_rows())
+        provider = StoredPredictionsProvider("stored", results_dir=str(tmp_path))
+
+        provider.generate([chat_request("question 0")])
+
+        assert provider.coverage_report()["unused_entries"] == 2
+
+    def test_batch_coverage_is_logged(self, tmp_path: Path, caplog: Any) -> None:
+        write_results_dir(tmp_path, simple_rows())
+        provider = StoredPredictionsProvider("stored", results_dir=str(tmp_path))
+
+        with caplog.at_level("INFO"):
+            provider.generate([chat_request("question 0")])
+
+        assert any("Replay coverage" in record.message for record in caplog.records)
+
+
+class TestSamplesAndLogprobs:
+    def test_logprobs_raises(self, tmp_path: Path) -> None:
+        write_results_dir(tmp_path, simple_rows())
+        provider = StoredPredictionsProvider("stored", results_dir=str(tmp_path))
+
+        with pytest.raises(NotImplementedError, match="no logprobs"):
+            provider.logprobs([chat_request("question 0")])
+
+    @pytest.mark.anyio
+    async def test_alogprobs_raises(self, tmp_path: Path, anyio_backend: str) -> None:
+        write_results_dir(tmp_path, simple_rows())
+        provider = StoredPredictionsProvider("stored", results_dir=str(tmp_path))
+
+        with pytest.raises(NotImplementedError):
+            await provider.alogprobs([chat_request("question 0")])
+
+    @pytest.mark.anyio
+    async def test_agenerate_matches_generate(self, tmp_path: Path, anyio_backend: str) -> None:
+        write_results_dir(tmp_path, simple_rows())
+        provider = StoredPredictionsProvider("stored", results_dir=str(tmp_path))
+
+        outputs = await provider.agenerate([chat_request("question 0")])
+        assert outputs[0][0].text == "answer 0"
+
+    def test_more_samples_than_stored_raises(self, tmp_path: Path) -> None:
+        write_results_dir(tmp_path, simple_rows())
+        provider = StoredPredictionsProvider("stored", results_dir=str(tmp_path))
+
+        with pytest.raises(ReplayCoverageError, match="never fabricates"):
+            provider.generate([chat_request("question 0")], SamplingParams(num_samples=2))
+
+    def test_multiple_stored_samples_are_replayed(self, tmp_path: Path) -> None:
+        rows = [
+            (
+                0,
+                1,
+                [{"role": "user", "content": "q"}],
+                [{"text": "sample A"}, {"text": "sample B"}],
+            )
+        ]
+        write_results_dir(tmp_path, rows)
+        provider = StoredPredictionsProvider("stored", results_dir=str(tmp_path))
+
+        outputs = provider.generate([chat_request("q")], SamplingParams(num_samples=2))
+        assert [o.text for o in outputs[0]] == ["sample A", "sample B"]
+
+
+class TestTrajectoryPreservation:
+    def test_trajectory_is_reattached_to_metadata(self, tmp_path: Path) -> None:
+        """The runner rebuilds Response.trajectory from metadata['trajectory']."""
+        req_dir = tmp_path / "requests" / MODEL_DIR
+        pred_dir = tmp_path / "predictions" / MODEL_DIR
+        req_dir.mkdir(parents=True)
+        pred_dir.mkdir(parents=True)
+        trajectory = {"turns": [{"role": "assistant", "content": "hi"}], "final_answer": "answer"}
+        (req_dir / f"{TASK}-requests.jsonl").write_text(
+            json.dumps(
+                {
+                    "doc_id": 0,
+                    "native_id": 1,
+                    "request": {"context": [{"role": "user", "content": "q"}]},
+                }
+            )
+            + "\n"
+        )
+        (pred_dir / f"{TASK}-predictions.jsonl").write_text(
+            json.dumps(
+                {
+                    "doc_id": 0,
+                    "native_id": 1,
+                    "model_output": [{"text": "answer"}],
+                    "trajectory": trajectory,
+                }
+            )
+            + "\n"
+        )
+
+        provider = StoredPredictionsProvider("stored", results_dir=str(tmp_path))
+        output = provider.generate([chat_request("q")])[0][0]
+        assert output.metadata["trajectory"] == trajectory
+
+        off = StoredPredictionsProvider(
+            "stored", results_dir=str(tmp_path), preserve_trajectory=False
+        )
+        assert "trajectory" not in off.generate([chat_request("q")])[0][0].metadata
+
+
+class TestProviderWiring:
+    def test_create_provider_python_kind(self, tmp_path: Path) -> None:
+        """The provider is reachable through provider.kind=python + kwargs.class."""
+        from olmo_eval.inference import create_provider
+
+        write_results_dir(tmp_path, simple_rows())
+        provider = create_provider(
+            "python",
+            "stored",
+            **{
+                "class": "olmo_eval.inference.providers.replay.StoredPredictionsProvider",
+                "results_dir": str(tmp_path),
+            },
+        )
+        assert isinstance(provider, StoredPredictionsProvider)
+        assert provider.generate([chat_request("question 0")])[0][0].text == "answer 0"
+
+
+# ─────────────────────────────────────────────────────────────
+# Real data: DeepResearch Bench predictions saved on this host.
+# ─────────────────────────────────────────────────────────────
+
+DRB_EVIDENCE = Path(os.environ.get("DRB_EVIDENCE_DIR", "/tmp/drb-evidence"))
+DRB_PREDICTIONS = [
+    DRB_EVIDENCE / "fixed-drb-predictions.jsonl",
+    DRB_EVIDENCE / "agent_disco-drb-predictions.jsonl",
+]
+
+
+def _real_drb_task_and_requests() -> tuple[Any, list[Any], list[LMRequest]]:
+    """Load the real DeepResearch Bench task, its instances, and its live requests."""
+    from olmo_eval.evals.tasks.common import get_task
+
+    task = get_task("deepresearch_bench")
+    instances = list(task.instances)
+    return task, instances, [task.format_request(instance) for instance in instances]
+
+
+def _build_real_drb_results_dir(tmp_path: Path, predictions_path: Path) -> Path:
+    """Pair real saved DRB predictions with real DRB requests.
+
+    The requests file is produced by the same `build_requests()` code the runner uses,
+    over the real DeepResearch Bench instances, so `request.context` holds exactly what
+    the original run recorded. The predictions come from disk verbatim.
+    """
+    from olmo_eval.runners.io.builders import build_requests
+
+    task, instances, requests = _real_drb_task_and_requests()
+    rows = build_requests(instances, requests, "deepresearch_bench", task.config.sampling_params)
+
+    req_dir = tmp_path / "requests" / "real-model"
+    pred_dir = tmp_path / "predictions" / "real-model"
+    req_dir.mkdir(parents=True)
+    pred_dir.mkdir(parents=True)
+    (req_dir / "deepresearch_bench-requests.jsonl").write_text(
+        "\n".join(json.dumps(r) for r in rows) + "\n"
+    )
+    (pred_dir / "deepresearch_bench-predictions.jsonl").write_bytes(predictions_path.read_bytes())
+    return tmp_path
+
+
+@pytest.mark.skipif(
+    not all(p.exists() for p in DRB_PREDICTIONS),
+    reason="real DeepResearch Bench predictions are not present on this host",
+)
+@pytest.mark.parametrize("predictions_path", DRB_PREDICTIONS, ids=lambda p: p.stem)
+def test_real_deepresearch_bench_round_trip(tmp_path: Path, predictions_path: Path) -> None:
+    """Every instance must come back with byte-identical stored text."""
+    root = _build_real_drb_results_dir(tmp_path, predictions_path)
+    provider = StoredPredictionsProvider("stored", results_dir=str(root))
+
+    _, _, live_requests = _real_drb_task_and_requests()
+    stored = {
+        row["doc_id"]: row
+        for row in (
+            json.loads(line) for line in predictions_path.read_text().splitlines() if line.strip()
+        )
+    }
+
+    outputs = provider.generate(live_requests)
+
+    assert len(outputs) == len(live_requests)
+    assert len(outputs) == len(stored)
+    for doc_id, out in enumerate(outputs):
+        assert out[0].text == stored[doc_id]["model_output"][0]["text"], f"doc_id={doc_id}"
+
+    report = provider.coverage_report()
+    assert report["missing"] == 0
+    assert report["matched"] == len(live_requests)
+    assert report["unused_entries"] == 0
+
+
+@pytest.mark.skipif(
+    not DRB_PREDICTIONS[0].exists(),
+    reason="real DeepResearch Bench predictions are not present on this host",
+)
+def test_real_empty_predictions_replay_as_empty(tmp_path: Path) -> None:
+    """The real `fixed` run contains genuinely empty reports; they must stay empty."""
+    predictions_path = DRB_PREDICTIONS[0]
+    root = _build_real_drb_results_dir(tmp_path, predictions_path)
+    provider = StoredPredictionsProvider("stored", results_dir=str(root))
+
+    _, _, live_requests = _real_drb_task_and_requests()
+    stored_texts = [
+        json.loads(line)["model_output"][0]["text"]
+        for line in predictions_path.read_text().splitlines()
+        if line.strip()
+    ]
+    expected_empty = sum(1 for text in stored_texts if text == "")
+    assert expected_empty > 0, "fixture assumption: this run has empty reports"
+
+    outputs = provider.generate(live_requests)
+
+    assert sum(1 for out in outputs if out[0].text == "") == expected_empty
+    assert provider.coverage_report()["empty_text_replayed"] == expected_empty
+    assert provider.coverage_report()["missing"] == 0
+
+
+@pytest.mark.skipif(
+    not DRB_PREDICTIONS[0].exists(),
+    reason="real DeepResearch Bench predictions are not present on this host",
+)
+def test_real_predictions_with_one_instance_dropped_fail_loudly(tmp_path: Path) -> None:
+    """Deleting one real prediction row must surface as a named, loud failure."""
+    predictions_path = DRB_PREDICTIONS[0]
+    root = _build_real_drb_results_dir(tmp_path, predictions_path)
+    pred_file = root / "predictions" / "real-model" / "deepresearch_bench-predictions.jsonl"
+    lines = [line for line in pred_file.read_text().splitlines() if line.strip()]
+    dropped = json.loads(lines[3])
+    pred_file.write_text("\n".join(lines[:3] + lines[4:]) + "\n")
+
+    provider = StoredPredictionsProvider("stored", results_dir=str(root))
+    _, _, live_requests = _real_drb_task_and_requests()
+
+    with pytest.raises(ReplayCoverageError) as excinfo:
+        provider.generate(live_requests)
+
+    message = str(excinfo.value)
+    assert "1 of 100" in message
+    assert f"doc_id={dropped['doc_id']}" in message

--- a/tests/providers/test_vllm_server_startup.py
+++ b/tests/providers/test_vllm_server_startup.py
@@ -179,6 +179,86 @@ class TestVLLMServerStartupTimeout:
         assert env["VLLM_PORT"] == "23456"
 
     @pytest.mark.anyio
+    async def test_isolated_venv_bin_is_prepended_to_child_path(self):
+        """vLLM must see its own venv's scripts (e.g. ninja) on PATH.
+
+        flashinfer JIT-compiles kernels on the first forward pass by running a
+        bare "ninja". Without the isolated venv's bin directory on PATH that
+        lookup fails and the engine dies after the readiness probe has passed.
+        """
+        import os
+
+        from olmo_eval.inference.providers.vllm_server_utils import VLLMServerProcess
+
+        mock_process = MagicMock()
+        mock_process.pid = 12345
+        mock_process.poll.return_value = None
+
+        original_path = os.pathsep.join(["/opt/venv/bin", "/usr/local/bin", "/usr/bin"])
+
+        with (
+            patch.dict(
+                "os.environ",
+                {"VLLM_PYTHON": "/opt/vllm-venv/bin/python", "PATH": original_path},
+            ),
+            patch(
+                "olmo_eval.inference.providers.vllm_server_utils._find_free_internal_port",
+                return_value=23456,
+            ),
+            patch("subprocess.Popen", return_value=mock_process) as mock_popen,
+            patch(
+                "olmo_eval.inference.providers.vllm_server_utils._wait_for_server",
+                return_value=(True, None, None),
+            ),
+            patch("atexit.register"),
+        ):
+            server = VLLMServerProcess(model_name="test-model", port=8000)
+            server.start()
+
+            env = mock_popen.call_args.kwargs["env"]
+            entries = env["PATH"].split(os.pathsep)
+            assert entries[0] == "/opt/vllm-venv/bin"
+            # The image's own PATH must survive: prepend, never replace.
+            assert entries[1:] == original_path.split(os.pathsep)
+            # The parent process must not be affected.
+            assert os.environ["PATH"] == original_path
+
+    @pytest.mark.anyio
+    async def test_child_path_is_not_duplicated_for_same_venv(self):
+        """A bin directory already on PATH should not be added twice."""
+        import os
+
+        from olmo_eval.inference.providers.vllm_server_utils import VLLMServerProcess
+
+        mock_process = MagicMock()
+        mock_process.pid = 12345
+        mock_process.poll.return_value = None
+
+        original_path = os.pathsep.join(["/opt/vllm-venv/bin", "/usr/bin"])
+
+        with (
+            patch.dict(
+                "os.environ",
+                {"VLLM_PYTHON": "/opt/vllm-venv/bin/python", "PATH": original_path},
+            ),
+            patch(
+                "olmo_eval.inference.providers.vllm_server_utils._find_free_internal_port",
+                return_value=23456,
+            ),
+            patch("subprocess.Popen", return_value=mock_process) as mock_popen,
+            patch(
+                "olmo_eval.inference.providers.vllm_server_utils._wait_for_server",
+                return_value=(True, None, None),
+            ),
+            patch("atexit.register"),
+        ):
+            server = VLLMServerProcess(model_name="test-model", port=8000)
+            server.start()
+
+            env = mock_popen.call_args.kwargs["env"]
+            assert env["PATH"] == original_path
+
+    @pytest.mark.anyio
     async def test_sets_unique_internal_port_env(self):
         """Managed servers should pin vLLM's internal port selection base."""
         from olmo_eval.inference.providers.vllm_server_utils import VLLMServerProcess


### PR DESCRIPTION
## What this adds

DeepScholar-Bench as a first-class olmo-eval task, so the same single-agent scaffold that runs litsearch / SAGE / the other paper-search benchmarks also runs DeepScholar. One arm, comparable across all six benchmarks, while every published number still comes from the benchmark's own evaluator.

Three pieces:

1. **`arxiv_paper_search` tool** ([search.py](https://github.com/allenai/olmo-eval/blob/b2204fd40bbb46325f58a2ca3d374baf2df485e5/src/olmo_eval/harness/tools/search.py)). Searches Semantic Scholar and keeps only arXiv-provenanced papers (client-side `externalIds.ArXiv` filter), with a per-instance date cutoff so the agent cannot cite work newer than the query paper. Overfetches and pages (offsets 0/100/200) until it has arXiv papers to show. Two-tier output: citable results carry `arxiv.org/abs/<id>` links; context-only results don't.
2. **`arxiv_paper_search_agent` harness preset** ([presets.py](https://github.com/allenai/olmo-eval/blob/b2204fd40bbb46325f58a2ca3d374baf2df485e5/src/olmo_eval/harness/presets.py)). The shared openai_agents scaffold with only this tool. Kept separate from `paper_search_agent` so litsearch/SAGE numbers measured against Semantic Scholar search don't move. Its system prompt opens by telling the agent to search before it writes and to cite only what those searches returned, because Qwen3.5-9B otherwise answered some queries from memory in a single turn and every such answer was unexportable.
3. **`deepscholar_bench` task + `deepscholar_export` adapter** ([deepscholar_bench.py](https://github.com/allenai/olmo-eval/blob/b2204fd40bbb46325f58a2ca3d374baf2df485e5/src/olmo_eval/evals/tasks/deepscholar_bench.py), [deepscholar_export.py](https://github.com/allenai/olmo-eval/blob/b2204fd40bbb46325f58a2ca3d374baf2df485e5/src/olmo_eval/evals/tasks/deepscholar_export.py)). The task prompts the upstream generation prompt verbatim over the 63 benchmark queries. The adapter turns each prediction into the exact folder layout upstream's `DeepScholarBaseParser` reads (`final_report.md` / `intro.md` / `paper.csv`), resolving the model's citations ([n], footnotes, bare URLs) against the trajectory's retrieved sources and rewriting them as `[Title](arxiv.org/abs/<id>)` links, the only citation form the official scorer credits. Queries whose answer cites nothing resolvable are excluded and counted in `exportable_rate`; task-level metrics are bookkeeping only, never benchmark scores.

Scoring stays out of band: the export is fed to the pinned official evaluator (`guestrin-lab/deepscholar-bench` at pinned ref `c95413b3`, `python -m eval.main`), so reported metrics come from the benchmark's own instrument.

## Why Semantic Scholar as the arXiv backend

Paired replay of 200 real agent queries against both backends: S2 gold-hit@10 24.2% vs 19.7% for the arXiv API (n=198, every backbone stratum favors S2). The deciding issues are behavioral: the arXiv API ANDs every query word over metadata and returns confident junk instead of an empty list when nothing matches; its `submittedDate` filter is silently dropped when combined with multi-word queries (a one-day window returns 646k results with a five-word query, 1 result with a single word); and its rate limiting 429s well-spaced requests after a burst. The approach follows the S2-with-arXiv-filter shim in `roryd/deepscholar-bench-s2patch`, reimplemented as a harness tool for the agent side.

## The final-report delimiter

Weak backbones write their deliberation into the final answer and the scorer reads all of it (`cite_p` and the organization judge both punish it). The benchmark's user prompt is run verbatim and cannot be edited, so the contract lives in the preset's system prompt instead: deliberate freely, then write a line containing exactly `=== FINAL REPORT ===` and put the whole Related Works section and its reference list after it. The export splits there ([deepscholar_citations.py](https://github.com/allenai/olmo-eval/blob/b2204fd40bbb46325f58a2ca3d374baf2df485e5/src/olmo_eval/evals/tasks/deepscholar_citations.py)).

The contract is measured, never enforced. When the marker is missing the splitter falls back to the model's own Related Works heading, then to the first citation-bearing paragraph, and reports which rule chose the text in `split_tier`. Every candidate passes the same fuse first: if the tail resolves no citation while the full answer does, the full answer is kept, so splitting can never export less than not splitting. `marker_compliance_rate` counts the answers that wrote the marker; `marker_misuse_rate` counts the ones that wrote it and then put the report above it, because a disobedient backbone and a misread prompt need different fixes.

On an archived Qwen3.8-27B corpus the heading tier removed 488k characters of deliberation across 57 answers without losing a single export.

## Status

The branch is synced with current main, including the partial-failure accounting and the scaffold-level `enable_thinking` default. It stays a draft to anchor the design discussion, in particular how this unified-agent arm and the external `deepscholar_bench` eval (which drives the upstream `deepscholar_base` reference pipeline) should coexist and be labeled.

Validated end-to-end on Beaker: smoke and full-63 generation plus official scoring for Qwen3.5-9B, and a fresh smoke of the synced branch that generated, exported and split as expected. The unit suite, ruff and ty match a main baseline run the same way.

## Eval cost

About $0.23 per example across the seven official metrics, dominated by the four gpt-4o-judged ones (~$0.20); `reference_coverage` and a Semantic-Scholar-based `document_importance` are effectively free.

