### PR TITLE
Fail loudly on two silent multimodal eval faults

### DIFF
--- a/src/olmo_eval/common/scorers/charxiv_judge.py
+++ b/src/olmo_eval/common/scorers/charxiv_judge.py
@@ -5,8 +5,9 @@ and ``src/reasoning_utils.py::get_reasoning_result_gpt``: model ``gpt-4o-2024-05
 ``response_format={"type": "json_object"}``, ``n=1, temperature=0, top_p=1, seed=42``,
 ``max_tokens`` starting at 256 and doubling (cap 1024) when the JSON reply is truncated
 ("Unterminated string"), at most 10 retries, and the official dummy fallback (score ``-1``)
-when grading ultimately fails. Downstream stats count ``-1`` as 0, as in the official
-``get_stats.py``.
+when grading ultimately fails. Retries wait a randomized exponential backoff, which the
+official script omits: without it a transient API condition exhausts every attempt at once.
+Downstream stats count ``-1`` as 0, as in the official ``get_stats.py``.
 
 Successful (validated) grading replies are cached on disk so re-runs are free; the cache dir
 comes from ``CHARXIV_GPT_CACHE_DIR`` or a fresh per-process temp dir (never a shared cache).
@@ -15,10 +16,12 @@ Requires ``OPENAI_API_KEY`` on cache misses.
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import json
 import logging
 import os
+import random
 import tempfile
 from collections.abc import Callable
 from dataclasses import dataclass, field
@@ -32,6 +35,8 @@ from olmo_eval.common.types import Instance, LMOutput
 logger = logging.getLogger(__name__)
 
 CHARXIV_JUDGE_MODEL = "gpt-4o-2024-05-13"
+_RETRY_BASE_DELAY = 1.0
+_RETRY_MAX_DELAY = 30.0
 
 _ASYNC_CLIENTS: dict[str, Any] = {}
 _PROCESS_CACHE_DIR: list[str] = []
@@ -64,6 +69,16 @@ def _get_client(model: str):
     return _ASYNC_CLIENTS[model]
 
 
+def _retry_delay(attempt: int) -> float:
+    """Randomized exponential backoff, in seconds, for grading attempt ``attempt``.
+
+    Grading runs many calls at once, so a transient API condition otherwise burns
+    every retry within milliseconds and turns a gradable response into a dummy
+    score that downstream stats count as zero.
+    """
+    return min(_RETRY_MAX_DELAY, _RETRY_BASE_DELAY * 2 ** (attempt - 1)) * (0.5 + random.random())
+
+
 async def _charxiv_chat_json(
     prompt: str,
     *,
@@ -88,6 +103,7 @@ async def _charxiv_chat_json(
     curr_retries = 0
     max_tokens = 256
     content: dict | None = None
+    response: str | None = None
     while curr_retries < max_retries:
         try:
             response = (
@@ -119,8 +135,13 @@ async def _charxiv_chat_json(
                 max_tokens = min(1024, max_tokens * 2)
             else:
                 curr_retries += 1
+                await asyncio.sleep(_retry_delay(curr_retries))
     if content is None:
-        logger.warning("CharXiv grading failed after %d retries", max_retries)
+        logger.warning(
+            "CharXiv grading failed after %d retries; last reply: %.200s",
+            max_retries,
+            response,
+        )
         return dummy
 
     os.makedirs(cache_dir, exist_ok=True)

--- a/src/olmo_eval/inference/providers/olmo_core_vlm_utils.py
+++ b/src/olmo_eval/inference/providers/olmo_core_vlm_utils.py
@@ -464,7 +464,41 @@ def _load_mm_olmo_state_dict(checkpoint_dir: str, model_cfg: Any) -> dict[str, t
         )
         hf_state_dict["lm_head.weight"] = base_embedding
 
-    return molmo2_hf_state_dict_to_multimodal_lm(hf_state_dict, model_cfg)
+    state_dict = molmo2_hf_state_dict_to_multimodal_lm(hf_state_dict, model_cfg)
+    _verify_lm_head_is_untied(state_dict, model_cfg, checkpoint_dir)
+    return state_dict
+
+
+def _verify_lm_head_is_untied(
+    state_dict: dict[str, torch.Tensor], model_cfg: Any, checkpoint_dir: str
+) -> None:
+    """Reject a load that gave an untied model the embedding table as its LM head.
+
+    An untied checkpoint keeps its output projection in a separate tensor whose
+    shape matches the embedding table, so a read that returns the wrong one of
+    the pair loads cleanly and leaves every other weight intact. The model then
+    generates from the wrong projection: the output is noise, the score sits at
+    chance, and nothing raises. Compare the two tensors instead, since a trained
+    untied head is never bit-for-bit equal to the embeddings.
+    """
+    import torch
+
+    lm_cfg = getattr(model_cfg, "lm", None)
+    if lm_cfg is None or getattr(lm_cfg, "tie_word_embeddings", False):
+        return
+
+    head = state_dict.get("lm.lm_head.w_out.weight")
+    embeddings = state_dict.get("lm.embeddings.weight")
+    if head is None or embeddings is None or head.shape != embeddings.shape:
+        return
+
+    if torch.equal(head, embeddings):
+        raise _config_error(
+            checkpoint_dir,
+            "the LM head loaded byte-identical to the token embeddings even though the "
+            "model is not weight-tied, which means the checkpoint read returned the wrong "
+            "tensor; retry the load",
+        )
 
 
 def load_checkpoint_weights(


### PR DESCRIPTION
Both fixes come out of the Molmo2-8B sweep on the new multi-image / CharXiv benchmarks, where a job reported `Success` with a plausible score while being wrong.

## 1. Reject a load whose LM head duplicates the embeddings

`Molmo2-8B` scored **0.1223 on MMMU-Pro (chance) with zero failed instances**, emitting noise (`'Ψ梭梭梭…'`, `'tqdm traveled traveled'`).

Cause: the loaded `lm.lm_head.w_out.weight` came back byte-identical to `lm.embeddings.weight` (md5 `3150fdf99033` instead of `04d532c7137b`). Every other tensor matched a good load, so the backbone ran all 36 blocks correctly and only the final projection was wrong.

It is possible because the checkpoint's two largest tensors are indistinguishable except by shard filename:

```
model.transformer.wte.embedding   __R_0.distcp  offset=0  length=19449385
model.transformer.ff_out.weight   __R_1.distcp  offset=0  length=19449385
```

both 151936x4096, replicated across 16 ranks. `Molmo2-4B` is genuinely weight-tied and ships no `ff_out`, so it cannot hit this — hence 4B fine, 8B garbage. Reproduced on Beaker with byte-identical output across runs; local loads of the same checkpoint were fine, so the read is intermittent.

`_verify_lm_head_is_untied` compares the two tensors after conversion and fails the load when they match on a model the config says is untied. A trained untied head is never bit-for-bit equal to the embeddings, so there are no false positives; genuinely tied checkpoints are unaffected.

## 2. Back off between CharXiv grading retries

`charxiv_reasoning` on the 8B scored **0.2410 with `n_invalid` = 273** — 273 of 1000 gradings exhausted all ten retries and fell back to the official dummy (`score = -1`), which `get_stats.py` counts as 0.

The retry ladder had no wait between attempts, so with grading fanned out over many concurrent calls one transient API condition burned all ten retries in milliseconds. Replaying failed gradings against the same model and prompt returned valid replies on the first attempt, and all sampled ones deserved `score = 1` — these were gradable responses scored zero.

Retries now wait a randomized exponential backoff (1s base, doubling, 30s cap), and the last raw reply is logged when grading gives up. Model, prompt, `max_tokens` ladder, retry count and dummy fallback are unchanged, so grading stays at official parity.

Rerun of the same task with the fix:

| | score | n_invalid | grading errors | exhausted retries |
|---|---|---|---|---|
| before | 0.2410 | 273 | 4140 | 273 |
| after | **0.3260** | **0** | 41 | **0** |

## Verification

- `ruff check` / `ruff format --check` clean; 2054 tests pass, 9 skipped.
- Guard exercised on all four cases: untied + equal head raises; untied + real head passes; genuinely tied model with equal head passes; missing/mismatched shapes pass.
- Judge fix exercised with a client that fails three times then succeeds — recovers on attempt 4 instead of returning the dummy.
- Six guarded 8B benchmark reruns loaded cleanly with zero guard trips and coherent outputs (MMMU-Pro 0.2835 vs the broken run's 0.1223).

`ty` reports 3 pre-existing diagnostics in files this PR does not touch (`litellm.py`, `olmo_core.py`, `vllm_server.py`).
