### PR TITLE
olmo_core: accept uncapped max_tokens in the request trace

### DIFF
--- a/src/olmo_eval/inference/providers/olmo_core.py
+++ b/src/olmo_eval/inference/providers/olmo_core.py
@@ -381,7 +381,10 @@ class OlmoCoreProvider(InferenceProvider):
         return input_ids
 
     def _build_generation_kwargs(self, params: SamplingParams) -> dict[str, object]:
-        if params.max_tokens <= 0:
+        # ``max_tokens=None`` means "generate to the context limit"; the
+        # generation path resolves it per prompt via ``_resolve_max_tokens``,
+        # and the request-trace path never resolves it at all.
+        if params.max_tokens is not None and params.max_tokens <= 0:
             raise ValueError("OlmoCoreProvider requires sampling max_tokens > 0")
         if params.num_samples <= 0:
             raise ValueError("OlmoCoreProvider requires sampling num_samples > 0")

--- a/tests/providers/test_olmo_core_provider.py
+++ b/tests/providers/test_olmo_core_provider.py
@@ -353,6 +353,26 @@ def test_generate_uncapped_fills_context(
     assert call["max_length"] == 32
 
 
+def test_describe_request_handles_uncapped_max_tokens(
+    fake_provider: tuple[OlmoCoreProvider, FakeGenerationModule, FakeTokenizer],
+) -> None:
+    """The trace path never resolves ``max_tokens``, so it must tolerate None.
+
+    ``describe_request`` is called for every request before generation, so
+    raising here would fail an uncapped task before inference starts.
+    """
+    provider, _, _ = fake_provider
+
+    trace = provider.describe_request(
+        LMRequest(request_type=RequestType.COMPLETION, prompt="Prompt"),
+        SamplingParams(max_tokens=None),
+    )
+
+    assert trace is not None
+    assert trace["provider"] == "OlmoCoreProvider"
+    assert trace["generation_kwargs"]["use_cache"] is True
+
+
 def test_generate_left_truncates_to_leave_completion_room(
     fake_provider: tuple[OlmoCoreProvider, FakeGenerationModule, FakeTokenizer],
 ) -> None:


### PR DESCRIPTION
`OlmoCoreProvider._build_generation_kwargs` rejects `max_tokens <= 0`, which raises `TypeError: '<=' not supported between instances of 'NoneType' and 'int'` when `max_tokens` is `None`.

The generation path never hit this — `generate()` calls `_resolve_max_tokens()` first, which replaces `None` with the room left in the context. But `describe_request()` builds the same kwargs *without* resolving, and `runners/asynq/processing.py` traces every request before generation. So any task using `max_tokens=None` fails on this provider before inference starts.

That affects the three migrated post-training tasks in flight — #307 `popqa:chat`, #308 `omega_500`, #309 `gpqa_*:cot` — all of which use `max_tokens=None` (generate to the model's context limit) to avoid the fixed-131k footgun in #310. They ran fine on `vllm_server`, which is why this wasn't caught by the parity runs.

`None` now passes the guard; a concrete non-positive limit is still rejected.

Regression test added: `describe_request` with `SamplingParams(max_tokens=None)` on the existing fake-provider fixture. Verified it raises `TypeError` at `olmo_core.py:384` without the fix. Full suite 1958 passed, ruff/ty clean.

Reported by Codex review on #308.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LMFjgUqHjQA3aCeB4QmEHZ
