### PR TITLE
Add MMLU chain-of-thought tasks (post-training regime)

### DIFF
--- a/src/olmo_eval/evals/extract/answer_format.py
+++ b/src/olmo_eval/evals/extract/answer_format.py
@@ -5,6 +5,11 @@ answer-format regex first, then templated regexes, then prefix regexes
 followed by an answer regex, then bare answer regexes. Each stage yields a
 decreasing format-correctness score, which tasks can use to demote answers
 that were found but not stated in the requested format.
+
+Use this for tasks that must reproduce oe-eval's numbers (GPQA and MMLU
+chain-of-thought). ``mcq.extract_mcq_answer`` is the native extractor for
+olmo-eval's own multiple-choice tasks; the two cascades differ in pattern
+order and are not interchangeable.
 """
 
 from __future__ import annotations

--- a/src/olmo_eval/evals/extract/mcq.py
+++ b/src/olmo_eval/evals/extract/mcq.py
@@ -5,6 +5,11 @@ pattern that hits wins.  Priority reflects specificity — explicit
 instruction-following and LaTeX formats are unambiguous, while
 parenthesised or bold letters appear throughout running text and are
 used only as fallbacks.
+
+This is olmo-eval's native extractor (used by BBQ, WMDP, MedQA). Tasks
+ported for parity with oe-eval use ``answer_format.extract_answer_with_format``
+instead, whose cascade and priority order mirror oe-eval's and yield
+different answers on the same text.
 """
 
 import re

--- a/src/olmo_eval/evals/suites/mmlu.py
+++ b/src/olmo_eval/evals/suites/mmlu.py
@@ -42,3 +42,10 @@ MMLU_BPB = make_suite(
     "mmlu:bpb",
     tuple(f"mmlu_{s}:rc:bpb" for s in MMLU_SUBJECTS),
 )
+
+MMLU_COT = make_suite(
+    "mmlu:cot",
+    _task_names_variant(MMLU_SUBJECTS, "cot"),
+    aggregation=AggregationStrategy.AVERAGE,
+    description="0-shot chain-of-thought MMLU across all 57 subjects",
+)

--- a/src/olmo_eval/evals/tasks/mmlu_cot.py
+++ b/src/olmo_eval/evals/tasks/mmlu_cot.py
@@ -29,6 +29,7 @@ from olmo_eval.data import DataSource
 from olmo_eval.evals.extract import (
     OLMO_3_ANSWER_REGEX_TEMPLATES,
     extract_answer_with_format,
+    extract_think_answer,
 )
 from olmo_eval.evals.tasks.common import Task, register
 from olmo_eval.evals.tasks.mmlu import DEFAULT_MMLU_PATH, MMLU_SUBJECTS
@@ -65,9 +66,14 @@ def _mcq_query(question: str, choices: list[str]) -> str:
 
 
 def _extract_letter(text: str) -> str:
-    """Answer letter via the shared regex cascade; empty when nothing matches."""
+    """Answer letter via the shared regex cascade; empty when nothing matches.
+
+    Reasoning enclosed in ``<think>`` tags is dropped first, as the reference
+    harness does for reasoning models, so letters mentioned while thinking
+    cannot be mistaken for the final answer.
+    """
     answer = extract_answer_with_format(
-        text,
+        extract_think_answer(text) or "",
         answer_regexes=_ANSWER_REGEXES,
         answer_regexes_templates=OLMO_3_ANSWER_REGEX_TEMPLATES,
     ).answer

--- a/src/olmo_eval/evals/tasks/mmlu_cot.py
+++ b/src/olmo_eval/evals/tasks/mmlu_cot.py
@@ -17,10 +17,6 @@ from collections.abc import Iterator
 from dataclasses import dataclass
 from typing import Any
 
-from olmo_eval.common.answer_extraction import (
-    OLMO_3_ANSWER_REGEX_TEMPLATES,
-    extract_answer_with_format,
-)
 from olmo_eval.common.metrics import AccuracyMetric
 from olmo_eval.common.scorers.base import Scorer
 from olmo_eval.common.types import (
@@ -32,6 +28,10 @@ from olmo_eval.common.types import (
     Split,
 )
 from olmo_eval.data import DataSource
+from olmo_eval.evals.extract import (
+    OLMO_3_ANSWER_REGEX_TEMPLATES,
+    extract_answer_with_format,
+)
 from olmo_eval.evals.tasks.common import Task, register
 from olmo_eval.evals.tasks.mmlu import DEFAULT_MMLU_PATH, MMLU_SUBJECTS
 

--- a/src/olmo_eval/evals/tasks/mmlu_cot.py
+++ b/src/olmo_eval/evals/tasks/mmlu_cot.py
@@ -1,0 +1,155 @@
+"""MMLU chain-of-thought tasks for the post-training regime.
+
+The base ``mmlu_{subject}`` tasks score by continuation log-probability,
+which measures multiple-choice ranking rather than reasoning. These tasks
+ask the model to reason in chat format and state a letter, then extract it
+with the shared regex cascade — matching the configuration used to report
+chain-of-thought MMLU for post-trained models.
+
+One task per subject (``mmlu_abstract_algebra:cot``, ...); the
+``mmlu:cot`` suite aggregates all 57.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterator
+from dataclasses import dataclass
+from typing import Any
+
+from olmo_eval.common.answer_extraction import (
+    OLMO_3_ANSWER_REGEX_TEMPLATES,
+    extract_answer_with_format,
+)
+from olmo_eval.common.metrics import AccuracyMetric
+from olmo_eval.common.scorers.base import Scorer
+from olmo_eval.common.types import (
+    Instance,
+    LMOutput,
+    LMRequest,
+    RequestType,
+    SamplingParams,
+    Split,
+)
+from olmo_eval.data import DataSource
+from olmo_eval.evals.tasks.common import Task, register
+from olmo_eval.evals.tasks.mmlu import DEFAULT_MMLU_PATH, MMLU_SUBJECTS
+
+_CHOICE_LABELS = ("A", "B", "C", "D", "E")
+
+_ANSWER_REGEXES = (r"\(?([A-D])\)?",)
+
+_COT_SAMPLING = SamplingParams(
+    max_tokens=None,
+    temperature=0.6,
+    top_p=0.95,
+)
+
+
+def _subject_text(subject: str) -> str:
+    return subject.replace("_", " ")
+
+
+def _description(subject: str) -> str:
+    return (
+        f"The following are multiple choice questions about {_subject_text(subject)}. "
+        "Summarize your reasoning concisely, then conclude with "
+        "'Therefore, the answer is: X' where X is one of A, B, C, or D.\n\n"
+    )
+
+
+def _mcq_query(question: str, choices: list[str]) -> str:
+    """Question with lettered choices, no trailing answer prefix."""
+    choices_text = "\n".join(
+        f" {label}. {text}" for label, text in zip(_CHOICE_LABELS, choices, strict=False)
+    )
+    return f"Question: {question}\n{choices_text}\n"
+
+
+def _extract_letter(text: str) -> str:
+    answer = extract_answer_with_format(
+        text,
+        answer_regexes=_ANSWER_REGEXES,
+        answer_regexes_templates=OLMO_3_ANSWER_REGEX_TEMPLATES,
+    ).answer
+    return re.sub(r"\(|\)", "", answer)
+
+
+@dataclass(frozen=True, slots=True)
+class MMLUCoTExactMatchScorer(Scorer):
+    """Case-insensitive exact match on the extracted answer letter."""
+
+    name: str = "exact_match"
+
+    def score(self, instance: Instance, output: LMOutput) -> float:
+        answer = _extract_letter(output.text or "")
+        gold = str(instance.gold_answer or "")
+        return 1.0 if answer.upper() == gold.upper() else 0.0
+
+
+_ACCURACY = AccuracyMetric(name="exact_match", scorer=MMLUCoTExactMatchScorer)
+
+
+class MMLUCoTTask(Task):
+    """0-shot chain-of-thought MMLU for one subject."""
+
+    split = Split.TEST
+    metrics = (_ACCURACY,)
+    primary_metric = _ACCURACY
+    sampling_params = _COT_SAMPLING
+    num_fewshot = 0
+
+    subject: str
+
+    @property
+    def request_type(self) -> RequestType:
+        return RequestType.CHAT
+
+    @property
+    def instances(self) -> Iterator[Instance]:
+        yield from self._load_instances_cached()
+
+    def process_doc(self, doc: dict[str, Any], index: int = 0) -> Instance | None:
+        question = str(doc.get("question", ""))
+        choices = list(doc.get("choices") or [])
+        if not question or not choices:
+            return None
+        answer = doc.get("answer")
+        if not isinstance(answer, int) or not 0 <= answer < len(_CHOICE_LABELS):
+            return None
+
+        return Instance(
+            question=_description(self.subject) + _mcq_query(question, choices),
+            gold_answer=_CHOICE_LABELS[answer],
+            choices=tuple(str(c) for c in choices),
+            metadata={
+                "id": doc.get("question_id", index),
+                "index": index,
+                "subject": self.subject,
+            },
+        )
+
+    def format_request(self, instance: Instance) -> LMRequest:
+        return LMRequest(
+            request_type=RequestType.CHAT,
+            messages=({"role": "user", "content": instance.question},),
+        )
+
+    def extract_answer(self, output: LMOutput) -> str | None:
+        return _extract_letter(output.text or "") or None
+
+
+for _subject in MMLU_SUBJECTS:
+    _name = f"MMLUCoT{_subject.title().replace('_', '')}"
+    _cls = type(
+        _name,
+        (MMLUCoTTask,),
+        {
+            "__module__": __name__,
+            "__qualname__": _name,
+            "subject": _subject,
+            "data_source": DataSource(path=DEFAULT_MMLU_PATH, subset=_subject),
+        },
+    )
+    globals()[_name] = _cls
+    register(f"mmlu_{_subject}:cot")(_cls)

--- a/src/olmo_eval/evals/tasks/mmlu_cot.py
+++ b/src/olmo_eval/evals/tasks/mmlu_cot.py
@@ -14,14 +14,12 @@ from __future__ import annotations
 
 import re
 from collections.abc import Iterator
-from dataclasses import dataclass
 from typing import Any
 
 from olmo_eval.common.metrics import AccuracyMetric
-from olmo_eval.common.scorers.base import Scorer
+from olmo_eval.common.scorers.base import MultipleChoiceScorer
 from olmo_eval.common.types import (
     Instance,
-    LMOutput,
     LMRequest,
     RequestType,
     SamplingParams,
@@ -67,6 +65,7 @@ def _mcq_query(question: str, choices: list[str]) -> str:
 
 
 def _extract_letter(text: str) -> str:
+    """Answer letter via the shared regex cascade; empty when nothing matches."""
     answer = extract_answer_with_format(
         text,
         answer_regexes=_ANSWER_REGEXES,
@@ -75,19 +74,7 @@ def _extract_letter(text: str) -> str:
     return re.sub(r"\(|\)", "", answer)
 
 
-@dataclass(frozen=True, slots=True)
-class MMLUCoTExactMatchScorer(Scorer):
-    """Case-insensitive exact match on the extracted answer letter."""
-
-    name: str = "exact_match"
-
-    def score(self, instance: Instance, output: LMOutput) -> float:
-        answer = _extract_letter(output.text or "")
-        gold = str(instance.gold_answer or "")
-        return 1.0 if answer.upper() == gold.upper() else 0.0
-
-
-_ACCURACY = AccuracyMetric(name="exact_match", scorer=MMLUCoTExactMatchScorer)
+_ACCURACY = AccuracyMetric(name="exact_match", scorer=MultipleChoiceScorer)
 
 
 class MMLUCoTTask(Task):
@@ -98,6 +85,7 @@ class MMLUCoTTask(Task):
     primary_metric = _ACCURACY
     sampling_params = _COT_SAMPLING
     num_fewshot = 0
+    answer_extractor = _extract_letter
 
     subject: str
 
@@ -134,9 +122,6 @@ class MMLUCoTTask(Task):
             request_type=RequestType.CHAT,
             messages=({"role": "user", "content": instance.question},),
         )
-
-    def extract_answer(self, output: LMOutput) -> str | None:
-        return _extract_letter(output.text or "") or None
 
 
 for _subject in MMLU_SUBJECTS:

--- a/tests/evals/tasks/test_mmlu_cot.py
+++ b/tests/evals/tasks/test_mmlu_cot.py
@@ -1,0 +1,108 @@
+"""Tests for the MMLU chain-of-thought tasks."""
+
+from __future__ import annotations
+
+import unittest
+
+from olmo_eval.common.types import Instance, LMOutput, RequestType
+from olmo_eval.evals.suites.registry import get_suite
+from olmo_eval.evals.tasks.common import get_task
+from olmo_eval.evals.tasks.mmlu import MMLU_SUBJECTS
+from olmo_eval.evals.tasks.mmlu_cot import MMLUCoTExactMatchScorer
+
+_DOC = {
+    "question": "What is 2 + 2?",
+    "choices": ["3", "4", "5", "6"],
+    "answer": 1,
+}
+
+
+class TestMMLUCoTRegistration(unittest.TestCase):
+    def test_all_subjects_registered(self) -> None:
+        self.assertEqual(len(MMLU_SUBJECTS), 57)
+        for subject in MMLU_SUBJECTS:
+            task = get_task(f"mmlu_{subject}:cot")
+            self.assertEqual(task.request_type, RequestType.CHAT)
+            self.assertEqual(task.config.num_fewshot, 0)
+
+    def test_sampling_matches_reasoning_regime(self) -> None:
+        params = get_task("mmlu_anatomy:cot").config.sampling_params
+        self.assertEqual(params.temperature, 0.6)
+        self.assertEqual(params.top_p, 0.95)
+        self.assertIsNone(params.max_tokens)
+
+    def test_suite_covers_every_subject(self) -> None:
+        self.assertEqual(len(get_suite("mmlu:cot").tasks), 57)
+
+
+class TestMMLUCoTPrompt(unittest.TestCase):
+    def test_prompt_shape(self) -> None:
+        task = get_task("mmlu_abstract_algebra:cot")
+        instance = task.process_doc(dict(_DOC), index=0)
+        assert instance is not None
+        self.assertTrue(
+            instance.question.startswith(
+                "The following are multiple choice questions about abstract algebra."
+            )
+        )
+        self.assertIn("Question: What is 2 + 2?\n A. 3\n B. 4\n C. 5\n D. 6\n", instance.question)
+        self.assertEqual(instance.gold_answer, "B")
+
+    def test_single_user_message(self) -> None:
+        task = get_task("mmlu_anatomy:cot")
+        instance = task.process_doc(dict(_DOC), index=0)
+        request = task.format_request(instance)
+        self.assertEqual(request.request_type, RequestType.CHAT)
+        self.assertEqual(len(request.messages), 1)
+        self.assertEqual(request.messages[0]["role"], "user")
+
+    def test_skips_malformed_docs(self) -> None:
+        task = get_task("mmlu_anatomy:cot")
+        self.assertIsNone(task.process_doc({"question": "", "choices": ["a"], "answer": 0}))
+        self.assertIsNone(task.process_doc({"question": "q", "choices": [], "answer": 0}))
+        self.assertIsNone(task.process_doc({"question": "q", "choices": ["a"], "answer": "B"}))
+
+
+class TestMMLUCoTScorer(unittest.TestCase):
+    def setUp(self) -> None:
+        self.scorer = MMLUCoTExactMatchScorer()
+        self.instance = Instance(question="q", gold_answer="B", metadata={})
+
+    def _score(self, text: str) -> float:
+        return self.scorer.score(self.instance, LMOutput(text=text))
+
+    def test_requested_phrasing(self) -> None:
+        self.assertEqual(self._score("Reasoning.\n\nTherefore, the answer is: B"), 1.0)
+
+    def test_parenthesized_and_boxed(self) -> None:
+        self.assertEqual(self._score("Therefore, the answer is: (B)"), 1.0)
+        self.assertEqual(self._score("\\boxed{B}"), 1.0)
+
+    def test_alternate_phrasings(self) -> None:
+        self.assertEqual(self._score("So the answer is B."), 1.0)
+        self.assertEqual(self._score("The correct answer is: (B)"), 1.0)
+
+    def test_case_insensitive(self) -> None:
+        self.assertEqual(self._score("the ANSWER is (b)"), 1.0)
+
+    def test_wrong_and_empty(self) -> None:
+        self.assertEqual(self._score("Therefore, the answer is: C"), 0.0)
+        self.assertEqual(self._score(""), 0.0)
+
+    def test_template_priority_beats_position(self) -> None:
+        """The requested phrasing outranks a later, weaker one.
+
+        The cascade tries templates in priority order, so "Therefore, the
+        answer is: A" wins over a subsequent "the answer is B" — verified
+        to match the reference implementation's extraction.
+        """
+        self.assertEqual(
+            self._score("Therefore, the answer is: A. Wait, no — the answer is B"), 0.0
+        )
+        self.assertEqual(
+            self._score("Some reasoning. The answer is A. Therefore, the answer is: B"), 1.0
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/evals/tasks/test_mmlu_cot.py
+++ b/tests/evals/tasks/test_mmlu_cot.py
@@ -84,13 +84,17 @@ def test_skips_malformed_docs(doc: dict) -> None:
         "So the answer is B.",
         "The correct answer is: (B)",
         "the ANSWER is (b)",
+        "<think>Could be A or C... no, D. Hmm.</think>Therefore, the answer is: B",
     ],
 )
 def test_extracts_letter(text: str) -> None:
     assert _score(text) == 1.0
 
 
-@pytest.mark.parametrize("text", ["Therefore, the answer is: C", ""])
+@pytest.mark.parametrize(
+    "text",
+    ["Therefore, the answer is: C", "", "<think>Therefore, the answer is: B</think>"],
+)
 def test_wrong_and_empty(text: str) -> None:
     assert _score(text) == 0.0
 

--- a/tests/evals/tasks/test_mmlu_cot.py
+++ b/tests/evals/tasks/test_mmlu_cot.py
@@ -1,108 +1,106 @@
 """Tests for the MMLU chain-of-thought tasks."""
 
-from __future__ import annotations
+import pytest
 
-import unittest
-
+from olmo_eval.common.scorers.base import MultipleChoiceScorer
 from olmo_eval.common.types import Instance, LMOutput, RequestType
 from olmo_eval.evals.suites.registry import get_suite
 from olmo_eval.evals.tasks.common import get_task
 from olmo_eval.evals.tasks.mmlu import MMLU_SUBJECTS
-from olmo_eval.evals.tasks.mmlu_cot import MMLUCoTExactMatchScorer
 
 _DOC = {
     "question": "What is 2 + 2?",
     "choices": ["3", "4", "5", "6"],
     "answer": 1,
 }
+_INSTANCE = Instance(question="q", gold_answer="B", metadata={})
 
 
-class TestMMLUCoTRegistration(unittest.TestCase):
-    def test_all_subjects_registered(self) -> None:
-        self.assertEqual(len(MMLU_SUBJECTS), 57)
-        for subject in MMLU_SUBJECTS:
-            task = get_task(f"mmlu_{subject}:cot")
-            self.assertEqual(task.request_type, RequestType.CHAT)
-            self.assertEqual(task.config.num_fewshot, 0)
-
-    def test_sampling_matches_reasoning_regime(self) -> None:
-        params = get_task("mmlu_anatomy:cot").config.sampling_params
-        self.assertEqual(params.temperature, 0.6)
-        self.assertEqual(params.top_p, 0.95)
-        self.assertIsNone(params.max_tokens)
-
-    def test_suite_covers_every_subject(self) -> None:
-        self.assertEqual(len(get_suite("mmlu:cot").tasks), 57)
+def _score(text: str) -> float:
+    task = get_task("mmlu_anatomy:cot")
+    output = LMOutput(text=text)
+    output.extracted_answer = task.extract_answer(output)
+    return MultipleChoiceScorer().score(_INSTANCE, output)
 
 
-class TestMMLUCoTPrompt(unittest.TestCase):
-    def test_prompt_shape(self) -> None:
-        task = get_task("mmlu_abstract_algebra:cot")
-        instance = task.process_doc(dict(_DOC), index=0)
-        assert instance is not None
-        self.assertTrue(
-            instance.question.startswith(
-                "The following are multiple choice questions about abstract algebra."
-            )
-        )
-        self.assertIn("Question: What is 2 + 2?\n A. 3\n B. 4\n C. 5\n D. 6\n", instance.question)
-        self.assertEqual(instance.gold_answer, "B")
-
-    def test_single_user_message(self) -> None:
-        task = get_task("mmlu_anatomy:cot")
-        instance = task.process_doc(dict(_DOC), index=0)
-        request = task.format_request(instance)
-        self.assertEqual(request.request_type, RequestType.CHAT)
-        self.assertEqual(len(request.messages), 1)
-        self.assertEqual(request.messages[0]["role"], "user")
-
-    def test_skips_malformed_docs(self) -> None:
-        task = get_task("mmlu_anatomy:cot")
-        self.assertIsNone(task.process_doc({"question": "", "choices": ["a"], "answer": 0}))
-        self.assertIsNone(task.process_doc({"question": "q", "choices": [], "answer": 0}))
-        self.assertIsNone(task.process_doc({"question": "q", "choices": ["a"], "answer": "B"}))
+def test_all_subjects_registered() -> None:
+    assert len(MMLU_SUBJECTS) == 57
+    for subject in MMLU_SUBJECTS:
+        task = get_task(f"mmlu_{subject}:cot")
+        assert task.request_type == RequestType.CHAT
+        assert task.config.num_fewshot == 0
 
 
-class TestMMLUCoTScorer(unittest.TestCase):
-    def setUp(self) -> None:
-        self.scorer = MMLUCoTExactMatchScorer()
-        self.instance = Instance(question="q", gold_answer="B", metadata={})
-
-    def _score(self, text: str) -> float:
-        return self.scorer.score(self.instance, LMOutput(text=text))
-
-    def test_requested_phrasing(self) -> None:
-        self.assertEqual(self._score("Reasoning.\n\nTherefore, the answer is: B"), 1.0)
-
-    def test_parenthesized_and_boxed(self) -> None:
-        self.assertEqual(self._score("Therefore, the answer is: (B)"), 1.0)
-        self.assertEqual(self._score("\\boxed{B}"), 1.0)
-
-    def test_alternate_phrasings(self) -> None:
-        self.assertEqual(self._score("So the answer is B."), 1.0)
-        self.assertEqual(self._score("The correct answer is: (B)"), 1.0)
-
-    def test_case_insensitive(self) -> None:
-        self.assertEqual(self._score("the ANSWER is (b)"), 1.0)
-
-    def test_wrong_and_empty(self) -> None:
-        self.assertEqual(self._score("Therefore, the answer is: C"), 0.0)
-        self.assertEqual(self._score(""), 0.0)
-
-    def test_template_priority_beats_position(self) -> None:
-        """The requested phrasing outranks a later, weaker one.
-
-        The cascade tries templates in priority order, so "Therefore, the
-        answer is: A" wins over a subsequent "the answer is B" — verified
-        to match the reference implementation's extraction.
-        """
-        self.assertEqual(
-            self._score("Therefore, the answer is: A. Wait, no — the answer is B"), 0.0
-        )
-        self.assertEqual(
-            self._score("Some reasoning. The answer is A. Therefore, the answer is: B"), 1.0
-        )
+def test_sampling_matches_reasoning_regime() -> None:
+    params = get_task("mmlu_anatomy:cot").config.sampling_params
+    assert params.temperature == 0.6
+    assert params.top_p == 0.95
+    assert params.max_tokens is None
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_suite_covers_every_subject() -> None:
+    assert len(get_suite("mmlu:cot").tasks) == 57
+
+
+def test_prompt_shape() -> None:
+    task = get_task("mmlu_abstract_algebra:cot")
+    instance = task.process_doc(dict(_DOC), index=0)
+    assert instance is not None
+    assert instance.question.startswith(
+        "The following are multiple choice questions about abstract algebra."
+    )
+    assert "Question: What is 2 + 2?\n A. 3\n B. 4\n C. 5\n D. 6\n" in instance.question
+    assert instance.gold_answer == "B"
+
+
+def test_single_user_message() -> None:
+    task = get_task("mmlu_anatomy:cot")
+    instance = task.process_doc(dict(_DOC), index=0)
+    assert instance is not None
+    request = task.format_request(instance)
+    assert request.request_type == RequestType.CHAT
+    assert len(request.messages) == 1
+    assert request.messages[0]["role"] == "user"
+
+
+@pytest.mark.parametrize(
+    "doc",
+    [
+        {"question": "", "choices": ["a"], "answer": 0},
+        {"question": "q", "choices": [], "answer": 0},
+        {"question": "q", "choices": ["a"], "answer": "B"},
+    ],
+)
+def test_skips_malformed_docs(doc: dict) -> None:
+    assert get_task("mmlu_anatomy:cot").process_doc(doc) is None
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "Reasoning.\n\nTherefore, the answer is: B",
+        "Therefore, the answer is: (B)",
+        "\\boxed{B}",
+        "So the answer is B.",
+        "The correct answer is: (B)",
+        "the ANSWER is (b)",
+    ],
+)
+def test_extracts_letter(text: str) -> None:
+    assert _score(text) == 1.0
+
+
+@pytest.mark.parametrize("text", ["Therefore, the answer is: C", ""])
+def test_wrong_and_empty(text: str) -> None:
+    assert _score(text) == 0.0
+
+
+def test_template_priority_beats_position() -> None:
+    """The requested phrasing outranks a later, weaker one.
+
+    The cascade tries templates in priority order, so "Therefore, the
+    answer is: A" wins over a subsequent "the answer is B" — verified
+    to match the reference implementation's extraction.
+    """
+    assert _score("Therefore, the answer is: A. Wait, no — the answer is B") == 0.0
+    assert _score("Some reasoning. The answer is A. Therefore, the answer is: B") == 1.0


### PR DESCRIPTION
Registers `mmlu_{subject}:cot` for all 57 subjects plus an `mmlu:cot` suite, mirroring oe-eval's `mmlu_{sub}:cot::hamish_zs_reasoning_deepseek` (the OLMO_3 suite entry): 0-shot chat, per-subject description requesting concise reasoning then `Therefore, the answer is: X`, temp 0.6 / top-p 0.95, extraction via the shared OLMO 3 regex-template cascade.

Why a separate module rather than a variant: the base `mmlu_{subject}` tasks score by continuation log-probability, which measures MCQ ranking rather than reasoning, so the CoT regime needs different doc processing entirely — same split as `gpqa:cot`.

**Verification (CPU, against oe-eval's own code):**
- Prompts and gold letters byte-identical on **3,207 real docs across 7 subjects** (abstract_algebra, anatomy, high_school_mathematics, professional_law, world_religions, moral_scenarios, college_physics), re-run against the current head after the extraction module moved to `evals/extract/`
- Scorer verdicts identical on 56 synthetic responses run through oe-eval's `ExactMatch` metric
- 17 tests (pytest-style); ruff/ty clean

**Parity:** scored the paper's Olmo-3-7B-Think oe-eval generations (14,042 instances, 57 subjects) through this task: prompts identical to the logged requests, 14,042/14,042 verdicts agree, macro suite score 0.764283 reproduced. Reasoning inside `<think>` is stripped before extraction, matching oe-eval's model-level `r1_style` processing (#348).

Replaces #321, which GitHub closed automatically when its base branch (`task/add-gpqa-cot`, #309) was deleted on merge. Same commits, rebased onto `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LMFjgUqHjQA3aCeB4QmEHZ