### PR TITLE
Keep model reasoning in the saved agent trajectory

### DIFF
--- a/src/olmo_eval/common/types/trajectory.py
+++ b/src/olmo_eval/common/types/trajectory.py
@@ -15,7 +15,8 @@ class AgentTurn:
     """A single turn in an agent trajectory.
 
     Represents either an assistant message (with optional tool calls)
-    or a tool response.
+    or a tool response. Assistant turns may also carry the model's
+    reasoning text when the provider exposes it.
     """
 
     role: Literal["assistant", "tool", "user", "system"]
@@ -25,6 +26,7 @@ class AgentTurn:
     timestamp_ms: int | None = None
     token_count: int | None = None
     metadata: dict[str, Any] = field(default_factory=dict)
+    reasoning: str | None = None
 
     @property
     def has_tool_calls(self) -> bool:
@@ -43,6 +45,7 @@ class AgentTurn:
         tool_calls: list[ToolCall] | None = None,
         timestamp_ms: int | None = None,
         token_count: int | None = None,
+        reasoning: str | None = None,
     ) -> "AgentTurn":
         """Create an assistant turn.
 
@@ -51,6 +54,7 @@ class AgentTurn:
             tool_calls: Optional list of tool calls made by the assistant.
             timestamp_ms: Optional timestamp in milliseconds.
             token_count: Optional token count for this turn.
+            reasoning: Optional reasoning text the model produced for this turn.
 
         Returns:
             A new AgentTurn with role="assistant".
@@ -61,6 +65,7 @@ class AgentTurn:
             tool_calls=tuple(tool_calls) if tool_calls else (),
             timestamp_ms=timestamp_ms,
             token_count=token_count,
+            reasoning=reasoning,
         )
 
     @classmethod
@@ -126,6 +131,8 @@ class AgentTurn:
             result["token_count"] = self.token_count
         if self.metadata:
             result["metadata"] = self.metadata
+        if self.reasoning is not None:
+            result["reasoning"] = self.reasoning
         return result
 
     @classmethod
@@ -146,6 +153,7 @@ class AgentTurn:
             timestamp_ms=data.get("timestamp_ms"),
             token_count=data.get("token_count"),
             metadata=data.get("metadata", {}),
+            reasoning=data.get("reasoning"),
         )
 
 

--- a/src/olmo_eval/harness/scaffolds/openai_agents.py
+++ b/src/olmo_eval/harness/scaffolds/openai_agents.py
@@ -88,6 +88,27 @@ def _resolve_chat_template_kwargs(provider: InferenceProvider) -> dict[str, Any]
     return resolved
 
 
+def _reasoning_text(raw: Any) -> str:
+    """Extract the reasoning text carried by an SDK ``ResponseReasoningItem``.
+
+    Chat Completions ``reasoning_content`` arrives as a single ``summary`` part.
+    Providers that return thinking blocks also fill ``content`` with the full
+    text, which then supersedes the summary so nothing is stored twice.
+
+    Args:
+        raw: The ``raw_item`` of a ``ReasoningItem``.
+
+    Returns:
+        The joined reasoning text, or an empty string if the item has none.
+    """
+    for attr in ("content", "summary"):
+        parts = getattr(raw, attr, None) or []
+        texts = [text for part in parts if (text := getattr(part, "text", ""))]
+        if texts:
+            return "\n\n".join(texts)
+    return ""
+
+
 def _make_tool_error_formatter(valid_tool_names: Sequence[str]) -> Any:
     """Build a ``RunConfig.tool_error_formatter`` that names the tools the model may call.
 
@@ -615,10 +636,21 @@ class OpenAIAgentsScaffold(Scaffold):
                     pass
             return AgentTrajectory(turns=tuple(turns))
 
+        # The SDK emits reasoning as its own item ahead of the message or tool call
+        # it belongs to, so hold it until that assistant turn is built.
+        pending_reasoning: str | None = None
+
         for item in items:
             item_class = type(item).__name__
 
-            if item_class == "MessageOutputItem":
+            if item_class == "ReasoningItem":
+                text = _reasoning_text(getattr(item, "raw_item", None))
+                if text:
+                    pending_reasoning = (
+                        f"{pending_reasoning}\n\n{text}" if pending_reasoning else text
+                    )
+
+            elif item_class == "MessageOutputItem":
                 raw = getattr(item, "raw_item", None)
                 content = ""
                 if raw is not None:
@@ -628,7 +660,17 @@ class OpenAIAgentsScaffold(Scaffold):
                             if hasattr(part, "text"):
                                 content += part.text
                 if content:
-                    turns.append(AgentTurn.assistant(content=content))
+                    # One model response yields one reasoning block. When the response has
+                    # text it lands here, and any tool-call turns built from the same
+                    # response carry none.
+                    turns.append(AgentTurn.assistant(content=content, reasoning=pending_reasoning))
+                    pending_reasoning = None
+                elif pending_reasoning:
+                    # A message with no text part (e.g. a refusal) still ends the response
+                    # that produced this reasoning; keep it here so it cannot slide onto a
+                    # later, unrelated turn.
+                    turns.append(AgentTurn.assistant(reasoning=pending_reasoning))
+                    pending_reasoning = None
 
             elif item_class == "ToolCallItem":
                 raw = getattr(item, "raw_item", None)
@@ -643,9 +685,21 @@ class OpenAIAgentsScaffold(Scaffold):
                         arguments=arguments,
                         metadata=raw_dict,
                     )
-                    turns.append(AgentTurn.assistant(content="", tool_calls=[tool_call]))
+                    # Without a text part the block lands on the first tool-call turn of
+                    # the response; the remaining tool-call turns carry none.
+                    turns.append(
+                        AgentTurn.assistant(
+                            content="", tool_calls=[tool_call], reasoning=pending_reasoning
+                        )
+                    )
+                    pending_reasoning = None
 
             elif item_class == "ToolCallOutputItem":
+                if pending_reasoning:
+                    # A tool output means the response that produced this reasoning is
+                    # over (its own items had no branch above); flush rather than carry it.
+                    turns.append(AgentTurn.assistant(reasoning=pending_reasoning))
+                    pending_reasoning = None
                 output = getattr(item, "output", None)
                 raw = getattr(item, "raw_item", None)
                 # Extract tool_call_id from raw_item
@@ -666,6 +720,11 @@ class OpenAIAgentsScaffold(Scaffold):
                     content=content,
                 )
                 turns.append(AgentTurn.tool([tool_result]))
+
+        if pending_reasoning:
+            # No assistant item followed this reasoning (the run stopped after it);
+            # keep it on an otherwise empty assistant turn rather than dropping it.
+            turns.append(AgentTurn.assistant(reasoning=pending_reasoning))
 
         return AgentTrajectory(turns=tuple(turns))
 

--- a/src/olmo_eval/harness/scaffolds/openai_agents.py
+++ b/src/olmo_eval/harness/scaffolds/openai_agents.py
@@ -6,6 +6,7 @@ import logging
 from collections.abc import Sequence
 from contextvars import ContextVar
 from dataclasses import replace
+from functools import lru_cache
 from typing import TYPE_CHECKING, Any
 
 from olmo_eval.common.types import LMOutput, LMRequest, SamplingParams
@@ -107,6 +108,67 @@ def _reasoning_text(raw: Any) -> str:
         if texts:
             return "\n\n".join(texts)
     return ""
+
+
+def _mirror_vllm_reasoning(message: Any) -> None:
+    """Expose a provider's ``reasoning`` field under the name the SDK converter reads.
+
+    Providers such as vLLM 0.19 return the reasoning parser output as
+    ``message.reasoning``, a field outside the OpenAI schema, while openai-agents 0.20
+    builds a ``ReasoningItem`` only from ``reasoning_content`` or ``thinking_blocks``.
+    Copying the text onto ``reasoning_content`` before conversion keeps the thinking.
+    The copy should be removed once the SDK reads ``reasoning`` itself (openai-agents
+    0.21.1 and later, which require openai 3.x).
+
+    Nothing changes when the server already returned a non-empty ``reasoning_content``
+    or ``thinking_blocks``, or when the message carries no reasoning at all (OpenAI, or
+    vLLM without a reasoning parser). The SDK replays ``reasoning_content`` into later
+    requests only for model names containing ``deepseek``, so a DeepSeek-named model
+    served by vLLM sends the mirrored text back as assistant history; vLLM 0.19.1
+    ignores that key.
+
+    Args:
+        message: The ``ChatCompletionMessage`` of a choice, mutated in place.
+    """
+    if getattr(message, "reasoning_content", None) or getattr(message, "thinking_blocks", None):
+        return
+    reasoning = getattr(message, "reasoning", None)
+    if isinstance(reasoning, str) and reasoning:
+        # ChatCompletionMessage allows extra fields, so this lands in model_extra next
+        # to ``reasoning`` and is picked up by the converter's getattr.
+        message.reasoning_content = reasoning
+
+
+@lru_cache(maxsize=1)
+def _chat_completions_model_class() -> type:
+    """Return the SDK model class the scaffold instantiates, importing the SDK lazily.
+
+    The subclass hooks the point where the raw ``ChatCompletion`` is visible before
+    conversion: ``OpenAIChatCompletionsModel._fetch_response``. The SDK's ``get_response``
+    (the path behind ``Runner.run``) awaits it with ``stream=False`` and hands
+    ``choices[0].message`` to ``Converter.message_to_output_items``. ``stream_response``
+    calls it with ``stream=True`` and receives a ``(Response, AsyncStream)`` pair, which
+    passes through untouched; the SDK's stream handler already reads ``delta.reasoning``
+    on that path. The hook is private SDK surface, so the scaffold tests pin it. The
+    subclass becomes unnecessary with openai-agents 0.21.1 or later, whose converter
+    reads ``reasoning`` itself.
+    """
+    from agents import OpenAIChatCompletionsModel  # type: ignore[ty:unresolved-import]
+    from openai.types.chat import ChatCompletion
+
+    class ReasoningFieldChatCompletionsModel(OpenAIChatCompletionsModel):
+        """Chat Completions model that normalizes the vLLM reasoning field."""
+
+        async def _fetch_response(self, *args: Any, **kwargs: Any) -> Any:
+            completion = await super()._fetch_response(*args, **kwargs)
+            if isinstance(completion, ChatCompletion):
+                for choice in completion.choices:
+                    message = getattr(choice, "message", None)
+                    if message is not None:
+                        _mirror_vllm_reasoning(message)
+            return completion
+
+    return ReasoningFieldChatCompletionsModel
 
 
 def _make_tool_error_formatter(valid_tool_names: Sequence[str]) -> Any:
@@ -274,7 +336,6 @@ class OpenAIAgentsScaffold(Scaffold):
         from agents import (  # type: ignore[ty:unresolved-import]
             Agent,
             ModelSettings,
-            OpenAIChatCompletionsModel,
             function_tool,
             set_tracing_disabled,
         )
@@ -294,7 +355,9 @@ class OpenAIAgentsScaffold(Scaffold):
             f"model={provider.model_name}"
         )
 
-        model = OpenAIChatCompletionsModel(
+        # vLLM returns thinking as ``reasoning``, which the SDK does not convert; the
+        # subclass mirrors it onto ``reasoning_content`` so it reaches the saved trajectory.
+        model = _chat_completions_model_class()(
             openai_client=client,
             model=provider.model_name,
         )

--- a/tests/core/harness/test_openai_agents_scaffold.py
+++ b/tests/core/harness/test_openai_agents_scaffold.py
@@ -13,7 +13,9 @@ from olmo_eval.harness.scaffolds.openai_agents import (
     DEFAULT_CHAT_TEMPLATE_KWARGS,
     FORCED_FINAL_ANSWER_INSTRUCTION,
     OpenAIAgentsScaffold,
+    _chat_completions_model_class,
     _make_tool_error_formatter,
+    _mirror_vllm_reasoning,
 )
 
 pytest.importorskip("agents")
@@ -381,11 +383,11 @@ def _stub_openai_client():
     return SimpleNamespace(base_url="http://localhost:8000/v1")
 
 
-def _self_hosted_provider(chat_template_kwargs=None, client=None):
+def _self_hosted_provider(chat_template_kwargs=None, client=None, model_name="test-model"):
     """Provider shaped like VLLMServerProvider: exposes ``chat_template_kwargs``."""
     openai_client = client if client is not None else _stub_openai_client()
     return SimpleNamespace(
-        model_name="test-model",
+        model_name=model_name,
         chat_template_kwargs=chat_template_kwargs,
         get_openai_client=lambda: openai_client,
     )
@@ -741,3 +743,301 @@ class TestModelRefusal:
 
         assert "I cannot help with that." in result.final_output.text
         assert result.error is not None
+
+
+def _scripted_client(*messages: dict[str, Any]):
+    """Real AsyncOpenAI over a mock transport that answers with ``messages`` in order.
+
+    Returns the client and the request bodies the SDK sent, so a test can check both
+    what came back and what was replayed into the next request. Running out of scripted
+    messages fails the test.
+    """
+    import json
+
+    import httpx
+    from openai import AsyncOpenAI
+
+    queue = list(messages)
+    requests: list[dict[str, Any]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(json.loads(request.content.decode()))
+        if not queue:
+            # pytest.fail raises a BaseException, which the OpenAI client's retry loop
+            # cannot swallow the way it would an AssertionError from the transport.
+            pytest.fail(
+                f"scripted client got request {len(requests)} but only "
+                f"{len(requests) - 1} message(s) were scripted"
+            )
+        message = queue.pop(0)
+        return httpx.Response(
+            200,
+            json={
+                "id": "chatcmpl-test",
+                "object": "chat.completion",
+                "created": 0,
+                "model": "test-model",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": message,
+                        "finish_reason": "tool_calls" if message.get("tool_calls") else "stop",
+                    }
+                ],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+            },
+        )
+
+    client = AsyncOpenAI(
+        api_key="test-key-not-real",
+        base_url="http://test.invalid/v1",
+        http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+    )
+    return client, requests
+
+
+def _vllm_message(content: str | None, reasoning: str, tool_calls=None) -> dict[str, Any]:
+    """Assistant message shaped like vLLM 0.19: thinking under ``reasoning`` only."""
+    message: dict[str, Any] = {"role": "assistant", "content": content, "reasoning": reasoning}
+    if tool_calls:
+        message["tool_calls"] = tool_calls
+    return message
+
+
+def _reasoning_summaries(items) -> list[list[str]]:
+    return [
+        [part.text for part in item.summary]
+        for item in items
+        if type(item).__name__ == "ResponseReasoningItem"
+    ]
+
+
+class TestVllmReasoningField:
+    """vLLM returns thinking as ``message.reasoning``, which openai-agents 0.20 ignores.
+
+    The scaffold's model subclass mirrors it onto ``reasoning_content`` as soon as the raw
+    ChatCompletion comes back, so the SDK's own converter emits the ReasoningItem.
+    """
+
+    async def _output_items(self, message: dict[str, Any]):
+        from agents import ModelSettings, ModelTracing
+
+        client, _ = _scripted_client(message)
+        async with client:
+            model = _chat_completions_model_class()(openai_client=client, model="test-model")
+            response = await model.get_response(
+                system_instructions=None,
+                input="hello",
+                model_settings=ModelSettings(),
+                tools=[],
+                output_schema=None,
+                handoffs=[],
+                tracing=ModelTracing.DISABLED,
+            )
+        return response.output
+
+    @pytest.mark.anyio
+    async def test_vllm_reasoning_becomes_a_reasoning_item(self):
+        items = await self._output_items(_vllm_message("answer", "thought"))
+
+        assert [type(i).__name__ for i in items] == [
+            "ResponseReasoningItem",
+            "ResponseOutputMessage",
+        ]
+        assert _reasoning_summaries(items) == [["thought"]]
+
+    @pytest.mark.anyio
+    async def test_vllm_reasoning_on_a_tool_call_message(self):
+        call = {
+            "id": "call_1",
+            "type": "function",
+            "function": {"name": "paper_search", "arguments": '{"query":"olmo"}'},
+        }
+        items = await self._output_items(_vllm_message(None, "tool thought", [call]))
+
+        assert [type(i).__name__ for i in items] == [
+            "ResponseReasoningItem",
+            "ResponseFunctionToolCall",
+        ]
+        assert _reasoning_summaries(items) == [["tool thought"]]
+
+    @pytest.mark.anyio
+    async def test_reasoning_content_is_left_alone(self):
+        """DeepSeek already uses the field the SDK reads; the shim must not touch it."""
+        items = await self._output_items(
+            {"role": "assistant", "content": "answer", "reasoning_content": "rc"}
+        )
+
+        assert _reasoning_summaries(items) == [["rc"]]
+
+    @pytest.mark.anyio
+    async def test_reasoning_content_wins_over_a_stray_reasoning_field(self):
+        items = await self._output_items(
+            {
+                "role": "assistant",
+                "content": "answer",
+                "reasoning_content": "rc",
+                "reasoning": "raw",
+            }
+        )
+
+        assert _reasoning_summaries(items) == [["rc"]]
+
+    @pytest.mark.anyio
+    async def test_a_message_without_reasoning_is_untouched(self):
+        items = await self._output_items({"role": "assistant", "content": "answer"})
+
+        assert [type(i).__name__ for i in items] == ["ResponseOutputMessage"]
+
+    def test_mirroring_only_adds_the_field_for_the_vllm_shape(self):
+        from openai.types.chat import ChatCompletionMessage
+
+        vllm = ChatCompletionMessage.model_validate(
+            {"role": "assistant", "content": "a", "reasoning": "t"}
+        )
+        deepseek = ChatCompletionMessage.model_validate(
+            {"role": "assistant", "content": "a", "reasoning_content": "rc"}
+        )
+        plain = ChatCompletionMessage(role="assistant", content="a")
+        plain_before = plain.model_dump()
+
+        for message in (vllm, deepseek, plain):
+            _mirror_vllm_reasoning(message)
+
+        assert vllm.model_extra == {"reasoning": "t", "reasoning_content": "t"}
+        assert deepseek.model_extra == {"reasoning_content": "rc"}
+        assert not plain.model_extra
+        assert plain.model_dump() == plain_before
+
+    @pytest.mark.parametrize(
+        ("extra", "reasoning_content_after"),
+        [
+            pytest.param({"reasoning": ""}, None, id="empty_reasoning"),
+            pytest.param({"reasoning": ["x"]}, None, id="non_string_reasoning"),
+            pytest.param(
+                {"reasoning": "t", "thinking_blocks": [{"type": "thinking", "thinking": "b"}]},
+                None,
+                id="thinking_blocks_present",
+            ),
+            pytest.param(
+                {"reasoning": "t", "reasoning_content": ""}, "t", id="empty_reasoning_content"
+            ),
+        ],
+    )
+    def test_mirroring_edge_shapes(self, extra, reasoning_content_after):
+        from openai.types.chat import ChatCompletionMessage
+
+        message = ChatCompletionMessage.model_validate(
+            {"role": "assistant", "content": "a", **extra}
+        )
+        before = message.model_dump()
+
+        _mirror_vllm_reasoning(message)
+
+        assert getattr(message, "reasoning_content", None) == reasoning_content_after
+        if reasoning_content_after is None:
+            assert message.model_dump() == before
+
+    def test_the_sdk_hook_point_is_still_there(self):
+        """Fail loudly if the SDK renames the private method the scaffold overrides.
+
+        ``get_response`` must still await ``self._fetch_response`` and hand its result to
+        the converter; otherwise the override is dead code and reasoning is silently lost.
+        """
+        import inspect
+
+        from agents import OpenAIChatCompletionsModel
+
+        hook = getattr(OpenAIChatCompletionsModel, "_fetch_response", None)
+        assert inspect.iscoroutinefunction(hook), (
+            "OpenAIChatCompletionsModel._fetch_response is gone; the reasoning shim no longer runs"
+        )
+        assert "self._fetch_response(" in inspect.getsource(OpenAIChatCompletionsModel.get_response)
+        assert "message_to_output_items(" in inspect.getsource(
+            OpenAIChatCompletionsModel.get_response
+        )
+        assert issubclass(_chat_completions_model_class(), OpenAIChatCompletionsModel)
+
+    @pytest.mark.anyio
+    async def test_vllm_reasoning_reaches_the_saved_trajectory(self):
+        """Scaffold -> SDK Runner -> converter -> AgentTurn.reasoning, with no replay."""
+        call = {
+            "id": "call_1",
+            "type": "function",
+            "function": {"name": "paper_search", "arguments": '{"query":"olmo"}'},
+        }
+        client, requests = _scripted_client(
+            _vllm_message(None, "Search first.", [call]),
+            _vllm_message("Final.", "Now answer."),
+        )
+
+        async with client:
+            result = await OpenAIAgentsScaffold().run(
+                provider=_self_hosted_provider(client=client),
+                config=HarnessConfig(
+                    name="test", max_turns=3, tools=(_named_tool("paper_search"),)
+                ),
+                request=_agent_request(),
+                enable_compaction=False,
+            )
+
+        assert result.final_output.text == "Final."
+        assert result.trajectory is not None
+        turns = result.trajectory.turns
+        assert [t.role for t in turns] == ["assistant", "tool", "assistant"]
+        assert turns[0].reasoning == "Search first."
+        assert turns[0].tool_calls[0].function.name == "paper_search"
+        assert turns[2].content == "Final."
+        assert turns[2].reasoning == "Now answer."
+        assert turns[2].to_dict()["reasoning"] == "Now answer."
+
+        # The mirrored field is not replayed to a non-DeepSeek model, so what the server
+        # sees on later turns is exactly what it saw before the shim.
+        assert len(requests) == 2
+        assistant_messages = [m for m in requests[1]["messages"] if m.get("role") == "assistant"]
+        assert assistant_messages
+        assert all(
+            "reasoning_content" not in m and "reasoning" not in m for m in assistant_messages
+        )
+
+    @pytest.mark.anyio
+    @pytest.mark.parametrize(
+        ("model_name", "replayed"), [("deepseek-r1", True), ("qwen3-8b", False)]
+    )
+    async def test_mirrored_reasoning_is_replayed_only_to_deepseek_names(
+        self, model_name, replayed
+    ):
+        """The SDK replays ``reasoning_content`` to models named deepseek, mirrored or not.
+
+        vLLM 0.19.1 ignores the key in assistant history, so for a DeepSeek model served
+        by vLLM this is extra payload rather than a behavior change.
+        """
+        call = {
+            "id": "call_1",
+            "type": "function",
+            "function": {"name": "paper_search", "arguments": '{"query":"olmo"}'},
+        }
+        client, requests = _scripted_client(
+            _vllm_message(None, "Search first.", [call]),
+            _vllm_message("Final.", "Now answer."),
+        )
+
+        async with client:
+            result = await OpenAIAgentsScaffold().run(
+                provider=_self_hosted_provider(client=client, model_name=model_name),
+                config=HarnessConfig(
+                    name="test", max_turns=3, tools=(_named_tool("paper_search"),)
+                ),
+                request=_agent_request(),
+                enable_compaction=False,
+            )
+
+        assert result.trajectory is not None
+        assert result.trajectory.turns[0].reasoning == "Search first."
+        assert len(requests) == 2
+        assert requests[1]["model"] == model_name
+        assistant_messages = [m for m in requests[1]["messages"] if m.get("role") == "assistant"]
+        assert [m.get("reasoning_content") for m in assistant_messages] == (
+            ["Search first."] if replayed else [None]
+        )
+        assert all("reasoning" not in m for m in assistant_messages)

--- a/tests/core/harness/test_openai_agents_scaffold.py
+++ b/tests/core/harness/test_openai_agents_scaffold.py
@@ -48,6 +48,48 @@ def _tool_turn_items(agent, output: str = "Search result text"):
     ]
 
 
+def _reasoning_item(agent, *summary: str, content: tuple[str, ...] = ()):
+    from agents.items import ReasoningItem
+    from openai.types.responses import ResponseReasoningItem
+    from openai.types.responses.response_reasoning_item import Content, Summary
+
+    raw = ResponseReasoningItem(
+        id="rs_1",
+        type="reasoning",
+        summary=[Summary(text=text, type="summary_text") for text in summary],
+        content=[Content(text=text, type="reasoning_text") for text in content] or None,
+    )
+    return ReasoningItem(agent=agent, raw_item=raw)
+
+
+def _message_item(agent, text: str):
+    from agents.items import MessageOutputItem
+    from openai.types.responses import ResponseOutputMessage, ResponseOutputText
+
+    raw = ResponseOutputMessage(
+        id="msg_1",
+        type="message",
+        role="assistant",
+        status="completed",
+        content=[ResponseOutputText(text=text, type="output_text", annotations=[])],
+    )
+    return MessageOutputItem(agent=agent, raw_item=raw)
+
+
+def _refusal_message_item(agent, refusal: str):
+    from agents.items import MessageOutputItem
+    from openai.types.responses import ResponseOutputMessage, ResponseOutputRefusal
+
+    raw = ResponseOutputMessage(
+        id="msg_1",
+        type="message",
+        role="assistant",
+        status="completed",
+        content=[ResponseOutputRefusal(refusal=refusal, type="refusal")],
+    )
+    return MessageOutputItem(agent=agent, raw_item=raw)
+
+
 class _FakeRunData:
     def __init__(self, *, new_items, final_output=None):
         self.new_items = new_items
@@ -205,6 +247,134 @@ class TestOpenAIAgentsMaxTurns:
         assert result.trajectory.total_tool_calls == 1
         assert result.trajectory.tool_result_sequence[0].content == "Normal tool result"
         assert len(run_calls) == 1
+
+
+class TestReasoningItems:
+    """The SDK emits reasoning as a ReasoningItem ahead of the turn it belongs to."""
+
+    def _convert(self, items):
+        return OpenAIAgentsScaffold()._convert_trajectory(_FakeRunData(new_items=items))
+
+    def test_reasoning_lands_on_the_following_message_turn(self):
+        from agents import Agent
+
+        agent = Agent(name="test-agent")
+        trajectory = self._convert(
+            [_reasoning_item(agent, "Think first."), _message_item(agent, "Final answer.")]
+        )
+
+        assert [turn.role for turn in trajectory.turns] == ["assistant"]
+        turn = trajectory.turns[0]
+        assert turn.content == "Final answer."
+        assert turn.reasoning == "Think first."
+        assert "Think first." not in turn.content
+
+    def test_reasoning_lands_on_the_following_tool_call_turn(self):
+        from agents import Agent
+
+        agent = Agent(name="test-agent")
+        trajectory = self._convert(
+            [_reasoning_item(agent, "Plan the search."), *_tool_turn_items(agent)]
+        )
+
+        assert [turn.role for turn in trajectory.turns] == ["assistant", "tool"]
+        assert trajectory.turns[0].has_tool_calls
+        assert trajectory.turns[0].reasoning == "Plan the search."
+        assert trajectory.turns[1].reasoning is None
+
+    def test_trailing_reasoning_is_kept_on_an_empty_assistant_turn(self):
+        from agents import Agent
+
+        agent = Agent(name="test-agent")
+        trajectory = self._convert(
+            [*_tool_turn_items(agent), _reasoning_item(agent, "Cut off here.")]
+        )
+
+        assert [turn.role for turn in trajectory.turns] == ["assistant", "tool", "assistant"]
+        last = trajectory.turns[-1]
+        assert last.content == ""
+        assert not last.has_tool_calls
+        assert last.reasoning == "Cut off here."
+
+    def test_reasoning_before_a_refusal_stays_on_that_response(self):
+        from agents import Agent
+
+        agent = Agent(name="test-agent")
+        trajectory = self._convert(
+            [
+                _reasoning_item(agent, "Think first."),
+                _refusal_message_item(agent, "I cannot help with that."),
+                _message_item(agent, "Final answer."),
+            ]
+        )
+
+        assert [turn.role for turn in trajectory.turns] == ["assistant", "assistant"]
+        assert trajectory.turns[0].content == ""
+        assert trajectory.turns[0].reasoning == "Think first."
+        assert trajectory.turns[1].content == "Final answer."
+        assert trajectory.turns[1].reasoning is None
+
+    def test_pending_reasoning_is_flushed_before_a_tool_output(self):
+        from agents import Agent
+
+        agent = Agent(name="test-agent")
+        _, tool_output = _tool_turn_items(agent)
+        trajectory = self._convert(
+            [_reasoning_item(agent, "Orphaned."), tool_output, _message_item(agent, "Final.")]
+        )
+
+        assert [turn.role for turn in trajectory.turns] == ["assistant", "tool", "assistant"]
+        assert trajectory.turns[0].content == ""
+        assert trajectory.turns[0].reasoning == "Orphaned."
+        assert trajectory.turns[2].reasoning is None
+
+    def test_content_parts_supersede_the_summary(self):
+        from agents import Agent
+
+        agent = Agent(name="test-agent")
+        item = _reasoning_item(agent, "summary", content=("block one", "block two"))
+        trajectory = self._convert([item, _message_item(agent, "Done.")])
+
+        assert trajectory.turns[0].reasoning == "block one\n\nblock two"
+
+    def test_turns_without_reasoning_serialize_unchanged(self):
+        from agents import Agent
+
+        agent = Agent(name="test-agent")
+        trajectory = self._convert([*_tool_turn_items(agent), _message_item(agent, "Done.")])
+
+        assert len(trajectory.turns) == 3
+        for turn in trajectory.turns:
+            assert turn.reasoning is None
+            assert "reasoning" not in turn.to_dict()
+
+    @pytest.mark.anyio
+    async def test_run_keeps_reasoning_in_the_harness_result(self, monkeypatch):
+        from agents import Agent, Runner
+
+        agent = Agent(name="test-agent", instructions="Use tools.")
+        run_result = _FakeRunData(
+            new_items=[_reasoning_item(agent, "Think first."), _message_item(agent, "Final.")],
+            final_output="Final.",
+        )
+
+        async def fake_run(**kwargs):
+            return run_result
+
+        _patch_scaffold_agent(monkeypatch, agent)
+        monkeypatch.setattr(Runner, "run", staticmethod(fake_run))
+
+        result = await OpenAIAgentsScaffold().run(
+            provider=SimpleNamespace(),
+            config=HarnessConfig(name="test", max_turns=3),
+            request=_agent_request(),
+            enable_compaction=False,
+        )
+
+        assert result.final_output.text == "Final."
+        assert result.trajectory is not None
+        assert result.trajectory.turns[0].reasoning == "Think first."
+        assert result.trajectory.turns[0].content == "Final."
 
 
 def _stub_openai_client():

--- a/tests/core/test_trajectory_types.py
+++ b/tests/core/test_trajectory_types.py
@@ -281,6 +281,41 @@ class TestAgentTurnSerialization:
         assert restored.timestamp_ms == original.timestamp_ms
         assert restored.token_count == original.token_count
 
+    def test_to_dict_omits_reasoning_when_absent(self):
+        """Turns without reasoning must serialize exactly as before the field existed."""
+        turn = AgentTurn.assistant(content="Hello")
+        assert turn.reasoning is None
+        assert "reasoning" not in turn.to_dict()
+
+    def test_roundtrip_with_reasoning(self):
+        """Reasoning survives to_dict/from_dict and stays separate from content."""
+        original = AgentTurn.assistant(content="Answer", reasoning="Think it through first.")
+        data = original.to_dict()
+        assert data["content"] == "Answer"
+        assert data["reasoning"] == "Think it through first."
+        restored = AgentTurn.from_dict(data)
+        assert restored.reasoning == original.reasoning
+        assert restored.content == original.content
+
+    def test_from_dict_without_reasoning_key_reserializes_identically(self):
+        """A dict written before the reasoning field loads and re-serializes unchanged."""
+        data = {
+            "role": "assistant",
+            "content": "Searching",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "search", "arguments": '{"q": "test"}'},
+                }
+            ],
+            "timestamp_ms": 99999,
+            "token_count": 25,
+        }
+        turn = AgentTurn.from_dict(data)
+        assert turn.reasoning is None
+        assert turn.to_dict() == data
+
 
 class TestAgentTrajectorySerialization:
     """Tests for AgentTrajectory serialization."""
@@ -368,3 +403,16 @@ class TestAgentTrajectorySerialization:
         assert restored.state_snapshot == original.state_snapshot
         assert restored.metadata == original.metadata
         assert restored.tool_call_names() == original.tool_call_names()
+
+    def test_from_dict_without_reasoning_reserializes_identically(self):
+        """A trajectory saved before the reasoning field round-trips unchanged."""
+        data = {
+            "turns": [
+                {"role": "user", "content": "Hello"},
+                {"role": "assistant", "content": "Hi there"},
+            ],
+            "final_answer": "Hi there",
+        }
+        traj = AgentTrajectory.from_dict(data)
+        assert all(turn.reasoning is None for turn in traj.turns)
+        assert traj.to_dict() == data


### PR DESCRIPTION
The openai-agents SDK converts Chat Completions `reasoning_content` into a `ReasoningItem`, but `_convert_trajectory` only handled message, tool call and tool output items, so reasoning was dropped before the trajectory was saved. `AgentTurn` gains an optional `reasoning` field and the converter a `ReasoningItem` branch that attaches the item to the assistant turn that follows it, flushing onto an otherwise empty assistant turn at a tool output or the end of the run so it never crosses a response boundary. Turns without reasoning serialize exactly as before: [trajectory.py](https://github.com/allenai/olmo-eval/blob/87d6d44b9ceb47e1d506db79768562888bf5049b/src/olmo_eval/common/types/trajectory.py), [openai_agents.py](https://github.com/allenai/olmo-eval/blob/87d6d44b9ceb47e1d506db79768562888bf5049b/src/olmo_eval/harness/scaffolds/openai_agents.py).

vLLM returns thinking as `reasoning`, a field the pinned SDK's Chat Completions converter does not read, so behind a vLLM server the new branch would still see nothing. The scaffold therefore instantiates a small subclass of `OpenAIChatCompletionsModel` that mirrors `reasoning` onto `reasoning_content` on the raw completion before the SDK converts it, and does nothing when a non-empty `reasoning_content` or thinking blocks are already present or when there is no reasoning. The SDK releases that read the field themselves require openai 3.x, which this repository's pins exclude, so the mirror stays until that migration.

Checked on Beaker with Qwen3.5-9B behind vLLM 0.19.1 (`--reasoning-parser qwen3`, thinking enabled) on three litsearch instances: all seven model responses produced reasoning and all seven are saved on the assistant turns, with none of that text in any turn content, tool argument or final output. Also checked with a one-instance litsearch run against deepseek-reasoner, and end to end through the SDK Runner over a mock transport answering in vLLM 0.19.1's message shape, with nothing extra replayed to the server: [test_openai_agents_scaffold.py](https://github.com/allenai/olmo-eval/blob/87d6d44b9ceb47e1d506db79768562888bf5049b/tests/core/harness/test_openai_agents_scaffold.py), [test_trajectory_types.py](https://github.com/allenai/olmo-eval/blob/87d6d44b9ceb47e1d506db79768562888bf5049b/tests/core/test_trajectory_types.py). The new scaffold tests skip in CI like the existing ones in that file.
