### PR TITLE
ifeval_ood: read the public IFBench_test dataset

### DIFF
--- a/src/olmo_eval/common/scorers/ifeval.py
+++ b/src/olmo_eval/common/scorers/ifeval.py
@@ -1,7 +1,7 @@
 """Scorer for IFBench / IFEval instruction-following evaluation.
 
 Uses the ``ifbench`` package registry, which covers the original IFEval
-(DEFAULT) verifiers, the OOD verifiers used by ``allenai/IFBench_test2``,
+(DEFAULT) verifiers, the OOD verifiers used by ``allenai/IFBench_test``,
 and the verifiers used by the multi-turn ``VGraf/ifeval_mt`` slices. The
 scorer evaluates a response against per-instance instructions (looked up
 in ``instance.metadata["instruction_id_list"]`` / ``"kwargs"``) and writes

--- a/src/olmo_eval/evals/tasks/ifeval_ood.py
+++ b/src/olmo_eval/evals/tasks/ifeval_ood.py
@@ -1,6 +1,6 @@
 """IFEval OOD: out-of-distribution instruction-following slice of IFBench.
 
-Dataset: ``allenai/IFBench_test2`` (300 prompts), each carrying a list of
+Dataset: ``allenai/IFBench_test`` (300 prompts), each carrying a list of
 instruction IDs and per-instruction kwargs. Verifiers come from the vendored
 registry in :mod:`olmo_eval.common.scorers.ifeval_deps`.
 
@@ -35,7 +35,7 @@ _PRIMARY_METRIC = IFEvalPromptLooseAccuracy()
 
 @register("ifeval_ood")
 class IFEvalOOD(Task):
-    data_source = DataSource(path="allenai/IFBench_test2", split="train")
+    data_source = DataSource(path="allenai/IFBench_test", split="train")
     split = Split.TRAIN
     metrics = (
         IFEvalPromptStrictAccuracy(),


### PR DESCRIPTION
`ifeval_ood` reads `allenai/IFBench_test2`, which is private and gated behind the allenai org's fine-grained-token policy. Anyone holding a classic HF token gets a load failure, so the task is unrunnable — this is what has IFBench stuck on the migration tracker.

`allenai/IFBench_test` is the benchmark's canonical published set, is public and ungated, and carries the same data. Switching to it makes the task runnable without changing any score.

## Verification that the swap is score-neutral

`IFBench_test2` can't be read from an unprivileged environment, so its contents were recovered from the request file of an oe-eval run that could read it (result dataset `01M0X9N1R1VDM1YEH9J16NTFGX`, experiment `01M0X8SCW6QS5V5BSXP73RKP1V`) and diffed against the public set on `key`, `prompt`, `instruction_id_list` and non-null `kwargs`:

```
public  allenai/IFBench_test : n=300
recovered IFBench_test2      : n=300
row-order mismatches         : 0
content hashes               : equal
```

Task level, after the switch: 300 instances load, all **58** distinct instruction types resolve in the `ifbench` registry, and all 300 score end to end with **zero** verifier build errors.

The same identity was confirmed independently against `ifbench/data/IFBench_test.jsonl` in the official [allenai/IFBench](https://github.com/allenai/IFBench) repo.

## Notes

- **oe-eval hardcodes `IFBench_test2` too** (`oe_eval/tasks/oe_eval_tasks/ood_ifeval.py:37`). Cross-harness IFBench parity wants the same switch there — separate repo, separate change.
- This does **not** unblock the whole `ifbench` suite. The two `ifeval_mt` tasks read `VGraf/ifeval_mt`, which was already accessible.
- Two docstrings referring to the private copy are updated alongside the data source.
- Worth someone at Ai2 establishing why the private duplicate exists before it's relied on again.

Full suite 1957 passed, ruff/ty clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LMFjgUqHjQA3aCeB4QmEHZ
