### PR TITLE
Add LiveCodeBench code generation task

### DIFF
--- a/src/olmo_eval/common/execution/__init__.py
+++ b/src/olmo_eval/common/execution/__init__.py
@@ -1,6 +1,11 @@
 """Execution helpers for scoring and sandboxed code execution."""
 
-from .environment import ExecutionEnvironment, ExecutionResult, ScoringContext
+from .environment import (
+    ExecutionEnvironment,
+    ExecutionResult,
+    ScoringContext,
+    StagingExecutionEnvironment,
+)
 from .process_pool import (
     ProcessOutputScore,
     ProcessPoolManager,
@@ -20,6 +25,7 @@ __all__ = [
     "ProcessScoringPoolConfig",
     "ScoringContext",
     "SerializedProcessScorer",
+    "StagingExecutionEnvironment",
     "default_process_pool_workers",
     "serialize_process_scorer",
 ]

--- a/src/olmo_eval/common/execution/environment.py
+++ b/src/olmo_eval/common/execution/environment.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
@@ -37,6 +38,23 @@ class ExecutionEnvironment(Protocol):
 
     async def execute_code(
         self, code: str, language: str = "python", timeout: float | None = None
+    ) -> ExecutionResult: ...
+
+
+@runtime_checkable
+class StagingExecutionEnvironment(ExecutionEnvironment, Protocol):
+    """Execution environment that can place files before running a command.
+
+    Command text reaches the container as a process argument, which the
+    operating system caps at a small size. Payloads too large for that limit
+    are staged as files instead, in the same environment the command runs in.
+    """
+
+    async def execute_with_files(
+        self,
+        command: str,
+        files: Mapping[str, str],
+        timeout: float | None = None,
     ) -> ExecutionResult: ...
 
 

--- a/src/olmo_eval/common/scorers/code_execution/scripts/__init__.py
+++ b/src/olmo_eval/common/scorers/code_execution/scripts/__init__.py
@@ -1,0 +1,19 @@
+"""Python programs that are staged into a sandbox and run there.
+
+These are loaded as text rather than imported: they execute inside the
+container, against its interpreter, not in the harness process.
+"""
+
+from importlib import resources
+
+
+def get_script(name: str) -> str:
+    """Load a sandbox script by name.
+
+    Args:
+        name: Script name without the .py extension (e.g., "livecodebench_grader").
+
+    Returns:
+        The script source as a string.
+    """
+    return resources.files(__package__).joinpath(f"{name}.py").read_text()

--- a/src/olmo_eval/common/scorers/code_execution/scripts/livecodebench_grader.py
+++ b/src/olmo_eval/common/scorers/code_execution/scripts/livecodebench_grader.py
@@ -1,0 +1,403 @@
+"""Grade one LiveCodeBench solution against a problem's test cases.
+
+Runs inside a sandbox, not in the harness process. Reads ``problem.json`` and
+``solution.py`` from its own directory and prints a single JSON verdict to
+stdout.
+
+Problems come in two shapes. A problem with a function name expects the
+solution to define that function (on a ``Solution`` class for LeetCode
+problems); its inputs and outputs are JSON values compared directly. A problem
+without one is a whole program: inputs are fed to stdin and the captured
+stdout is compared line by line, falling back to decimal comparison so that
+numerically equal output is not rejected over formatting.
+
+Ported from the reference implementation:
+https://github.com/LiveCodeBench/LiveCodeBench/blob/main/lcb_runner/evaluation/testing_util.py
+"""
+
+import ast
+import base64
+import faulthandler
+import json
+import os
+import pickle
+import signal
+import sys
+import time
+import zlib
+from decimal import Decimal
+from io import StringIO
+from types import ModuleType
+from typing import Any
+from unittest.mock import mock_open, patch
+
+# Prelude the reference harness prepends to every solution, so that solutions
+# relying on names from a bare `from x import *` still resolve.
+IMPORT_PRELUDE = (
+    "from string import *\nfrom re import *\nfrom datetime import *\n"
+    "from collections import *\nfrom heapq import *\nfrom bisect import *\n"
+    "from copy import *\nfrom math import *\nfrom random import *\n"
+    "from statistics import *\nfrom itertools import *\nfrom functools import *\n"
+    "from operator import *\nfrom io import *\nfrom sys import *\nfrom json import *\n"
+    "from builtins import *\nfrom typing import *\nimport string\nimport re\n"
+    "import datetime\nimport collections\nimport heapq\nimport bisect\nimport copy\n"
+    "import math\nimport random\nimport statistics\nimport itertools\n"
+    "import functools\nimport operator\nimport io\nimport sys\nimport json\n"
+    "sys.setrecursionlimit(50000)\n"
+)
+
+
+class TimeoutException(Exception):
+    """Raised by the alarm handler when a test case runs too long."""
+
+
+def timeout_handler(signum, frame):
+    raise TimeoutException
+
+
+class Capturing(list):
+    """Collect everything a block writes to stdout."""
+
+    def __enter__(self):
+        self._stdout = sys.stdout
+        sys.stdout = self._stringio = StringIO()
+        return self
+
+    def __exit__(self, *args):
+        self.append(self._stringio.getvalue())
+        del self._stringio
+        sys.stdout = self._stdout
+
+
+class MockBuffer:
+    """Byte-oriented view of the stdin stand-in."""
+
+    def __init__(self, inputs):
+        self.lines = inputs.split("\n")
+        self.index = 0
+
+    def read(self, *args):
+        return "\n".join(self.lines).encode()
+
+    def readline(self, *args):
+        if self.index >= len(self.lines):
+            return b""
+        line = self.lines[self.index]
+        self.index += 1
+        return (line + "\n").encode()
+
+
+class MockStdin:
+    """Stand-in for sys.stdin that also exposes a .buffer."""
+
+    def __init__(self, inputs):
+        self.stringio = StringIO(inputs)
+        self.buffer = MockBuffer(inputs)
+
+    def read(self, *args):
+        return self.stringio.read()
+
+    def readline(self, *args):
+        return self.stringio.readline()
+
+    def readlines(self, *args):
+        return self.stringio.readlines()
+
+    def __getattr__(self, name):
+        return getattr(self.stringio, name)
+
+
+def clean_if_name(code):
+    """Drop an ``if __name__ == '__main__'`` guard, keeping its body."""
+    try:
+        tree = ast.parse(code)
+        last_block = tree.body[-1]
+        if isinstance(last_block, ast.If):
+            condition = last_block.test
+            if ast.unparse(condition).strip() == "__name__ == '__main__'":
+                code = ast.unparse(tree.body[:-1]) + "\n" + ast.unparse(last_block.body)
+    except Exception:
+        pass
+    return code
+
+
+def make_function(code):
+    """Wrap a whole program in a function so it can be called per test case."""
+    try:
+        imports = []
+        body = []
+        tree = ast.parse(code)
+        for stmt in tree.body:
+            if isinstance(stmt, (ast.Import, ast.ImportFrom)):
+                imports.append(stmt)
+            else:
+                body.append(stmt)
+
+        wrapper = ast.parse("def wrapped_function():\n    pass\n")
+        function = wrapper.body[0]
+        if not isinstance(function, ast.FunctionDef):
+            return code
+        function.body = body or [ast.Pass()]
+        ast.fix_missing_locations(wrapper)
+
+        import_source = "\n".join(ast.unparse(stmt) for stmt in imports)
+        return IMPORT_PRELUDE + "\n" + import_source + "\n" + ast.unparse(wrapper)
+    except Exception:
+        return code
+
+
+def call_method(method, inputs):
+    """Call a wrapped program with `inputs` standing in for stdin."""
+    if isinstance(inputs, list):
+        inputs = "\n".join(inputs)
+
+    line_iterator = iter(inputs.split("\n"))
+    mock_stdin = MockStdin(inputs)
+
+    @patch("builtins.open", mock_open(read_data=inputs))
+    @patch("sys.stdin", mock_stdin)
+    @patch("sys.stdin.readline", lambda *args: next(line_iterator))
+    @patch("sys.stdin.readlines", lambda *args: inputs.split("\n"))
+    @patch("sys.stdin.read", lambda *args: inputs)
+    def _inner(_method):
+        try:
+            return _method()
+        except SystemExit:
+            pass
+
+    return _inner(method)
+
+
+class CompilationError(Exception):
+    """Raised when a solution's module body will not execute."""
+
+
+def compile_code(code, timeout):
+    """Execute a solution's module body and return the object to call into."""
+    signal.alarm(timeout)
+    try:
+        module = ModuleType("tmp_sol", "")
+        exec(code, module.__dict__)
+        # LeetCode problems wrap their answer in a Solution class; everything
+        # else exposes the function at module level.
+        if "class Solution" in code:
+            return module.Solution()
+        return module
+    except Exception as exc:
+        # A solution that does not compile is a failed solution, reported the
+        # same way as one whose entry point is missing.
+        raise CompilationError(repr(exc)) from exc
+    finally:
+        signal.alarm(0)
+
+
+def get_stripped_lines(value):
+    return [line.strip() for line in value.strip().split("\n")]
+
+
+def convert_line_to_decimals(line):
+    try:
+        return True, [Decimal(element) for element in line.split()]
+    except Exception:
+        return False, []
+
+
+def grade_call_based(code, inputs, outputs, fn_name, timeout):
+    """Grade a solution by calling `fn_name` with each test case's arguments."""
+    code = IMPORT_PRELUDE + "\n\n" + code
+    compiled = compile_code(code, timeout)
+    method = getattr(compiled, fn_name, None)
+    if method is None:
+        return False, {"error_code": -4, "error_message": "Function not found in generated code"}
+
+    parsed_inputs = [[json.loads(line) for line in case.split("\n")] for case in inputs]
+    parsed_outputs = [json.loads(case) for case in outputs]
+
+    for gt_input, gt_output in zip(parsed_inputs, parsed_outputs, strict=False):
+        signal.alarm(timeout)
+        faulthandler.enable()
+        try:
+            prediction = method(*gt_input)
+            signal.alarm(0)
+
+            # Tuples and lists are not distinguished: ground truth is never a tuple.
+            if isinstance(prediction, tuple):
+                prediction = list(prediction)
+
+            if prediction != gt_output:
+                return False, {"error_code": -2, "error_message": "Wrong Answer"}
+        except Exception as exc:
+            if "timeoutexception" in repr(exc).lower():
+                return False, {"error_code": -3, "error_message": "Time Limit Exceeded"}
+            return False, {"error_code": -4, "error_message": f"Runtime Error: {exc!r}"}
+        finally:
+            signal.alarm(0)
+            faulthandler.disable()
+
+    return True, {}
+
+
+def grade_stdio(code, inputs, outputs, timeout):
+    """Grade a whole-program solution by feeding stdin and reading stdout."""
+    code = make_function(clean_if_name(code))
+    compiled = compile_code(code, timeout)
+    method = getattr(compiled, "wrapped_function", None)
+    if method is None:
+        return False, {"error_code": -4, "error_message": "Function not found in generated code"}
+
+    for gt_input, gt_output in zip(inputs, outputs, strict=False):
+        signal.alarm(timeout)
+        faulthandler.enable()
+        with Capturing() as captured:
+            try:
+                call_method(method, gt_input)
+                signal.alarm(0)
+            except Exception as exc:
+                if "timeoutexception" in repr(exc).lower():
+                    return False, {"error_code": -3, "error_message": "Time Limit Exceeded"}
+                return False, {"error_code": -4, "error_message": f"Runtime Error: {exc!r}"}
+            finally:
+                signal.alarm(0)
+                faulthandler.disable()
+
+        prediction_lines = get_stripped_lines(captured[0])
+        expected_lines = get_stripped_lines(gt_output)
+
+        if len(prediction_lines) != len(expected_lines):
+            return False, {
+                "error_code": -2,
+                "error_message": "Wrong answer: mismatched output length",
+            }
+
+        for idx, (predicted, expected) in enumerate(
+            zip(prediction_lines, expected_lines, strict=True)
+        ):
+            if predicted == expected:
+                continue
+            # Compare numerically before rejecting: Decimal avoids the false
+            # equalities that float comparison would introduce on large values.
+            ok_prediction, decimal_prediction = convert_line_to_decimals(predicted)
+            ok_expected, decimal_expected = convert_line_to_decimals(expected)
+            if ok_prediction and ok_expected and decimal_prediction == decimal_expected:
+                continue
+            return False, {
+                "error_code": -2,
+                "error_message": f"Wrong answer at line {idx}",
+            }
+
+    return True, {}
+
+
+def decode_test_cases(encoded):
+    """Decode a test case blob, which may be JSON or compressed pickle."""
+    if not encoded:
+        return []
+    try:
+        return json.loads(encoded)
+    except json.JSONDecodeError:
+        try:
+            return json.loads(
+                pickle.loads(zlib.decompress(base64.b64decode(encoded.encode("utf-8"))))
+            )
+        except Exception:
+            return []
+
+
+def reliability_guard():
+    """Disable calls that would let a solution damage the run.
+
+    This is defence in depth for accidental damage inside an already isolated
+    container, not a security boundary.
+    """
+    import builtins
+    import shutil
+    import subprocess
+
+    faulthandler.disable()
+
+    # Disabling a name means replacing it with None, which is by definition
+    # not what its declared type allows.
+    untyped_builtins: Any = builtins
+    untyped_builtins.exit = None
+    untyped_builtins.quit = None
+
+    os.environ["OMP_NUM_THREADS"] = "1"
+
+    for module, name in (
+        (os, "kill"),
+        (os, "system"),
+        (os, "remove"),
+        (os, "removedirs"),
+        (os, "rmdir"),
+        (os, "fchdir"),
+        (os, "chdir"),
+        (os, "setuid"),
+        (os, "fork"),
+        (os, "forkpty"),
+        (os, "killpg"),
+        (os, "rename"),
+        (os, "renames"),
+        (os, "truncate"),
+        (os, "unlink"),
+        (os, "fchmod"),
+        (os, "fchown"),
+        (os, "chmod"),
+        (os, "chown"),
+        (os, "chroot"),
+        (shutil, "rmtree"),
+        (shutil, "move"),
+        (shutil, "chown"),
+        (subprocess, "Popen"),
+    ):
+        if hasattr(module, name):
+            setattr(module, name, None)
+
+    loaded_modules: Any = sys.modules
+    for blocked in ("ipdb", "joblib", "resource", "psutil", "tkinter"):
+        loaded_modules[blocked] = None
+
+
+def main():
+    here = os.path.dirname(os.path.abspath(__file__))
+    with open(os.path.join(here, "problem.json")) as handle:
+        problem = json.load(handle)
+    with open(os.path.join(here, "solution.py")) as handle:
+        solution = handle.read()
+
+    test_cases = decode_test_cases(problem["public_test_cases"]) + decode_test_cases(
+        problem["private_test_cases"]
+    )
+    inputs = [case["input"] for case in test_cases]
+    outputs = [case["output"] for case in test_cases]
+    fn_name = problem.get("fn_name")
+    timeout = int(problem.get("timeout", 6))
+
+    signal.signal(signal.SIGALRM, timeout_handler)
+    reliability_guard()
+
+    started = time.time()
+    try:
+        if fn_name:
+            passed, detail = grade_call_based(solution, inputs, outputs, fn_name, timeout)
+        else:
+            passed, detail = grade_stdio(solution, inputs, outputs, timeout)
+    except CompilationError as exc:
+        passed, detail = False, {"error_code": -4, "error_message": f"Compilation error: {exc}"}
+    except TimeoutException:
+        passed, detail = False, {"error_code": -3, "error_message": "Time Limit Exceeded"}
+    except Exception as exc:
+        passed, detail = False, {"error_code": -5, "error_message": f"TestRunnerError: {exc!r}"}
+
+    verdict = {
+        "passed": passed,
+        "num_tests": len(inputs),
+        "elapsed": round(time.time() - started, 3),
+    }
+    verdict.update(detail)
+    # The harness reads the last line of stdout; solutions print freely above it.
+    sys.stdout = sys.__stdout__
+    print(json.dumps(verdict))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/olmo_eval/data/backends/huggingface.py
+++ b/src/olmo_eval/data/backends/huggingface.py
@@ -48,7 +48,11 @@ class HuggingFaceBackend:
 
         kwargs: dict[str, Any] = {}
         if source.data_files is not None:
-            kwargs["data_files"] = source.data_files
+            kwargs["data_files"] = (
+                list(source.data_files)
+                if isinstance(source.data_files, tuple)
+                else source.data_files
+            )
         if source.revision is not None:
             kwargs["revision"] = source.revision
 
@@ -87,21 +91,27 @@ class HuggingFaceBackend:
         from datasets import load_dataset
         from huggingface_hub import HfApi
 
-        api = HfApi(token=token)
-        repo_files = api.list_repo_files(path, repo_type="dataset")
+        declared = kwargs.get("data_files")
+        if declared is not None:
+            # An explicit file list names the split exactly; subset matching
+            # would silently widen it to every data file in the repository.
+            candidates = [declared] if isinstance(declared, str) else list(declared)
+        else:
+            api = HfApi(token=token)
+            repo_files = api.list_repo_files(path, repo_type="dataset")
 
-        # Find data files matching the subset name
-        subset = source.subset or ""
-        candidates = [
-            f
-            for f in repo_files
-            if subset in f and f.rsplit(".", 1)[-1] in ("jsonl", "json", "parquet", "csv")
-        ]
-        if not candidates:
-            raise FileNotFoundError(
-                f"No data files matching subset '{subset}' in {path}. "
-                f"This dataset has a legacy loading script that is no longer supported."
-            )
+            # Find data files matching the subset name
+            subset = source.subset or ""
+            candidates = [
+                f
+                for f in repo_files
+                if subset in f and f.rsplit(".", 1)[-1] in ("jsonl", "json", "parquet", "csv")
+            ]
+            if not candidates:
+                raise FileNotFoundError(
+                    f"No data files matching subset '{subset}' in {path}. "
+                    f"This dataset has a legacy loading script that is no longer supported."
+                )
 
         ext = candidates[0].rsplit(".", 1)[-1]
         module = "json" if ext in ("json", "jsonl") else ext

--- a/src/olmo_eval/data/sources.py
+++ b/src/olmo_eval/data/sources.py
@@ -40,7 +40,9 @@ class DataSource:
     subset: str | None = None
     split: str = "test"
     source_type: SourceType | None = None
-    data_files: str | None = None
+    #: Data file(s) to load, relative to the repository root. A tuple selects
+    #: several files that together form one split.
+    data_files: str | tuple[str, ...] | None = None
     revision: str | None = None
 
     def __post_init__(self) -> None:
@@ -157,6 +159,8 @@ class DataSource:
             "subset": self.subset,
             "split": self.split,
             "source_type": self.source_type.value if self.source_type else None,
-            "data_files": self.data_files,
+            "data_files": list(self.data_files)
+            if isinstance(self.data_files, tuple)
+            else self.data_files,
             "revision": self.revision,
         }

--- a/src/olmo_eval/evals/tasks/livecodebench.py
+++ b/src/olmo_eval/evals/tasks/livecodebench.py
@@ -1,0 +1,357 @@
+"""LiveCodeBench code generation task.
+
+LiveCodeBench collects programming contest problems tagged by contest date, so
+a model can be scored on problems published after its training data was
+collected. Solutions are graded by running them against the contest's own test
+cases inside a sandbox.
+
+Paper: https://arxiv.org/abs/2403.07974
+Dataset: livecodebench/code_generation_lite
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import shlex
+import uuid
+from collections.abc import Iterator
+from dataclasses import dataclass, replace
+from functools import lru_cache
+from typing import TYPE_CHECKING, Any
+
+from olmo_eval.common.execution.environment import StagingExecutionEnvironment
+from olmo_eval.common.formatters import ChatFormatter
+from olmo_eval.common.metrics import PassAtKMetric
+from olmo_eval.common.scorers import ExecutionScorer, SandboxRequiredError
+from olmo_eval.common.scorers.code_execution.scripts import get_script
+from olmo_eval.common.types import (
+    Instance,
+    LMOutput,
+    LMRequest,
+    SamplingParams,
+    Split,
+)
+from olmo_eval.data import DataSource
+from olmo_eval.evals.extract import extract_code
+from olmo_eval.evals.tasks.common import Task, register, register_variant
+
+if TYPE_CHECKING:
+    from olmo_eval.common.execution import ExecutionEnvironment
+
+logger = logging.getLogger(__name__)
+
+LIVECODEBENCH_REPO = "livecodebench/code_generation_lite"
+
+# Each release adds one data file; a window of files is one contest date range.
+RELEASE_V3_FILES: tuple[str, ...] = ("test.jsonl", "test2.jsonl", "test3.jsonl")
+RELEASE_V4_V6_FILES: tuple[str, ...] = ("test4.jsonl", "test5.jsonl", "test6.jsonl")
+
+SYSTEM_PROMPT = (
+    "You are an expert Python programmer. You will be given a question (problem "
+    "specification) and will generate a correct Python program that matches the "
+    "specification and passes all tests."
+)
+
+# The reasoning line sits between the problem statement and the per-problem
+# format instruction, so both parts are substituted here rather than folded
+# into the instance question.
+USER_TEMPLATE = (
+    "### Question:\n{question}\n\n"
+    "### Format:\n{reasoning_instruction}{format_instruction}\n\n"
+    "### Answer: (use the provided format with backticks)\n\n"
+)
+
+THINK_INSTRUCTION = (
+    "Provide CONCISE reasoning on how to arrive at the answer in the <think> </think> tag.\n"
+)
+
+STARTER_CODE_INSTRUCTION = (
+    "You will use the following starter code to write the solution to the problem "
+    "and enclose your code within delimiters."
+)
+
+STDIN_INSTRUCTION = (
+    "Read the inputs from stdin solve the problem and write the answer to stdout "
+    "(do not directly test on the sample inputs). Enclose your code within delimiters "
+    "as follows. Ensure that when the python program runs, it reads the inputs, runs "
+    "the algorithm and writes output to STDOUT.\n```python\n# YOUR CODE HERE\n```"
+)
+
+
+@lru_cache(maxsize=4)
+def _test_case_rows(repo: str, files: tuple[str, ...]) -> Any:
+    """Open a release's data files for random access by row.
+
+    Test payloads run to gigabytes per release, so they are read here when a
+    solution is graded rather than carried on every instance, which would put
+    them in the request records written for the run.
+    """
+    from datasets import load_dataset
+
+    return load_dataset(
+        "json",
+        data_files={"train": [f"hf://datasets/{repo}/{name}" for name in files]},
+        split="train",
+    )
+
+
+def _parse_verdict(output: str) -> dict[str, Any] | None:
+    """Read the grader's JSON verdict, which is the last line it prints."""
+    for line in reversed((output or "").strip().splitlines()):
+        line = line.strip()
+        if line.startswith("{") and line.endswith("}"):
+            try:
+                return json.loads(line)
+            except json.JSONDecodeError:
+                continue
+    return None
+
+
+@dataclass(slots=True)
+class LiveCodeBenchFormatter(ChatFormatter):
+    """Chat formatter that fills in each problem's answer format instruction.
+
+    Whether the model is asked to reason in ``<think>`` tags is part of the
+    prompt, so regimes that differ only in that line differ only by formatter.
+    """
+
+    reasoning_instruction: str = ""
+
+    def format(
+        self,
+        instance: Instance,
+        fewshot: list[Instance] | None = None,
+    ) -> LMRequest:
+        content = USER_TEMPLATE.format(
+            question=instance.question,
+            reasoning_instruction=self.reasoning_instruction,
+            format_instruction=instance.metadata.get("format_instruction", ""),
+        )
+        messages: list[dict[str, str]] = []
+        if self.system_prompt:
+            messages.append({"role": "system", "content": self.system_prompt})
+        messages.append({"role": "user", "content": content})
+        return LMRequest(
+            request_type=self.request_type,
+            messages=tuple(messages),
+            system_prompt=self.system_prompt or None,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class LiveCodeBenchScorer(ExecutionScorer):
+    """Run one solution against a problem's contest test cases in a sandbox.
+
+    The test cases are staged as a file rather than passed in the command,
+    because a single problem's cases can run to tens of megabytes and command
+    text is bounded by the operating system's argument size limit.
+    """
+
+    name: str = "code_exec"
+    #: Per test case, matching the reference harness.
+    timeout: float = 6.0
+    #: Ceiling for one solution across all of its test cases. Grading stops at
+    #: the first failure, so only a solution that passes runs the full set.
+    overall_timeout: float = 900.0
+    max_output_len: int = 4000
+
+    async def ascore(
+        self,
+        instance: Instance,
+        output: LMOutput,
+        execution_env: ExecutionEnvironment,
+    ) -> float:
+        if output.extracted_answer is None:
+            output.metadata["execution_result"] = {"success": False, "error": "No extracted answer"}
+            return 0.0
+
+        if not isinstance(execution_env, StagingExecutionEnvironment):
+            raise SandboxRequiredError(
+                f"{type(self).__name__} needs an execution environment that can stage "
+                "files; LiveCodeBench test cases are too large to pass as a command."
+            )
+
+        metadata = instance.metadata
+        row = _test_case_rows(metadata["test_repo"], tuple(metadata["test_files"]))[metadata["row"]]
+        if row["question_id"] != metadata["id"]:
+            # Grading against another problem's tests would score every
+            # solution wrong while still looking like a plausible result.
+            raise RuntimeError(
+                f"Test cases for problem {metadata['id']} are not at row "
+                f"{metadata['row']}; the dataset's row order changed."
+            )
+        problem = {
+            "public_test_cases": row["public_test_cases"],
+            "private_test_cases": row["private_test_cases"],
+            "fn_name": metadata.get("fn_name"),
+            "timeout": self.timeout,
+        }
+
+        work_dir = f"/tmp/lcb-{uuid.uuid4().hex}"
+        quoted = shlex.quote(work_dir)
+        result = await execution_env.execute_with_files(
+            f"cd {quoted} && python3 grade.py; status=$?; rm -rf {quoted}; exit $status",
+            {
+                f"{work_dir}/grade.py": get_script("livecodebench_grader"),
+                f"{work_dir}/problem.json": json.dumps(problem),
+                f"{work_dir}/solution.py": output.extracted_answer,
+            },
+            timeout=self.overall_timeout,
+        )
+
+        verdict = _parse_verdict(result.output)
+        passed = bool(verdict and verdict.get("passed"))
+        output.metadata["execution_result"] = {
+            "success": passed,
+            "exit_code": result.exit_code,
+            "error": result.error or (verdict or {}).get("error_message", ""),
+            "output": result.output[: self.max_output_len] if result.output else "",
+        }
+        if verdict is None:
+            logger.warning(
+                "No grader verdict for instance %s: %s",
+                metadata.get("id", "?"),
+                (result.error or result.output or "")[:200],
+            )
+        return 1.0 if passed else 0.0
+
+
+PASS_AT_KS = (1, 5, 10)
+METRICS = tuple(PassAtKMetric(k=k, scorer=LiveCodeBenchScorer) for k in PASS_AT_KS)
+PASS_AT_1 = PassAtKMetric(k=1, scorer=LiveCodeBenchScorer)
+
+THINK_FORMATTER = LiveCodeBenchFormatter(
+    system_prompt=SYSTEM_PROMPT,
+    reasoning_instruction=THINK_INSTRUCTION,
+)
+PLAIN_FORMATTER = LiveCodeBenchFormatter(system_prompt=SYSTEM_PROMPT)
+
+# Defaults mirror oe-eval's ``livecodebench_codegeneration::olmo3:adapt``, the
+# OLMo 3 post-training regime. max_tokens=None generates to the model's context
+# limit, matching the reference regime's effective behavior on any context size.
+ADAPT_SAMPLING = SamplingParams(
+    max_tokens=None,
+    temperature=0.6,
+    top_p=0.95,
+    num_samples=10,
+)
+
+
+@register("livecodebench")
+class LiveCodeBench(Task):
+    """LiveCodeBench release_v3: contests through the v3 cutoff (612 problems)."""
+
+    release_files: tuple[str, ...] = RELEASE_V3_FILES
+
+    data_source = DataSource(
+        path=LIVECODEBENCH_REPO,
+        data_files=RELEASE_V3_FILES,
+        split="train",
+    )
+    split = Split.TRAIN
+    formatter = THINK_FORMATTER
+    metrics = METRICS
+    primary_metric = PASS_AT_1
+    sampling_params = ADAPT_SAMPLING
+    # Test execution is slow and long-tailed; keep a share of shared sandbox
+    # pools comparable to the other heavyweight code tasks.
+    sandbox_allocation_weight = 6.0
+
+    @property
+    def instances(self) -> Iterator[Instance]:
+        yield from self._load_instances_cached()
+
+    def process_doc(self, doc: dict[str, Any], index: int = 0) -> Instance:
+        starter_code = (doc.get("starter_code") or "").strip()
+        if starter_code:
+            format_instruction = (
+                f"{STARTER_CODE_INSTRUCTION}\n```python\n{doc['starter_code']}\n```"
+            )
+        else:
+            format_instruction = STDIN_INSTRUCTION
+
+        problem_metadata = json.loads(doc["metadata"]) if doc.get("metadata") else {}
+        contest_date = doc.get("contest_date", "unknown")
+        if hasattr(contest_date, "isoformat"):
+            contest_date = contest_date.isoformat()
+
+        return Instance(
+            question=doc["question_content"],
+            metadata={
+                "id": doc["question_id"],
+                # Located by row so the scorer can read this problem's test
+                # cases without them travelling on the instance.
+                "row": index,
+                "test_repo": LIVECODEBENCH_REPO,
+                "test_files": self.release_files,
+                "format_instruction": format_instruction,
+                "fn_name": problem_metadata.get("func_name"),
+                "platform": doc.get("platform", "unknown"),
+                "difficulty": doc.get("difficulty", "unknown"),
+                "contest_date": contest_date,
+            },
+        )
+
+    def format_request(self, instance: Instance) -> LMRequest:
+        assert self.config.formatter is not None
+        return self.config.formatter.format(instance, self.get_fewshot())
+
+    def extract_answer(self, output: LMOutput) -> str | None:
+        return extract_code(output.text)
+
+
+@register("livecodebench_hidden")
+class LiveCodeBenchHidden(LiveCodeBench):
+    """LiveCodeBench v4-v6: contests after the v3 cutoff (443 problems).
+
+    Held out from the main task so that problems postdating a model's training
+    data can be scored separately.
+    """
+
+    release_files: tuple[str, ...] = RELEASE_V4_V6_FILES
+
+    data_source = DataSource(
+        path=LIVECODEBENCH_REPO,
+        data_files=RELEASE_V4_V6_FILES,
+        split="train",
+    )
+
+
+for _task_name in ("livecodebench", "livecodebench_hidden"):
+    # Mirrors oe-eval's ``::tulu``: no reasoning instruction, shorter budget.
+    register_variant(
+        _task_name,
+        "tulu",
+        formatter=PLAIN_FORMATTER,
+        sampling_params=SamplingParams(
+            max_tokens=2048,
+            temperature=0.2,
+            top_p=0.95,
+            num_samples=10,
+        ),
+    )
+
+    # Mirrors oe-eval's ``::tulu-thinker_deepseek_lite``: the default regime
+    # scored on a single sample, for cheaper iteration.
+    register_variant(
+        _task_name,
+        "lite",
+        metrics=(PASS_AT_1,),
+        primary_metric=PASS_AT_1,
+        sampling_params=replace(ADAPT_SAMPLING, num_samples=1),
+    )
+
+    # Mirrors oe-eval's ``:grpo::tulu-thinker``, used for RL runs.
+    register_variant(
+        _task_name,
+        "grpo",
+        metrics=tuple(PassAtKMetric(k=k, scorer=LiveCodeBenchScorer) for k in (1, 2, 4, 8, 10)),
+        primary_metric=PassAtKMetric(k=10, scorer=LiveCodeBenchScorer),
+        sampling_params=SamplingParams(
+            max_tokens=16384,
+            temperature=1.0,
+            top_p=1.0,
+            num_samples=10,
+        ),
+    )

--- a/src/olmo_eval/harness/sandbox/executor.py
+++ b/src/olmo_eval/harness/sandbox/executor.py
@@ -11,7 +11,7 @@ import os
 import random
 import time
 import uuid
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass
 from typing import Any, TypeVar
 
@@ -796,6 +796,30 @@ class SandboxExecutor:
             stderr=response.stderr or "",
             exit_code=response.exit_code,
         )
+
+    async def write_files(self, files: Mapping[str, str]) -> None:
+        """Write files into the sandbox filesystem.
+
+        Contents travel in the request body rather than in a command argument,
+        so they are not bounded by the operating system's argument size limit.
+
+        Args:
+            files: Mapping of absolute sandbox path to file content.
+
+        Raises:
+            RuntimeError: If the sandbox is not started.
+        """
+        if self._runtime is None:
+            raise RuntimeError("Sandbox not started. Call start() first or use async context.")
+
+        from swerex.runtime.abstract import WriteFileRequest
+
+        for path, content in files.items():
+            request = WriteFileRequest(path=path, content=content)
+            await self._run_with_transport_retries(
+                lambda request=request: self._runtime.write_file(request),
+                operation="file write",
+            )
 
     async def execute_code(
         self,

--- a/src/olmo_eval/harness/sandbox/manager.py
+++ b/src/olmo_eval/harness/sandbox/manager.py
@@ -8,7 +8,7 @@ import concurrent.futures
 import contextlib
 import time
 import uuid
-from collections.abc import AsyncIterator, Awaitable, Callable, Sequence
+from collections.abc import AsyncIterator, Awaitable, Callable, Mapping, Sequence
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from typing import TypeVar
@@ -99,6 +99,20 @@ class CapabilityExecutionEnvironment:
         return await self.manager.execute_code(
             code,
             language,
+            timeout,
+            capabilities=self.capabilities,
+            failover_on_quarantine=True,
+        )
+
+    async def execute_with_files(
+        self,
+        command: str,
+        files: Mapping[str, str],
+        timeout: float | None = None,
+    ) -> ExecutionResult:
+        return await self.manager.execute_with_files(
+            command,
+            files,
             timeout,
             capabilities=self.capabilities,
             failover_on_quarantine=True,
@@ -528,6 +542,41 @@ class SandboxManager:
         return await self._execute_with_lease(
             required,
             lambda executor: executor.execute_code(code, language, timeout),
+            failover_on_quarantine=failover_on_quarantine,
+        )
+
+    async def execute_with_files(
+        self,
+        command: str,
+        files: Mapping[str, str],
+        timeout: float | None = None,
+        capabilities: frozenset[str] | None = None,
+        *,
+        failover_on_quarantine: bool = False,
+    ) -> ExecutionResult:
+        """Stage files and run a command against them on one executor.
+
+        Both steps hold the same lease, so the command sees the files that
+        were written for it rather than the contents of another executor.
+
+        Args:
+            command: The command to execute once the files are in place.
+            files: Mapping of absolute sandbox path to file content.
+            timeout: Optional timeout override in seconds.
+            capabilities: Optional required capabilities. If None, uses default.
+
+        Returns:
+            ExecutionResult with success status, output, and exit code.
+        """
+        required = capabilities or Capability.DEFAULT
+
+        async def stage_and_execute(executor: SandboxExecutor) -> ExecutionResult:
+            await executor.write_files(files)
+            return await executor.execute_command(command, timeout)
+
+        return await self._execute_with_lease(
+            required,
+            stage_and_execute,
             failover_on_quarantine=failover_on_quarantine,
         )
 

--- a/tests/core/harness/test_sandbox_file_staging.py
+++ b/tests/core/harness/test_sandbox_file_staging.py
@@ -1,0 +1,102 @@
+"""Tests for staging files into a sandbox before running a command."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Mapping
+
+import pytest
+
+from olmo_eval.common.execution import ExecutionResult
+from olmo_eval.harness.sandbox import Capability, SandboxConfig, SandboxManager, SandboxMode
+
+
+class _StagingExecutor:
+    """Executor that records the files written to it and the commands it ran."""
+
+    def __init__(self, name: str, *, max_concurrency: int = 2) -> None:
+        self.name = name
+        self.config = SandboxConfig(
+            image="test",
+            mode=SandboxMode.MODAL,
+            capabilities=Capability.DEFAULT,
+            max_concurrency=max_concurrency,
+        )
+        self.running = True
+        self.files: dict[str, str] = {}
+        self.commands: list[str] = []
+        #: Files present when each command ran, to catch a command that
+        #: executes somewhere its files were never written.
+        self.files_at_command: list[set[str]] = []
+
+    @property
+    def is_running(self) -> bool:
+        return self.running
+
+    async def write_files(self, files: Mapping[str, str]) -> None:
+        await asyncio.sleep(0.01)
+        self.files.update(files)
+
+    async def execute_command(self, command: str, timeout: float | None = None) -> ExecutionResult:
+        del timeout
+        self.commands.append(command)
+        self.files_at_command.append(set(self.files))
+        return ExecutionResult(success=True, output='{"passed": true}')
+
+
+def _manager(*executors: _StagingExecutor) -> SandboxManager:
+    manager = SandboxManager([])
+    manager._executors = list(executors)  # type: ignore[assignment]
+    manager._active_operations = {id(executor): 0 for executor in executors}
+    return manager
+
+
+@pytest.mark.anyio
+async def test_files_are_written_before_the_command_runs() -> None:
+    executor = _StagingExecutor("sb-0")
+    manager = _manager(executor)
+
+    result = await manager.execute_with_files(
+        "python3 grade.py",
+        {"/tmp/work/grade.py": "print(1)", "/tmp/work/problem.json": "{}"},
+    )
+
+    assert result.success
+    assert executor.commands == ["python3 grade.py"]
+    assert executor.files_at_command == [{"/tmp/work/grade.py", "/tmp/work/problem.json"}]
+
+
+@pytest.mark.anyio
+async def test_command_runs_on_the_executor_that_received_the_files() -> None:
+    first = _StagingExecutor("sb-0")
+    second = _StagingExecutor("sb-1")
+    manager = _manager(first, second)
+
+    # Enough concurrent calls to spread across both executors.
+    await asyncio.gather(
+        *(
+            manager.execute_with_files(
+                f"python3 grade.py {index}",
+                {f"/tmp/work-{index}/solution.py": f"# {index}"},
+            )
+            for index in range(6)
+        )
+    )
+
+    assert first.commands and second.commands, "expected work on both executors"
+    for executor in (first, second):
+        for command, staged in zip(executor.commands, executor.files_at_command, strict=True):
+            index = command.rsplit(" ", 1)[-1]
+            assert f"/tmp/work-{index}/solution.py" in staged
+
+
+@pytest.mark.anyio
+async def test_staging_respects_executor_capacity() -> None:
+    executor = _StagingExecutor("sb-0", max_concurrency=1)
+    manager = _manager(executor)
+
+    await asyncio.gather(
+        *(manager.execute_with_files(f"cmd {index}", {f"/tmp/{index}": "x"}) for index in range(4))
+    )
+
+    assert len(executor.commands) == 4

--- a/tests/data/test_hub_file_selection.py
+++ b/tests/data/test_hub_file_selection.py
@@ -1,0 +1,138 @@
+"""Tests for data file selection when a repository has a legacy loading script.
+
+`datasets` refuses to run legacy loading scripts, so the HuggingFace backend
+falls back to reading the repository's data files directly. That fallback has
+to load the files the caller asked for.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from olmo_eval.data import DataSource
+from olmo_eval.data.backends.huggingface import HuggingFaceBackend
+
+
+class _RecordingLoader:
+    """Stands in for `datasets.load_dataset`, recording how it was called."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def __call__(self, path: str, **kwargs: Any) -> list[dict[str, str]]:
+        self.calls.append({"path": path, **kwargs})
+        return [{"doc": "loaded"}]
+
+
+@pytest.fixture
+def recording_loader(monkeypatch: pytest.MonkeyPatch) -> _RecordingLoader:
+    import datasets
+
+    loader = _RecordingLoader()
+    monkeypatch.setattr(datasets, "load_dataset", loader)
+    return loader
+
+
+def _all_repo_files(monkeypatch: pytest.MonkeyPatch, files: list[str]) -> None:
+    """Make the Hub report `files` as the repository's contents."""
+    import huggingface_hub
+
+    class _StubApi:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+        def list_repo_files(self, path: str, repo_type: str = "dataset") -> list[str]:
+            del path, repo_type
+            return files
+
+    monkeypatch.setattr(huggingface_hub, "HfApi", _StubApi)
+
+
+def test_declared_data_files_are_the_only_ones_loaded(
+    recording_loader: _RecordingLoader,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The repository holds six data files; the caller asked for three of them.
+    _all_repo_files(
+        monkeypatch,
+        ["test.jsonl", "test2.jsonl", "test3.jsonl", "test4.jsonl", "test5.jsonl", "test6.jsonl"],
+    )
+    source = DataSource(
+        path="org/scripted-repo",
+        data_files=("test.jsonl", "test2.jsonl", "test3.jsonl"),
+        split="train",
+    )
+
+    HuggingFaceBackend._load_from_hub_files(
+        "org/scripted-repo",
+        source,
+        streaming=False,
+        token=None,
+        data_files=["test.jsonl", "test2.jsonl", "test3.jsonl"],
+    )
+
+    assert recording_loader.calls[0]["data_files"] == {
+        "train": [
+            "hf://datasets/org/scripted-repo/test.jsonl",
+            "hf://datasets/org/scripted-repo/test2.jsonl",
+            "hf://datasets/org/scripted-repo/test3.jsonl",
+        ]
+    }
+
+
+def test_a_single_declared_data_file_is_not_widened(
+    recording_loader: _RecordingLoader,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Without a subset, substring matching accepts every file in the repository.
+    _all_repo_files(monkeypatch, ["test.jsonl", "test2.jsonl", "test3.jsonl"])
+    source = DataSource(path="org/scripted-repo", data_files="test.jsonl", split="train")
+
+    HuggingFaceBackend._load_from_hub_files(
+        "org/scripted-repo",
+        source,
+        streaming=False,
+        token=None,
+        data_files="test.jsonl",
+    )
+
+    assert recording_loader.calls[0]["data_files"] == {
+        "train": ["hf://datasets/org/scripted-repo/test.jsonl"]
+    }
+
+
+def test_subset_matching_still_applies_without_declared_files(
+    recording_loader: _RecordingLoader,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _all_repo_files(monkeypatch, ["math/test.jsonl", "biology/test.jsonl", "README.md"])
+    source = DataSource(path="org/scripted-repo", subset="math", split="test")
+
+    HuggingFaceBackend._load_from_hub_files(
+        "org/scripted-repo",
+        source,
+        streaming=False,
+        token=None,
+    )
+
+    assert recording_loader.calls[0]["data_files"] == {
+        "test": ["hf://datasets/org/scripted-repo/math/test.jsonl"]
+    }
+
+
+def test_missing_subset_files_raise(
+    recording_loader: _RecordingLoader,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _all_repo_files(monkeypatch, ["math/test.jsonl"])
+    source = DataSource(path="org/scripted-repo", subset="chemistry", split="test")
+
+    with pytest.raises(FileNotFoundError):
+        HuggingFaceBackend._load_from_hub_files(
+            "org/scripted-repo",
+            source,
+            streaming=False,
+            token=None,
+        )

--- a/tests/data/test_sources.py
+++ b/tests/data/test_sources.py
@@ -119,3 +119,24 @@ class TestDataSourceMethods:
         source = DataSource(path="cais/mmlu", subset="math")
         new_source = source.with_subset(None)
         assert new_source.subset is None
+
+
+class TestDataSourceDataFiles:
+    """Tests for selecting specific data files."""
+
+    def test_multiple_data_files_survive_split_and_subset_changes(self):
+        source = DataSource(path="org/repo", data_files=("a.jsonl", "b.jsonl"))
+        assert source.with_split("train").data_files == ("a.jsonl", "b.jsonl")
+        assert source.with_subset("other").data_files == ("a.jsonl", "b.jsonl")
+
+    def test_multiple_data_files_serialize_as_a_list(self):
+        source = DataSource(path="org/repo", data_files=("a.jsonl", "b.jsonl"))
+        assert source.to_dict()["data_files"] == ["a.jsonl", "b.jsonl"]
+
+    def test_single_data_file_serializes_unchanged(self):
+        source = DataSource(path="org/repo", data_files="a.jsonl")
+        assert source.to_dict()["data_files"] == "a.jsonl"
+
+    def test_source_with_multiple_data_files_is_hashable(self):
+        source = DataSource(path="org/repo", data_files=("a.jsonl", "b.jsonl"))
+        assert hash(source) == hash(DataSource(path="org/repo", data_files=("a.jsonl", "b.jsonl")))

--- a/tests/evals/tasks/test_livecodebench.py
+++ b/tests/evals/tasks/test_livecodebench.py
@@ -1,0 +1,475 @@
+"""Tests for the LiveCodeBench task, its prompts, and its grader."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from collections.abc import Mapping
+from typing import Any
+
+import pytest
+
+from olmo_eval.common.execution import ExecutionResult
+from olmo_eval.common.scorers import SandboxRequiredError
+from olmo_eval.common.scorers.code_execution.scripts import get_script
+from olmo_eval.common.types import Instance, LMOutput, RequestType
+from olmo_eval.evals.tasks.common import get_task
+from olmo_eval.evals.tasks.livecodebench import (
+    RELEASE_V3_FILES,
+    RELEASE_V4_V6_FILES,
+    SYSTEM_PROMPT,
+    LiveCodeBenchScorer,
+)
+
+STDIN_DOC = {
+    "question_id": "abc123_a",
+    "question_content": "Print the sum of two integers.",
+    "starter_code": "",
+    "metadata": "{}",
+    "platform": "atcoder",
+    "difficulty": "easy",
+    "contest_date": "2024-01-01T00:00:00",
+    "public_test_cases": "[]",
+    "private_test_cases": "[]",
+}
+
+STARTER_DOC = {
+    **STDIN_DOC,
+    "question_id": "2727",
+    "starter_code": (
+        "class Solution:\n    def countSeniors(self, details: List[str]) -> int:\n        "
+    ),
+    "metadata": json.dumps({"func_name": "countSeniors"}),
+    "platform": "leetcode",
+}
+
+
+# ---------------------------------------------------------------------------
+# Instances and prompts
+# ---------------------------------------------------------------------------
+
+
+def test_stdin_problem_asks_for_a_whole_program() -> None:
+    task = get_task("livecodebench")
+    instance = task.process_doc(STDIN_DOC, index=7)
+
+    assert instance.question == "Print the sum of two integers."
+    assert instance.metadata["id"] == "abc123_a"
+    assert instance.metadata["fn_name"] is None
+    assert "reads the inputs" in instance.metadata["format_instruction"]
+
+
+def test_starter_code_problem_carries_its_function_name() -> None:
+    task = get_task("livecodebench")
+    instance = task.process_doc(STARTER_DOC, index=0)
+
+    assert instance.metadata["fn_name"] == "countSeniors"
+    assert "starter code" in instance.metadata["format_instruction"]
+    assert "def countSeniors" in instance.metadata["format_instruction"]
+
+
+def test_test_cases_are_referenced_not_carried() -> None:
+    # Payloads reach tens of megabytes per problem, and instance metadata is
+    # written into the run's request records.
+    task = get_task("livecodebench")
+    instance = task.process_doc(STDIN_DOC, index=7)
+
+    assert instance.metadata["row"] == 7
+    assert instance.metadata["test_files"] == RELEASE_V3_FILES
+    assert "public_test_cases" not in instance.metadata
+    assert "private_test_cases" not in instance.metadata
+
+
+def test_default_prompt_requests_reasoning_in_think_tags() -> None:
+    task = get_task("livecodebench")
+    request = task.format_request(task.process_doc(STDIN_DOC))
+
+    assert request.request_type == RequestType.CHAT
+    assert request.messages[0] == {"role": "system", "content": SYSTEM_PROMPT}
+    user = request.messages[1]["content"]
+    assert user.startswith("### Question:\nPrint the sum of two integers.\n\n### Format:\n")
+    assert "<think> </think> tag" in user
+    assert user.endswith("### Answer: (use the provided format with backticks)\n\n")
+
+
+def test_tulu_variant_drops_the_reasoning_line() -> None:
+    task = get_task("livecodebench:tulu")
+    user = task.format_request(task.process_doc(STDIN_DOC)).messages[1]["content"]
+
+    assert "<think>" not in user
+    assert user.startswith(
+        "### Question:\nPrint the sum of two integers.\n\n### Format:\nRead the inputs from stdin"
+    )
+
+
+def test_answer_extraction_ignores_a_reasoning_block() -> None:
+    task = get_task("livecodebench")
+    output = LMOutput(text="<think>plan</think>\n```python\nprint(1)\n```")
+
+    assert task.extract_answer(output) == "print(1)\n"
+
+
+# ---------------------------------------------------------------------------
+# Releases and variants
+# ---------------------------------------------------------------------------
+
+
+def test_releases_select_different_contest_windows() -> None:
+    assert get_task("livecodebench").config.data_source.data_files == RELEASE_V3_FILES
+    assert get_task("livecodebench_hidden").config.data_source.data_files == RELEASE_V4_V6_FILES
+    assert not set(RELEASE_V3_FILES) & set(RELEASE_V4_V6_FILES)
+
+
+def test_default_regime_samples_ten_completions() -> None:
+    config = get_task("livecodebench").config
+
+    assert config.sampling_params is not None
+    assert config.sampling_params.num_samples == 10
+    assert config.sampling_params.temperature == pytest.approx(0.6)
+    assert config.sampling_params.top_p == pytest.approx(0.95)
+    # Generation is bounded by the model's context, not a fixed budget.
+    assert config.sampling_params.max_tokens is None
+    assert [metric.name for metric in config.metrics] == ["pass_at_1", "pass_at_5", "pass_at_10"]
+    assert config.primary_metric is not None
+    assert config.primary_metric.name == "pass_at_1"
+
+
+def test_lite_variant_scores_a_single_sample() -> None:
+    config = get_task("livecodebench:lite").config
+
+    assert config.sampling_params is not None
+    assert config.sampling_params.num_samples == 1
+    assert config.sampling_params.temperature == pytest.approx(0.6)
+    assert [metric.name for metric in config.metrics] == ["pass_at_1"]
+
+
+def test_grpo_variant_reports_pass_at_10() -> None:
+    config = get_task("livecodebench:grpo").config
+
+    assert config.sampling_params is not None
+    assert config.sampling_params.temperature == pytest.approx(1.0)
+    assert config.sampling_params.top_p == pytest.approx(1.0)
+    assert config.sampling_params.max_tokens == 16384
+    assert config.primary_metric is not None
+    assert config.primary_metric.name == "pass_at_10"
+
+
+def test_variants_are_registered_for_both_releases() -> None:
+    for variant in ("tulu", "lite", "grpo"):
+        assert get_task(f"livecodebench_hidden:{variant}") is not None
+
+
+# ---------------------------------------------------------------------------
+# Scorer
+# ---------------------------------------------------------------------------
+
+
+class _StubStagingEnv:
+    """Execution environment that records staged files and returns a verdict."""
+
+    def __init__(self, output: str = '{"passed": true}', success: bool = True) -> None:
+        self.output = output
+        self.success = success
+        self.staged: dict[str, str] = {}
+        self.commands: list[str] = []
+
+    @property
+    def is_running(self) -> bool:
+        return True
+
+    async def execute(self, command: str, timeout: float | None = None) -> str:
+        return ""
+
+    async def execute_command(self, command: str, timeout: float | None = None) -> ExecutionResult:
+        return ExecutionResult(success=self.success, output=self.output)
+
+    async def execute_code(
+        self, code: str, language: str = "python", timeout: float | None = None
+    ) -> ExecutionResult:
+        return ExecutionResult(success=self.success, output=self.output)
+
+    async def execute_with_files(
+        self, command: str, files: Mapping[str, str], timeout: float | None = None
+    ) -> ExecutionResult:
+        self.commands.append(command)
+        self.staged.update(files)
+        return ExecutionResult(success=self.success, output=self.output)
+
+
+class _NonStagingEnv:
+    """Execution environment that cannot stage files."""
+
+    @property
+    def is_running(self) -> bool:
+        return True
+
+    async def execute(self, command: str, timeout: float | None = None) -> str:
+        return ""
+
+    async def execute_command(self, command: str, timeout: float | None = None) -> ExecutionResult:
+        return ExecutionResult(success=True)
+
+    async def execute_code(
+        self, code: str, language: str = "python", timeout: float | None = None
+    ) -> ExecutionResult:
+        return ExecutionResult(success=True)
+
+
+def _instance() -> Instance:
+    return Instance(
+        question="Print the sum.",
+        metadata={
+            "id": "abc123_a",
+            "row": 3,
+            "test_repo": "org/repo",
+            "test_files": RELEASE_V3_FILES,
+            "fn_name": None,
+        },
+    )
+
+
+@pytest.fixture
+def stub_rows(monkeypatch: pytest.MonkeyPatch) -> None:
+    rows = [
+        {"question_id": f"q{index}", "public_test_cases": "[]", "private_test_cases": ""}
+        for index in range(4)
+    ]
+    rows[3] = {
+        "question_id": "abc123_a",
+        "public_test_cases": '[{"input": "1", "output": "1"}]',
+        "private_test_cases": "",
+    }
+
+    def fake_rows(repo: str, files: tuple[str, ...]) -> Any:
+        del repo, files
+        return rows
+
+    monkeypatch.setattr(
+        "olmo_eval.evals.tasks.livecodebench._test_case_rows",
+        fake_rows,
+    )
+
+
+@pytest.mark.anyio
+class TestLiveCodeBenchScorer:
+    async def test_stages_grader_problem_and_solution(self, stub_rows: None) -> None:
+        scorer = LiveCodeBenchScorer()
+        env = _StubStagingEnv()
+        output = LMOutput(text="unused")
+        output.extracted_answer = "print(1)"
+
+        score = await scorer.ascore(_instance(), output, env)
+
+        assert score == 1.0
+        staged = sorted(os.path.basename(path) for path in env.staged)
+        assert staged == ["grade.py", "problem.json", "solution.py"]
+
+        work_dirs = {os.path.dirname(path) for path in env.staged}
+        assert len(work_dirs) == 1, "all files belong to one working directory"
+        work_dir = work_dirs.pop()
+        assert work_dir in env.commands[0]
+
+        problem = json.loads(env.staged[f"{work_dir}/problem.json"])
+        assert problem["public_test_cases"] == '[{"input": "1", "output": "1"}]'
+        assert problem["timeout"] == scorer.timeout
+        assert env.staged[f"{work_dir}/solution.py"] == "print(1)"
+
+    async def test_working_directory_is_cleaned_up(self, stub_rows: None) -> None:
+        scorer = LiveCodeBenchScorer()
+        env = _StubStagingEnv()
+        output = LMOutput(text="unused")
+        output.extracted_answer = "print(1)"
+
+        await scorer.ascore(_instance(), output, env)
+
+        assert "rm -rf" in env.commands[0]
+
+    async def test_failing_verdict_scores_zero(self, stub_rows: None) -> None:
+        scorer = LiveCodeBenchScorer()
+        env = _StubStagingEnv(
+            output='{"passed": false, "error_code": -2, "error_message": "Wrong Answer"}'
+        )
+        output = LMOutput(text="unused")
+        output.extracted_answer = "print(2)"
+
+        score = await scorer.ascore(_instance(), output, env)
+
+        assert score == 0.0
+        assert output.metadata["execution_result"]["error"] == "Wrong Answer"
+
+    async def test_unparseable_output_scores_zero(self, stub_rows: None) -> None:
+        scorer = LiveCodeBenchScorer()
+        env = _StubStagingEnv(output="container died", success=False)
+        output = LMOutput(text="unused")
+        output.extracted_answer = "print(1)"
+
+        assert await scorer.ascore(_instance(), output, env) == 0.0
+        assert output.metadata["execution_result"]["success"] is False
+
+    async def test_missing_answer_scores_zero_without_executing(self) -> None:
+        scorer = LiveCodeBenchScorer()
+        env = _StubStagingEnv()
+        output = LMOutput(text="no code here")
+
+        assert await scorer.ascore(_instance(), output, env) == 0.0
+        assert env.commands == []
+
+    async def test_environment_without_staging_is_rejected(self, stub_rows: None) -> None:
+        scorer = LiveCodeBenchScorer()
+        output = LMOutput(text="unused")
+        output.extracted_answer = "print(1)"
+
+        with pytest.raises(SandboxRequiredError):
+            await scorer.ascore(_instance(), output, _NonStagingEnv())
+
+    async def test_row_pointing_at_another_problem_is_rejected(self, stub_rows: None) -> None:
+        # Silent misalignment would grade every solution against the wrong tests.
+        scorer = LiveCodeBenchScorer()
+        instance = _instance()
+        instance.metadata["row"] = 1
+        output = LMOutput(text="unused")
+        output.extracted_answer = "print(1)"
+
+        with pytest.raises(RuntimeError, match="row order changed"):
+            await scorer.ascore(instance, output, _StubStagingEnv())
+
+
+# ---------------------------------------------------------------------------
+# Grader
+# ---------------------------------------------------------------------------
+
+
+def _grade(
+    solution: str,
+    tests: list[dict[str, str]],
+    fn_name: str | None = None,
+    timeout: int = 5,
+) -> dict[str, Any]:
+    """Run the container-side grader the way the sandbox would."""
+    with tempfile.TemporaryDirectory() as work_dir:
+        with open(os.path.join(work_dir, "grade.py"), "w") as handle:
+            handle.write(get_script("livecodebench_grader"))
+        with open(os.path.join(work_dir, "problem.json"), "w") as handle:
+            json.dump(
+                {
+                    "public_test_cases": json.dumps(tests),
+                    "private_test_cases": "",
+                    "fn_name": fn_name,
+                    "timeout": timeout,
+                },
+                handle,
+            )
+        with open(os.path.join(work_dir, "solution.py"), "w") as handle:
+            handle.write(solution)
+
+        process = subprocess.run(
+            [sys.executable, "grade.py"],
+            cwd=work_dir,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+
+    verdicts = [line for line in process.stdout.strip().splitlines() if line.startswith("{")]
+    return json.loads(verdicts[-1])
+
+
+SUM_TESTS = [
+    {"input": "1 2\n", "output": "3\n"},
+    {"input": "10 20\n", "output": "30\n"},
+]
+
+
+class TestGraderStdinMode:
+    def test_correct_program_passes(self) -> None:
+        solution = "a, b = map(int, input().split())\nprint(a + b)\n"
+        assert _grade(solution, SUM_TESTS)["passed"] is True
+
+    def test_wrong_program_fails(self) -> None:
+        verdict = _grade("a, b = map(int, input().split())\nprint(a - b)\n", SUM_TESTS)
+        assert verdict["passed"] is False
+        assert verdict["error_code"] == -2
+
+    def test_main_guard_is_unwrapped(self) -> None:
+        solution = (
+            "def main():\n"
+            "    a, b = map(int, input().split())\n"
+            "    print(a + b)\n"
+            "if __name__ == '__main__':\n"
+            "    main()\n"
+        )
+        assert _grade(solution, SUM_TESTS)["passed"] is True
+
+    def test_extra_output_line_fails(self) -> None:
+        solution = "a, b = map(int, input().split())\nprint(a + b)\nprint('done')\n"
+        verdict = _grade(solution, SUM_TESTS)
+        assert verdict["passed"] is False
+        assert "length" in verdict["error_message"]
+
+    def test_numerically_equal_output_passes(self) -> None:
+        # Formatting differences must not fail an otherwise correct answer.
+        tests = [{"input": "1\n", "output": "1.50\n"}]
+        assert _grade("input()\nprint(1.5)\n", tests)["passed"] is True
+
+    def test_runtime_error_fails(self) -> None:
+        verdict = _grade("raise ValueError('boom')\n", SUM_TESTS)
+        assert verdict["passed"] is False
+        assert verdict["error_code"] == -4
+
+    def test_endless_loop_times_out(self) -> None:
+        verdict = _grade("while True:\n    pass\n", SUM_TESTS, timeout=2)
+        assert verdict["passed"] is False
+        assert verdict["error_code"] == -3
+
+    def test_syntax_error_is_reported_as_a_compilation_failure(self) -> None:
+        verdict = _grade("  this is not python\n", SUM_TESTS)
+        assert verdict["passed"] is False
+        assert verdict["error_code"] == -4
+        assert "Compilation error" in verdict["error_message"]
+
+
+DOUBLE_TESTS = [
+    {"input": "[1, 2, 3]", "output": "[2, 4, 6]"},
+    {"input": "[]", "output": "[]"},
+]
+
+
+class TestGraderCallMode:
+    def test_correct_solution_class_passes(self) -> None:
+        solution = (
+            "class Solution:\n"
+            "    def double(self, nums: List[int]) -> List[int]:\n"
+            "        return [n * 2 for n in nums]\n"
+        )
+        assert _grade(solution, DOUBLE_TESTS, fn_name="double")["passed"] is True
+
+    def test_wrong_solution_fails(self) -> None:
+        solution = (
+            "class Solution:\n"
+            "    def double(self, nums: List[int]) -> List[int]:\n"
+            "        return nums\n"
+        )
+        verdict = _grade(solution, DOUBLE_TESTS, fn_name="double")
+        assert verdict["passed"] is False
+        assert verdict["error_code"] == -2
+
+    def test_tuple_result_is_accepted(self) -> None:
+        # Ground truth is never a tuple, so a tuple answer is not a mismatch.
+        solution = (
+            "class Solution:\n"
+            "    def double(self, nums: List[int]) -> List[int]:\n"
+            "        return tuple(n * 2 for n in nums)\n"
+        )
+        assert _grade(solution, DOUBLE_TESTS, fn_name="double")["passed"] is True
+
+    def test_missing_function_fails(self) -> None:
+        verdict = _grade("class Solution:\n    pass\n", DOUBLE_TESTS, fn_name="double")
+        assert verdict["passed"] is False
+        assert verdict["error_code"] == -4
+
+    def test_module_level_function_is_found(self) -> None:
+        solution = "def double(nums):\n    return [n * 2 for n in nums]\n"
+        assert _grade(solution, DOUBLE_TESTS, fn_name="double")["passed"] is True

--- a/tests/integration/test_livecodebench_sandbox.py
+++ b/tests/integration/test_livecodebench_sandbox.py
@@ -1,0 +1,180 @@
+"""Integration test for LiveCodeBench grading in a real sandbox.
+
+Requires Docker and the LiveCodeBench dataset. Test cases are staged into the
+container as files, which is the part that cannot be exercised with a stub:
+the payload is far too large to pass in a command, so nothing about this path
+is covered by the unit tests.
+
+    pytest tests/integration/test_livecodebench_sandbox.py -v
+"""
+
+from __future__ import annotations
+
+import subprocess
+from collections.abc import AsyncIterator
+
+import pytest
+
+from olmo_eval.common.types import Instance, LMOutput
+from olmo_eval.evals.tasks.common import get_task
+from olmo_eval.evals.tasks.livecodebench import RELEASE_V3_FILES, LiveCodeBenchScorer
+from olmo_eval.harness.sandbox import Capability, SandboxConfig, SandboxManager, SandboxMode
+
+pytestmark = pytest.mark.integration
+
+SANDBOX_IMAGE = "ghcr.io/astral-sh/uv:python3.12-bookworm-slim"
+
+# A whole-program problem: stdin in, stdout compared line by line.
+STDIN_PROBLEM_ID = "1873_B"
+STDIN_SOLUTION = """
+import sys
+
+def main():
+    data = sys.stdin.read().split()
+    t = int(data[0])
+    idx = 1
+    out = []
+    for _ in range(t):
+        n = int(data[idx])
+        idx += 1
+        digits = [int(x) for x in data[idx : idx + n]]
+        idx += n
+        best = 0
+        for i in range(n):
+            product = 1
+            for j in range(n):
+                product *= digits[j] + (1 if i == j else 0)
+            best = max(best, product)
+        out.append(str(best))
+    print("\\n".join(out))
+
+main()
+"""
+
+# A call-based problem: the named function is invoked with parsed arguments.
+CALL_PROBLEM_FN = "countSeniors"
+CALL_SOLUTION = """
+class Solution:
+    def countSeniors(self, details: List[str]) -> int:
+        return sum(1 for d in details if int(d[11:13]) > 60)
+"""
+
+
+def _docker_available() -> bool:
+    try:
+        result = subprocess.run(
+            ["docker", "version", "--format", "{{.Server.Version}}"],
+            capture_output=True,
+            timeout=15,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return result.returncode == 0
+
+
+@pytest.fixture(scope="module")
+def livecodebench_instances() -> dict[str, Instance]:
+    """Real instances, keyed by problem id."""
+    task = get_task("livecodebench")
+    return {instance.metadata["id"]: instance for instance in task.instances}
+
+
+@pytest.fixture
+async def sandbox() -> AsyncIterator[object]:
+    """A single running sandbox with swe-rex injected into the image."""
+    if not _docker_available():
+        pytest.skip("Docker is not available")
+
+    manager = SandboxManager(
+        [
+            SandboxConfig(
+                image=SANDBOX_IMAGE,
+                mode=SandboxMode.DOCKER,
+                container_runtime="docker",
+                instances=1,
+                startup_timeout=900.0,
+                command_timeout=900.0,
+                inject_swerex=True,
+            )
+        ],
+        owner="livecodebench-test",
+    )
+    await manager.start()
+    try:
+        yield manager.for_capabilities(Capability.DEFAULT)
+    finally:
+        await manager.stop()
+
+
+def _call_based_instance(instances: dict[str, Instance]) -> Instance:
+    for instance in instances.values():
+        if instance.metadata.get("fn_name") == CALL_PROBLEM_FN:
+            return instance
+    pytest.skip(f"No problem with function {CALL_PROBLEM_FN} in this release")
+
+
+async def _score(scorer: LiveCodeBenchScorer, instance: Instance, code: str, sandbox) -> float:
+    output = LMOutput(text="unused")
+    output.extracted_answer = code
+    return await scorer.ascore(instance, output, sandbox)
+
+
+@pytest.mark.anyio
+async def test_correct_stdin_solution_passes(
+    sandbox, livecodebench_instances: dict[str, Instance]
+) -> None:
+    instance = livecodebench_instances[STDIN_PROBLEM_ID]
+    assert instance.metadata["fn_name"] is None
+
+    score = await _score(LiveCodeBenchScorer(), instance, STDIN_SOLUTION, sandbox)
+
+    assert score == 1.0
+
+
+@pytest.mark.anyio
+async def test_wrong_stdin_solution_fails(
+    sandbox, livecodebench_instances: dict[str, Instance]
+) -> None:
+    instance = livecodebench_instances[STDIN_PROBLEM_ID]
+    wrong = STDIN_SOLUTION.replace("best = max(best, product)", "best = max(best, product + 1)")
+
+    score = await _score(LiveCodeBenchScorer(), instance, wrong, sandbox)
+
+    assert score == 0.0
+
+
+@pytest.mark.anyio
+async def test_correct_call_based_solution_passes(
+    sandbox, livecodebench_instances: dict[str, Instance]
+) -> None:
+    instance = _call_based_instance(livecodebench_instances)
+
+    score = await _score(LiveCodeBenchScorer(), instance, CALL_SOLUTION, sandbox)
+
+    assert score == 1.0
+
+
+@pytest.mark.anyio
+async def test_private_test_cases_reach_the_container(
+    sandbox, livecodebench_instances: dict[str, Instance]
+) -> None:
+    """The staged payload must be the problem's full case list, not just public ones."""
+    instance = livecodebench_instances[STDIN_PROBLEM_ID]
+    output = LMOutput(text="unused")
+    output.extracted_answer = STDIN_SOLUTION
+
+    await LiveCodeBenchScorer().ascore(instance, output, sandbox)
+
+    result = output.metadata["execution_result"]
+    assert result["success"] is True
+    # The grader reports how many cases it ran; public cases alone are few.
+    assert '"num_tests"' in result["output"]
+
+
+@pytest.mark.anyio
+async def test_release_files_are_the_v3_window(
+    livecodebench_instances: dict[str, Instance],
+) -> None:
+    assert len(livecodebench_instances) == 612
+    instance = next(iter(livecodebench_instances.values()))
+    assert tuple(instance.metadata["test_files"]) == RELEASE_V3_FILES


### PR DESCRIPTION
Ports LiveCodeBench from [oe-eval](https://github.com/allenai/oe-eval). Contest problems are tagged by contest date, so a model can be scored on problems published after its training data was collected, and solutions are graded by running them against the contest's own test cases.

Third in a stack — contains #349 (sandbox file staging) and #350 (data file selection), both of which this depends on. **Review those first;** the LiveCodeBench-specific change is the last commit.

## Tasks and variants

| spec | mirrors oe-eval |
|---|---|
| `livecodebench` | `::olmo3:adapt` — think-tag prompt, temp 0.6, top_p 0.95, context-bounded generation, 10 samples, pass@1/5/10 |
| `livecodebench:tulu` | `::tulu` — no reasoning instruction, temp 0.2, 2048 tokens |
| `livecodebench:lite` | `..._lite` — single sample, pass@1, for cheap iteration |
| `livecodebench:grpo` | `:grpo::tulu-thinker` — temp 1.0, top_p 1.0, 16384 tokens, primary pass@10 |

`livecodebench` is release_v3 (612 problems); `livecodebench_hidden` is the v4–v6 window after the v3 cutoff (443 problems), registered separately so problems postdating a model's training data can be scored on their own. Both carry all four variants.

Left out: `::tulu-thinker` (temp 0.8, superseded by the deepseek regime) and `::olmo3:midtrain` (the base regime plus stop sequences). Easy to add if wanted. Nothing is taken from oe-eval-internal, which is deprecated and whose `no_think_tags` configs drop the system prompt in a way oe-eval's do not.

## What makes this task different

Its fixtures. HumanEval ships a few hundred bytes of assertions per problem; LiveCodeBench ships the contest's real input/output pairs. Measured across release_v3:

- median problem: tens of KB
- p90: **10–20MB**
- largest: **92MB** compressed, 199MB decoded
- release total: 2.6GB compressed

Neither oe-eval nor upstream caps them, and capping is not viable: even a 4MB budget truncates 26% of release_v3 problems, keeping a median of 43% of their tests, which would break comparability with published numbers.

Two consequences:

**They reach the container as staged files** rather than in the command string — the capability added in #349.

**They are kept off the instances.** `build_requests` splats `instance.metadata` into the run's request records, so carrying payloads there would write gigabytes per run. Instances carry a dataset row reference and the scorer reads the payload when it grades.

That row reference is an implicit coupling, so the scorer refuses to grade a row whose `question_id` does not match the instance. Grading against another problem's tests would score every solution wrong while still producing a plausible-looking number. Alignment was checked across both releases: 612 and 443 instances, all unique ids, zero mismatches.

## Grading

A port of the reference harness, staged into the container as a script, following the existing `harness/sandbox/scripts/` + `get_script()` pattern.

- **Call-based problems** (LeetCode) invoke a named function on a `Solution` instance and compare parsed values; a tuple result is not counted as a mismatch, since ground truth is never a tuple.
- **Whole-program problems** get stdin fed and stdout compared line by line, with a decimal fallback so numerically equal output is not failed over formatting. `if __name__ == '__main__'` guards are unwrapped so the program can be called per test case.
- Compile failures, missing entry points, wrong answers and timeouts are distinguished in the recorded error code. A solution that does not compile is a failed solution, not a failure of the grader.

## Verification

- **Prompts byte-identical to oe-eval** across 61 real problems (52 starter-code, 9 stdin) in both the thinking and non-thinking regimes, checked against an independently constructed copy of oe-eval's template.
- **Grader correct on real dataset problems** in both modes: correct solutions pass, wrong answers and missing functions fail with the right codes, `__main__` guards unwrap, infinite loops time out.
- **End to end in Docker** (mock model, `release_v3`): the grader ran in the container, decoded the compressed blobs there — reporting 14, 14 and 15 cases for the three problems, the real per-problem counts — and returned verdicts the scorer turned into pass@1.
- **Integration test** (`tests/integration/test_livecodebench_sandbox.py`, skipped without Docker) covers what stubs cannot: correct solutions to a whole-program and a call-based problem both score 1.0 through the real staging path, a wrong one scores 0.0.
- 31 unit tests for prompts, release selection, variants, the scorer, and the grader. Full suite: 2193 passed, 8 skipped.

## Still open

No real model has generated solutions yet — a short vLLM run would confirm the last mile and give a first pass@1 to compare against oe-eval's.

Unrelated, but noticed while testing: the `codex_python` harness preset cannot start locally. Its image has no `swerex-remote` and the preset sets neither `inject_swerex` nor a startup timeout above 60s, so all four instances fail. `codex_universal` sets both. I worked around it with an inline sandbox override rather than change the preset here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)