### PR TITLE
Restore oe-eval's ZebraLogic prompt template verbatim

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,6 +193,8 @@ select = [
 "src/olmo_eval/evals/tasks/squad.py" = ["E501"]
 # Static fewshot data with long string literals
 "src/olmo_eval/evals/tasks/constants/*" = ["E501"]
+# Verbatim prompt template from the oe-eval/ZeroEval reference implementation
+"src/olmo_eval/evals/tasks/zebralogic.py" = ["E501", "W291"]
 [tool.ruff.format]
 docstring-code-format = true
 

--- a/src/olmo_eval/evals/tasks/zebralogic.py
+++ b/src/olmo_eval/evals/tasks/zebralogic.py
@@ -26,11 +26,9 @@ from olmo_eval.evals.tasks.common.base import Task
 from olmo_eval.evals.tasks.common.registry import register, register_variant
 
 ZEBRA_GRID = """
-# Example Puzzle
+# Example Puzzle 
 
-There are 3 houses, numbered 1 to 3 from left to right, as seen from across the street.
-Each house is occupied by a different person. Each house has a unique attribute for each
-of the following characteristics:
+There are 3 houses, numbered 1 to 3 from left to right, as seen from across the street. Each house is occupied by a different person. Each house has a unique attribute for each of the following characteristics:
  - Each person has a unique name: `Peter`, `Eric`, `Arnold`.
  - Each person has a unique favorite drink: `tea`, `water`, `milk`
 
@@ -42,29 +40,27 @@ of the following characteristics:
 
 ## Answer to the Example Puzzle
 
-{{
-    "reasoning": "Given Clue 1, we know Peter is in House 2. According to Clue 2,
-Arnold is directly left of the one who only drinks water. The person in House 3
-cannot be on the left of anyone, so Arnold must be in House 1. Thus, Peter drinks
-water, and Eric lives in House 3. Then, according to Clue 3, Eric drinks milk.
-Therefore, Arnold drinks tea.",
-    "solution": {{
-        "House 1": {{
+{
+    "reasoning": "Given Clue 1, we know Peter is in House 2. According to Clue 2, Arnold is directly left of the one who only drinks water. The person in House 3 cannot be on the left of anyone, so Arnold must be in House 1. Thus, Peter drinks water, and Eric lives in House 3. Then, according to Clue 3, Eric drinks milk. Therefore, Arnold drinks tea.",
+    "solution": {
+        "House 1": {
             "Name": "Arnold",
             "Drink": "tea"
-        }},
-        "House 2": {{
+        },
+        "House 2": {
             "Name": "Peter",
             "Drink": "water"
-        }},
-        "House 3": {{
+        },
+        "House 3": {
             "Name": "Eric",
             "Drink": "milk"
-        }}
-    }}
-}}
+        }
+    }
+}
 
-# Puzzle to Solve \n\n{puzzle}
+# Puzzle to Solve 
+
+{puzzle}
 
 
 # Instruction


### PR DESCRIPTION
Fixes #342. The port escaped `ZEBRA_GRID`'s braces as if the string were a `.format()` template, but substitution is `.replace()`, so every prompt rendered the example answer as `{{…}}` — malformed JSON shown as the required output format (a model that mimics it scores `parsed=0`) — and re-wrapped oe-eval's long lines, changing prompt text on all docs.

This copies oe-eval's `ZEBRA_GRID` byte-for-byte (verified: rendered prompts now identical between harnesses on the same doc) and adds the file to the existing verbatim-template `per-file-ignores` idiom for `E501`/`W291`.

Independent of #334 (chat formatting) — same file, non-overlapping hunks, either merge order is clean. Existing zebralogic numbers shift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LMFjgUqHjQA3aCeB4QmEHZ