### PR TITLE
Let sandboxes receive files too large for a command

### DIFF
--- a/src/olmo_eval/common/execution/__init__.py
+++ b/src/olmo_eval/common/execution/__init__.py
@@ -1,6 +1,11 @@
 """Execution helpers for scoring and sandboxed code execution."""
 
-from .environment import ExecutionEnvironment, ExecutionResult, ScoringContext
+from .environment import (
+    ExecutionEnvironment,
+    ExecutionResult,
+    ScoringContext,
+    StagingExecutionEnvironment,
+)
 from .process_pool import (
     ProcessOutputScore,
     ProcessPoolManager,
@@ -20,6 +25,7 @@ __all__ = [
     "ProcessScoringPoolConfig",
     "ScoringContext",
     "SerializedProcessScorer",
+    "StagingExecutionEnvironment",
     "default_process_pool_workers",
     "serialize_process_scorer",
 ]

--- a/src/olmo_eval/common/execution/environment.py
+++ b/src/olmo_eval/common/execution/environment.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
@@ -37,6 +38,23 @@ class ExecutionEnvironment(Protocol):
 
     async def execute_code(
         self, code: str, language: str = "python", timeout: float | None = None
+    ) -> ExecutionResult: ...
+
+
+@runtime_checkable
+class StagingExecutionEnvironment(ExecutionEnvironment, Protocol):
+    """Execution environment that can place files before running a command.
+
+    Command text reaches the container as a process argument, which the
+    operating system caps at a small size. Payloads too large for that limit
+    are staged as files instead, in the same environment the command runs in.
+    """
+
+    async def execute_with_files(
+        self,
+        command: str,
+        files: Mapping[str, str],
+        timeout: float | None = None,
     ) -> ExecutionResult: ...
 
 

--- a/src/olmo_eval/harness/sandbox/executor.py
+++ b/src/olmo_eval/harness/sandbox/executor.py
@@ -11,7 +11,7 @@ import os
 import random
 import time
 import uuid
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass
 from typing import Any, TypeVar
 
@@ -796,6 +796,30 @@ class SandboxExecutor:
             stderr=response.stderr or "",
             exit_code=response.exit_code,
         )
+
+    async def write_files(self, files: Mapping[str, str]) -> None:
+        """Write files into the sandbox filesystem.
+
+        Contents travel in the request body rather than in a command argument,
+        so they are not bounded by the operating system's argument size limit.
+
+        Args:
+            files: Mapping of absolute sandbox path to file content.
+
+        Raises:
+            RuntimeError: If the sandbox is not started.
+        """
+        if self._runtime is None:
+            raise RuntimeError("Sandbox not started. Call start() first or use async context.")
+
+        from swerex.runtime.abstract import WriteFileRequest
+
+        for path, content in files.items():
+            request = WriteFileRequest(path=path, content=content)
+            await self._run_with_transport_retries(
+                lambda request=request: self._runtime.write_file(request),
+                operation="file write",
+            )
 
     async def execute_code(
         self,

--- a/src/olmo_eval/harness/sandbox/executor.py
+++ b/src/olmo_eval/harness/sandbox/executor.py
@@ -797,7 +797,7 @@ class SandboxExecutor:
             exit_code=response.exit_code,
         )
 
-    async def write_files(self, files: Mapping[str, str]) -> None:
+    async def write_files(self, files: Mapping[str, str], timeout: float | None = None) -> None:
         """Write files into the sandbox filesystem.
 
         Contents travel in the request body rather than in a command argument,
@@ -805,19 +805,32 @@ class SandboxExecutor:
 
         Args:
             files: Mapping of absolute sandbox path to file content.
+            timeout: Seconds allowed for each file, defaulting to the config's
+                command timeout. A write that exceeds it is retried like any
+                other transport failure, so a file can take up to the retry
+                budget times this value before the write is given up on.
 
         Raises:
             RuntimeError: If the sandbox is not started.
+            SandboxTransportError: If a write still fails after retries.
         """
         if self._runtime is None:
             raise RuntimeError("Sandbox not started. Call start() first or use async context.")
 
         from swerex.runtime.abstract import WriteFileRequest
 
+        effective_timeout = timeout if timeout is not None else self.config.command_timeout
+
         for path, content in files.items():
             request = WriteFileRequest(path=path, content=content)
             await self._run_with_transport_retries(
-                lambda request=request: self._runtime.write_file(request),
+                # The runtime's request carries no timeout of its own, so this
+                # bound is the only thing keeping a stalled upload from waiting
+                # on the HTTP client's default.
+                lambda request=request: asyncio.wait_for(
+                    self._runtime.write_file(request),
+                    timeout=effective_timeout,
+                ),
                 # Naming the path here puts it in the retry logs and in the
                 # error raised once retries are exhausted, so a failure points
                 # at the file rather than at file writing in general.

--- a/src/olmo_eval/harness/sandbox/executor.py
+++ b/src/olmo_eval/harness/sandbox/executor.py
@@ -818,7 +818,10 @@ class SandboxExecutor:
             request = WriteFileRequest(path=path, content=content)
             await self._run_with_transport_retries(
                 lambda request=request: self._runtime.write_file(request),
-                operation="file write",
+                # Naming the path here puts it in the retry logs and in the
+                # error raised once retries are exhausted, so a failure points
+                # at the file rather than at file writing in general.
+                operation=f"file write to {path}",
             )
 
     async def execute_code(

--- a/src/olmo_eval/harness/sandbox/manager.py
+++ b/src/olmo_eval/harness/sandbox/manager.py
@@ -562,7 +562,10 @@ class SandboxManager:
         Args:
             command: The command to execute once the files are in place.
             files: Mapping of absolute sandbox path to file content.
-            timeout: Optional timeout override in seconds.
+            timeout: Seconds allowed for each step, applied to every file
+                write and to the command separately rather than to the
+                operation as a whole. Defaults to the executor's command
+                timeout.
             capabilities: Optional required capabilities. If None, uses default.
 
         Returns:
@@ -571,7 +574,7 @@ class SandboxManager:
         required = capabilities or Capability.DEFAULT
 
         async def stage_and_execute(executor: SandboxExecutor) -> ExecutionResult:
-            await executor.write_files(files)
+            await executor.write_files(files, timeout)
             return await executor.execute_command(command, timeout)
 
         return await self._execute_with_lease(

--- a/src/olmo_eval/harness/sandbox/manager.py
+++ b/src/olmo_eval/harness/sandbox/manager.py
@@ -8,7 +8,7 @@ import concurrent.futures
 import contextlib
 import time
 import uuid
-from collections.abc import AsyncIterator, Awaitable, Callable, Sequence
+from collections.abc import AsyncIterator, Awaitable, Callable, Mapping, Sequence
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from typing import TypeVar
@@ -99,6 +99,20 @@ class CapabilityExecutionEnvironment:
         return await self.manager.execute_code(
             code,
             language,
+            timeout,
+            capabilities=self.capabilities,
+            failover_on_quarantine=True,
+        )
+
+    async def execute_with_files(
+        self,
+        command: str,
+        files: Mapping[str, str],
+        timeout: float | None = None,
+    ) -> ExecutionResult:
+        return await self.manager.execute_with_files(
+            command,
+            files,
             timeout,
             capabilities=self.capabilities,
             failover_on_quarantine=True,
@@ -528,6 +542,41 @@ class SandboxManager:
         return await self._execute_with_lease(
             required,
             lambda executor: executor.execute_code(code, language, timeout),
+            failover_on_quarantine=failover_on_quarantine,
+        )
+
+    async def execute_with_files(
+        self,
+        command: str,
+        files: Mapping[str, str],
+        timeout: float | None = None,
+        capabilities: frozenset[str] | None = None,
+        *,
+        failover_on_quarantine: bool = False,
+    ) -> ExecutionResult:
+        """Stage files and run a command against them on one executor.
+
+        Both steps hold the same lease, so the command sees the files that
+        were written for it rather than the contents of another executor.
+
+        Args:
+            command: The command to execute once the files are in place.
+            files: Mapping of absolute sandbox path to file content.
+            timeout: Optional timeout override in seconds.
+            capabilities: Optional required capabilities. If None, uses default.
+
+        Returns:
+            ExecutionResult with success status, output, and exit code.
+        """
+        required = capabilities or Capability.DEFAULT
+
+        async def stage_and_execute(executor: SandboxExecutor) -> ExecutionResult:
+            await executor.write_files(files)
+            return await executor.execute_command(command, timeout)
+
+        return await self._execute_with_lease(
+            required,
+            stage_and_execute,
             failover_on_quarantine=failover_on_quarantine,
         )
 

--- a/tests/core/harness/sandbox_stubs.py
+++ b/tests/core/harness/sandbox_stubs.py
@@ -1,0 +1,108 @@
+"""Stand-ins for sandbox executors, shared by the manager tests.
+
+A `TrackingExecutor` records what was asked of it and how much of it ran at
+once, so a test can assert routing, capacity and staging behavior without a
+container. `make_manager` wires executors into a `SandboxManager` the way
+`start()` would, without starting anything.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Mapping
+
+from olmo_eval.common.execution import ExecutionResult
+from olmo_eval.harness.sandbox import Capability, SandboxConfig, SandboxManager, SandboxMode
+from olmo_eval.harness.sandbox.errors import SandboxTransportError
+
+
+class TrackingExecutor:
+    """Executor stub that counts operations in flight and records requests."""
+
+    def __init__(
+        self,
+        name: str,
+        *,
+        capabilities: frozenset[str] = Capability.DEFAULT,
+        max_concurrency: int = 2,
+        fail_and_quarantine: bool = False,
+        fail_transport: bool = False,
+        output: str = "",
+    ) -> None:
+        self.name = name
+        self.config = SandboxConfig(
+            image="test",
+            mode=SandboxMode.MODAL,
+            capabilities=capabilities,
+            max_concurrency=max_concurrency,
+        )
+        self.running = True
+        self.fail_and_quarantine = fail_and_quarantine
+        self.fail_transport = fail_transport
+        self.output = output
+
+        #: Operations of any kind this executor has completed.
+        self.calls = 0
+        self.active = 0
+        #: Highest number of operations in flight at once. Every operation
+        #: counts, so a lease that bounds writing as well as executing shows
+        #: up here.
+        self.peak = 0
+
+        self.files: dict[str, str] = {}
+        self.commands: list[str] = []
+        #: Files present when each command ran, to catch a command that
+        #: executes somewhere its files were never written.
+        self.files_at_command: list[set[str]] = []
+        #: Timeout passed to each write, to check the caller's bound reaches
+        #: staging and not just the command.
+        self.write_timeouts: list[float | None] = []
+
+    @property
+    def is_running(self) -> bool:
+        return self.running
+
+    async def _run(self) -> None:
+        """Simulate one operation, honoring the configured failure mode."""
+        self.calls += 1
+        self.active += 1
+        self.peak = max(self.peak, self.active)
+        try:
+            await asyncio.sleep(0.01)
+            if self.fail_and_quarantine:
+                self.running = False
+                raise ConnectionResetError("sandbox disconnected")
+            if self.fail_transport:
+                raise SandboxTransportError("request retries exhausted")
+        finally:
+            self.active -= 1
+
+    async def execute_code(
+        self,
+        code: str,
+        language: str = "python",
+        timeout: float | None = None,
+    ) -> ExecutionResult:
+        del code, language, timeout
+        await self._run()
+        return ExecutionResult(success=True, output=self.output)
+
+    async def execute_command(self, command: str, timeout: float | None = None) -> ExecutionResult:
+        del timeout
+        await self._run()
+        self.commands.append(command)
+        self.files_at_command.append(set(self.files))
+        return ExecutionResult(success=True, output=self.output)
+
+    async def write_files(self, files: Mapping[str, str], timeout: float | None = None) -> None:
+        self.write_timeouts.append(timeout)
+        await self._run()
+        self.files.update(files)
+
+
+def make_manager(*executors: TrackingExecutor) -> SandboxManager:
+    """Return a manager over `executors` without starting any sandbox."""
+    manager = SandboxManager([])
+    manager._executors = list(executors)  # type: ignore[assignment]
+    manager._active_operations = {id(executor): 0 for executor in executors}
+    return manager

--- a/tests/core/harness/test_sandbox_file_staging.py
+++ b/tests/core/harness/test_sandbox_file_staging.py
@@ -3,73 +3,23 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Mapping
+import time
 
 import pytest
 
-from olmo_eval.common.execution import ExecutionResult
-from olmo_eval.harness.sandbox import Capability, SandboxConfig, SandboxManager, SandboxMode
+from olmo_eval.harness.sandbox import SandboxConfig, SandboxExecutor, SandboxMode
+from olmo_eval.harness.sandbox.errors import SandboxTransportError
+from tests.core.harness.sandbox_stubs import TrackingExecutor, make_manager
 
-
-class _StagingExecutor:
-    """Executor that records the files written to it and the commands it ran."""
-
-    def __init__(self, name: str, *, max_concurrency: int = 2) -> None:
-        self.name = name
-        self.config = SandboxConfig(
-            image="test",
-            mode=SandboxMode.MODAL,
-            capabilities=Capability.DEFAULT,
-            max_concurrency=max_concurrency,
-        )
-        self.running = True
-        self.files: dict[str, str] = {}
-        self.commands: list[str] = []
-        #: Files present when each command ran, to catch a command that
-        #: executes somewhere its files were never written.
-        self.files_at_command: list[set[str]] = []
-        self.active = 0
-        #: Highest number of staging operations in flight at once, to check
-        #: that a lease bounds writing as well as executing.
-        self.peak = 0
-
-    @property
-    def is_running(self) -> bool:
-        return self.running
-
-    async def write_files(self, files: Mapping[str, str]) -> None:
-        self.active += 1
-        self.peak = max(self.peak, self.active)
-        try:
-            await asyncio.sleep(0.01)
-            self.files.update(files)
-        finally:
-            self.active -= 1
-
-    async def execute_command(self, command: str, timeout: float | None = None) -> ExecutionResult:
-        del timeout
-        self.active += 1
-        self.peak = max(self.peak, self.active)
-        try:
-            await asyncio.sleep(0.01)
-            self.commands.append(command)
-            self.files_at_command.append(set(self.files))
-            return ExecutionResult(success=True, output='{"passed": true}')
-        finally:
-            self.active -= 1
-
-
-def _manager(*executors: _StagingExecutor) -> SandboxManager:
-    manager = SandboxManager([])
-    manager._executors = list(executors)  # type: ignore[assignment]
-    manager._active_operations = {id(executor): 0 for executor in executors}
-    return manager
+# ---------------------------------------------------------------------------
+# Staging through the manager
+# ---------------------------------------------------------------------------
 
 
 @pytest.mark.anyio
 async def test_files_are_written_before_the_command_runs() -> None:
-    executor = _StagingExecutor("sb-0")
-    manager = _manager(executor)
+    executor = TrackingExecutor("sb-0")
+    manager = make_manager(executor)
 
     result = await manager.execute_with_files(
         "python3 grade.py",
@@ -83,9 +33,9 @@ async def test_files_are_written_before_the_command_runs() -> None:
 
 @pytest.mark.anyio
 async def test_command_runs_on_the_executor_that_received_the_files() -> None:
-    first = _StagingExecutor("sb-0")
-    second = _StagingExecutor("sb-1")
-    manager = _manager(first, second)
+    first = TrackingExecutor("sb-0")
+    second = TrackingExecutor("sb-1")
+    manager = make_manager(first, second)
 
     # Enough concurrent calls to spread across both executors.
     await asyncio.gather(
@@ -107,8 +57,8 @@ async def test_command_runs_on_the_executor_that_received_the_files() -> None:
 
 @pytest.mark.anyio
 async def test_staging_respects_executor_capacity() -> None:
-    executor = _StagingExecutor("sb-0", max_concurrency=1)
-    manager = _manager(executor)
+    executor = TrackingExecutor("sb-0", max_concurrency=1)
+    manager = make_manager(executor)
 
     await asyncio.gather(
         *(manager.execute_with_files(f"cmd {index}", {f"/tmp/{index}": "x"}) for index in range(4))
@@ -122,8 +72,8 @@ async def test_staging_respects_executor_capacity() -> None:
 
 @pytest.mark.anyio
 async def test_staging_uses_every_slot_an_executor_allows() -> None:
-    executor = _StagingExecutor("sb-0", max_concurrency=3)
-    manager = _manager(executor)
+    executor = TrackingExecutor("sb-0", max_concurrency=3)
+    manager = make_manager(executor)
 
     await asyncio.gather(
         *(manager.execute_with_files(f"cmd {index}", {f"/tmp/{index}": "x"}) for index in range(6))
@@ -131,3 +81,84 @@ async def test_staging_uses_every_slot_an_executor_allows() -> None:
 
     assert len(executor.commands) == 6
     assert 1 < executor.peak <= 3
+
+
+@pytest.mark.anyio
+async def test_timeout_reaches_the_file_writes() -> None:
+    # The bound has to cover staging, not just the command that follows it.
+    executor = TrackingExecutor("sb-0")
+    manager = make_manager(executor)
+
+    await manager.execute_with_files("cmd", {"/tmp/a": "x"}, timeout=900)
+
+    assert executor.write_timeouts == [900]
+
+
+# ---------------------------------------------------------------------------
+# The write itself is bounded
+# ---------------------------------------------------------------------------
+
+
+class _HangingRuntime:
+    """Runtime whose file writes never complete on their own."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def write_file(self, request: object) -> None:
+        del request
+        self.calls += 1
+        await asyncio.sleep(3600)
+
+
+class _HealthyDeployment:
+    async def is_alive(self, *, timeout: float) -> bool:
+        del timeout
+        return True
+
+
+def _executor_with_hanging_writes(**config: object) -> tuple[SandboxExecutor, _HangingRuntime]:
+    executor = SandboxExecutor(
+        SandboxConfig(image="test", mode=SandboxMode.MODAL, **config),  # type: ignore[arg-type]
+        name="test-sandbox",
+    )
+    runtime = _HangingRuntime()
+    executor._runtime = runtime
+    executor._deployment = _HealthyDeployment()
+    return executor, runtime
+
+
+@pytest.fixture(autouse=True)
+def _no_retry_backoff(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Retry immediately so a timed-out write is re-attempted without waiting."""
+    monkeypatch.setattr(
+        "olmo_eval.harness.sandbox.executor._exponential_backoff",
+        lambda initial_delay, retry: 0.0,
+    )
+
+
+@pytest.mark.anyio
+async def test_a_stalled_write_is_given_up_on_within_the_timeout() -> None:
+    executor, runtime = _executor_with_hanging_writes()
+    started = time.monotonic()
+
+    with pytest.raises(SandboxTransportError, match="file write to /tmp/fixture.json"):
+        await executor.write_files({"/tmp/fixture.json": "x" * 1024}, timeout=0.05)
+
+    # Timed out on every attempt, then stopped, rather than waiting on the
+    # HTTP client's own default.
+    assert runtime.calls == 4
+    assert time.monotonic() - started < 2.0
+
+
+@pytest.mark.anyio
+async def test_writes_default_to_the_command_timeout() -> None:
+    # A caller that gives no timeout still gets a bound, the same one commands use.
+    executor, runtime = _executor_with_hanging_writes(command_timeout=0.05)
+    started = time.monotonic()
+
+    with pytest.raises(SandboxTransportError):
+        await executor.write_files({"/tmp/fixture.json": "x"})
+
+    assert runtime.calls == 4
+    assert time.monotonic() - started < 2.0

--- a/tests/core/harness/test_sandbox_file_staging.py
+++ b/tests/core/harness/test_sandbox_file_staging.py
@@ -28,20 +28,35 @@ class _StagingExecutor:
         #: Files present when each command ran, to catch a command that
         #: executes somewhere its files were never written.
         self.files_at_command: list[set[str]] = []
+        self.active = 0
+        #: Highest number of staging operations in flight at once, to check
+        #: that a lease bounds writing as well as executing.
+        self.peak = 0
 
     @property
     def is_running(self) -> bool:
         return self.running
 
     async def write_files(self, files: Mapping[str, str]) -> None:
-        await asyncio.sleep(0.01)
-        self.files.update(files)
+        self.active += 1
+        self.peak = max(self.peak, self.active)
+        try:
+            await asyncio.sleep(0.01)
+            self.files.update(files)
+        finally:
+            self.active -= 1
 
     async def execute_command(self, command: str, timeout: float | None = None) -> ExecutionResult:
         del timeout
-        self.commands.append(command)
-        self.files_at_command.append(set(self.files))
-        return ExecutionResult(success=True, output='{"passed": true}')
+        self.active += 1
+        self.peak = max(self.peak, self.active)
+        try:
+            await asyncio.sleep(0.01)
+            self.commands.append(command)
+            self.files_at_command.append(set(self.files))
+            return ExecutionResult(success=True, output='{"passed": true}')
+        finally:
+            self.active -= 1
 
 
 def _manager(*executors: _StagingExecutor) -> SandboxManager:
@@ -100,3 +115,19 @@ async def test_staging_respects_executor_capacity() -> None:
     )
 
     assert len(executor.commands) == 4
+    # One slot means writing and running never overlap, so a concurrent
+    # caller cannot replace a file between another's write and its command.
+    assert executor.peak == 1
+
+
+@pytest.mark.anyio
+async def test_staging_uses_every_slot_an_executor_allows() -> None:
+    executor = _StagingExecutor("sb-0", max_concurrency=3)
+    manager = _manager(executor)
+
+    await asyncio.gather(
+        *(manager.execute_with_files(f"cmd {index}", {f"/tmp/{index}": "x"}) for index in range(6))
+    )
+
+    assert len(executor.commands) == 6
+    assert 1 < executor.peak <= 3

--- a/tests/core/harness/test_sandbox_file_staging.py
+++ b/tests/core/harness/test_sandbox_file_staging.py
@@ -1,0 +1,102 @@
+"""Tests for staging files into a sandbox before running a command."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Mapping
+
+import pytest
+
+from olmo_eval.common.execution import ExecutionResult
+from olmo_eval.harness.sandbox import Capability, SandboxConfig, SandboxManager, SandboxMode
+
+
+class _StagingExecutor:
+    """Executor that records the files written to it and the commands it ran."""
+
+    def __init__(self, name: str, *, max_concurrency: int = 2) -> None:
+        self.name = name
+        self.config = SandboxConfig(
+            image="test",
+            mode=SandboxMode.MODAL,
+            capabilities=Capability.DEFAULT,
+            max_concurrency=max_concurrency,
+        )
+        self.running = True
+        self.files: dict[str, str] = {}
+        self.commands: list[str] = []
+        #: Files present when each command ran, to catch a command that
+        #: executes somewhere its files were never written.
+        self.files_at_command: list[set[str]] = []
+
+    @property
+    def is_running(self) -> bool:
+        return self.running
+
+    async def write_files(self, files: Mapping[str, str]) -> None:
+        await asyncio.sleep(0.01)
+        self.files.update(files)
+
+    async def execute_command(self, command: str, timeout: float | None = None) -> ExecutionResult:
+        del timeout
+        self.commands.append(command)
+        self.files_at_command.append(set(self.files))
+        return ExecutionResult(success=True, output='{"passed": true}')
+
+
+def _manager(*executors: _StagingExecutor) -> SandboxManager:
+    manager = SandboxManager([])
+    manager._executors = list(executors)  # type: ignore[assignment]
+    manager._active_operations = {id(executor): 0 for executor in executors}
+    return manager
+
+
+@pytest.mark.anyio
+async def test_files_are_written_before_the_command_runs() -> None:
+    executor = _StagingExecutor("sb-0")
+    manager = _manager(executor)
+
+    result = await manager.execute_with_files(
+        "python3 grade.py",
+        {"/tmp/work/grade.py": "print(1)", "/tmp/work/problem.json": "{}"},
+    )
+
+    assert result.success
+    assert executor.commands == ["python3 grade.py"]
+    assert executor.files_at_command == [{"/tmp/work/grade.py", "/tmp/work/problem.json"}]
+
+
+@pytest.mark.anyio
+async def test_command_runs_on_the_executor_that_received_the_files() -> None:
+    first = _StagingExecutor("sb-0")
+    second = _StagingExecutor("sb-1")
+    manager = _manager(first, second)
+
+    # Enough concurrent calls to spread across both executors.
+    await asyncio.gather(
+        *(
+            manager.execute_with_files(
+                f"python3 grade.py {index}",
+                {f"/tmp/work-{index}/solution.py": f"# {index}"},
+            )
+            for index in range(6)
+        )
+    )
+
+    assert first.commands and second.commands, "expected work on both executors"
+    for executor in (first, second):
+        for command, staged in zip(executor.commands, executor.files_at_command, strict=True):
+            index = command.rsplit(" ", 1)[-1]
+            assert f"/tmp/work-{index}/solution.py" in staged
+
+
+@pytest.mark.anyio
+async def test_staging_respects_executor_capacity() -> None:
+    executor = _StagingExecutor("sb-0", max_concurrency=1)
+    manager = _manager(executor)
+
+    await asyncio.gather(
+        *(manager.execute_with_files(f"cmd {index}", {f"/tmp/{index}": "x"}) for index in range(4))
+    )
+
+    assert len(executor.commands) == 4

--- a/tests/core/harness/test_sandbox_manager_capacity.py
+++ b/tests/core/harness/test_sandbox_manager_capacity.py
@@ -6,72 +6,15 @@ import asyncio
 
 import pytest
 
-from olmo_eval.common.execution import ExecutionResult
-from olmo_eval.harness.sandbox import Capability, SandboxConfig, SandboxManager, SandboxMode
+from olmo_eval.harness.sandbox import Capability
 from olmo_eval.harness.sandbox.errors import SandboxTransportError
-
-
-class _TrackingExecutor:
-    def __init__(
-        self,
-        name: str,
-        *,
-        capabilities: frozenset[str] = Capability.DEFAULT,
-        max_concurrency: int = 2,
-        fail_and_quarantine: bool = False,
-        fail_transport: bool = False,
-    ) -> None:
-        self.name = name
-        self.config = SandboxConfig(
-            image="test",
-            mode=SandboxMode.MODAL,
-            capabilities=capabilities,
-            max_concurrency=max_concurrency,
-        )
-        self.running = True
-        self.fail_and_quarantine = fail_and_quarantine
-        self.fail_transport = fail_transport
-        self.active = 0
-        self.peak = 0
-        self.calls = 0
-
-    @property
-    def is_running(self) -> bool:
-        return self.running
-
-    async def execute_code(
-        self,
-        code: str,
-        language: str = "python",
-        timeout: float | None = None,
-    ) -> ExecutionResult:
-        del code, language, timeout
-        self.calls += 1
-        self.active += 1
-        self.peak = max(self.peak, self.active)
-        try:
-            await asyncio.sleep(0.01)
-            if self.fail_and_quarantine:
-                self.running = False
-                raise ConnectionResetError("sandbox disconnected")
-            if self.fail_transport:
-                raise SandboxTransportError("request retries exhausted")
-            return ExecutionResult(success=True)
-        finally:
-            self.active -= 1
-
-
-def _manager(*executors: _TrackingExecutor) -> SandboxManager:
-    manager = SandboxManager([])
-    manager._executors = list(executors)  # type: ignore[assignment]
-    manager._active_operations = {id(executor): 0 for executor in executors}
-    return manager
+from tests.core.harness.sandbox_stubs import TrackingExecutor, make_manager
 
 
 @pytest.mark.anyio
 async def test_each_executor_enforces_its_own_capacity() -> None:
-    executors = [_TrackingExecutor(f"sandbox-{idx}") for idx in range(3)]
-    manager = _manager(*executors)
+    executors = [TrackingExecutor(f"sandbox-{idx}") for idx in range(3)]
+    manager = make_manager(*executors)
     environment = manager.for_capabilities(Capability.DEFAULT)
 
     await asyncio.gather(*(environment.execute_code("pass") for _ in range(18)))
@@ -85,10 +28,10 @@ async def test_each_executor_enforces_its_own_capacity() -> None:
 async def test_capability_environment_routes_each_operation_across_pool() -> None:
     capability = frozenset({"sandbox:bigcodebench"})
     executors = [
-        _TrackingExecutor(f"bcb-{idx}", capabilities=capability, max_concurrency=1)
+        TrackingExecutor(f"bcb-{idx}", capabilities=capability, max_concurrency=1)
         for idx in range(5)
     ]
-    manager = _manager(*executors)
+    manager = make_manager(*executors)
     environment = manager.for_capabilities(capability)
 
     await asyncio.gather(*(environment.execute_code("pass") for _ in range(5)))
@@ -98,9 +41,9 @@ async def test_capability_environment_routes_each_operation_across_pool() -> Non
 
 @pytest.mark.anyio
 async def test_scoring_environment_fails_over_after_quarantine() -> None:
-    broken = _TrackingExecutor("broken", fail_and_quarantine=True)
-    healthy = _TrackingExecutor("healthy")
-    manager = _manager(broken, healthy)
+    broken = TrackingExecutor("broken", fail_and_quarantine=True)
+    healthy = TrackingExecutor("healthy")
+    manager = make_manager(broken, healthy)
     environment = manager.for_capabilities(Capability.DEFAULT)
 
     result = await environment.execute_code("pass")
@@ -112,9 +55,9 @@ async def test_scoring_environment_fails_over_after_quarantine() -> None:
 
 @pytest.mark.anyio
 async def test_scoring_environment_does_not_fail_over_from_healthy_sandbox() -> None:
-    broken = _TrackingExecutor("broken", fail_transport=True)
-    healthy = _TrackingExecutor("healthy")
-    manager = _manager(broken, healthy)
+    broken = TrackingExecutor("broken", fail_transport=True)
+    healthy = TrackingExecutor("healthy")
+    manager = make_manager(broken, healthy)
     environment = manager.for_capabilities(Capability.DEFAULT)
 
     with pytest.raises(SandboxTransportError):


### PR DESCRIPTION
## Problem

A scorer reaches a sandbox only through a command string. swe-rex runs that through `execve`, which caps a **single argument at 128KB** (`MAX_ARG_STRLEN`). Fixtures larger than that cannot reach the container at all — the request succeeds and the failure happens inside, at the exec boundary.

That is fine for the code evals we have today, where the test payload is a few hundred bytes of assertions. It rules out any task whose fixtures are megabytes rather than kilobytes.

## Approach

swe-rex already serves a `POST /write_file` endpoint whose payload travels in the request body rather than in argv. It was simply never surfaced: `SandboxExecutor` keeps its runtime private, and `CapabilityExecutionEnvironment` published only `execute` / `execute_command` / `execute_code`.

- `SandboxExecutor.write_files()` exposes it, going through the same transport retries as every other runtime call.
- `SandboxManager.execute_with_files()` stages files and runs a command against them **while holding a single lease**.

The lease is the crux. `execute_command` leases an executor from the pool per call, so a separate write and run can land on different containers, and the command would execute somewhere its files were never written. Both steps now happen inside one `_execute_with_lease`.

`StagingExecutionEnvironment` is declared separately from `ExecutionEnvironment` rather than added to it, so environments that cannot stage files still satisfy the base protocol, and a scorer needing the capability fails a type check instead of an attribute lookup at runtime.

## Tests

`tests/core/harness/test_sandbox_file_staging.py` asserts the properties that matter:

- files are present before the command runs
- with several executors and concurrent calls, each command runs on the executor that received *its* files
- staging respects per-executor concurrency limits

## Notes

No existing task changes behavior; this only adds a capability. First caller is the LiveCodeBench task, whose test payloads are 10–20MB at p90 — see #354.

🤖 Generated with [Claude Code](https://claude.com/claude-code)