### PR TITLE
Load the data files a caller asked for from script-based repos

### DIFF
--- a/src/olmo_eval/data/backends/huggingface.py
+++ b/src/olmo_eval/data/backends/huggingface.py
@@ -48,7 +48,11 @@ class HuggingFaceBackend:
 
         kwargs: dict[str, Any] = {}
         if source.data_files is not None:
-            kwargs["data_files"] = source.data_files
+            kwargs["data_files"] = (
+                list(source.data_files)
+                if isinstance(source.data_files, tuple)
+                else source.data_files
+            )
         if source.revision is not None:
             kwargs["revision"] = source.revision
 
@@ -87,21 +91,27 @@ class HuggingFaceBackend:
         from datasets import load_dataset
         from huggingface_hub import HfApi
 
-        api = HfApi(token=token)
-        repo_files = api.list_repo_files(path, repo_type="dataset")
+        declared = kwargs.get("data_files")
+        if declared is not None:
+            # An explicit file list names the split exactly; subset matching
+            # would silently widen it to every data file in the repository.
+            candidates = [declared] if isinstance(declared, str) else list(declared)
+        else:
+            api = HfApi(token=token)
+            repo_files = api.list_repo_files(path, repo_type="dataset")
 
-        # Find data files matching the subset name
-        subset = source.subset or ""
-        candidates = [
-            f
-            for f in repo_files
-            if subset in f and f.rsplit(".", 1)[-1] in ("jsonl", "json", "parquet", "csv")
-        ]
-        if not candidates:
-            raise FileNotFoundError(
-                f"No data files matching subset '{subset}' in {path}. "
-                f"This dataset has a legacy loading script that is no longer supported."
-            )
+            # Find data files matching the subset name
+            subset = source.subset or ""
+            candidates = [
+                f
+                for f in repo_files
+                if subset in f and f.rsplit(".", 1)[-1] in ("jsonl", "json", "parquet", "csv")
+            ]
+            if not candidates:
+                raise FileNotFoundError(
+                    f"No data files matching subset '{subset}' in {path}. "
+                    f"This dataset has a legacy loading script that is no longer supported."
+                )
 
         ext = candidates[0].rsplit(".", 1)[-1]
         module = "json" if ext in ("json", "jsonl") else ext

--- a/src/olmo_eval/data/backends/huggingface.py
+++ b/src/olmo_eval/data/backends/huggingface.py
@@ -8,6 +8,39 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from olmo_eval.data.sources import DataSource
 
+#: File types the fallback loader can read, mapped to the loader module.
+_SUPPORTED_EXTENSIONS: dict[str, str] = {
+    "jsonl": "json",
+    "json": "json",
+    "parquet": "parquet",
+    "csv": "csv",
+}
+
+
+def _loader_module(file_names: list[str], path: str) -> str:
+    """Return the loader module the given data files need.
+
+    One module reads the whole split, so the files have to agree on a type.
+    Naming an unreadable or mixed set fails here rather than as an obscure
+    parsing error from the loader.
+    """
+    unreadable = sorted(
+        name for name in file_names if name.rsplit(".", 1)[-1] not in _SUPPORTED_EXTENSIONS
+    )
+    if unreadable:
+        raise ValueError(
+            f"Cannot read {', '.join(unreadable)} from {path}. "
+            f"Supported file types: {', '.join(sorted(_SUPPORTED_EXTENSIONS))}."
+        )
+
+    modules = {_SUPPORTED_EXTENSIONS[name.rsplit(".", 1)[-1]] for name in file_names}
+    if len(modules) > 1:
+        raise ValueError(
+            f"Data files for {path} mix file types ({', '.join(sorted(file_names))}), "
+            f"which cannot be read as one split."
+        )
+    return modules.pop()
+
 
 class HuggingFaceBackend:
     """Load datasets from HuggingFace Hub.
@@ -91,21 +124,31 @@ class HuggingFaceBackend:
         from datasets import load_dataset
         from huggingface_hub import HfApi
 
+        revision = kwargs.get("revision")
+
         declared = kwargs.get("data_files")
         if declared is not None:
             # An explicit file list names the split exactly; subset matching
             # would silently widen it to every data file in the repository.
             candidates = [declared] if isinstance(declared, str) else list(declared)
+            if not candidates:
+                raise ValueError(
+                    f"data_files for {path} is empty, so there is nothing to load. "
+                    f"Name the file(s) to read, or leave data_files unset to select "
+                    f"them by subset."
+                )
         else:
             api = HfApi(token=token)
-            repo_files = api.list_repo_files(path, repo_type="dataset")
+            # The listing has to come from the same revision the files are
+            # read from, or selection is computed against other contents.
+            repo_files = api.list_repo_files(path, repo_type="dataset", revision=revision)
 
             # Find data files matching the subset name
             subset = source.subset or ""
             candidates = [
                 f
                 for f in repo_files
-                if subset in f and f.rsplit(".", 1)[-1] in ("jsonl", "json", "parquet", "csv")
+                if subset in f and f.rsplit(".", 1)[-1] in _SUPPORTED_EXTENSIONS
             ]
             if not candidates:
                 raise FileNotFoundError(
@@ -113,9 +156,9 @@ class HuggingFaceBackend:
                     f"This dataset has a legacy loading script that is no longer supported."
                 )
 
-        ext = candidates[0].rsplit(".", 1)[-1]
-        module = "json" if ext in ("json", "jsonl") else ext
-        data_urls = [f"hf://datasets/{path}/{f}" for f in candidates]
+        module = _loader_module(candidates, path)
+        at_revision = f"@{revision}" if revision else ""
+        data_urls = [f"hf://datasets/{path}{at_revision}/{f}" for f in candidates]
 
         return load_dataset(
             module,

--- a/src/olmo_eval/data/sources.py
+++ b/src/olmo_eval/data/sources.py
@@ -40,7 +40,9 @@ class DataSource:
     subset: str | None = None
     split: str = "test"
     source_type: SourceType | None = None
-    data_files: str | None = None
+    #: Data file(s) to load, relative to the repository root. A tuple selects
+    #: several files that together form one split.
+    data_files: str | tuple[str, ...] | None = None
     revision: str | None = None
 
     def __post_init__(self) -> None:
@@ -157,6 +159,8 @@ class DataSource:
             "subset": self.subset,
             "split": self.split,
             "source_type": self.source_type.value if self.source_type else None,
-            "data_files": self.data_files,
+            "data_files": list(self.data_files)
+            if isinstance(self.data_files, tuple)
+            else self.data_files,
             "revision": self.revision,
         }

--- a/tests/data/test_hub_file_selection.py
+++ b/tests/data/test_hub_file_selection.py
@@ -1,0 +1,138 @@
+"""Tests for data file selection when a repository has a legacy loading script.
+
+`datasets` refuses to run legacy loading scripts, so the HuggingFace backend
+falls back to reading the repository's data files directly. That fallback has
+to load the files the caller asked for.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from olmo_eval.data import DataSource
+from olmo_eval.data.backends.huggingface import HuggingFaceBackend
+
+
+class _RecordingLoader:
+    """Stands in for `datasets.load_dataset`, recording how it was called."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def __call__(self, path: str, **kwargs: Any) -> list[dict[str, str]]:
+        self.calls.append({"path": path, **kwargs})
+        return [{"doc": "loaded"}]
+
+
+@pytest.fixture
+def recording_loader(monkeypatch: pytest.MonkeyPatch) -> _RecordingLoader:
+    import datasets
+
+    loader = _RecordingLoader()
+    monkeypatch.setattr(datasets, "load_dataset", loader)
+    return loader
+
+
+def _all_repo_files(monkeypatch: pytest.MonkeyPatch, files: list[str]) -> None:
+    """Make the Hub report `files` as the repository's contents."""
+    import huggingface_hub
+
+    class _StubApi:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+        def list_repo_files(self, path: str, repo_type: str = "dataset") -> list[str]:
+            del path, repo_type
+            return files
+
+    monkeypatch.setattr(huggingface_hub, "HfApi", _StubApi)
+
+
+def test_declared_data_files_are_the_only_ones_loaded(
+    recording_loader: _RecordingLoader,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The repository holds six data files; the caller asked for three of them.
+    _all_repo_files(
+        monkeypatch,
+        ["test.jsonl", "test2.jsonl", "test3.jsonl", "test4.jsonl", "test5.jsonl", "test6.jsonl"],
+    )
+    source = DataSource(
+        path="org/scripted-repo",
+        data_files=("test.jsonl", "test2.jsonl", "test3.jsonl"),
+        split="train",
+    )
+
+    HuggingFaceBackend._load_from_hub_files(
+        "org/scripted-repo",
+        source,
+        streaming=False,
+        token=None,
+        data_files=["test.jsonl", "test2.jsonl", "test3.jsonl"],
+    )
+
+    assert recording_loader.calls[0]["data_files"] == {
+        "train": [
+            "hf://datasets/org/scripted-repo/test.jsonl",
+            "hf://datasets/org/scripted-repo/test2.jsonl",
+            "hf://datasets/org/scripted-repo/test3.jsonl",
+        ]
+    }
+
+
+def test_a_single_declared_data_file_is_not_widened(
+    recording_loader: _RecordingLoader,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Without a subset, substring matching accepts every file in the repository.
+    _all_repo_files(monkeypatch, ["test.jsonl", "test2.jsonl", "test3.jsonl"])
+    source = DataSource(path="org/scripted-repo", data_files="test.jsonl", split="train")
+
+    HuggingFaceBackend._load_from_hub_files(
+        "org/scripted-repo",
+        source,
+        streaming=False,
+        token=None,
+        data_files="test.jsonl",
+    )
+
+    assert recording_loader.calls[0]["data_files"] == {
+        "train": ["hf://datasets/org/scripted-repo/test.jsonl"]
+    }
+
+
+def test_subset_matching_still_applies_without_declared_files(
+    recording_loader: _RecordingLoader,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _all_repo_files(monkeypatch, ["math/test.jsonl", "biology/test.jsonl", "README.md"])
+    source = DataSource(path="org/scripted-repo", subset="math", split="test")
+
+    HuggingFaceBackend._load_from_hub_files(
+        "org/scripted-repo",
+        source,
+        streaming=False,
+        token=None,
+    )
+
+    assert recording_loader.calls[0]["data_files"] == {
+        "test": ["hf://datasets/org/scripted-repo/math/test.jsonl"]
+    }
+
+
+def test_missing_subset_files_raise(
+    recording_loader: _RecordingLoader,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _all_repo_files(monkeypatch, ["math/test.jsonl"])
+    source = DataSource(path="org/scripted-repo", subset="chemistry", split="test")
+
+    with pytest.raises(FileNotFoundError):
+        HuggingFaceBackend._load_from_hub_files(
+            "org/scripted-repo",
+            source,
+            streaming=False,
+            token=None,
+        )

--- a/tests/data/test_hub_file_selection.py
+++ b/tests/data/test_hub_file_selection.py
@@ -35,16 +35,24 @@ def recording_loader(monkeypatch: pytest.MonkeyPatch) -> _RecordingLoader:
     return loader
 
 
-def _all_repo_files(monkeypatch: pytest.MonkeyPatch, files: list[str]) -> None:
-    """Make the Hub report `files` as the repository's contents."""
+def _all_repo_files(
+    monkeypatch: pytest.MonkeyPatch, files: list[str], listed: dict[str, Any] | None = None
+) -> None:
+    """Make the Hub report `files` as the repository's contents.
+
+    `listed`, when given, records the arguments the listing was asked for.
+    """
     import huggingface_hub
 
     class _StubApi:
         def __init__(self, *args: Any, **kwargs: Any) -> None:
             pass
 
-        def list_repo_files(self, path: str, repo_type: str = "dataset") -> list[str]:
-            del path, repo_type
+        def list_repo_files(
+            self, path: str, repo_type: str = "dataset", revision: str | None = None
+        ) -> list[str]:
+            if listed is not None:
+                listed.update(path=path, repo_type=repo_type, revision=revision)
             return files
 
     monkeypatch.setattr(huggingface_hub, "HfApi", _StubApi)
@@ -135,4 +143,115 @@ def test_missing_subset_files_raise(
             source,
             streaming=False,
             token=None,
+        )
+
+
+def test_revision_reaches_both_the_listing_and_the_files(
+    recording_loader: _RecordingLoader,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A listing taken from a different revision selects against other
+    # contents, and files read from the default branch are the wrong data.
+    listed: dict[str, Any] = {}
+    _all_repo_files(monkeypatch, ["math/test.jsonl"], listed)
+    source = DataSource(path="org/scripted-repo", subset="math", split="test", revision="abc123")
+
+    HuggingFaceBackend._load_from_hub_files(
+        "org/scripted-repo",
+        source,
+        streaming=False,
+        token=None,
+        revision="abc123",
+    )
+
+    assert listed["revision"] == "abc123"
+    assert recording_loader.calls[0]["data_files"] == {
+        "test": ["hf://datasets/org/scripted-repo@abc123/math/test.jsonl"]
+    }
+
+
+def test_declared_files_are_read_at_the_requested_revision(
+    recording_loader: _RecordingLoader,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _all_repo_files(monkeypatch, ["test.jsonl"])
+    source = DataSource(
+        path="org/scripted-repo", data_files=("test.jsonl",), split="train", revision="v1.0"
+    )
+
+    HuggingFaceBackend._load_from_hub_files(
+        "org/scripted-repo",
+        source,
+        streaming=False,
+        token=None,
+        data_files=["test.jsonl"],
+        revision="v1.0",
+    )
+
+    assert recording_loader.calls[0]["data_files"] == {
+        "train": ["hf://datasets/org/scripted-repo@v1.0/test.jsonl"]
+    }
+
+
+def test_no_revision_leaves_urls_unpinned(
+    recording_loader: _RecordingLoader,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _all_repo_files(monkeypatch, ["test.jsonl"])
+    source = DataSource(path="org/scripted-repo", data_files="test.jsonl", split="train")
+
+    HuggingFaceBackend._load_from_hub_files(
+        "org/scripted-repo", source, streaming=False, token=None, data_files="test.jsonl"
+    )
+
+    assert recording_loader.calls[0]["data_files"] == {
+        "train": ["hf://datasets/org/scripted-repo/test.jsonl"]
+    }
+
+
+def test_empty_declared_data_files_is_rejected(
+    recording_loader: _RecordingLoader,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _all_repo_files(monkeypatch, ["test.jsonl"])
+    source = DataSource(path="org/scripted-repo", data_files=(), split="train")
+
+    with pytest.raises(ValueError, match="nothing to load"):
+        HuggingFaceBackend._load_from_hub_files(
+            "org/scripted-repo", source, streaming=False, token=None, data_files=[]
+        )
+
+
+def test_unreadable_declared_file_type_is_rejected(
+    recording_loader: _RecordingLoader,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A typo naming a documentation file would otherwise surface as an
+    # obscure parsing error from the loader.
+    _all_repo_files(monkeypatch, ["README.md"])
+    source = DataSource(path="org/scripted-repo", data_files="README.md", split="train")
+
+    with pytest.raises(ValueError, match="Cannot read README.md"):
+        HuggingFaceBackend._load_from_hub_files(
+            "org/scripted-repo", source, streaming=False, token=None, data_files="README.md"
+        )
+
+
+def test_mixed_declared_file_types_are_rejected(
+    recording_loader: _RecordingLoader,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # One loader module reads the whole split, so the files must agree.
+    _all_repo_files(monkeypatch, ["a.jsonl", "b.parquet"])
+    source = DataSource(
+        path="org/scripted-repo", data_files=("a.jsonl", "b.parquet"), split="train"
+    )
+
+    with pytest.raises(ValueError, match="mix file types"):
+        HuggingFaceBackend._load_from_hub_files(
+            "org/scripted-repo",
+            source,
+            streaming=False,
+            token=None,
+            data_files=["a.jsonl", "b.parquet"],
         )

--- a/tests/data/test_hub_file_selection.py
+++ b/tests/data/test_hub_file_selection.py
@@ -255,3 +255,101 @@ def test_mixed_declared_file_types_are_rejected(
             token=None,
             data_files=["a.jsonl", "b.parquet"],
         )
+
+
+class _ScriptRejectingLoader(_RecordingLoader):
+    """Stands in for `datasets.load_dataset` against a repository with a script.
+
+    The first call names the repository and fails the way `datasets` v4+ fails
+    on a legacy loading script. Later calls name a loader module and succeed,
+    so a test can follow a load all the way through the fallback.
+    """
+
+    def __init__(self, error: Exception) -> None:
+        super().__init__()
+        self.error = error
+
+    def __call__(self, path: str, **kwargs: Any) -> list[dict[str, str]]:
+        self.calls.append({"path": path, **kwargs})
+        if len(self.calls) == 1:
+            raise self.error
+        return [{"doc": "loaded"}]
+
+
+def _reject_scripts(monkeypatch: pytest.MonkeyPatch, error: Exception) -> _ScriptRejectingLoader:
+    """Make loading the repository itself raise `error`."""
+    import datasets
+
+    loader = _ScriptRejectingLoader(error)
+    monkeypatch.setattr(datasets, "load_dataset", loader)
+    return loader
+
+
+def test_load_carries_declared_files_and_revision_into_the_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The public entry point has to hand the fallback what the source asked
+    # for; dropping either one reads the wrong files, or the right files at
+    # the wrong revision.
+    loader = _reject_scripts(monkeypatch, RuntimeError("Dataset scripts are no longer supported"))
+    _all_repo_files(monkeypatch, ["test.jsonl", "test2.jsonl", "test3.jsonl"])
+    source = DataSource(
+        path="org/scripted-repo",
+        data_files=("test.jsonl", "test2.jsonl"),
+        split="train",
+        revision="abc123",
+    )
+
+    assert list(HuggingFaceBackend().load(source)) == [{"doc": "loaded"}]
+
+    attempted, fell_back = loader.calls
+    assert attempted["path"] == "org/scripted-repo"
+    # `datasets` rejects a tuple, so the source's files arrive as a list.
+    assert attempted["data_files"] == ["test.jsonl", "test2.jsonl"]
+    assert attempted["revision"] == "abc123"
+    assert fell_back["data_files"] == {
+        "train": [
+            "hf://datasets/org/scripted-repo@abc123/test.jsonl",
+            "hf://datasets/org/scripted-repo@abc123/test2.jsonl",
+        ]
+    }
+
+
+def test_load_reaches_subset_matching_without_declared_files(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    loader = _reject_scripts(monkeypatch, RuntimeError("Dataset scripts are no longer supported"))
+    _all_repo_files(monkeypatch, ["math/test.jsonl", "biology/test.jsonl", "README.md"])
+    source = DataSource(path="org/scripted-repo", subset="math", split="test")
+
+    assert list(HuggingFaceBackend().load(source)) == [{"doc": "loaded"}]
+
+    attempted, fell_back = loader.calls
+    assert "data_files" not in attempted
+    assert "revision" not in attempted
+    assert fell_back["data_files"] == {"test": ["hf://datasets/org/scripted-repo/math/test.jsonl"]}
+
+
+def test_load_falls_back_when_the_library_reports_a_cache_miss(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The library's own fallback logic swallows the script error and raises
+    # this instead, so the cache miss has to trigger the fallback too.
+    loader = _reject_scripts(monkeypatch, ValueError("Couldn't find cache for org/scripted-repo"))
+    _all_repo_files(monkeypatch, ["test.jsonl"])
+    source = DataSource(path="org/scripted-repo", data_files="test.jsonl", split="train")
+
+    assert list(HuggingFaceBackend().load(source)) == [{"doc": "loaded"}]
+
+    assert loader.calls[1]["data_files"] == {
+        "train": ["hf://datasets/org/scripted-repo/test.jsonl"]
+    }
+
+
+def test_load_does_not_swallow_unrelated_failures(monkeypatch: pytest.MonkeyPatch) -> None:
+    _reject_scripts(monkeypatch, ValueError("Split 'train' not found"))
+    _all_repo_files(monkeypatch, ["test.jsonl"])
+    source = DataSource(path="org/scripted-repo", data_files="test.jsonl", split="train")
+
+    with pytest.raises(ValueError, match="not found"):
+        list(HuggingFaceBackend().load(source))

--- a/tests/data/test_sources.py
+++ b/tests/data/test_sources.py
@@ -119,3 +119,24 @@ class TestDataSourceMethods:
         source = DataSource(path="cais/mmlu", subset="math")
         new_source = source.with_subset(None)
         assert new_source.subset is None
+
+
+class TestDataSourceDataFiles:
+    """Tests for selecting specific data files."""
+
+    def test_multiple_data_files_survive_split_and_subset_changes(self):
+        source = DataSource(path="org/repo", data_files=("a.jsonl", "b.jsonl"))
+        assert source.with_split("train").data_files == ("a.jsonl", "b.jsonl")
+        assert source.with_subset("other").data_files == ("a.jsonl", "b.jsonl")
+
+    def test_multiple_data_files_serialize_as_a_list(self):
+        source = DataSource(path="org/repo", data_files=("a.jsonl", "b.jsonl"))
+        assert source.to_dict()["data_files"] == ["a.jsonl", "b.jsonl"]
+
+    def test_single_data_file_serializes_unchanged(self):
+        source = DataSource(path="org/repo", data_files="a.jsonl")
+        assert source.to_dict()["data_files"] == "a.jsonl"
+
+    def test_source_with_multiple_data_files_is_hashable(self):
+        source = DataSource(path="org/repo", data_files=("a.jsonl", "b.jsonl"))
+        assert hash(source) == hash(DataSource(path="org/repo", data_files=("a.jsonl", "b.jsonl")))


### PR DESCRIPTION
## The bug

`datasets` 4.x refuses to run a repository's legacy loading script, so `HuggingFaceBackend` falls back to reading the repository's data files directly. That fallback chose files by testing whether the **subset name appears in the filename**:

```python
subset = source.subset or ""
candidates = [f for f in repo_files if subset in f and ...]
```

With no subset configured, `subset` is `""` — and `"" in filename` is true for every file in the repository. Any explicitly declared `data_files` was ignored, and a request for one file quietly returned all of them.

Measured on `livecodebench/code_generation_lite`, whose six files are separate benchmark releases: asking for the 400 problems in `test.jsonl` returned **all 1055** across all six, with nothing to indicate the request had been widened. A caller gets a plausible-looking dataset that is not the one they asked for.

## Fix

The fallback now loads exactly the files a caller declared, and falls back to subset matching only when none were declared.

`DataSource.data_files` also accepts a `tuple[str, ...]` as well as a `str`, since one split can span several files — something the underlying `load_dataset` has always supported (`str | Sequence[str] | Mapping[...]`) and that `DataSource` had narrowed since the initial commit.

## Why the union type, and not tuple everywhere

`tuple` alone would be a quiet breaking change. `DataSource.to_dict()` feeds `TaskConfig.to_dict()`, which feeds `compute_task_hash()`, and results are stored under that hash. Serializing `"olympiad/test.jsonl"` as `["olympiad/test.jsonl"]` moves the hash:

```
frontierscience_olympiad, data_files as str   : 5901a8f78e0afbee
frontierscience_olympiad, data_files as tuple : 04f9e11d001651d9
```

**11 registered tasks** declare `data_files` today (`frontierscience_*`, `astabench_*`, eight `basic_skills_*`). Moving their hashes would detach every stored result from future runs, and the analysis tooling joins on `task_hash`.

So existing single-file declarations stay strings and serialize as strings. A separate consideration: `data_source` is reachable from CLI overrides, where values arrive as strings, and an always-tuple field would silently `list()` a string into seven single-character filenames.

## Tests

- `tests/data/test_hub_file_selection.py` — declared files are the only ones loaded; a single declared file is not widened; subset matching still works when nothing is declared; a missing subset still raises.
- `tests/data/test_sources.py` — tuple `data_files` survives `with_split`/`with_subset`, serializes as a list, leaves single-file declarations untouched, and keeps `DataSource` hashable.

Independent of #352 — the two share no files and can be reviewed in either order. #354 (LiveCodeBench) depends on both and contains them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
