### PR TITLE
Add ai2/holmes to WEKA_CLUSTERS

### DIFF
--- a/src/olmo_eval/common/constants/infrastructure.py
+++ b/src/olmo_eval/common/constants/infrastructure.py
@@ -126,6 +126,7 @@ WEKA_CLUSTERS: set[str] = {
     "ai2/ceres",
     "ai2/neptune",
     "ai2/titan",
+    "ai2/holmes",
 }
 """Clusters with Weka storage available.
 


### PR DESCRIPTION
`ai2/holmes` is Weka-backed — Molmo2 stage-1 trains there against `/weka/oe-training-default` and
writes its checkpoints to the same mount — but it was missing from `WEKA_CLUSTERS`, so
`cluster_has_weka("ai2/holmes")` returned `False`.

That flag gates the entire Weka env block in `job_assembler.py`, so a holmes job received none of
`UV_CACHE_DIR`, `HF_HOME`, `HF_HUB_CACHE`, `INSPECT_CACHE_DIR`. Meanwhile the install command emits

```
uv pip install --cache-dir "$UV_CACHE_DIR" ...
```

unconditionally, so with the variable unset `uv` aborted before the job ran at all:

```
error: a value is required for '--cache-dir <CACHE_DIR>' but none was supplied
```

**Every eval launched at holmes through this launcher failed this way** — 10 of them while
evaluating a Molmo2 stage-1 checkpoint. `--uv-cache-dir` on the command line can't work around it
either, because that value is only applied inside the same `cluster_has_weka` branch, so it is
silently discarded for a cluster that isn't listed.

Worth having for its own sake too: without `HF_HOME`/`HF_HUB_CACHE`, a holmes eval re-downloads the
tokenizer and processor every run instead of reading the shared cache.

## Verification

- `cluster_has_weka("ai2/holmes")` → `True` (`ai2/jupiter` still `True`, `ai2/augusta` still `False`)
- a holmes `--dry-run` spec now carries `UV_CACHE_DIR`, `HF_HOME`, `HF_HUB_CACHE`,
  `INSPECT_CACHE_DIR`, where before it carried none
- `make lint` clean

One-line change; no behavior change for any already-listed cluster.