### PR TITLE
Add credentialed BFCL v4 web evaluation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,6 +136,7 @@ conflicts = [
 
 [tool.setuptools.package-data]
 "olmo_eval.analysis.pairwise_viewer" = ["static/*.css", "static/*.js", "templates/*.html"]
+"olmo_eval.evals.external.benchmarks.bfcl" = ["patches/*.patch"]
 "olmo_eval.evals.tasks" = ["*.jsonl"]
 
 [dependency-groups]
@@ -248,6 +249,9 @@ allowed-unresolved-imports = [
     "crawl4ai.**",
     "modal.**",
     "swerex.**",
+    # Installed only inside the pinned BFCL external-eval sandbox.
+    "bfcl_eval.**",
+    "sentence_transformers.**",
 ]
 
 [tool.gantry]

--- a/src/olmo_eval/evals/external/benchmarks/bfcl/__init__.py
+++ b/src/olmo_eval/evals/external/benchmarks/bfcl/__init__.py
@@ -4,6 +4,8 @@ Repository: https://github.com/ShishirPatil/gorilla/tree/main/berkeley-function-
 """
 
 from olmo_eval.evals.external.benchmarks.bfcl.eval import BFCLV4NonWebExternalEval
+from olmo_eval.evals.external.benchmarks.bfcl.web import BFCLV4WebExternalEval
 from olmo_eval.evals.external.registry import register_external_eval
 
 register_external_eval(BFCLV4NonWebExternalEval())
+register_external_eval(BFCLV4WebExternalEval())

--- a/src/olmo_eval/evals/external/benchmarks/bfcl/__init__.py
+++ b/src/olmo_eval/evals/external/benchmarks/bfcl/__init__.py
@@ -1,0 +1,9 @@
+"""Berkeley Function Calling Leaderboard (BFCL) v4 external evaluations.
+
+Repository: https://github.com/ShishirPatil/gorilla/tree/main/berkeley-function-call-leaderboard
+"""
+
+from olmo_eval.evals.external.benchmarks.bfcl.eval import BFCLV4NonWebExternalEval
+from olmo_eval.evals.external.registry import register_external_eval
+
+register_external_eval(BFCLV4NonWebExternalEval())

--- a/src/olmo_eval/evals/external/benchmarks/bfcl/eval.py
+++ b/src/olmo_eval/evals/external/benchmarks/bfcl/eval.py
@@ -7,6 +7,7 @@ import logging
 import shlex
 import tempfile
 import time
+from contextlib import ExitStack
 from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -117,16 +118,27 @@ class BFCLV4NonWebExternalEval(SandboxedExternalEval):
 
     @property
     def run_command(self) -> str:
-        return (
-            "bfcl_runner.py run --provider-model MODEL --provider-url URL "
-            "--categories non_live,live,multi_turn,memory"
-        )
+        return "bfcl_runner.py run --provider-model MODEL --provider-url URL --suite non_web"
+
+    @property
+    def _suite(self) -> str:
+        return "non_web"
+
+    def _parse_args(self, args: dict[str, Any]) -> BFCLV4Args:
+        return BFCLV4Args.from_dict(args)
+
+    def _create_sensitive_volumes(self, stack: ExitStack) -> tuple[tuple[str, str], ...]:
+        return ()
+
+    def _extra_run_command_parts(self, bfcl_args: BFCLV4Args) -> list[str]:
+        return ["--encoder-revision", BFCL_ENCODER_REVISION]
 
     def _create_bfcl_sandbox_config(
         self,
         container_runtime: str,
         output_dir: str | None,
         artifact_dir: Path,
+        extra_volumes: tuple[tuple[str, str], ...] = (),
     ) -> Any:
         config = self._create_sandbox_config(container_runtime, output_dir)
         env = dict(config.environment)
@@ -143,10 +155,14 @@ class BFCLV4NonWebExternalEval(SandboxedExternalEval):
         scorer_patch_path = (
             Path(__file__).with_name("patches") / "0001-check-multi-turn-irrelevance.patch"
         )
-        volumes = config.volumes + (
-            (str(runner_path), _RUNNER_CONTAINER_PATH),
-            (str(scorer_patch_path), _SCORER_PATCH_CONTAINER_PATH),
-            (str(artifact_dir), _ARTIFACT_CONTAINER_PATH),
+        volumes = (
+            config.volumes
+            + (
+                (str(runner_path), _RUNNER_CONTAINER_PATH),
+                (str(scorer_patch_path), _SCORER_PATCH_CONTAINER_PATH),
+                (str(artifact_dir), _ARTIFACT_CONTAINER_PATH),
+            )
+            + extra_volumes
         )
         return replace(
             config,
@@ -183,12 +199,13 @@ class BFCLV4NonWebExternalEval(SandboxedExternalEval):
             str(bfcl_args.temperature),
             "--num-threads",
             str(bfcl_args.num_threads),
-            "--encoder-revision",
-            BFCL_ENCODER_REVISION,
+            "--suite",
+            self._suite,
             "--bfcl-commit",
             BFCL_COMMIT,
             "--scorer-patch-sha256",
             BFCL_SCORER_PATCH_SHA256,
+            *self._extra_run_command_parts(bfcl_args),
         ]
         return " ".join(shlex.quote(part) for part in parts)
 
@@ -203,7 +220,7 @@ class BFCLV4NonWebExternalEval(SandboxedExternalEval):
         all_output: list[str] = []
 
         try:
-            bfcl_args = BFCLV4Args.from_dict(args)
+            bfcl_args = self._parse_args(args)
         except (TypeError, ValueError) as error:
             return self._error_result(str(error), start_time)
 
@@ -230,59 +247,63 @@ class BFCLV4NonWebExternalEval(SandboxedExternalEval):
             temporary_dir = tempfile.TemporaryDirectory(prefix=f"{self.name}_")
             artifact_dir = Path(temporary_dir.name)
 
-        sandbox_config = self._create_bfcl_sandbox_config(
-            container_runtime, output_dir, artifact_dir
-        )
-
         result: ExternalEvalResult
         try:
-            async with SandboxExecutor(sandbox_config, name=self.name) as executor:
-                if setup_error := await self._run_setup(executor, all_output, start_time):
-                    return setup_error
-
-                sandbox_url = self._get_provider_url_for_sandbox(provider_url)
-                if is_local and not await self._check_provider_health(executor, sandbox_url):
-                    return self._error_result(
-                        f"Provider not reachable at {sandbox_url}",
-                        start_time,
-                        "\n".join(all_output),
-                    )
-
-                run_command = self._build_run_command(model_name, sandbox_url, bfcl_args)
-                logger.info(f"[{self.name}] Running BFCL v4 non-web suite")
-                run_result = await executor.execute_command(
-                    run_command,
-                    timeout=self.timeout_seconds,
-                    stream=True,
-                    log_prefix=self.name,
+            with ExitStack() as stack:
+                extra_volumes = self._create_sensitive_volumes(stack)
+                sandbox_config = self._create_bfcl_sandbox_config(
+                    container_runtime,
+                    output_dir,
+                    artifact_dir,
+                    extra_volumes=extra_volumes,
                 )
-                all_output.append(f"$ {run_command}\n{run_result.output}")
+                async with SandboxExecutor(sandbox_config, name=self.name) as executor:
+                    if setup_error := await self._run_setup(executor, all_output, start_time):
+                        return setup_error
 
-                summary_path = artifact_dir / "summary.json"
-                if not run_result.success:
-                    return self._error_result(
-                        f"BFCL runner exited with code {run_result.exit_code}",
-                        start_time,
-                        "\n".join(all_output),
-                    )
-                if not summary_path.is_file():
-                    return self._error_result(
-                        "BFCL runner completed without summary.json",
-                        start_time,
-                        "\n".join(all_output),
-                    )
+                    sandbox_url = self._get_provider_url_for_sandbox(provider_url)
+                    if is_local and not await self._check_provider_health(executor, sandbox_url):
+                        return self._error_result(
+                            f"Provider not reachable at {sandbox_url}",
+                            start_time,
+                            "\n".join(all_output),
+                        )
 
-                summary = json.loads(summary_path.read_text())
-                result = ExternalEvalResult(
-                    name=self.name,
-                    metrics=summary["metrics"],
-                    metadata={
-                        **summary["metadata"],
-                        "artifacts_dir": str(artifact_dir) if output_dir else None,
-                    },
-                    predictions=summary.get("predictions"),
-                    raw_output="\n".join(all_output),
-                )
+                    run_command = self._build_run_command(model_name, sandbox_url, bfcl_args)
+                    logger.info(f"[{self.name}] Running BFCL v4 {self._suite} suite")
+                    run_result = await executor.execute_command(
+                        run_command,
+                        timeout=self.timeout_seconds,
+                        stream=True,
+                        log_prefix=self.name,
+                    )
+                    all_output.append(f"$ {run_command}\n{run_result.output}")
+
+                    summary_path = artifact_dir / "summary.json"
+                    if not run_result.success:
+                        return self._error_result(
+                            f"BFCL runner exited with code {run_result.exit_code}",
+                            start_time,
+                            "\n".join(all_output),
+                        )
+                    if not summary_path.is_file():
+                        return self._error_result(
+                            "BFCL runner completed without summary.json",
+                            start_time,
+                            "\n".join(all_output),
+                        )
+
+                    summary = json.loads(summary_path.read_text())
+                    result = ExternalEvalResult(
+                        name=self.name,
+                        metrics=summary["metrics"],
+                        metadata={
+                            **summary["metadata"],
+                            "artifacts_dir": str(artifact_dir) if output_dir else None,
+                        },
+                        predictions=summary.get("predictions"),
+                        raw_output="\n".join(all_output),
+                    )
         except Exception as error:
             logger.exception(f"[{self.name}] Execution failed")
             return self._error_result(str(error), start_time, "\n".join(all_output))

--- a/src/olmo_eval/evals/external/benchmarks/bfcl/eval.py
+++ b/src/olmo_eval/evals/external/benchmarks/bfcl/eval.py
@@ -1,0 +1,296 @@
+"""BFCL v4 non-web external evaluation."""
+
+from __future__ import annotations
+
+import json
+import logging
+import shlex
+import tempfile
+import time
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from olmo_eval.evals.external.base import SandboxedExternalEval
+from olmo_eval.evals.external.result import ExternalEvalResult
+
+if TYPE_CHECKING:
+    from olmo_eval.inference.base import InferenceProvider
+
+logger = logging.getLogger(__name__)
+
+BFCL_REPOSITORY = "https://github.com/ShishirPatil/gorilla.git"
+BFCL_COMMIT = "6ea57973c7a6097fd7c5915698c54c17c5b1b6c8"
+BFCL_ENCODER_REPOSITORY = "sentence-transformers/all-MiniLM-L6-v2"
+BFCL_ENCODER_REVISION = "1110a243fdf4706b3f48f1d95db1a4f5529b4d41"
+BFCL_SCORER_PATCH_SHA256 = "5ff242c9273854b9c5ca70b039f7d0bbdc58126e9ce4cb5caf23c65279ee1ccf"
+
+_RUNNER_CONTAINER_PATH = "/opt/olmo-eval/bfcl_runner.py"
+_SCORER_PATCH_CONTAINER_PATH = "/opt/olmo-eval/0001-check-multi-turn-irrelevance.patch"
+_ARTIFACT_CONTAINER_PATH = "/output"
+
+
+@dataclass(frozen=True)
+class BFCLV4Args:
+    """Runtime arguments for the official BFCL generator."""
+
+    temperature: float = 0.001
+    num_threads: int = 100
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> BFCLV4Args:
+        temperature = float(data.get("temperature", 0.001))
+        num_threads = int(data.get("num_threads", 100))
+        if temperature < 0:
+            raise ValueError("temperature must be non-negative")
+        if num_threads < 1:
+            raise ValueError("num_threads must be positive")
+        return cls(temperature=temperature, num_threads=num_threads)
+
+
+class BFCLV4NonWebExternalEval(SandboxedExternalEval):
+    """Official BFCL v4 excluding the credentialed web-search slice.
+
+    The returned primary metric is the contribution of these categories to the
+    official fixed-weight BFCL v4 score. Its maximum is 0.8 because web search,
+    which contributes the remaining 0.2, is deliberately not run here.
+    """
+
+    @property
+    def name(self) -> str:
+        return "bfcl_v4_non_web"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Runs the official BFCL v4 non-live, live, multi-turn, and memory suites "
+            "against an OpenAI-compatible endpoint. Web search is excluded."
+        )
+
+    @property
+    def sandbox_image(self) -> str:
+        return "ghcr.io/astral-sh/uv:python3.11-bookworm"
+
+    @property
+    def working_dir(self) -> str:
+        return "/workspace"
+
+    @property
+    def timeout_seconds(self) -> float:
+        return 8 * 60 * 60
+
+    @property
+    def setup_command(self) -> tuple[str, ...]:
+        gorilla_dir = f"{self.working_dir}/gorilla"
+        bfcl_dir = f"{gorilla_dir}/berkeley-function-call-leaderboard"
+        python = f"{bfcl_dir}/.venv/bin/python"
+        return (
+            f"git clone --filter=blob:none {BFCL_REPOSITORY} {gorilla_dir}",
+            (
+                f"cd {gorilla_dir} && git checkout --detach {BFCL_COMMIT} && "
+                f'test "$(git rev-parse HEAD)" = {BFCL_COMMIT}'
+            ),
+            (
+                f"echo '{BFCL_SCORER_PATCH_SHA256}  {_SCORER_PATCH_CONTAINER_PATH}' | "
+                f"sha256sum -c - && cd {gorilla_dir} && "
+                f"git apply --check {_SCORER_PATCH_CONTAINER_PATH} && "
+                f"git apply {_SCORER_PATCH_CONTAINER_PATH}"
+            ),
+            (
+                f"cd {bfcl_dir} && uv venv --python 3.11 && "
+                "uv pip install --python .venv/bin/python --torch-backend cpu -e . soundfile"
+            ),
+            (
+                f"{python} {_RUNNER_CONTAINER_PATH} prepare "
+                f"--cache-dir {self.working_dir}/hf-cache "
+                f"--encoder-repository {BFCL_ENCODER_REPOSITORY} "
+                f"--encoder-revision {BFCL_ENCODER_REVISION}"
+            ),
+        )
+
+    @property
+    def arguments(self) -> dict[str, tuple[str, Any | None]]:
+        return {
+            "temperature": ("Sampling temperature used by the official BFCL generator", 0.001),
+            "num_threads": ("Maximum concurrent model requests", 100),
+        }
+
+    @property
+    def run_command(self) -> str:
+        return (
+            "bfcl_runner.py run --provider-model MODEL --provider-url URL "
+            "--categories non_live,live,multi_turn,memory"
+        )
+
+    def _create_bfcl_sandbox_config(
+        self,
+        container_runtime: str,
+        output_dir: str | None,
+        artifact_dir: Path,
+    ) -> Any:
+        config = self._create_sandbox_config(container_runtime, output_dir)
+        env = dict(config.environment)
+        env["HF_HOME"] = f"{self.working_dir}/hf-cache"
+        env["HF_HUB_CACHE"] = f"{self.working_dir}/hf-cache/hub"
+
+        # This adapter targets the local OpenAI-compatible model endpoint that
+        # olmo-eval launches. The OpenAI client requires a non-empty value even
+        # though the endpoint does not authenticate. Never forward an ambient
+        # credential into the benchmark container.
+        env["OPENAI_API_KEY"] = "EMPTY"
+
+        runner_path = Path(__file__).with_name("runner.py")
+        scorer_patch_path = (
+            Path(__file__).with_name("patches") / "0001-check-multi-turn-irrelevance.patch"
+        )
+        volumes = config.volumes + (
+            (str(runner_path), _RUNNER_CONTAINER_PATH),
+            (str(scorer_patch_path), _SCORER_PATCH_CONTAINER_PATH),
+            (str(artifact_dir), _ARTIFACT_CONTAINER_PATH),
+        )
+        return replace(
+            config,
+            environment=tuple(env.items()),
+            volumes=volumes,
+            inject_swerex=True,
+            # Docker's json-file logger does not support the `path` log option
+            # used by the shared sandbox logger. The BFCL runner's raw output
+            # and artifacts are persisted separately.
+            log_dir=None if container_runtime == "docker" else config.log_dir,
+        )
+
+    def _build_run_command(
+        self,
+        model_name: str,
+        provider_url: str,
+        bfcl_args: BFCLV4Args,
+    ) -> str:
+        bfcl_dir = f"{self.working_dir}/gorilla/berkeley-function-call-leaderboard"
+        python = f"{bfcl_dir}/.venv/bin/python"
+        parts = [
+            python,
+            _RUNNER_CONTAINER_PATH,
+            "run",
+            "--bfcl-root",
+            bfcl_dir,
+            "--output-dir",
+            _ARTIFACT_CONTAINER_PATH,
+            "--provider-model",
+            model_name,
+            "--provider-url",
+            provider_url,
+            "--temperature",
+            str(bfcl_args.temperature),
+            "--num-threads",
+            str(bfcl_args.num_threads),
+            "--encoder-revision",
+            BFCL_ENCODER_REVISION,
+            "--bfcl-commit",
+            BFCL_COMMIT,
+            "--scorer-patch-sha256",
+            BFCL_SCORER_PATCH_SHA256,
+        ]
+        return " ".join(shlex.quote(part) for part in parts)
+
+    async def execute(
+        self,
+        provider: InferenceProvider,
+        args: dict[str, Any],
+        output_dir: str | None = None,
+        container_runtime: str = "podman",
+    ) -> ExternalEvalResult:
+        start_time = time.time()
+        all_output: list[str] = []
+
+        try:
+            bfcl_args = BFCLV4Args.from_dict(args)
+        except (TypeError, ValueError) as error:
+            return self._error_result(str(error), start_time)
+
+        provider_url = getattr(provider, "base_url", None)
+        if not provider_url:
+            return self._error_result(
+                "BFCL v4 requires a provider exposing an OpenAI-compatible base_url",
+                start_time,
+            )
+        model_name = provider.model_name
+        is_local = self._is_local_provider(provider, provider_url)
+
+        try:
+            from olmo_eval.harness.sandbox.executor import SandboxExecutor
+        except ImportError as error:
+            return self._error_result(f"SWE-ReX not installed: {error}", start_time)
+
+        output_root = Path(output_dir) if output_dir else None
+        if output_root is not None:
+            output_root.mkdir(parents=True, exist_ok=True)
+            artifact_dir = Path(tempfile.mkdtemp(prefix=f"{self.name}_artifacts_", dir=output_root))
+            temporary_dir = None
+        else:
+            temporary_dir = tempfile.TemporaryDirectory(prefix=f"{self.name}_")
+            artifact_dir = Path(temporary_dir.name)
+
+        sandbox_config = self._create_bfcl_sandbox_config(
+            container_runtime, output_dir, artifact_dir
+        )
+
+        result: ExternalEvalResult
+        try:
+            async with SandboxExecutor(sandbox_config, name=self.name) as executor:
+                if setup_error := await self._run_setup(executor, all_output, start_time):
+                    return setup_error
+
+                sandbox_url = self._get_provider_url_for_sandbox(provider_url)
+                if is_local and not await self._check_provider_health(executor, sandbox_url):
+                    return self._error_result(
+                        f"Provider not reachable at {sandbox_url}",
+                        start_time,
+                        "\n".join(all_output),
+                    )
+
+                run_command = self._build_run_command(model_name, sandbox_url, bfcl_args)
+                logger.info(f"[{self.name}] Running BFCL v4 non-web suite")
+                run_result = await executor.execute_command(
+                    run_command,
+                    timeout=self.timeout_seconds,
+                    stream=True,
+                    log_prefix=self.name,
+                )
+                all_output.append(f"$ {run_command}\n{run_result.output}")
+
+                summary_path = artifact_dir / "summary.json"
+                if not run_result.success:
+                    return self._error_result(
+                        f"BFCL runner exited with code {run_result.exit_code}",
+                        start_time,
+                        "\n".join(all_output),
+                    )
+                if not summary_path.is_file():
+                    return self._error_result(
+                        "BFCL runner completed without summary.json",
+                        start_time,
+                        "\n".join(all_output),
+                    )
+
+                summary = json.loads(summary_path.read_text())
+                result = ExternalEvalResult(
+                    name=self.name,
+                    metrics=summary["metrics"],
+                    metadata={
+                        **summary["metadata"],
+                        "artifacts_dir": str(artifact_dir) if output_dir else None,
+                    },
+                    predictions=summary.get("predictions"),
+                    raw_output="\n".join(all_output),
+                )
+        except Exception as error:
+            logger.exception(f"[{self.name}] Execution failed")
+            return self._error_result(str(error), start_time, "\n".join(all_output))
+        finally:
+            if temporary_dir is not None:
+                temporary_dir.cleanup()
+
+        result.duration_seconds = time.time() - start_time
+        if output_dir:
+            self._save_results(result, output_dir)
+        return result

--- a/src/olmo_eval/evals/external/benchmarks/bfcl/patches/0001-check-multi-turn-irrelevance.patch
+++ b/src/olmo_eval/evals/external/benchmarks/bfcl/patches/0001-check-multi-turn-irrelevance.patch
@@ -1,0 +1,25 @@
+diff --git a/berkeley-function-call-leaderboard/bfcl_eval/eval_checker/eval_runner.py b/berkeley-function-call-leaderboard/bfcl_eval/eval_checker/eval_runner.py
+index 46d64fe..9721c73 100644
+--- a/berkeley-function-call-leaderboard/bfcl_eval/eval_checker/eval_runner.py
++++ b/berkeley-function-call-leaderboard/bfcl_eval/eval_checker/eval_runner.py
+@@ -237,0 +238,20 @@ def _evaluate_single_multi_turn_entry(
++    # multi_turn_checker executes calls on empty-ground-truth turns for state
++    # accounting, but deliberately leaves the abstention verdict to this
++    # dedicated checker.
++    accuracy_checker_result = multi_turn_irrelevance_checker(
++        multi_turn_model_result_list_decoded,
++        ground_truth_list,
++    )
++    if not accuracy_checker_result["valid"]:
++        return {
++            "id": test_entry_id,
++            "model_name": model_name,
++            "test_category": test_category,
++            "valid": accuracy_checker_result.pop("valid"),
++            "error": accuracy_checker_result,
++            "prompt": prompt_entry,
++            "model_result_raw": model_result_list,
++            "model_result_decoded": multi_turn_model_result_list_decoded,
++            "possible_answer": ground_truth_list,
++        }
++

--- a/src/olmo_eval/evals/external/benchmarks/bfcl/runner.py
+++ b/src/olmo_eval/evals/external/benchmarks/bfcl/runner.py
@@ -1,0 +1,393 @@
+"""Run and validate a pinned BFCL v4 checkout inside the evaluation sandbox."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+from collections import Counter, defaultdict
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+BFCL_REGISTRY_NAME = "olmo-eval-provider-FC"
+BFCL_DISPLAY_NAME = "OLMo Eval Provider (FC)"
+NON_WEB_COLLECTIONS = ("non_live", "live", "multi_turn", "memory")
+EXPECTED_RESULT_FILES = 23
+EXPECTED_SCORE_FILES = 20
+EXPECTED_RESULT_ROWS = 5_017
+EXPECTED_COVERED_WEIGHT = 0.8
+
+
+def _read_jsonl(path: Path) -> list[dict[str, Any]]:
+    entries: list[dict[str, Any]] = []
+    with path.open() as file_handle:
+        for line_number, line in enumerate(file_handle, start=1):
+            try:
+                value = json.loads(line)
+            except json.JSONDecodeError as error:
+                raise ValueError(
+                    f"Invalid JSON in {path} at line {line_number}: {error}"
+                ) from error
+            if not isinstance(value, dict):
+                raise ValueError(f"Expected a JSON object in {path} at line {line_number}")
+            entries.append(value)
+    return entries
+
+
+def _validate_result_inventory(
+    result_root: Path,
+    expected: dict[Path, set[str]],
+) -> int:
+    actual_files = {
+        path.relative_to(result_root) for path in result_root.rglob("BFCL_v4_*_result.json")
+    }
+    if actual_files != set(expected):
+        missing = sorted(str(path) for path in set(expected) - actual_files)
+        unexpected = sorted(str(path) for path in actual_files - set(expected))
+        raise ValueError(
+            f"BFCL result-file inventory mismatch: missing={missing}, unexpected={unexpected}"
+        )
+
+    row_count = 0
+    for relative_path, expected_ids in expected.items():
+        entries = _read_jsonl(result_root / relative_path)
+        ids = [entry.get("id") for entry in entries]
+        if any(not isinstance(entry_id, str) for entry_id in ids):
+            raise ValueError(f"Malformed BFCL result ID in {relative_path}")
+        duplicate_ids = sorted(entry_id for entry_id, count in Counter(ids).items() if count > 1)
+        if duplicate_ids:
+            raise ValueError(f"Duplicate BFCL result IDs in {relative_path}: {duplicate_ids}")
+        if set(ids) != expected_ids:
+            missing = sorted(expected_ids - set(ids))
+            unexpected = sorted(set(ids) - expected_ids)
+            raise ValueError(
+                f"BFCL result-ID mismatch in {relative_path}: "
+                f"missing={missing}, unexpected={unexpected}"
+            )
+        for entry in entries:
+            if "result" not in entry:
+                raise ValueError(f"BFCL result {entry.get('id')!r} has no result field")
+            if "traceback" in entry:
+                raise ValueError(f"BFCL inference traceback recorded for {entry.get('id')!r}")
+            if isinstance(entry["result"], str) and entry["result"].startswith(
+                "Error during inference:"
+            ):
+                raise ValueError(f"BFCL inference error recorded for {entry.get('id')!r}")
+        row_count += len(entries)
+    return row_count
+
+
+def _validate_score_inventory(
+    score_root: Path,
+    expected: dict[Path, set[str]],
+) -> dict[str, dict[str, float | int]]:
+    actual_files = {
+        path.relative_to(score_root) for path in score_root.rglob("BFCL_v4_*_score.json")
+    }
+    if actual_files != set(expected):
+        missing = sorted(str(path) for path in set(expected) - actual_files)
+        unexpected = sorted(str(path) for path in actual_files - set(expected))
+        raise ValueError(
+            f"BFCL score-file inventory mismatch: missing={missing}, unexpected={unexpected}"
+        )
+
+    scores: dict[str, dict[str, float | int]] = {}
+    for relative_path, expected_ids in expected.items():
+        entries = _read_jsonl(score_root / relative_path)
+        if not entries:
+            raise ValueError(f"Empty BFCL score file: {relative_path}")
+        header, failures = entries[0], entries[1:]
+        category = relative_path.name.removeprefix("BFCL_v4_").removesuffix("_score.json")
+        total_count = header.get("total_count")
+        correct_count = header.get("correct_count")
+        accuracy = header.get("accuracy")
+        if total_count != len(expected_ids):
+            raise ValueError(
+                f"BFCL score count mismatch for {category}: {total_count} != {len(expected_ids)}"
+            )
+        if (
+            not isinstance(total_count, int)
+            or not isinstance(correct_count, int)
+            or not isinstance(accuracy, (int, float))
+        ):
+            raise ValueError(f"Malformed BFCL score header for {category}: {header}")
+        failure_ids = [entry.get("id") for entry in failures]
+        if any(not isinstance(entry_id, str) for entry_id in failure_ids):
+            raise ValueError(f"Malformed BFCL failure ID in {relative_path}")
+        if any(entry.get("valid") is not False for entry in failures):
+            raise ValueError(f"Malformed BFCL failure record in {relative_path}")
+        if len(failure_ids) != len(set(failure_ids)):
+            raise ValueError(f"Duplicate BFCL failure IDs in {relative_path}")
+        if not set(failure_ids).issubset(expected_ids):
+            raise ValueError(f"Unexpected BFCL failure IDs in {relative_path}")
+        if correct_count != total_count - len(failures):
+            raise ValueError(f"BFCL correct-count mismatch for {category}")
+        expected_accuracy = correct_count / total_count
+        if not math.isclose(float(accuracy), expected_accuracy, rel_tol=0, abs_tol=1e-12):
+            raise ValueError(f"BFCL accuracy mismatch for {category}")
+        scores[category] = {
+            "accuracy": float(accuracy),
+            "correct_count": correct_count,
+            "total_count": total_count,
+        }
+    return scores
+
+
+def _unweighted(scores: dict[str, dict[str, float | int]], categories: tuple[str, ...]) -> float:
+    return sum(float(scores[category]["accuracy"]) for category in categories) / len(categories)
+
+
+def _weighted(scores: dict[str, dict[str, float | int]], categories: tuple[str, ...]) -> float:
+    total = sum(int(scores[category]["total_count"]) for category in categories)
+    return (
+        sum(
+            float(scores[category]["accuracy"]) * int(scores[category]["total_count"])
+            for category in categories
+        )
+        / total
+    )
+
+
+def _compute_metrics(scores: dict[str, dict[str, float | int]]) -> dict[str, float]:
+    simple = _unweighted(scores, ("simple_python", "simple_java", "simple_javascript"))
+    non_live = (
+        simple
+        + float(scores["multiple"]["accuracy"])
+        + float(scores["parallel"]["accuracy"])
+        + float(scores["parallel_multiple"]["accuracy"])
+    ) / 4
+    live = _weighted(
+        scores,
+        ("live_simple", "live_multiple", "live_parallel", "live_parallel_multiple"),
+    )
+    irrelevance = _unweighted(scores, ("irrelevance", "live_irrelevance"))
+    multi_turn = _unweighted(
+        scores,
+        (
+            "multi_turn_base",
+            "multi_turn_miss_func",
+            "multi_turn_miss_param",
+            "multi_turn_long_context",
+        ),
+    )
+    memory = _unweighted(scores, ("memory_kv", "memory_vector", "memory_rec_sum"))
+    contribution = 0.1 * non_live + 0.1 * live + 0.1 * irrelevance + 0.3 * multi_turn + 0.2 * memory
+    return {
+        "non_web_weighted_contribution": contribution,
+        "non_live_accuracy": non_live,
+        "live_accuracy": live,
+        "irrelevance_accuracy": irrelevance,
+        "multi_turn_accuracy": multi_turn,
+        "memory_accuracy": memory,
+        "live_relevance_accuracy": float(scores["live_relevance"]["accuracy"]),
+    }
+
+
+def _register_model(provider_model: str) -> None:
+    from bfcl_eval.constants.model_config import MODEL_CONFIG_MAPPING, ModelConfig
+    from bfcl_eval.model_handler.api_inference.openai_completion import (
+        OpenAICompletionsHandler,
+    )
+
+    MODEL_CONFIG_MAPPING[BFCL_REGISTRY_NAME] = ModelConfig(
+        model_name=provider_model,
+        display_name=BFCL_DISPLAY_NAME,
+        url="https://github.com/allenai/olmo-eval",
+        org="Allen Institute for AI",
+        license="N/A",
+        model_handler=OpenAICompletionsHandler,
+        is_fc_model=True,
+        underscore_to_dot=True,
+    )
+
+
+def _build_expected_inventories() -> tuple[dict[Path, set[str]], dict[Path, set[str]]]:
+    from bfcl_eval.constants.category_mapping import TEST_COLLECTION_MAPPING
+    from bfcl_eval.utils import (
+        extract_test_category_from_id,
+        get_directory_structure_by_category,
+        get_directory_structure_by_id,
+        get_file_name_by_category,
+        load_dataset_entry,
+    )
+
+    result_inventory: dict[Path, set[str]] = defaultdict(set)
+    score_inventory: dict[Path, set[str]] = {}
+    for collection in NON_WEB_COLLECTIONS:
+        for category in TEST_COLLECTION_MAPPING[collection]:
+            entries = load_dataset_entry(category)
+            for entry in entries:
+                result_category = extract_test_category_from_id(entry["id"])
+                path = (
+                    Path(BFCL_REGISTRY_NAME)
+                    / get_directory_structure_by_id(entry["id"])
+                    / get_file_name_by_category(result_category, is_result_file=True)
+                )
+                result_inventory[path].add(entry["id"])
+
+            scoring_entries = load_dataset_entry(category, include_prereq=False)
+            score_path = (
+                Path(BFCL_REGISTRY_NAME)
+                / get_directory_structure_by_category(category)
+                / get_file_name_by_category(category, is_score_file=True)
+            )
+            score_inventory[score_path] = {entry["id"] for entry in scoring_entries}
+
+    if len(result_inventory) != EXPECTED_RESULT_FILES:
+        raise ValueError(f"Pinned BFCL checkout produced {len(result_inventory)} result files")
+    if len(score_inventory) != EXPECTED_SCORE_FILES:
+        raise ValueError(f"Pinned BFCL checkout produced {len(score_inventory)} score files")
+    expected_rows = sum(len(ids) for ids in result_inventory.values())
+    if expected_rows != EXPECTED_RESULT_ROWS:
+        raise ValueError(f"Pinned BFCL checkout produced {expected_rows} expected rows")
+    return dict(result_inventory), score_inventory
+
+
+def _prepare_encoder(cache_dir: Path, repository: str, revision: str) -> None:
+    from huggingface_hub import snapshot_download
+
+    hub_cache = cache_dir / "hub"
+    snapshot = Path(
+        snapshot_download(repo_id=repository, revision=revision, cache_dir=hub_cache)
+    ).resolve()
+    if snapshot.name != revision:
+        raise ValueError(f"Encoder resolved to {snapshot.name}, expected {revision}")
+
+    cache_repo = hub_cache / f"models--{repository.replace('/', '--')}"
+    ref = cache_repo / "refs" / "main"
+    ref.parent.mkdir(parents=True, exist_ok=True)
+    # huggingface_hub reads this file verbatim; a trailing newline would become
+    # part of the snapshot directory name and break offline resolution.
+    ref.write_text(revision)
+
+    os.environ["HF_HOME"] = str(cache_dir)
+    os.environ["HF_HUB_CACHE"] = str(hub_cache)
+    os.environ["HF_HUB_OFFLINE"] = "1"
+    os.environ["TRANSFORMERS_OFFLINE"] = "1"
+    from sentence_transformers import SentenceTransformer
+
+    SentenceTransformer("all-MiniLM-L6-v2", device="cpu", local_files_only=True)
+
+
+def _run(args: argparse.Namespace) -> None:
+    os.environ["OPENAI_BASE_URL"] = args.provider_url
+    os.environ.setdefault("OPENAI_API_KEY", "EMPTY")
+    os.environ["HF_HUB_OFFLINE"] = "1"
+    os.environ["TRANSFORMERS_OFFLINE"] = "1"
+    os.environ["TOKENIZERS_PARALLELISM"] = "false"
+
+    _register_model(args.provider_model)
+
+    from bfcl_eval._llm_response_generation import main as generation_main
+    from bfcl_eval.eval_checker.eval_runner import main as evaluation_main
+
+    output_dir = Path(args.output_dir).resolve()
+    result_dir = output_dir / "result"
+    score_dir = output_dir / "score"
+    result_dir.mkdir(parents=True, exist_ok=True)
+    score_dir.mkdir(parents=True, exist_ok=True)
+
+    generation_main(
+        SimpleNamespace(
+            model=[BFCL_REGISTRY_NAME],
+            test_category=list(NON_WEB_COLLECTIONS),
+            temperature=args.temperature,
+            include_input_log=False,
+            exclude_state_log=False,
+            num_gpus=1,
+            num_threads=args.num_threads,
+            gpu_memory_utilization=0.9,
+            backend="vllm",
+            skip_server_setup=False,
+            local_model_path=None,
+            result_dir=result_dir,
+            allow_overwrite=False,
+            run_ids=False,
+            enable_lora=False,
+            max_lora_rank=None,
+            lora_modules=None,
+        )
+    )
+    evaluation_main(
+        [BFCL_REGISTRY_NAME],
+        list(NON_WEB_COLLECTIONS),
+        str(result_dir),
+        str(score_dir),
+    )
+
+    expected_results, expected_scores = _build_expected_inventories()
+    row_count = _validate_result_inventory(result_dir, expected_results)
+    scores = _validate_score_inventory(score_dir, expected_scores)
+    metrics = _compute_metrics(scores)
+
+    summary = {
+        "metrics": metrics,
+        "metadata": {
+            "benchmark": "BFCL v4",
+            "bfcl_commit": args.bfcl_commit,
+            "scorer_patch_sha256": args.scorer_patch_sha256,
+            "encoder_revision": args.encoder_revision,
+            "covered_weight": EXPECTED_COVERED_WEIGHT,
+            "excluded_categories": ["web_search_base", "web_search_no_snippet"],
+            "result_file_count": len(expected_results),
+            "score_file_count": len(expected_scores),
+            "num_tasks": row_count,
+            "provider_model": args.provider_model,
+            # BFCL renormalizes missing agentic subsections in its partial-run
+            # top-line CSV. The fixed-weight contribution above is therefore
+            # computed from the validated native leaf scores, not that partial
+            # aggregate.
+            "official_partial_overall_used": False,
+        },
+        "predictions": [
+            {
+                "native_id": category,
+                "instance_metrics": {"accuracy": {"external": score["accuracy"]}},
+                "correct_count": score["correct_count"],
+                "total_count": score["total_count"],
+            }
+            for category, score in sorted(scores.items())
+        ],
+    }
+    (output_dir / "summary.json").write_text(json.dumps(summary, indent=2, sort_keys=True))
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    prepare = subparsers.add_parser("prepare")
+    prepare.add_argument("--cache-dir", type=Path, required=True)
+    prepare.add_argument("--encoder-repository", required=True)
+    prepare.add_argument("--encoder-revision", required=True)
+
+    run = subparsers.add_parser("run")
+    run.add_argument("--bfcl-root", type=Path, required=True)
+    run.add_argument("--output-dir", required=True)
+    run.add_argument("--provider-model", required=True)
+    run.add_argument("--provider-url", required=True)
+    run.add_argument("--temperature", type=float, required=True)
+    run.add_argument("--num-threads", type=int, required=True)
+    run.add_argument("--encoder-revision", required=True)
+    run.add_argument("--bfcl-commit", default="6ea57973c7a6097fd7c5915698c54c17c5b1b6c8")
+    run.add_argument("--scorer-patch-sha256", required=True)
+    return parser
+
+
+def main() -> None:
+    args = _build_parser().parse_args()
+    if args.command == "prepare":
+        _prepare_encoder(args.cache_dir, args.encoder_repository, args.encoder_revision)
+    else:
+        if args.temperature < 0:
+            raise ValueError("temperature must be non-negative")
+        if args.num_threads < 1:
+            raise ValueError("num_threads must be positive")
+        os.chdir(args.bfcl_root)
+        _run(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/olmo_eval/evals/external/benchmarks/bfcl/runner.py
+++ b/src/olmo_eval/evals/external/benchmarks/bfcl/runner.py
@@ -3,10 +3,14 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import math
 import os
+import threading
+import time
 from collections import Counter, defaultdict
+from datetime import UTC, datetime
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -14,10 +18,15 @@ from typing import Any
 BFCL_REGISTRY_NAME = "olmo-eval-provider-FC"
 BFCL_DISPLAY_NAME = "OLMo Eval Provider (FC)"
 NON_WEB_COLLECTIONS = ("non_live", "live", "multi_turn", "memory")
-EXPECTED_RESULT_FILES = 23
-EXPECTED_SCORE_FILES = 20
-EXPECTED_RESULT_ROWS = 5_017
-EXPECTED_COVERED_WEIGHT = 0.8
+WEB_COLLECTIONS = ("web_search",)
+NON_WEB_EXPECTED_RESULT_FILES = 23
+NON_WEB_EXPECTED_SCORE_FILES = 20
+NON_WEB_EXPECTED_RESULT_ROWS = 5_017
+NON_WEB_EXPECTED_COVERED_WEIGHT = 0.8
+WEB_EXPECTED_RESULT_FILES = 2
+WEB_EXPECTED_SCORE_FILES = 2
+WEB_EXPECTED_RESULT_ROWS = 200
+WEB_EXPECTED_COVERED_WEIGHT = 0.2
 
 
 def _read_jsonl(path: Path) -> list[dict[str, Any]]:
@@ -150,7 +159,7 @@ def _weighted(scores: dict[str, dict[str, float | int]], categories: tuple[str, 
     )
 
 
-def _compute_metrics(scores: dict[str, dict[str, float | int]]) -> dict[str, float]:
+def _compute_non_web_metrics(scores: dict[str, dict[str, float | int]]) -> dict[str, float]:
     simple = _unweighted(scores, ("simple_python", "simple_java", "simple_javascript"))
     non_live = (
         simple
@@ -185,6 +194,16 @@ def _compute_metrics(scores: dict[str, dict[str, float | int]]) -> dict[str, flo
     }
 
 
+def _compute_web_metrics(scores: dict[str, dict[str, float | int]]) -> dict[str, float]:
+    web_search = _unweighted(scores, ("web_search_base", "web_search_no_snippet"))
+    return {
+        "web_weighted_contribution": 0.2 * web_search,
+        "web_search_accuracy": web_search,
+        "web_search_base_accuracy": float(scores["web_search_base"]["accuracy"]),
+        "web_search_no_snippet_accuracy": float(scores["web_search_no_snippet"]["accuracy"]),
+    }
+
+
 def _register_model(provider_model: str) -> None:
     from bfcl_eval.constants.model_config import MODEL_CONFIG_MAPPING, ModelConfig
     from bfcl_eval.model_handler.api_inference.openai_completion import (
@@ -203,7 +222,13 @@ def _register_model(provider_model: str) -> None:
     )
 
 
-def _build_expected_inventories() -> tuple[dict[Path, set[str]], dict[Path, set[str]]]:
+def _build_expected_inventories(
+    collections: tuple[str, ...],
+    *,
+    expected_result_files: int,
+    expected_score_files: int,
+    expected_result_rows: int,
+) -> tuple[dict[Path, set[str]], dict[Path, set[str]]]:
     from bfcl_eval.constants.category_mapping import TEST_COLLECTION_MAPPING
     from bfcl_eval.utils import (
         extract_test_category_from_id,
@@ -215,7 +240,7 @@ def _build_expected_inventories() -> tuple[dict[Path, set[str]], dict[Path, set[
 
     result_inventory: dict[Path, set[str]] = defaultdict(set)
     score_inventory: dict[Path, set[str]] = {}
-    for collection in NON_WEB_COLLECTIONS:
+    for collection in collections:
         for category in TEST_COLLECTION_MAPPING[collection]:
             entries = load_dataset_entry(category)
             for entry in entries:
@@ -235,12 +260,12 @@ def _build_expected_inventories() -> tuple[dict[Path, set[str]], dict[Path, set[
             )
             score_inventory[score_path] = {entry["id"] for entry in scoring_entries}
 
-    if len(result_inventory) != EXPECTED_RESULT_FILES:
+    if len(result_inventory) != expected_result_files:
         raise ValueError(f"Pinned BFCL checkout produced {len(result_inventory)} result files")
-    if len(score_inventory) != EXPECTED_SCORE_FILES:
+    if len(score_inventory) != expected_score_files:
         raise ValueError(f"Pinned BFCL checkout produced {len(score_inventory)} score files")
     expected_rows = sum(len(ids) for ids in result_inventory.values())
-    if expected_rows != EXPECTED_RESULT_ROWS:
+    if expected_rows != expected_result_rows:
         raise ValueError(f"Pinned BFCL checkout produced {expected_rows} expected rows")
     return dict(result_inventory), score_inventory
 
@@ -271,12 +296,179 @@ def _prepare_encoder(cache_dir: Path, repository: str, revision: str) -> None:
     SentenceTransformer("all-MiniLM-L6-v2", device="cpu", local_files_only=True)
 
 
+def _read_serpapi_secret(path: Path) -> str:
+    secret = path.read_text().strip()
+    if not secret:
+        raise ValueError("The mounted SerpAPI secret file is empty")
+    return secret
+
+
+def _get_serpapi_remaining(api_key: str) -> int:
+    import requests
+
+    try:
+        response = requests.get(
+            "https://serpapi.com/account.json",
+            params={"api_key": api_key},
+            timeout=30,
+        )
+    except requests.RequestException as error:
+        raise RuntimeError(
+            f"SerpAPI account preflight request failed ({type(error).__name__})"
+        ) from None
+    if response.status_code != 200:
+        raise RuntimeError(f"SerpAPI account preflight returned HTTP {response.status_code}")
+    try:
+        payload = response.json()
+    except ValueError:
+        raise RuntimeError("SerpAPI account preflight returned invalid JSON") from None
+    remaining = payload.get("total_searches_left")
+    if not isinstance(remaining, int) or isinstance(remaining, bool) or remaining < 0:
+        raise ValueError("SerpAPI account response has no valid total_searches_left value")
+    return remaining
+
+
+def _classify_serpapi_response(response: Any) -> tuple[str, dict[str, Any]]:
+    if not isinstance(response, dict):
+        return "malformed_response", {"response_type": type(response).__name__}
+
+    # Treat an explicit provider error as authoritative even if the response
+    # also contains stale or partial result data.
+    error = response.get("error")
+    if error is not None:
+        error_text = str(error)
+        status = "rate_limited" if "429" in error_text else "error_payload"
+        return status, {"error_sha256": hashlib.sha256(error_text.encode()).hexdigest()}
+
+    organic_results = response.get("organic_results")
+    if isinstance(organic_results, list):
+        status = "organic_results" if organic_results else "empty_organic_results"
+        return status, {"organic_result_count": len(organic_results)}
+    if "organic_results" in response:
+        return "malformed_organic_results", {"organic_results_type": type(organic_results).__name__}
+
+    search_metadata = response.get("search_metadata")
+    search_information = response.get("search_information")
+    return "missing_organic_results", {
+        "response_keys": sorted(str(key) for key in response),
+        "search_status": (
+            search_metadata.get("status") if isinstance(search_metadata, dict) else None
+        ),
+        "organic_results_state": (
+            search_information.get("organic_results_state")
+            if isinstance(search_information, dict)
+            else None
+        ),
+    }
+
+
+def _install_serpapi_audit(audit_path: Path, web_search: Any | None = None) -> None:
+    if web_search is None:
+        from bfcl_eval.eval_checker.multi_turn_eval.func_source_code import web_search
+
+    original_get_dict = web_search.GoogleSearch.get_dict
+    write_lock = threading.Lock()
+    sequence = 0
+    audit_path.touch(exist_ok=False)
+
+    def audited_get_dict(search: Any) -> Any:
+        nonlocal sequence
+        params = getattr(search, "params_dict", {})
+        query = str(params.get("q", "")) if isinstance(params, dict) else ""
+        event: dict[str, Any] = {
+            "query_sha256": hashlib.sha256(query.encode()).hexdigest(),
+            "started_at": datetime.now(UTC).isoformat(),
+        }
+        started = time.monotonic()
+        try:
+            response = original_get_dict(search)
+        except Exception as error:
+            error_text = str(error)
+            rate_limited = "429" in error_text
+            event.update(
+                {
+                    "status": ("rate_limited_exception" if rate_limited else "exception"),
+                    "error_type": type(error).__name__,
+                    "error_sha256": hashlib.sha256(error_text.encode()).hexdigest(),
+                }
+            )
+            # The SerpAPI client may include its full request URL (and therefore
+            # the API key and raw query) in exception text. Preserve BFCL's 429
+            # retry signal without allowing either secret into captured output.
+            message = "429 from SerpAPI" if rate_limited else "SerpAPI request failed"
+            raise RuntimeError(message) from None
+        else:
+            status, fields = _classify_serpapi_response(response)
+            event.update({"status": status, **fields})
+            return response
+        finally:
+            event["duration_ms"] = round((time.monotonic() - started) * 1_000, 3)
+            with write_lock:
+                sequence += 1
+                event["sequence"] = sequence
+                with audit_path.open("a") as file_handle:
+                    file_handle.write(json.dumps(event, sort_keys=True) + "\n")
+
+    web_search.GoogleSearch.get_dict = audited_get_dict
+
+
+def _validate_serpapi_audit(audit_path: Path) -> dict[str, int]:
+    events = _read_jsonl(audit_path)
+    expected_sequences = list(range(1, len(events) + 1))
+    if [event.get("sequence") for event in events] != expected_sequences:
+        raise ValueError("SerpAPI audit sequence is incomplete or out of order")
+
+    forbidden_fields = {"api_key", "serpapi_api_key", "query", "keywords"}
+    for event in events:
+        if forbidden_fields.intersection(key.lower() for key in event):
+            raise ValueError("SerpAPI audit contains a sensitive field")
+        query_sha256 = event.get("query_sha256")
+        if (
+            not isinstance(query_sha256, str)
+            or len(query_sha256) != 64
+            or any(character not in "0123456789abcdef" for character in query_sha256)
+        ):
+            raise ValueError("SerpAPI audit contains an invalid query hash")
+
+    statuses = Counter(str(event.get("status")) for event in events)
+    terminal_statuses = {
+        "empty_organic_results",
+        "error_payload",
+        "exception",
+        "malformed_organic_results",
+        "malformed_response",
+        "missing_organic_results",
+    }
+    failures = {status: statuses[status] for status in terminal_statuses if statuses[status]}
+    if failures:
+        raise ValueError(f"SerpAPI audit contains terminal failures: {failures}")
+    allowed_statuses = {"organic_results", "rate_limited", "rate_limited_exception"}
+    unexpected = sorted(set(statuses) - allowed_statuses)
+    if unexpected:
+        raise ValueError(f"SerpAPI audit contains unexpected statuses: {unexpected}")
+    return dict(statuses)
+
+
 def _run(args: argparse.Namespace) -> None:
     os.environ["OPENAI_BASE_URL"] = args.provider_url
     os.environ.setdefault("OPENAI_API_KEY", "EMPTY")
     os.environ["HF_HUB_OFFLINE"] = "1"
     os.environ["TRANSFORMERS_OFFLINE"] = "1"
     os.environ["TOKENIZERS_PARALLELISM"] = "false"
+
+    collections = NON_WEB_COLLECTIONS if args.suite == "non_web" else WEB_COLLECTIONS
+    if args.suite == "web":
+        serpapi_key = _read_serpapi_secret(args.serpapi_secret_file)
+        os.environ["SERPAPI_API_KEY"] = serpapi_key
+        quota_before = _get_serpapi_remaining(serpapi_key)
+        if quota_before < args.minimum_serpapi_credits:
+            raise ValueError(
+                f"SerpAPI has {quota_before} searches left; "
+                f"{args.minimum_serpapi_credits} are required"
+            )
+    else:
+        serpapi_key = None
+        quota_before = None
 
     _register_model(args.provider_model)
 
@@ -288,11 +480,14 @@ def _run(args: argparse.Namespace) -> None:
     score_dir = output_dir / "score"
     result_dir.mkdir(parents=True, exist_ok=True)
     score_dir.mkdir(parents=True, exist_ok=True)
+    audit_path = output_dir / "serpapi_audit.jsonl"
+    if args.suite == "web":
+        _install_serpapi_audit(audit_path)
 
     generation_main(
         SimpleNamespace(
             model=[BFCL_REGISTRY_NAME],
-            test_category=list(NON_WEB_COLLECTIONS),
+            test_category=list(collections),
             temperature=args.temperature,
             include_input_log=False,
             exclude_state_log=False,
@@ -312,15 +507,45 @@ def _run(args: argparse.Namespace) -> None:
     )
     evaluation_main(
         [BFCL_REGISTRY_NAME],
-        list(NON_WEB_COLLECTIONS),
+        list(collections),
         str(result_dir),
         str(score_dir),
     )
 
-    expected_results, expected_scores = _build_expected_inventories()
+    if args.suite == "non_web":
+        expected_results, expected_scores = _build_expected_inventories(
+            NON_WEB_COLLECTIONS,
+            expected_result_files=NON_WEB_EXPECTED_RESULT_FILES,
+            expected_score_files=NON_WEB_EXPECTED_SCORE_FILES,
+            expected_result_rows=NON_WEB_EXPECTED_RESULT_ROWS,
+        )
+        covered_weight = NON_WEB_EXPECTED_COVERED_WEIGHT
+        excluded_categories = ["web_search_base", "web_search_no_snippet"]
+    else:
+        expected_results, expected_scores = _build_expected_inventories(
+            WEB_COLLECTIONS,
+            expected_result_files=WEB_EXPECTED_RESULT_FILES,
+            expected_score_files=WEB_EXPECTED_SCORE_FILES,
+            expected_result_rows=WEB_EXPECTED_RESULT_ROWS,
+        )
+        covered_weight = WEB_EXPECTED_COVERED_WEIGHT
+        excluded_categories = ["non_live", "live", "multi_turn", "memory"]
+
     row_count = _validate_result_inventory(result_dir, expected_results)
     scores = _validate_score_inventory(score_dir, expected_scores)
-    metrics = _compute_metrics(scores)
+    metrics = (
+        _compute_non_web_metrics(scores)
+        if args.suite == "non_web"
+        else _compute_web_metrics(scores)
+    )
+
+    if args.suite == "web":
+        assert serpapi_key is not None
+        audit_statuses = _validate_serpapi_audit(audit_path)
+        quota_after = _get_serpapi_remaining(serpapi_key)
+    else:
+        audit_statuses = None
+        quota_after = None
 
     summary = {
         "metrics": metrics,
@@ -328,9 +553,10 @@ def _run(args: argparse.Namespace) -> None:
             "benchmark": "BFCL v4",
             "bfcl_commit": args.bfcl_commit,
             "scorer_patch_sha256": args.scorer_patch_sha256,
+            "suite": args.suite,
             "encoder_revision": args.encoder_revision,
-            "covered_weight": EXPECTED_COVERED_WEIGHT,
-            "excluded_categories": ["web_search_base", "web_search_no_snippet"],
+            "covered_weight": covered_weight,
+            "excluded_categories": excluded_categories,
             "result_file_count": len(expected_results),
             "score_file_count": len(expected_scores),
             "num_tasks": row_count,
@@ -340,6 +566,9 @@ def _run(args: argparse.Namespace) -> None:
             # computed from the validated native leaf scores, not that partial
             # aggregate.
             "official_partial_overall_used": False,
+            "serpapi_audit_statuses": audit_statuses,
+            "serpapi_quota_before": quota_before,
+            "serpapi_quota_after": quota_after,
         },
         "predictions": [
             {
@@ -370,7 +599,10 @@ def _build_parser() -> argparse.ArgumentParser:
     run.add_argument("--provider-url", required=True)
     run.add_argument("--temperature", type=float, required=True)
     run.add_argument("--num-threads", type=int, required=True)
-    run.add_argument("--encoder-revision", required=True)
+    run.add_argument("--suite", choices=("non_web", "web"), required=True)
+    run.add_argument("--encoder-revision")
+    run.add_argument("--serpapi-secret-file", type=Path)
+    run.add_argument("--minimum-serpapi-credits", type=int, default=628)
     run.add_argument("--bfcl-commit", default="6ea57973c7a6097fd7c5915698c54c17c5b1b6c8")
     run.add_argument("--scorer-patch-sha256", required=True)
     return parser
@@ -385,6 +617,12 @@ def main() -> None:
             raise ValueError("temperature must be non-negative")
         if args.num_threads < 1:
             raise ValueError("num_threads must be positive")
+        if args.minimum_serpapi_credits < 0:
+            raise ValueError("minimum-serpapi-credits must be non-negative")
+        if args.suite == "non_web" and not args.encoder_revision:
+            raise ValueError("encoder-revision is required for the non-web suite")
+        if args.suite == "web" and args.serpapi_secret_file is None:
+            raise ValueError("serpapi-secret-file is required for the web suite")
         os.chdir(args.bfcl_root)
         _run(args)
 

--- a/src/olmo_eval/evals/external/benchmarks/bfcl/web.py
+++ b/src/olmo_eval/evals/external/benchmarks/bfcl/web.py
@@ -1,0 +1,125 @@
+"""Credentialed BFCL v4 web-search external evaluation."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from contextlib import ExitStack
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from olmo_eval.evals.external.benchmarks.bfcl.eval import (
+    BFCLV4Args,
+    BFCLV4NonWebExternalEval,
+)
+
+_SERPAPI_SECRET_CONTAINER_PATH = "/run/secrets/serpapi_api_key"
+_DEFAULT_MINIMUM_SERPAPI_CREDITS = 628
+
+
+@dataclass(frozen=True)
+class BFCLV4WebArgs(BFCLV4Args):
+    """Runtime arguments for the credentialed official web-search suite."""
+
+    num_threads: int = 4
+    minimum_serpapi_credits: int = _DEFAULT_MINIMUM_SERPAPI_CREDITS
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> BFCLV4WebArgs:
+        common = BFCLV4Args.from_dict(
+            {
+                "temperature": data.get("temperature", 0.001),
+                "num_threads": data.get("num_threads", 4),
+            }
+        )
+        minimum_credits = int(data.get("minimum_serpapi_credits", _DEFAULT_MINIMUM_SERPAPI_CREDITS))
+        if minimum_credits < 0:
+            raise ValueError("minimum_serpapi_credits must be non-negative")
+        return cls(
+            temperature=common.temperature,
+            num_threads=common.num_threads,
+            minimum_serpapi_credits=minimum_credits,
+        )
+
+
+class BFCLV4WebExternalEval(BFCLV4NonWebExternalEval):
+    """Official BFCL v4 web-search categories with audited SerpAPI requests.
+
+    This is intentionally separate from the non-web suite: it consumes a paid,
+    live external service and can fail for reasons unrelated to the evaluated
+    model. Its fixed-weight contribution has a maximum of 0.2.
+    """
+
+    @property
+    def name(self) -> str:
+        return "bfcl_v4_web"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Runs the official BFCL v4 web-search and no-snippet categories against "
+            "an OpenAI-compatible endpoint, with quota preflight and audited SerpAPI calls."
+        )
+
+    @property
+    def required_secrets(self) -> tuple[str, ...]:
+        return ("SERPAPI_API_KEY",)
+
+    @property
+    def setup_command(self) -> tuple[str, ...]:
+        # Web search does not use the sentence encoder required by memory_vector.
+        return super().setup_command[:-1]
+
+    @property
+    def arguments(self) -> dict[str, tuple[str, Any | None]]:
+        return {
+            "temperature": ("Sampling temperature used by the official BFCL generator", 0.001),
+            "num_threads": ("Maximum concurrent model requests", 4),
+            "minimum_serpapi_credits": (
+                "Minimum account balance required before a complete web run",
+                _DEFAULT_MINIMUM_SERPAPI_CREDITS,
+            ),
+        }
+
+    @property
+    def run_command(self) -> str:
+        return "bfcl_runner.py run --provider-model MODEL --provider-url URL --suite web"
+
+    @property
+    def _suite(self) -> str:
+        return "web"
+
+    def _parse_args(self, args: dict[str, Any]) -> BFCLV4WebArgs:
+        return BFCLV4WebArgs.from_dict(args)
+
+    def _build_env_vars(self, secrets: tuple[str, ...] | None = None) -> dict[str, str]:
+        # required_secrets makes orchestration inject the key into the outer
+        # process. It must not become a Docker `-e KEY=value` argument, which is
+        # observable in process listings and sandbox debug logs.
+        return {}
+
+    def _create_sensitive_volumes(self, stack: ExitStack) -> tuple[tuple[str, str], ...]:
+        secret = os.environ.get("SERPAPI_API_KEY")
+        if not secret:
+            raise ValueError("Missing required secret: SERPAPI_API_KEY")
+
+        secret_dir = Path(stack.enter_context(tempfile.TemporaryDirectory(prefix="bfcl_secret_")))
+        secret_dir.chmod(0o700)
+        secret_path = secret_dir / "serpapi_api_key"
+        descriptor = os.open(secret_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        with os.fdopen(descriptor, "w") as file_handle:
+            file_handle.write(secret)
+        if secret_path.stat().st_mode & 0o077:
+            raise ValueError("SerpAPI secret file permissions are too broad")
+        return ((str(secret_path), _SERPAPI_SECRET_CONTAINER_PATH),)
+
+    def _extra_run_command_parts(self, bfcl_args: BFCLV4Args) -> list[str]:
+        if not isinstance(bfcl_args, BFCLV4WebArgs):
+            raise TypeError("BFCL web suite requires BFCLV4WebArgs")
+        return [
+            "--serpapi-secret-file",
+            _SERPAPI_SECRET_CONTAINER_PATH,
+            "--minimum-serpapi-credits",
+            str(bfcl_args.minimum_serpapi_credits),
+        ]

--- a/tests/evals/external/benchmarks/test_bfcl_external.py
+++ b/tests/evals/external/benchmarks/test_bfcl_external.py
@@ -1,0 +1,200 @@
+"""Tests for the BFCL v4 external evaluation."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import tempfile
+import tomllib
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from olmo_eval.evals.external.benchmarks.bfcl.eval import (
+    BFCL_COMMIT,
+    BFCL_ENCODER_REVISION,
+    BFCL_SCORER_PATCH_SHA256,
+    BFCLV4Args,
+    BFCLV4NonWebExternalEval,
+)
+from olmo_eval.evals.external.benchmarks.bfcl.runner import (
+    _compute_metrics,
+    _validate_result_inventory,
+    _validate_score_inventory,
+)
+
+
+def _write_jsonl(path: Path, entries: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("".join(f"{json.dumps(entry)}\n" for entry in entries))
+
+
+class TestBFCLV4Args(unittest.TestCase):
+    def test_defaults_match_official_generation_temperature(self) -> None:
+        self.assertEqual(BFCLV4Args.from_dict({}), BFCLV4Args())
+
+    def test_rejects_invalid_runtime_arguments(self) -> None:
+        with self.assertRaisesRegex(ValueError, "temperature"):
+            BFCLV4Args.from_dict({"temperature": -0.1})
+        with self.assertRaisesRegex(ValueError, "num_threads"):
+            BFCLV4Args.from_dict({"num_threads": 0})
+
+    def test_run_command_quotes_provider_values(self) -> None:
+        command = BFCLV4NonWebExternalEval()._build_run_command(
+            "model name; false", "http://localhost:8000/v1?x=1&y=2", BFCLV4Args()
+        )
+        self.assertIn("'model name; false'", command)
+        self.assertIn("'http://localhost:8000/v1?x=1&y=2'", command)
+        self.assertIn(BFCL_ENCODER_REVISION, command)
+        self.assertNotIn("SERPAPI_API_KEY", command)
+
+    def test_setup_pins_bfcl_and_encoder(self) -> None:
+        commands = "\n".join(BFCLV4NonWebExternalEval().setup_command)
+        self.assertIn(BFCL_COMMIT, commands)
+        self.assertIn(BFCL_ENCODER_REVISION, commands)
+        self.assertIn(BFCL_SCORER_PATCH_SHA256, commands)
+        self.assertIn("soundfile", commands)
+
+        patch_path = (
+            Path(__file__).parents[4]
+            / "src/olmo_eval/evals/external/benchmarks/bfcl/patches"
+            / "0001-check-multi-turn-irrelevance.patch"
+        )
+        self.assertEqual(
+            hashlib.sha256(patch_path.read_bytes()).hexdigest(), BFCL_SCORER_PATCH_SHA256
+        )
+
+        pyproject = tomllib.loads((Path(__file__).parents[4] / "pyproject.toml").read_text())
+        package_data = pyproject["tool"]["setuptools"]["package-data"]
+        self.assertIn(
+            "patches/*.patch",
+            package_data["olmo_eval.evals.external.benchmarks.bfcl"],
+        )
+
+    def test_sandbox_never_forwards_ambient_openai_key(self) -> None:
+        evaluator = BFCLV4NonWebExternalEval()
+        with (
+            tempfile.TemporaryDirectory() as temporary_dir,
+            mock.patch.dict("os.environ", {"OPENAI_API_KEY": "real-secret"}),
+        ):
+            config = evaluator._create_bfcl_sandbox_config("docker", None, Path(temporary_dir))
+        self.assertEqual(dict(config.environment)["OPENAI_API_KEY"], "EMPTY")
+        self.assertTrue(config.inject_swerex)
+        self.assertIsNone(config.log_dir)
+
+
+class TestBFCLInventoryValidation(unittest.TestCase):
+    def test_accepts_complete_result_and_score_inventories(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_dir:
+            root = Path(temporary_dir)
+            result_relative = Path("model/non_live/BFCL_v4_simple_python_result.json")
+            score_relative = Path("model/non_live/BFCL_v4_simple_python_score.json")
+            _write_jsonl(
+                root / "result" / result_relative,
+                [
+                    {"id": "simple_python_0", "result": [{"f": "{}"}]},
+                    {"id": "simple_python_1", "result": []},
+                ],
+            )
+            _write_jsonl(
+                root / "score" / score_relative,
+                [
+                    {"accuracy": 0.5, "correct_count": 1, "total_count": 2},
+                    {"id": "simple_python_1", "valid": False},
+                ],
+            )
+
+            self.assertEqual(
+                _validate_result_inventory(
+                    root / "result",
+                    {result_relative: {"simple_python_0", "simple_python_1"}},
+                ),
+                2,
+            )
+            scores = _validate_score_inventory(
+                root / "score",
+                {score_relative: {"simple_python_0", "simple_python_1"}},
+            )
+            self.assertEqual(scores["simple_python"]["accuracy"], 0.5)
+
+    def test_rejects_missing_duplicate_and_inference_error_results(self) -> None:
+        cases = (
+            ([{"id": "a_0", "result": []}], {"a_0", "a_1"}, "result-ID mismatch"),
+            (
+                [{"id": "a_0", "result": []}, {"id": "a_0", "result": []}],
+                {"a_0"},
+                "Duplicate",
+            ),
+            (
+                [{"id": "a_0", "result": "Error during inference: timeout"}],
+                {"a_0"},
+                "inference error",
+            ),
+            (
+                [{"id": "a_0", "result": [], "traceback": "boom"}],
+                {"a_0"},
+                "traceback",
+            ),
+        )
+        for entries, expected_ids, message in cases:
+            with self.subTest(message=message), tempfile.TemporaryDirectory() as temporary_dir:
+                root = Path(temporary_dir)
+                relative = Path("model/non_live/BFCL_v4_a_result.json")
+                _write_jsonl(root / relative, entries)
+                with self.assertRaisesRegex(ValueError, message):
+                    _validate_result_inventory(root, {relative: expected_ids})
+
+    def test_rejects_inconsistent_score_header(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_dir:
+            root = Path(temporary_dir)
+            relative = Path("model/non_live/BFCL_v4_a_score.json")
+            _write_jsonl(
+                root / relative,
+                [
+                    {"accuracy": 1.0, "correct_count": 2, "total_count": 2},
+                    {"id": "a_1", "valid": False},
+                ],
+            )
+            with self.assertRaisesRegex(ValueError, "correct-count mismatch"):
+                _validate_score_inventory(root, {relative: {"a_0", "a_1"}})
+
+
+class TestBFCLMetrics(unittest.TestCase):
+    def test_fixed_weight_non_web_contribution(self) -> None:
+        categories = {
+            "simple_python": (1.0, 400),
+            "simple_java": (1.0, 100),
+            "simple_javascript": (1.0, 50),
+            "multiple": (1.0, 200),
+            "parallel": (1.0, 200),
+            "parallel_multiple": (1.0, 200),
+            "irrelevance": (1.0, 240),
+            "live_simple": (1.0, 258),
+            "live_multiple": (1.0, 1053),
+            "live_parallel": (1.0, 16),
+            "live_parallel_multiple": (1.0, 24),
+            "live_irrelevance": (1.0, 884),
+            "live_relevance": (1.0, 16),
+            "multi_turn_base": (1.0, 200),
+            "multi_turn_miss_func": (1.0, 200),
+            "multi_turn_miss_param": (1.0, 200),
+            "multi_turn_long_context": (1.0, 200),
+            "memory_kv": (1.0, 155),
+            "memory_vector": (1.0, 155),
+            "memory_rec_sum": (1.0, 155),
+        }
+        scores = {
+            category: {
+                "accuracy": accuracy,
+                "correct_count": int(accuracy * count),
+                "total_count": count,
+            }
+            for category, (accuracy, count) in categories.items()
+        }
+        metrics = _compute_metrics(scores)
+        self.assertAlmostEqual(metrics["non_web_weighted_contribution"], 0.8)
+        self.assertLessEqual(metrics["non_web_weighted_contribution"], 0.8)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/evals/external/benchmarks/test_bfcl_external.py
+++ b/tests/evals/external/benchmarks/test_bfcl_external.py
@@ -7,8 +7,12 @@ import json
 import tempfile
 import tomllib
 import unittest
+from contextlib import ExitStack
 from pathlib import Path
+from types import SimpleNamespace
 from unittest import mock
+
+import requests
 
 from olmo_eval.evals.external.benchmarks.bfcl.eval import (
     BFCL_COMMIT,
@@ -18,9 +22,18 @@ from olmo_eval.evals.external.benchmarks.bfcl.eval import (
     BFCLV4NonWebExternalEval,
 )
 from olmo_eval.evals.external.benchmarks.bfcl.runner import (
-    _compute_metrics,
+    _classify_serpapi_response,
+    _compute_non_web_metrics,
+    _compute_web_metrics,
+    _get_serpapi_remaining,
+    _install_serpapi_audit,
     _validate_result_inventory,
     _validate_score_inventory,
+    _validate_serpapi_audit,
+)
+from olmo_eval.evals.external.benchmarks.bfcl.web import (
+    BFCLV4WebArgs,
+    BFCLV4WebExternalEval,
 )
 
 
@@ -191,9 +204,196 @@ class TestBFCLMetrics(unittest.TestCase):
             }
             for category, (accuracy, count) in categories.items()
         }
-        metrics = _compute_metrics(scores)
+        metrics = _compute_non_web_metrics(scores)
         self.assertAlmostEqual(metrics["non_web_weighted_contribution"], 0.8)
         self.assertLessEqual(metrics["non_web_weighted_contribution"], 0.8)
+
+    def test_fixed_weight_web_contribution(self) -> None:
+        scores = {
+            "web_search_base": {"accuracy": 1.0, "correct_count": 100, "total_count": 100},
+            "web_search_no_snippet": {
+                "accuracy": 0.5,
+                "correct_count": 50,
+                "total_count": 100,
+            },
+        }
+        metrics = _compute_web_metrics(scores)
+        self.assertEqual(metrics["web_search_accuracy"], 0.75)
+        self.assertAlmostEqual(metrics["web_weighted_contribution"], 0.15)
+
+
+class TestBFCLWeb(unittest.TestCase):
+    def test_web_arguments_are_conservative_and_validated(self) -> None:
+        self.assertEqual(BFCLV4WebArgs.from_dict({}).num_threads, 4)
+        self.assertEqual(BFCLV4WebArgs.from_dict({}).minimum_serpapi_credits, 628)
+        with self.assertRaisesRegex(ValueError, "minimum_serpapi_credits"):
+            BFCLV4WebArgs.from_dict({"minimum_serpapi_credits": -1})
+
+    def test_secret_is_file_mounted_and_never_forwarded_in_docker_environment(self) -> None:
+        evaluator = BFCLV4WebExternalEval()
+        secret = "test-serpapi-secret"
+        with (
+            tempfile.TemporaryDirectory() as artifact_dir,
+            mock.patch.dict("os.environ", {"SERPAPI_API_KEY": secret}, clear=True),
+            ExitStack() as stack,
+        ):
+            volumes = evaluator._create_sensitive_volumes(stack)
+            secret_path = Path(volumes[0][0])
+            self.assertEqual(secret_path.read_text(), secret)
+            self.assertEqual(secret_path.stat().st_mode & 0o077, 0)
+
+            config = evaluator._create_bfcl_sandbox_config(
+                "docker", None, Path(artifact_dir), extra_volumes=volumes
+            )
+            command = evaluator._build_run_command("model", "http://provider/v1", BFCLV4WebArgs())
+            serialized_config = repr(config)
+
+        self.assertFalse(secret_path.exists())
+        self.assertEqual(evaluator.required_secrets, ("SERPAPI_API_KEY",))
+        self.assertNotIn(secret, serialized_config)
+        self.assertNotIn(secret, command)
+        self.assertNotIn("SERPAPI_API_KEY", dict(config.environment))
+        self.assertEqual(evaluator._build_env_vars(("SERPAPI_API_KEY",)), {})
+        self.assertIn("--suite web", command)
+
+    def test_missing_secret_fails_before_sandbox_creation(self) -> None:
+        evaluator = BFCLV4WebExternalEval()
+        with (
+            mock.patch.dict("os.environ", {}, clear=True),
+            ExitStack() as stack,
+            self.assertRaisesRegex(ValueError, "SERPAPI_API_KEY"),
+        ):
+            evaluator._create_sensitive_volumes(stack)
+
+    def test_classifies_serpapi_payloads_without_preserving_content(self) -> None:
+        self.assertEqual(
+            _classify_serpapi_response({"organic_results": [{"title": "secret"}]})[0],
+            "organic_results",
+        )
+        self.assertEqual(
+            _classify_serpapi_response({"organic_results": []})[0],
+            "empty_organic_results",
+        )
+        status, fields = _classify_serpapi_response({"error": "upstream failure"})
+        self.assertEqual(status, "error_payload")
+        self.assertNotIn("upstream failure", repr(fields))
+        self.assertEqual(_classify_serpapi_response({"error": "429 limit"})[0], "rate_limited")
+        self.assertEqual(
+            _classify_serpapi_response(
+                {"organic_results": [{"title": "partial"}], "error": "429 limit"}
+            )[0],
+            "rate_limited",
+        )
+        self.assertEqual(
+            _classify_serpapi_response({"search_metadata": {}})[0], "missing_organic_results"
+        )
+
+    def test_audits_every_search_and_accepts_only_recoverable_statuses(self) -> None:
+        class FakeGoogleSearch:
+            responses = [
+                {"organic_results": [{"title": "result"}]},
+                {"error": "429 throughput limit"},
+            ]
+
+            def __init__(self, query: str) -> None:
+                self.params_dict = {"q": query, "api_key": "test-secret"}
+
+            def get_dict(self):
+                return self.responses.pop(0)
+
+        fake_module = SimpleNamespace(GoogleSearch=FakeGoogleSearch)
+        with tempfile.TemporaryDirectory() as temporary_dir:
+            audit_path = Path(temporary_dir) / "serpapi_audit.jsonl"
+            _install_serpapi_audit(audit_path, fake_module)
+            fake_module.GoogleSearch("private query 1").get_dict()
+            fake_module.GoogleSearch("private query 2").get_dict()
+
+            statuses = _validate_serpapi_audit(audit_path)
+            serialized = audit_path.read_text()
+
+        self.assertEqual(statuses, {"organic_results": 1, "rate_limited": 1})
+        self.assertNotIn("private query", serialized)
+        self.assertNotIn("test-secret", serialized)
+
+    def test_account_preflight_redacts_request_exception(self) -> None:
+        secret = "test-serpapi-secret"
+        error = requests.ConnectionError(
+            f"request failed for https://serpapi.com/account.json?api_key={secret}"
+        )
+        with (
+            mock.patch("requests.get", side_effect=error),
+            self.assertRaisesRegex(RuntimeError, "ConnectionError") as raised,
+        ):
+            _get_serpapi_remaining(secret)
+        self.assertNotIn(secret, str(raised.exception))
+
+    def test_search_exception_redacts_key_and_query(self) -> None:
+        secret = "test-serpapi-secret"
+        query = "private query"
+
+        class FakeGoogleSearch:
+            def __init__(self, query: str) -> None:
+                self.params_dict = {"q": query, "api_key": secret}
+
+            def get_dict(self):
+                raise RuntimeError(
+                    f"request failed for https://serpapi.com/search?q={query}&api_key={secret}"
+                )
+
+        fake_module = SimpleNamespace(GoogleSearch=FakeGoogleSearch)
+        with tempfile.TemporaryDirectory() as temporary_dir:
+            audit_path = Path(temporary_dir) / "serpapi_audit.jsonl"
+            _install_serpapi_audit(audit_path, fake_module)
+            with self.assertRaisesRegex(RuntimeError, "SerpAPI request failed") as raised:
+                fake_module.GoogleSearch(query).get_dict()
+            serialized = audit_path.read_text()
+
+        self.assertNotIn(secret, str(raised.exception))
+        self.assertNotIn(query, str(raised.exception))
+        self.assertNotIn(secret, serialized)
+        self.assertNotIn(query, serialized)
+
+    def test_rate_limit_exception_preserves_retry_signal_without_secrets(self) -> None:
+        secret = "test-serpapi-secret"
+        query = "private query"
+
+        class FakeGoogleSearch:
+            def __init__(self, query: str) -> None:
+                self.params_dict = {"q": query, "api_key": secret}
+
+            def get_dict(self):
+                raise RuntimeError(f"429 for https://serpapi.com/search?q={query}&api_key={secret}")
+
+        fake_module = SimpleNamespace(GoogleSearch=FakeGoogleSearch)
+        with tempfile.TemporaryDirectory() as temporary_dir:
+            audit_path = Path(temporary_dir) / "serpapi_audit.jsonl"
+            _install_serpapi_audit(audit_path, fake_module)
+            with self.assertRaisesRegex(RuntimeError, "429 from SerpAPI") as raised:
+                fake_module.GoogleSearch(query).get_dict()
+            statuses = _validate_serpapi_audit(audit_path)
+            serialized = audit_path.read_text()
+
+        self.assertEqual(statuses, {"rate_limited_exception": 1})
+        self.assertNotIn(secret, str(raised.exception))
+        self.assertNotIn(query, str(raised.exception))
+        self.assertNotIn(secret, serialized)
+        self.assertNotIn(query, serialized)
+
+    def test_rejects_terminal_serpapi_failures(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_dir:
+            audit_path = Path(temporary_dir) / "serpapi_audit.jsonl"
+            _write_jsonl(
+                audit_path,
+                [
+                    {
+                        "sequence": 1,
+                        "query_sha256": "a" * 64,
+                        "status": "error_payload",
+                    }
+                ],
+            )
+            with self.assertRaisesRegex(ValueError, "terminal failures"):
+                _validate_serpapi_audit(audit_path)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Add an opt-in `bfcl_v4_web` external evaluation covering BFCL v4's credentialed web-search categories:

- `web_search_base`
- `web_search_no_snippet`

Together these categories contribute the remaining 20% of the official BFCL v4 score. They are kept separate from the deterministic non-web evaluation in #340 because they use a paid, live external service and can fail for reasons unrelated to the evaluated model.

Depends on #340.

## Implementation

- Reuses the pinned official Gorilla checkout and OpenAI-compatible provider integration introduced in #340.
- Runs BFCL's official web generation and scoring paths.
- Validates the exact expected inventory:
  - 2 result files
  - 2 score files
  - 200 result rows
- Rejects missing or unexpected files, missing or duplicate IDs, inference errors, tracebacks, malformed scores, and inconsistent counts.
- Reports the official fixed-weight web contribution:

  `0.2 * mean(web_search_base, web_search_no_snippet)`

### Credential handling

- Requires `SERPAPI_API_KEY` only in the outer evaluation process.
- Writes the credential to a temporary mode-`0600` file.
- Mounts that file into the sandbox instead of forwarding the key through a container environment variable or command-line argument.
- Removes the temporary credential file when execution finishes.
- Prevents the key from appearing in the serialized sandbox configuration, run command, audit records, or persisted output.
- Performs a configurable quota preflight and records the quota before and after evaluation.

### Live-search auditing

The adapter wraps the pinned BFCL `GoogleSearch.get_dict()` boundary and records one sanitized event per request:

- monotonic sequence number
- SHA-256 of the query rather than the raw query
- response classification
- result count where available
- duration

Explicit SerpAPI errors take precedence over any stale or partial result data. Rate-limit responses retain BFCL's retry signal, while malformed responses, empty results, error payloads, missing results, non-rate-limit exceptions, and incomplete or out-of-order audit records fail closed.

## Why this is a separate evaluation

Web search is live, stochastic, credentialed, and paid. Combining it with the non-web suite would allow quota exhaustion, service failures, or changing search results to invalidate the deterministic 80% of BFCL v4.

The two evaluations report their fixed-weight contributions independently:

- `bfcl_v4_non_web`: maximum `0.8`
- `bfcl_v4_web`: maximum `0.2`

Their contributions can be added when both runs use the same model and evaluation configuration.

## Validation

- 19 focused BFCL tests passed on the combined branch.
- Repository unit suite: `2168 passed, 8 skipped`.
- Full Ruff lint and formatting checks passed.
- Full `ty` type checking passed.
- `git diff --check` passed.
- A freshly built wheel contains the runner, web adapter, and scorer patch.
- The exact 200-example official web workload completed against `allenai/Olmo-3-7B-Instruct` with:
  - 2 result files
  - 2 score files
  - 200 unique rows
  - no tracebacks or inference errors
- The reference model emitted no tool calls in that run, so both categories correctly scored `0.0` and no search credits were consumed. This validates the model/provider, inventory, scoring, and zero-score paths, but is not presented as a model-quality result.
- The remaining live-search boundary was exercised separately through the same pinned official `WebSearchAPI` and proposed audit wrapper:
  - one successful SerpAPI request
  - organic results returned
  - quota changed from `6107` to `6106`
  - exactly one sanitized audit event
  - no raw query or credential persisted