### PR TITLE
Load the data files a caller asked for from script-based repos

### DIFF
--- a/src/olmo_eval/common/execution/__init__.py
+++ b/src/olmo_eval/common/execution/__init__.py
@@ -1,6 +1,11 @@
 """Execution helpers for scoring and sandboxed code execution."""
 
-from .environment import ExecutionEnvironment, ExecutionResult, ScoringContext
+from .environment import (
+    ExecutionEnvironment,
+    ExecutionResult,
+    ScoringContext,
+    StagingExecutionEnvironment,
+)
 from .process_pool import (
     ProcessOutputScore,
     ProcessPoolManager,
@@ -20,6 +25,7 @@ __all__ = [
     "ProcessScoringPoolConfig",
     "ScoringContext",
     "SerializedProcessScorer",
+    "StagingExecutionEnvironment",
     "default_process_pool_workers",
     "serialize_process_scorer",
 ]

--- a/src/olmo_eval/common/execution/environment.py
+++ b/src/olmo_eval/common/execution/environment.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
@@ -37,6 +38,23 @@ class ExecutionEnvironment(Protocol):
 
     async def execute_code(
         self, code: str, language: str = "python", timeout: float | None = None
+    ) -> ExecutionResult: ...
+
+
+@runtime_checkable
+class StagingExecutionEnvironment(ExecutionEnvironment, Protocol):
+    """Execution environment that can place files before running a command.
+
+    Command text reaches the container as a process argument, which the
+    operating system caps at a small size. Payloads too large for that limit
+    are staged as files instead, in the same environment the command runs in.
+    """
+
+    async def execute_with_files(
+        self,
+        command: str,
+        files: Mapping[str, str],
+        timeout: float | None = None,
     ) -> ExecutionResult: ...
 
 

--- a/src/olmo_eval/data/backends/huggingface.py
+++ b/src/olmo_eval/data/backends/huggingface.py
@@ -48,7 +48,11 @@ class HuggingFaceBackend:
 
         kwargs: dict[str, Any] = {}
         if source.data_files is not None:
-            kwargs["data_files"] = source.data_files
+            kwargs["data_files"] = (
+                list(source.data_files)
+                if isinstance(source.data_files, tuple)
+                else source.data_files
+            )
         if source.revision is not None:
             kwargs["revision"] = source.revision
 
@@ -87,21 +91,27 @@ class HuggingFaceBackend:
         from datasets import load_dataset
         from huggingface_hub import HfApi
 
-        api = HfApi(token=token)
-        repo_files = api.list_repo_files(path, repo_type="dataset")
+        declared = kwargs.get("data_files")
+        if declared is not None:
+            # An explicit file list names the split exactly; subset matching
+            # would silently widen it to every data file in the repository.
+            candidates = [declared] if isinstance(declared, str) else list(declared)
+        else:
+            api = HfApi(token=token)
+            repo_files = api.list_repo_files(path, repo_type="dataset")
 
-        # Find data files matching the subset name
-        subset = source.subset or ""
-        candidates = [
-            f
-            for f in repo_files
-            if subset in f and f.rsplit(".", 1)[-1] in ("jsonl", "json", "parquet", "csv")
-        ]
-        if not candidates:
-            raise FileNotFoundError(
-                f"No data files matching subset '{subset}' in {path}. "
-                f"This dataset has a legacy loading script that is no longer supported."
-            )
+            # Find data files matching the subset name
+            subset = source.subset or ""
+            candidates = [
+                f
+                for f in repo_files
+                if subset in f and f.rsplit(".", 1)[-1] in ("jsonl", "json", "parquet", "csv")
+            ]
+            if not candidates:
+                raise FileNotFoundError(
+                    f"No data files matching subset '{subset}' in {path}. "
+                    f"This dataset has a legacy loading script that is no longer supported."
+                )
 
         ext = candidates[0].rsplit(".", 1)[-1]
         module = "json" if ext in ("json", "jsonl") else ext

--- a/src/olmo_eval/data/sources.py
+++ b/src/olmo_eval/data/sources.py
@@ -40,7 +40,9 @@ class DataSource:
     subset: str | None = None
     split: str = "test"
     source_type: SourceType | None = None
-    data_files: str | None = None
+    #: Data file(s) to load, relative to the repository root. A tuple selects
+    #: several files that together form one split.
+    data_files: str | tuple[str, ...] | None = None
     revision: str | None = None
 
     def __post_init__(self) -> None:
@@ -157,6 +159,8 @@ class DataSource:
             "subset": self.subset,
             "split": self.split,
             "source_type": self.source_type.value if self.source_type else None,
-            "data_files": self.data_files,
+            "data_files": list(self.data_files)
+            if isinstance(self.data_files, tuple)
+            else self.data_files,
             "revision": self.revision,
         }

--- a/src/olmo_eval/harness/sandbox/executor.py
+++ b/src/olmo_eval/harness/sandbox/executor.py
@@ -11,7 +11,7 @@ import os
 import random
 import time
 import uuid
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass
 from typing import Any, TypeVar
 
@@ -796,6 +796,30 @@ class SandboxExecutor:
             stderr=response.stderr or "",
             exit_code=response.exit_code,
         )
+
+    async def write_files(self, files: Mapping[str, str]) -> None:
+        """Write files into the sandbox filesystem.
+
+        Contents travel in the request body rather than in a command argument,
+        so they are not bounded by the operating system's argument size limit.
+
+        Args:
+            files: Mapping of absolute sandbox path to file content.
+
+        Raises:
+            RuntimeError: If the sandbox is not started.
+        """
+        if self._runtime is None:
+            raise RuntimeError("Sandbox not started. Call start() first or use async context.")
+
+        from swerex.runtime.abstract import WriteFileRequest
+
+        for path, content in files.items():
+            request = WriteFileRequest(path=path, content=content)
+            await self._run_with_transport_retries(
+                lambda request=request: self._runtime.write_file(request),
+                operation="file write",
+            )
 
     async def execute_code(
         self,

--- a/src/olmo_eval/harness/sandbox/manager.py
+++ b/src/olmo_eval/harness/sandbox/manager.py
@@ -8,7 +8,7 @@ import concurrent.futures
 import contextlib
 import time
 import uuid
-from collections.abc import AsyncIterator, Awaitable, Callable, Sequence
+from collections.abc import AsyncIterator, Awaitable, Callable, Mapping, Sequence
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from typing import TypeVar
@@ -99,6 +99,20 @@ class CapabilityExecutionEnvironment:
         return await self.manager.execute_code(
             code,
             language,
+            timeout,
+            capabilities=self.capabilities,
+            failover_on_quarantine=True,
+        )
+
+    async def execute_with_files(
+        self,
+        command: str,
+        files: Mapping[str, str],
+        timeout: float | None = None,
+    ) -> ExecutionResult:
+        return await self.manager.execute_with_files(
+            command,
+            files,
             timeout,
             capabilities=self.capabilities,
             failover_on_quarantine=True,
@@ -528,6 +542,41 @@ class SandboxManager:
         return await self._execute_with_lease(
             required,
             lambda executor: executor.execute_code(code, language, timeout),
+            failover_on_quarantine=failover_on_quarantine,
+        )
+
+    async def execute_with_files(
+        self,
+        command: str,
+        files: Mapping[str, str],
+        timeout: float | None = None,
+        capabilities: frozenset[str] | None = None,
+        *,
+        failover_on_quarantine: bool = False,
+    ) -> ExecutionResult:
+        """Stage files and run a command against them on one executor.
+
+        Both steps hold the same lease, so the command sees the files that
+        were written for it rather than the contents of another executor.
+
+        Args:
+            command: The command to execute once the files are in place.
+            files: Mapping of absolute sandbox path to file content.
+            timeout: Optional timeout override in seconds.
+            capabilities: Optional required capabilities. If None, uses default.
+
+        Returns:
+            ExecutionResult with success status, output, and exit code.
+        """
+        required = capabilities or Capability.DEFAULT
+
+        async def stage_and_execute(executor: SandboxExecutor) -> ExecutionResult:
+            await executor.write_files(files)
+            return await executor.execute_command(command, timeout)
+
+        return await self._execute_with_lease(
+            required,
+            stage_and_execute,
             failover_on_quarantine=failover_on_quarantine,
         )
 

--- a/tests/core/harness/test_sandbox_file_staging.py
+++ b/tests/core/harness/test_sandbox_file_staging.py
@@ -1,0 +1,102 @@
+"""Tests for staging files into a sandbox before running a command."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Mapping
+
+import pytest
+
+from olmo_eval.common.execution import ExecutionResult
+from olmo_eval.harness.sandbox import Capability, SandboxConfig, SandboxManager, SandboxMode
+
+
+class _StagingExecutor:
+    """Executor that records the files written to it and the commands it ran."""
+
+    def __init__(self, name: str, *, max_concurrency: int = 2) -> None:
+        self.name = name
+        self.config = SandboxConfig(
+            image="test",
+            mode=SandboxMode.MODAL,
+            capabilities=Capability.DEFAULT,
+            max_concurrency=max_concurrency,
+        )
+        self.running = True
+        self.files: dict[str, str] = {}
+        self.commands: list[str] = []
+        #: Files present when each command ran, to catch a command that
+        #: executes somewhere its files were never written.
+        self.files_at_command: list[set[str]] = []
+
+    @property
+    def is_running(self) -> bool:
+        return self.running
+
+    async def write_files(self, files: Mapping[str, str]) -> None:
+        await asyncio.sleep(0.01)
+        self.files.update(files)
+
+    async def execute_command(self, command: str, timeout: float | None = None) -> ExecutionResult:
+        del timeout
+        self.commands.append(command)
+        self.files_at_command.append(set(self.files))
+        return ExecutionResult(success=True, output='{"passed": true}')
+
+
+def _manager(*executors: _StagingExecutor) -> SandboxManager:
+    manager = SandboxManager([])
+    manager._executors = list(executors)  # type: ignore[assignment]
+    manager._active_operations = {id(executor): 0 for executor in executors}
+    return manager
+
+
+@pytest.mark.anyio
+async def test_files_are_written_before_the_command_runs() -> None:
+    executor = _StagingExecutor("sb-0")
+    manager = _manager(executor)
+
+    result = await manager.execute_with_files(
+        "python3 grade.py",
+        {"/tmp/work/grade.py": "print(1)", "/tmp/work/problem.json": "{}"},
+    )
+
+    assert result.success
+    assert executor.commands == ["python3 grade.py"]
+    assert executor.files_at_command == [{"/tmp/work/grade.py", "/tmp/work/problem.json"}]
+
+
+@pytest.mark.anyio
+async def test_command_runs_on_the_executor_that_received_the_files() -> None:
+    first = _StagingExecutor("sb-0")
+    second = _StagingExecutor("sb-1")
+    manager = _manager(first, second)
+
+    # Enough concurrent calls to spread across both executors.
+    await asyncio.gather(
+        *(
+            manager.execute_with_files(
+                f"python3 grade.py {index}",
+                {f"/tmp/work-{index}/solution.py": f"# {index}"},
+            )
+            for index in range(6)
+        )
+    )
+
+    assert first.commands and second.commands, "expected work on both executors"
+    for executor in (first, second):
+        for command, staged in zip(executor.commands, executor.files_at_command, strict=True):
+            index = command.rsplit(" ", 1)[-1]
+            assert f"/tmp/work-{index}/solution.py" in staged
+
+
+@pytest.mark.anyio
+async def test_staging_respects_executor_capacity() -> None:
+    executor = _StagingExecutor("sb-0", max_concurrency=1)
+    manager = _manager(executor)
+
+    await asyncio.gather(
+        *(manager.execute_with_files(f"cmd {index}", {f"/tmp/{index}": "x"}) for index in range(4))
+    )
+
+    assert len(executor.commands) == 4

--- a/tests/data/test_hub_file_selection.py
+++ b/tests/data/test_hub_file_selection.py
@@ -1,0 +1,138 @@
+"""Tests for data file selection when a repository has a legacy loading script.
+
+`datasets` refuses to run legacy loading scripts, so the HuggingFace backend
+falls back to reading the repository's data files directly. That fallback has
+to load the files the caller asked for.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from olmo_eval.data import DataSource
+from olmo_eval.data.backends.huggingface import HuggingFaceBackend
+
+
+class _RecordingLoader:
+    """Stands in for `datasets.load_dataset`, recording how it was called."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def __call__(self, path: str, **kwargs: Any) -> list[dict[str, str]]:
+        self.calls.append({"path": path, **kwargs})
+        return [{"doc": "loaded"}]
+
+
+@pytest.fixture
+def recording_loader(monkeypatch: pytest.MonkeyPatch) -> _RecordingLoader:
+    import datasets
+
+    loader = _RecordingLoader()
+    monkeypatch.setattr(datasets, "load_dataset", loader)
+    return loader
+
+
+def _all_repo_files(monkeypatch: pytest.MonkeyPatch, files: list[str]) -> None:
+    """Make the Hub report `files` as the repository's contents."""
+    import huggingface_hub
+
+    class _StubApi:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+        def list_repo_files(self, path: str, repo_type: str = "dataset") -> list[str]:
+            del path, repo_type
+            return files
+
+    monkeypatch.setattr(huggingface_hub, "HfApi", _StubApi)
+
+
+def test_declared_data_files_are_the_only_ones_loaded(
+    recording_loader: _RecordingLoader,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The repository holds six data files; the caller asked for three of them.
+    _all_repo_files(
+        monkeypatch,
+        ["test.jsonl", "test2.jsonl", "test3.jsonl", "test4.jsonl", "test5.jsonl", "test6.jsonl"],
+    )
+    source = DataSource(
+        path="org/scripted-repo",
+        data_files=("test.jsonl", "test2.jsonl", "test3.jsonl"),
+        split="train",
+    )
+
+    HuggingFaceBackend._load_from_hub_files(
+        "org/scripted-repo",
+        source,
+        streaming=False,
+        token=None,
+        data_files=["test.jsonl", "test2.jsonl", "test3.jsonl"],
+    )
+
+    assert recording_loader.calls[0]["data_files"] == {
+        "train": [
+            "hf://datasets/org/scripted-repo/test.jsonl",
+            "hf://datasets/org/scripted-repo/test2.jsonl",
+            "hf://datasets/org/scripted-repo/test3.jsonl",
+        ]
+    }
+
+
+def test_a_single_declared_data_file_is_not_widened(
+    recording_loader: _RecordingLoader,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Without a subset, substring matching accepts every file in the repository.
+    _all_repo_files(monkeypatch, ["test.jsonl", "test2.jsonl", "test3.jsonl"])
+    source = DataSource(path="org/scripted-repo", data_files="test.jsonl", split="train")
+
+    HuggingFaceBackend._load_from_hub_files(
+        "org/scripted-repo",
+        source,
+        streaming=False,
+        token=None,
+        data_files="test.jsonl",
+    )
+
+    assert recording_loader.calls[0]["data_files"] == {
+        "train": ["hf://datasets/org/scripted-repo/test.jsonl"]
+    }
+
+
+def test_subset_matching_still_applies_without_declared_files(
+    recording_loader: _RecordingLoader,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _all_repo_files(monkeypatch, ["math/test.jsonl", "biology/test.jsonl", "README.md"])
+    source = DataSource(path="org/scripted-repo", subset="math", split="test")
+
+    HuggingFaceBackend._load_from_hub_files(
+        "org/scripted-repo",
+        source,
+        streaming=False,
+        token=None,
+    )
+
+    assert recording_loader.calls[0]["data_files"] == {
+        "test": ["hf://datasets/org/scripted-repo/math/test.jsonl"]
+    }
+
+
+def test_missing_subset_files_raise(
+    recording_loader: _RecordingLoader,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _all_repo_files(monkeypatch, ["math/test.jsonl"])
+    source = DataSource(path="org/scripted-repo", subset="chemistry", split="test")
+
+    with pytest.raises(FileNotFoundError):
+        HuggingFaceBackend._load_from_hub_files(
+            "org/scripted-repo",
+            source,
+            streaming=False,
+            token=None,
+        )

--- a/tests/data/test_sources.py
+++ b/tests/data/test_sources.py
@@ -119,3 +119,24 @@ class TestDataSourceMethods:
         source = DataSource(path="cais/mmlu", subset="math")
         new_source = source.with_subset(None)
         assert new_source.subset is None
+
+
+class TestDataSourceDataFiles:
+    """Tests for selecting specific data files."""
+
+    def test_multiple_data_files_survive_split_and_subset_changes(self):
+        source = DataSource(path="org/repo", data_files=("a.jsonl", "b.jsonl"))
+        assert source.with_split("train").data_files == ("a.jsonl", "b.jsonl")
+        assert source.with_subset("other").data_files == ("a.jsonl", "b.jsonl")
+
+    def test_multiple_data_files_serialize_as_a_list(self):
+        source = DataSource(path="org/repo", data_files=("a.jsonl", "b.jsonl"))
+        assert source.to_dict()["data_files"] == ["a.jsonl", "b.jsonl"]
+
+    def test_single_data_file_serializes_unchanged(self):
+        source = DataSource(path="org/repo", data_files="a.jsonl")
+        assert source.to_dict()["data_files"] == "a.jsonl"
+
+    def test_source_with_multiple_data_files_is_hashable(self):
+        source = DataSource(path="org/repo", data_files=("a.jsonl", "b.jsonl"))
+        assert hash(source) == hash(DataSource(path="org/repo", data_files=("a.jsonl", "b.jsonl")))


### PR DESCRIPTION
## The bug

`datasets` 4.x refuses to run a repository's legacy loading script, so `HuggingFaceBackend` falls back to reading the repository's data files directly. That fallback chose files by testing whether the **subset name appears in the filename**:

```python
subset = source.subset or ""
candidates = [f for f in repo_files if subset in f and ...]
```

With no subset configured, `subset` is `""` — and `"" in filename` is true for every file in the repository. Any explicitly declared `data_files` was ignored, and a request for one file quietly returned all of them.

Measured on `livecodebench/code_generation_lite`, whose six files are separate benchmark releases: asking for the 400 problems in `test.jsonl` returned **all 1055** across all six, with nothing to indicate the request had been widened. A caller gets a plausible-looking dataset that is not the one they asked for.

## Fix

The fallback now loads exactly the files a caller declared, and falls back to subset matching only when none were declared.

`DataSource.data_files` also accepts a `tuple[str, ...]` as well as a `str`, since one split can span several files — something the underlying `load_dataset` has always supported (`str | Sequence[str] | Mapping[...]`) and that `DataSource` had narrowed since the initial commit.

## Why the union type, and not tuple everywhere

`tuple` alone would be a quiet breaking change. `DataSource.to_dict()` feeds `TaskConfig.to_dict()`, which feeds `compute_task_hash()`, and results are stored under that hash. Serializing `"olympiad/test.jsonl"` as `["olympiad/test.jsonl"]` moves the hash:

```
frontierscience_olympiad, data_files as str   : 5901a8f78e0afbee
frontierscience_olympiad, data_files as tuple : 04f9e11d001651d9
```

**11 registered tasks** declare `data_files` today (`frontierscience_*`, `astabench_*`, eight `basic_skills_*`). Moving their hashes would detach every stored result from future runs, and the analysis tooling joins on `task_hash`.

So existing single-file declarations stay strings and serialize as strings. A separate consideration: `data_source` is reachable from CLI overrides, where values arrive as strings, and an always-tuple field would silently `list()` a string into seven single-character filenames.

## Tests

- `tests/data/test_hub_file_selection.py` — declared files are the only ones loaded; a single declared file is not widened; subset matching still works when nothing is declared; a missing subset still raises.
- `tests/data/test_sources.py` — tuple `data_files` survives `with_split`/`with_subset`, serializes as a list, leaves single-file declarations untouched, and keeps `DataSource` hashable.

Second in a three-PR stack; contains #349.

🤖 Generated with [Claude Code](https://claude.com/claude-code)