### PR TITLE
fix(gsm8k): honor zero-shot override

### DIFF
--- a/src/olmo_eval/evals/tasks/gsm8k.py
+++ b/src/olmo_eval/evals/tasks/gsm8k.py
@@ -74,10 +74,7 @@ class GSM8K(Task):
                     },
                 )
             )
-        num = self.config.num_fewshot
-        if num and num < len(instances):
-            instances = instances[:num]
-        return instances
+        return instances[: self.config.num_fewshot]
 
     def format_request(self, instance: Instance) -> LMRequest:
         fewshot = self.get_fewshot()

--- a/tests/evals/tasks/test_tasks.py
+++ b/tests/evals/tasks/test_tasks.py
@@ -61,6 +61,17 @@ def test_gsm8k_olmo3base_uses_first_sample_exact_match() -> None:
     assert task.config.output_score_aggregation == OutputScoreAggregation.FIRST
 
 
+@pytest.mark.parametrize("num_fewshot", [0, 3, 8])
+def test_gsm8k_prompt_honors_num_fewshot(num_fewshot: int) -> None:
+    task = get_task("gsm8k", config_overrides={"num_fewshot": num_fewshot})
+    instance = Instance(question="What is one plus one?", gold_answer="2")
+
+    prompt = task.format_request(instance).prompt
+
+    assert prompt.count("Question:") == num_fewshot + 1
+    assert prompt.endswith("Question: What is one plus one?\nAnswer:")
+
+
 class TestTaskRegistration:
     """Tests for task registration across all modules."""
 


### PR DESCRIPTION
## Summary

- honor  for GSM8K instead of silently retaining all eight fixed demonstrations
- add prompt-level regression coverage for 0-, 3-, and 8-shot configurations

## Validation

- ============================= test session starts ==============================
platform linux -- Python 3.12.13, pytest-9.0.3, pluggy-1.6.0
rootdir: /home/robert/proj/olmo-eval
configfile: pyproject.toml
plugins: anyio-4.9.0, cov-7.1.0
collected 42 items

tests/evals/tasks/test_tasks.py ........................................ [ 95%]
..                                                                       [100%]

============================== 42 passed in 0.39s ============================== (42 passed)
- ruff format..............................................................Passed
ruff check...............................................................Passed