### PR TITLE
ZebraLogic: difficulty subtasks and oe-eval-matched chat sampling

### DIFF
--- a/src/olmo_eval/evals/tasks/zebralogic.py
+++ b/src/olmo_eval/evals/tasks/zebralogic.py
@@ -261,6 +261,9 @@ class ParsedMetric(Metric):
 class ZebraLogic(Task):
     """ZebraLogic grid puzzle evaluation task."""
 
+    #: When set, keep only docs of this difficulty ("easy" or "hard").
+    _difficulty: str | None = None
+
     data_source = DataSource(
         path="allenai/ZebraLogicBench-private", subset="grid_mode", split="test"
     )
@@ -304,6 +307,8 @@ class ZebraLogic(Task):
             total_cells += len(columns) - 1
 
         difficulty = "easy" if size in EASY_SIZES else "hard"
+        if self._difficulty is not None and difficulty != self._difficulty:
+            return None
 
         return Instance(
             question=prompt_str,
@@ -327,20 +332,35 @@ class ZebraLogic(Task):
         )
 
 
+@register("zebralogic_easy")
+class ZebraLogicEasy(ZebraLogic):
+    """ZebraLogic restricted to easy puzzles (grid sizes 2*2 through 3*3)."""
+
+    _difficulty = "easy"
+
+
+@register("zebralogic_hard")
+class ZebraLogicHard(ZebraLogic):
+    """ZebraLogic restricted to hard puzzles (grid sizes 3*4 through 6*6)."""
+
+    _difficulty = "hard"
+
+
 # ---------------------------------------------------------------------------
 # Variants
 # ---------------------------------------------------------------------------
 
-# Chat variant for instruct and reasoning models.
-# Drops "\n\n" from stop sequences (which would truncate chain-of-thought
-# reasoning) and applies the model's chat template via ChatFormatter.
-register_variant(
-    "zebralogic",
-    "chat",
-    formatter=ChatFormatter(),
-    sampling_params=SamplingParams(
-        max_tokens=16384,
-        temperature=0.0,
-        stop_sequences=("Problem:",),
-    ),
-)
+# Chat variant for instruct and reasoning models. Mirrors oe-eval's
+# `zebralogic::olmo3:adapt` regime: sampled decoding, long generation, and no
+# stop sequences (the chat template supplies end-of-turn).
+for _task_name in ("zebralogic", "zebralogic_easy", "zebralogic_hard"):
+    register_variant(
+        _task_name,
+        "chat",
+        formatter=ChatFormatter(),
+        sampling_params=SamplingParams(
+            max_tokens=131072,
+            temperature=0.6,
+            top_p=0.95,
+        ),
+    )

--- a/src/olmo_eval/evals/tasks/zebralogic.py
+++ b/src/olmo_eval/evals/tasks/zebralogic.py
@@ -351,15 +351,16 @@ class ZebraLogicHard(ZebraLogic):
 # ---------------------------------------------------------------------------
 
 # Chat variant for instruct and reasoning models. Mirrors oe-eval's
-# `zebralogic::olmo3:adapt` regime: sampled decoding, long generation, and no
-# stop sequences (the chat template supplies end-of-turn).
+# `zebralogic::olmo3:adapt` regime: sampled decoding, generation bounded only
+# by the model's context (``max_tokens=None``), and no stop sequences (the
+# chat template supplies end-of-turn).
 for _task_name in ("zebralogic", "zebralogic_easy", "zebralogic_hard"):
     register_variant(
         _task_name,
         "chat",
         formatter=ChatFormatter(),
         sampling_params=SamplingParams(
-            max_tokens=131072,
+            max_tokens=None,
             temperature=0.6,
             top_p=0.95,
         ),


### PR DESCRIPTION
Two changes for the ZebraLogic dev/test plan:

**`zebralogic_easy` / `zebralogic_hard` subtasks** — filter by the existing difficulty tag (easy = grids 2\*2–3\*3, hard = the rest), so easy can serve as the dev split and hard as held-out test. Verified against the dataset (public twin, same `size` fields): 280 easy / 720 hard, disjoint and exhaustive over all 1000 docs and 25 grid sizes. Scoring config is inherited unchanged.

**`:chat` variant now mirrors oe-eval's `zebralogic::olmo3:adapt`** — temperature 0.6, top-p 0.95, generation bounded by the model context (`max_tokens=None`, standing in for oe-eval's 131072 on any context size — same idiom as `gpqa:cot`/`popqa`/`omega_500`), no stop sequences (chat template supplies end-of-turn), registered for all three tasks. The previous parameters (greedy, 16k, `"Problem:"` stop) matched no oe-eval regime, so pre-existing `:chat` numbers are not comparable — they were also completion-mode until #334.

Depends on #334 for `:chat` to actually format as chat (hunks don't overlap; either merge order is clean). Full suite: 2164 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LMFjgUqHjQA3aCeB4QmEHZ