### PR TITLE
Add LiveCodeBench code generation task

### DIFF
--- a/src/olmo_eval/common/scorers/__init__.py
+++ b/src/olmo_eval/common/scorers/__init__.py
@@ -22,7 +22,12 @@ from .citation import (
     score_citations_for_sections,
 )
 from .code_execution import CodeExecutionScorer, MultiplEScorer
-from .execution import ContextScorer, ExecutionScorer, SandboxRequiredError
+from .execution import (
+    ContextScorer,
+    ExecutionScorer,
+    SandboxRequiredError,
+    ScoringIncompleteError,
+)
 from .ifeval import IFEvalScorer
 from .llm_judge import (
     JudgeFn,
@@ -74,6 +79,7 @@ __all__ = [
     "RubricJudgeScorer",
     "SafetyScorer",
     "SandboxRequiredError",
+    "ScoringIncompleteError",
     "score_citation_group",
     "score_citations_for_sections",
     "Scorer",

--- a/src/olmo_eval/common/scorers/code_execution/scripts/__init__.py
+++ b/src/olmo_eval/common/scorers/code_execution/scripts/__init__.py
@@ -1,0 +1,19 @@
+"""Python programs that are staged into a sandbox and run there.
+
+These are loaded as text rather than imported: they execute inside the
+container, against its interpreter, not in the harness process.
+"""
+
+from importlib import resources
+
+
+def get_script(name: str) -> str:
+    """Load a sandbox script by name.
+
+    Args:
+        name: Script name without the .py extension (e.g., "livecodebench_grader").
+
+    Returns:
+        The script source as a string.
+    """
+    return resources.files(__package__).joinpath(f"{name}.py").read_text()

--- a/src/olmo_eval/common/scorers/code_execution/scripts/livecodebench_grader.py
+++ b/src/olmo_eval/common/scorers/code_execution/scripts/livecodebench_grader.py
@@ -1,0 +1,403 @@
+"""Grade one LiveCodeBench solution against a problem's test cases.
+
+Runs inside a sandbox, not in the harness process. Reads ``problem.json`` and
+``solution.py`` from its own directory and prints a single JSON verdict to
+stdout.
+
+Problems come in two shapes. A problem with a function name expects the
+solution to define that function (on a ``Solution`` class for LeetCode
+problems); its inputs and outputs are JSON values compared directly. A problem
+without one is a whole program: inputs are fed to stdin and the captured
+stdout is compared line by line, falling back to decimal comparison so that
+numerically equal output is not rejected over formatting.
+
+Ported from the reference implementation:
+https://github.com/LiveCodeBench/LiveCodeBench/blob/main/lcb_runner/evaluation/testing_util.py
+"""
+
+import ast
+import base64
+import faulthandler
+import json
+import os
+import pickle
+import signal
+import sys
+import time
+import zlib
+from decimal import Decimal
+from io import StringIO
+from types import ModuleType
+from typing import Any
+from unittest.mock import mock_open, patch
+
+# Prelude the reference harness prepends to every solution, so that solutions
+# relying on names from a bare `from x import *` still resolve.
+IMPORT_PRELUDE = (
+    "from string import *\nfrom re import *\nfrom datetime import *\n"
+    "from collections import *\nfrom heapq import *\nfrom bisect import *\n"
+    "from copy import *\nfrom math import *\nfrom random import *\n"
+    "from statistics import *\nfrom itertools import *\nfrom functools import *\n"
+    "from operator import *\nfrom io import *\nfrom sys import *\nfrom json import *\n"
+    "from builtins import *\nfrom typing import *\nimport string\nimport re\n"
+    "import datetime\nimport collections\nimport heapq\nimport bisect\nimport copy\n"
+    "import math\nimport random\nimport statistics\nimport itertools\n"
+    "import functools\nimport operator\nimport io\nimport sys\nimport json\n"
+    "sys.setrecursionlimit(50000)\n"
+)
+
+
+class TimeoutException(Exception):
+    """Raised by the alarm handler when a test case runs too long."""
+
+
+def timeout_handler(signum, frame):
+    raise TimeoutException
+
+
+class Capturing(list):
+    """Collect everything a block writes to stdout."""
+
+    def __enter__(self):
+        self._stdout = sys.stdout
+        sys.stdout = self._stringio = StringIO()
+        return self
+
+    def __exit__(self, *args):
+        self.append(self._stringio.getvalue())
+        del self._stringio
+        sys.stdout = self._stdout
+
+
+class MockBuffer:
+    """Byte-oriented view of the stdin stand-in."""
+
+    def __init__(self, inputs):
+        self.lines = inputs.split("\n")
+        self.index = 0
+
+    def read(self, *args):
+        return "\n".join(self.lines).encode()
+
+    def readline(self, *args):
+        if self.index >= len(self.lines):
+            return b""
+        line = self.lines[self.index]
+        self.index += 1
+        return (line + "\n").encode()
+
+
+class MockStdin:
+    """Stand-in for sys.stdin that also exposes a .buffer."""
+
+    def __init__(self, inputs):
+        self.stringio = StringIO(inputs)
+        self.buffer = MockBuffer(inputs)
+
+    def read(self, *args):
+        return self.stringio.read()
+
+    def readline(self, *args):
+        return self.stringio.readline()
+
+    def readlines(self, *args):
+        return self.stringio.readlines()
+
+    def __getattr__(self, name):
+        return getattr(self.stringio, name)
+
+
+def clean_if_name(code):
+    """Drop an ``if __name__ == '__main__'`` guard, keeping its body."""
+    try:
+        tree = ast.parse(code)
+        last_block = tree.body[-1]
+        if isinstance(last_block, ast.If):
+            condition = last_block.test
+            if ast.unparse(condition).strip() == "__name__ == '__main__'":
+                code = ast.unparse(tree.body[:-1]) + "\n" + ast.unparse(last_block.body)
+    except Exception:
+        pass
+    return code
+
+
+def make_function(code):
+    """Wrap a whole program in a function so it can be called per test case."""
+    try:
+        imports = []
+        body = []
+        tree = ast.parse(code)
+        for stmt in tree.body:
+            if isinstance(stmt, (ast.Import, ast.ImportFrom)):
+                imports.append(stmt)
+            else:
+                body.append(stmt)
+
+        wrapper = ast.parse("def wrapped_function():\n    pass\n")
+        function = wrapper.body[0]
+        if not isinstance(function, ast.FunctionDef):
+            return code
+        function.body = body or [ast.Pass()]
+        ast.fix_missing_locations(wrapper)
+
+        import_source = "\n".join(ast.unparse(stmt) for stmt in imports)
+        return IMPORT_PRELUDE + "\n" + import_source + "\n" + ast.unparse(wrapper)
+    except Exception:
+        return code
+
+
+def call_method(method, inputs):
+    """Call a wrapped program with `inputs` standing in for stdin."""
+    if isinstance(inputs, list):
+        inputs = "\n".join(inputs)
+
+    line_iterator = iter(inputs.split("\n"))
+    mock_stdin = MockStdin(inputs)
+
+    @patch("builtins.open", mock_open(read_data=inputs))
+    @patch("sys.stdin", mock_stdin)
+    @patch("sys.stdin.readline", lambda *args: next(line_iterator))
+    @patch("sys.stdin.readlines", lambda *args: inputs.split("\n"))
+    @patch("sys.stdin.read", lambda *args: inputs)
+    def _inner(_method):
+        try:
+            return _method()
+        except SystemExit:
+            pass
+
+    return _inner(method)
+
+
+class CompilationError(Exception):
+    """Raised when a solution's module body will not execute."""
+
+
+def compile_code(code, timeout):
+    """Execute a solution's module body and return the object to call into."""
+    signal.alarm(timeout)
+    try:
+        module = ModuleType("tmp_sol", "")
+        exec(code, module.__dict__)
+        # LeetCode problems wrap their answer in a Solution class; everything
+        # else exposes the function at module level.
+        if "class Solution" in code:
+            return module.Solution()
+        return module
+    except Exception as exc:
+        # A solution that does not compile is a failed solution, reported the
+        # same way as one whose entry point is missing.
+        raise CompilationError(repr(exc)) from exc
+    finally:
+        signal.alarm(0)
+
+
+def get_stripped_lines(value):
+    return [line.strip() for line in value.strip().split("\n")]
+
+
+def convert_line_to_decimals(line):
+    try:
+        return True, [Decimal(element) for element in line.split()]
+    except Exception:
+        return False, []
+
+
+def grade_call_based(code, inputs, outputs, fn_name, timeout):
+    """Grade a solution by calling `fn_name` with each test case's arguments."""
+    code = IMPORT_PRELUDE + "\n\n" + code
+    compiled = compile_code(code, timeout)
+    method = getattr(compiled, fn_name, None)
+    if method is None:
+        return False, {"error_code": -4, "error_message": "Function not found in generated code"}
+
+    parsed_inputs = [[json.loads(line) for line in case.split("\n")] for case in inputs]
+    parsed_outputs = [json.loads(case) for case in outputs]
+
+    for gt_input, gt_output in zip(parsed_inputs, parsed_outputs, strict=False):
+        signal.alarm(timeout)
+        faulthandler.enable()
+        try:
+            prediction = method(*gt_input)
+            signal.alarm(0)
+
+            # Tuples and lists are not distinguished: ground truth is never a tuple.
+            if isinstance(prediction, tuple):
+                prediction = list(prediction)
+
+            if prediction != gt_output:
+                return False, {"error_code": -2, "error_message": "Wrong Answer"}
+        except Exception as exc:
+            if "timeoutexception" in repr(exc).lower():
+                return False, {"error_code": -3, "error_message": "Time Limit Exceeded"}
+            return False, {"error_code": -4, "error_message": f"Runtime Error: {exc!r}"}
+        finally:
+            signal.alarm(0)
+            faulthandler.disable()
+
+    return True, {}
+
+
+def grade_stdio(code, inputs, outputs, timeout):
+    """Grade a whole-program solution by feeding stdin and reading stdout."""
+    code = make_function(clean_if_name(code))
+    compiled = compile_code(code, timeout)
+    method = getattr(compiled, "wrapped_function", None)
+    if method is None:
+        return False, {"error_code": -4, "error_message": "Function not found in generated code"}
+
+    for gt_input, gt_output in zip(inputs, outputs, strict=False):
+        signal.alarm(timeout)
+        faulthandler.enable()
+        with Capturing() as captured:
+            try:
+                call_method(method, gt_input)
+                signal.alarm(0)
+            except Exception as exc:
+                if "timeoutexception" in repr(exc).lower():
+                    return False, {"error_code": -3, "error_message": "Time Limit Exceeded"}
+                return False, {"error_code": -4, "error_message": f"Runtime Error: {exc!r}"}
+            finally:
+                signal.alarm(0)
+                faulthandler.disable()
+
+        prediction_lines = get_stripped_lines(captured[0])
+        expected_lines = get_stripped_lines(gt_output)
+
+        if len(prediction_lines) != len(expected_lines):
+            return False, {
+                "error_code": -2,
+                "error_message": "Wrong answer: mismatched output length",
+            }
+
+        for idx, (predicted, expected) in enumerate(
+            zip(prediction_lines, expected_lines, strict=True)
+        ):
+            if predicted == expected:
+                continue
+            # Compare numerically before rejecting: Decimal avoids the false
+            # equalities that float comparison would introduce on large values.
+            ok_prediction, decimal_prediction = convert_line_to_decimals(predicted)
+            ok_expected, decimal_expected = convert_line_to_decimals(expected)
+            if ok_prediction and ok_expected and decimal_prediction == decimal_expected:
+                continue
+            return False, {
+                "error_code": -2,
+                "error_message": f"Wrong answer at line {idx}",
+            }
+
+    return True, {}
+
+
+def decode_test_cases(encoded):
+    """Decode a test case blob, which may be JSON or compressed pickle."""
+    if not encoded:
+        return []
+    try:
+        return json.loads(encoded)
+    except json.JSONDecodeError:
+        try:
+            return json.loads(
+                pickle.loads(zlib.decompress(base64.b64decode(encoded.encode("utf-8"))))
+            )
+        except Exception:
+            return []
+
+
+def reliability_guard():
+    """Disable calls that would let a solution damage the run.
+
+    This is defence in depth for accidental damage inside an already isolated
+    container, not a security boundary.
+    """
+    import builtins
+    import shutil
+    import subprocess
+
+    faulthandler.disable()
+
+    # Disabling a name means replacing it with None, which is by definition
+    # not what its declared type allows.
+    untyped_builtins: Any = builtins
+    untyped_builtins.exit = None
+    untyped_builtins.quit = None
+
+    os.environ["OMP_NUM_THREADS"] = "1"
+
+    for module, name in (
+        (os, "kill"),
+        (os, "system"),
+        (os, "remove"),
+        (os, "removedirs"),
+        (os, "rmdir"),
+        (os, "fchdir"),
+        (os, "chdir"),
+        (os, "setuid"),
+        (os, "fork"),
+        (os, "forkpty"),
+        (os, "killpg"),
+        (os, "rename"),
+        (os, "renames"),
+        (os, "truncate"),
+        (os, "unlink"),
+        (os, "fchmod"),
+        (os, "fchown"),
+        (os, "chmod"),
+        (os, "chown"),
+        (os, "chroot"),
+        (shutil, "rmtree"),
+        (shutil, "move"),
+        (shutil, "chown"),
+        (subprocess, "Popen"),
+    ):
+        if hasattr(module, name):
+            setattr(module, name, None)
+
+    loaded_modules: Any = sys.modules
+    for blocked in ("ipdb", "joblib", "resource", "psutil", "tkinter"):
+        loaded_modules[blocked] = None
+
+
+def main():
+    here = os.path.dirname(os.path.abspath(__file__))
+    with open(os.path.join(here, "problem.json")) as handle:
+        problem = json.load(handle)
+    with open(os.path.join(here, "solution.py")) as handle:
+        solution = handle.read()
+
+    test_cases = decode_test_cases(problem["public_test_cases"]) + decode_test_cases(
+        problem["private_test_cases"]
+    )
+    inputs = [case["input"] for case in test_cases]
+    outputs = [case["output"] for case in test_cases]
+    fn_name = problem.get("fn_name")
+    timeout = int(problem.get("timeout", 6))
+
+    signal.signal(signal.SIGALRM, timeout_handler)
+    reliability_guard()
+
+    started = time.time()
+    try:
+        if fn_name:
+            passed, detail = grade_call_based(solution, inputs, outputs, fn_name, timeout)
+        else:
+            passed, detail = grade_stdio(solution, inputs, outputs, timeout)
+    except CompilationError as exc:
+        passed, detail = False, {"error_code": -4, "error_message": f"Compilation error: {exc}"}
+    except TimeoutException:
+        passed, detail = False, {"error_code": -3, "error_message": "Time Limit Exceeded"}
+    except Exception as exc:
+        passed, detail = False, {"error_code": -5, "error_message": f"TestRunnerError: {exc!r}"}
+
+    verdict = {
+        "passed": passed,
+        "num_tests": len(inputs),
+        "elapsed": round(time.time() - started, 3),
+    }
+    verdict.update(detail)
+    # The harness reads the last line of stdout; solutions print freely above it.
+    sys.stdout = sys.__stdout__
+    print(json.dumps(verdict))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/olmo_eval/common/scorers/code_execution/scripts/livecodebench_grader.py
+++ b/src/olmo_eval/common/scorers/code_execution/scripts/livecodebench_grader.py
@@ -71,20 +71,23 @@ def cancel_alarm():
     signal.setitimer(signal.ITIMER_REAL, 0)
 
 
+class CapturedOutput(StringIO):
+    """Stdout stand-in that survives a solution closing it."""
+
+    def close(self):
+        pass
+
+
 class Capturing(list):
     """Collect everything a block writes to stdout."""
 
     def __enter__(self):
         self._stdout = sys.stdout
-        sys.stdout = self._stringio = StringIO()
+        sys.stdout = self._stringio = CapturedOutput()
         return self
 
     def __exit__(self, *args):
-        try:
-            self.append(self._stringio.getvalue())
-        except ValueError:
-            # The solution closed stdout; whatever it wrote is gone.
-            self.append("")
+        self.append(self._stringio.getvalue())
         del self._stringio
         sys.stdout = self._stdout
 
@@ -387,11 +390,15 @@ def reliability_guard():
 
 
 MAX_ERROR_MESSAGE_LEN = 2000
+VERDICT_PREFIX = "LCB_VERDICT "
 
 
 def grade(solution, inputs, outputs, fn_name, timeout):
     """Grade a solution in this process and return ``(passed, detail)``."""
     signal.signal(signal.SIGALRM, timeout_handler)
+    # Contest answers can be integers far past the interpreter's default limit
+    # on converting between int and str; the reference harness raises it too.
+    sys.set_int_max_str_digits(50000)
     reliability_guard()
     try:
         if fn_name:
@@ -507,10 +514,10 @@ def main():
 
     verdict["num_tests"] = len(inputs)
     verdict["elapsed"] = round(time.time() - started, 3)
-    # The harness reads the last line of stdout. The child may have written
-    # there without a trailing newline, so start a fresh line first.
+    # The harness looks for the marked line. The child may have written to
+    # stdout without a trailing newline, so start a fresh line first.
     sys.stdout = sys.__stdout__
-    print("\n" + json.dumps(verdict), flush=True)
+    print("\n" + VERDICT_PREFIX + json.dumps(verdict), flush=True)
 
 
 if __name__ == "__main__":

--- a/src/olmo_eval/common/scorers/code_execution/scripts/livecodebench_grader.py
+++ b/src/olmo_eval/common/scorers/code_execution/scripts/livecodebench_grader.py
@@ -4,6 +4,12 @@ Runs inside a sandbox, not in the harness process. Reads ``problem.json`` and
 ``solution.py`` from its own directory and prints a single JSON verdict to
 stdout.
 
+The solution runs in a forked child, as it does in the reference harness, so
+that a solution which crashes the interpreter or exhausts its time budget is
+reported as a failed solution rather than leaving no verdict behind. Only a
+problem whose test cases cannot be decoded produces a verdict with no tests,
+which the harness treats as a grading failure rather than a score.
+
 Problems come in two shapes. A problem with a function name expects the
 solution to define that function (on a ``Solution`` class for LeetCode
 problems); its inputs and outputs are JSON values compared directly. A problem
@@ -21,6 +27,7 @@ import faulthandler
 import json
 import os
 import pickle
+import select
 import signal
 import sys
 import time
@@ -55,6 +62,15 @@ def timeout_handler(signum, frame):
     raise TimeoutException
 
 
+def start_alarm(seconds):
+    """Arm the per-case timer. Unlike ``signal.alarm`` this keeps fractions of a second."""
+    signal.setitimer(signal.ITIMER_REAL, seconds)
+
+
+def cancel_alarm():
+    signal.setitimer(signal.ITIMER_REAL, 0)
+
+
 class Capturing(list):
     """Collect everything a block writes to stdout."""
 
@@ -64,7 +80,11 @@ class Capturing(list):
         return self
 
     def __exit__(self, *args):
-        self.append(self._stringio.getvalue())
+        try:
+            self.append(self._stringio.getvalue())
+        except ValueError:
+            # The solution closed stdout; whatever it wrote is gone.
+            self.append("")
         del self._stringio
         sys.stdout = self._stdout
 
@@ -174,7 +194,7 @@ class CompilationError(Exception):
 
 def compile_code(code, timeout):
     """Execute a solution's module body and return the object to call into."""
-    signal.alarm(timeout)
+    start_alarm(timeout)
     try:
         module = ModuleType("tmp_sol", "")
         exec(code, module.__dict__)
@@ -183,12 +203,16 @@ def compile_code(code, timeout):
         if "class Solution" in code:
             return module.Solution()
         return module
+    except TimeoutException:
+        # Module-level work that never finishes is a slow solution, not a
+        # broken one.
+        raise
     except Exception as exc:
         # A solution that does not compile is a failed solution, reported the
         # same way as one whose entry point is missing.
         raise CompilationError(repr(exc)) from exc
     finally:
-        signal.alarm(0)
+        cancel_alarm()
 
 
 def get_stripped_lines(value):
@@ -213,12 +237,12 @@ def grade_call_based(code, inputs, outputs, fn_name, timeout):
     parsed_inputs = [[json.loads(line) for line in case.split("\n")] for case in inputs]
     parsed_outputs = [json.loads(case) for case in outputs]
 
-    for gt_input, gt_output in zip(parsed_inputs, parsed_outputs, strict=False):
-        signal.alarm(timeout)
+    for gt_input, gt_output in zip(parsed_inputs, parsed_outputs, strict=True):
+        start_alarm(timeout)
         faulthandler.enable()
         try:
             prediction = method(*gt_input)
-            signal.alarm(0)
+            cancel_alarm()
 
             # Tuples and lists are not distinguished: ground truth is never a tuple.
             if isinstance(prediction, tuple):
@@ -226,12 +250,14 @@ def grade_call_based(code, inputs, outputs, fn_name, timeout):
 
             if prediction != gt_output:
                 return False, {"error_code": -2, "error_message": "Wrong Answer"}
-        except Exception as exc:
-            if "timeoutexception" in repr(exc).lower():
-                return False, {"error_code": -3, "error_message": "Time Limit Exceeded"}
+        except TimeoutException:
+            return False, {"error_code": -3, "error_message": "Time Limit Exceeded"}
+        except (Exception, SystemExit) as exc:
+            # A whole-program solution may exit; a function that does so has
+            # no answer.
             return False, {"error_code": -4, "error_message": f"Runtime Error: {exc!r}"}
         finally:
-            signal.alarm(0)
+            cancel_alarm()
             faulthandler.disable()
 
     return True, {}
@@ -245,19 +271,19 @@ def grade_stdio(code, inputs, outputs, timeout):
     if method is None:
         return False, {"error_code": -4, "error_message": "Function not found in generated code"}
 
-    for gt_input, gt_output in zip(inputs, outputs, strict=False):
-        signal.alarm(timeout)
+    for gt_input, gt_output in zip(inputs, outputs, strict=True):
+        start_alarm(timeout)
         faulthandler.enable()
         with Capturing() as captured:
             try:
                 call_method(method, gt_input)
-                signal.alarm(0)
+                cancel_alarm()
+            except TimeoutException:
+                return False, {"error_code": -3, "error_message": "Time Limit Exceeded"}
             except Exception as exc:
-                if "timeoutexception" in repr(exc).lower():
-                    return False, {"error_code": -3, "error_message": "Time Limit Exceeded"}
                 return False, {"error_code": -4, "error_message": f"Runtime Error: {exc!r}"}
             finally:
-                signal.alarm(0)
+                cancel_alarm()
                 faulthandler.disable()
 
         prediction_lines = get_stripped_lines(captured[0])
@@ -289,18 +315,21 @@ def grade_stdio(code, inputs, outputs, timeout):
 
 
 def decode_test_cases(encoded):
-    """Decode a test case blob, which may be JSON or compressed pickle."""
+    """Decode a test case blob, which may be JSON or compressed pickle.
+
+    Raises ``ValueError`` for a blob in neither form, so that a payload the
+    grader cannot read is never mistaken for a problem with no tests.
+    """
     if not encoded:
         return []
     try:
         return json.loads(encoded)
     except json.JSONDecodeError:
-        try:
-            return json.loads(
-                pickle.loads(zlib.decompress(base64.b64decode(encoded.encode("utf-8"))))
-            )
-        except Exception:
-            return []
+        pass
+    try:
+        return json.loads(pickle.loads(zlib.decompress(base64.b64decode(encoded.encode("utf-8")))))
+    except Exception as exc:
+        raise ValueError(f"test cases are neither JSON nor compressed pickle: {exc!r}") from exc
 
 
 def reliability_guard():
@@ -357,6 +386,96 @@ def reliability_guard():
         loaded_modules[blocked] = None
 
 
+MAX_ERROR_MESSAGE_LEN = 2000
+
+
+def grade(solution, inputs, outputs, fn_name, timeout):
+    """Grade a solution in this process and return ``(passed, detail)``."""
+    signal.signal(signal.SIGALRM, timeout_handler)
+    reliability_guard()
+    try:
+        if fn_name:
+            return grade_call_based(solution, inputs, outputs, fn_name, timeout)
+        return grade_stdio(solution, inputs, outputs, timeout)
+    except CompilationError as exc:
+        return False, {"error_code": -4, "error_message": f"Compilation error: {exc}"}
+    except TimeoutException:
+        return False, {"error_code": -3, "error_message": "Time Limit Exceeded"}
+
+
+def grade_in_child(solution, inputs, outputs, fn_name, timeout, budget):
+    """Grade in a forked child and return the verdict fields it reports.
+
+    The child sends its verdict back over a pipe. A child that dies before
+    reporting, or is still running when ``budget`` seconds are up, is a failed
+    solution: the parent never depends on the solution's process surviving.
+    """
+    read_fd, write_fd = os.pipe()
+    pid = os.fork()
+    if pid == 0:
+        os.close(read_fd)
+        try:
+            passed, detail = grade(solution, inputs, outputs, fn_name, timeout)
+            verdict: dict[str, Any] = {"passed": passed, **detail}
+        except BaseException as exc:
+            verdict = {
+                "passed": False,
+                "error_code": -5,
+                "error_message": f"TestRunnerError: {exc!r}",
+            }
+        if "error_message" in verdict:
+            verdict["error_message"] = verdict["error_message"][:MAX_ERROR_MESSAGE_LEN]
+        with os.fdopen(write_fd, "wb") as pipe:
+            pipe.write(json.dumps(verdict).encode("utf-8"))
+        os._exit(0)
+
+    os.close(write_fd)
+    chunks = []
+    deadline = time.monotonic() + budget
+    try:
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                os.kill(pid, signal.SIGKILL)
+                os.waitpid(pid, 0)
+                return {
+                    "passed": False,
+                    "error_code": -3,
+                    "error_message": (
+                        f"Time Limit Exceeded: over the {budget:.0f}s budget for all tests"
+                    ),
+                }
+            ready, _, _ = select.select([read_fd], [], [], remaining)
+            if not ready:
+                continue
+            chunk = os.read(read_fd, 65536)
+            if not chunk:
+                break
+            chunks.append(chunk)
+    finally:
+        os.close(read_fd)
+    _, status = os.waitpid(pid, 0)
+
+    if chunks:
+        return json.loads(b"".join(chunks).decode("utf-8"))
+    if os.WIFSIGNALED(status):
+        # The interpreter itself died: deep recursion, memory exhaustion.
+        return {
+            "passed": False,
+            "error_code": -4,
+            "error_message": (
+                f"Runtime Error: solution process killed by signal {os.WTERMSIG(status)}"
+            ),
+        }
+    return {
+        "passed": False,
+        "error_code": -5,
+        "error_message": (
+            f"TestRunnerError: solution process exited {os.WEXITSTATUS(status)} without a verdict"
+        ),
+    }
+
+
 def main():
     here = os.path.dirname(os.path.abspath(__file__))
     with open(os.path.join(here, "problem.json")) as handle:
@@ -364,39 +483,34 @@ def main():
     with open(os.path.join(here, "solution.py")) as handle:
         solution = handle.read()
 
-    test_cases = decode_test_cases(problem["public_test_cases"]) + decode_test_cases(
-        problem["private_test_cases"]
-    )
-    inputs = [case["input"] for case in test_cases]
-    outputs = [case["output"] for case in test_cases]
     fn_name = problem.get("fn_name")
-    timeout = int(problem.get("timeout", 6))
-
-    signal.signal(signal.SIGALRM, timeout_handler)
-    reliability_guard()
+    timeout = float(problem.get("timeout", 6))
 
     started = time.time()
     try:
-        if fn_name:
-            passed, detail = grade_call_based(solution, inputs, outputs, fn_name, timeout)
-        else:
-            passed, detail = grade_stdio(solution, inputs, outputs, timeout)
-    except CompilationError as exc:
-        passed, detail = False, {"error_code": -4, "error_message": f"Compilation error: {exc}"}
-    except TimeoutException:
-        passed, detail = False, {"error_code": -3, "error_message": "Time Limit Exceeded"}
+        test_cases = decode_test_cases(problem["public_test_cases"]) + decode_test_cases(
+            problem["private_test_cases"]
+        )
+        inputs = [case["input"] for case in test_cases]
+        outputs = [case["output"] for case in test_cases]
     except Exception as exc:
-        passed, detail = False, {"error_code": -5, "error_message": f"TestRunnerError: {exc!r}"}
+        inputs = []
+        verdict: dict[str, Any] = {
+            "passed": False,
+            "error_code": -5,
+            "error_message": f"TestRunnerError: {exc!r}"[:MAX_ERROR_MESSAGE_LEN],
+        }
+    else:
+        # The reference harness gives the whole run this long before killing it.
+        budget = (timeout + 1) * len(inputs) + 5
+        verdict = grade_in_child(solution, inputs, outputs, fn_name, timeout, budget)
 
-    verdict = {
-        "passed": passed,
-        "num_tests": len(inputs),
-        "elapsed": round(time.time() - started, 3),
-    }
-    verdict.update(detail)
-    # The harness reads the last line of stdout; solutions print freely above it.
+    verdict["num_tests"] = len(inputs)
+    verdict["elapsed"] = round(time.time() - started, 3)
+    # The harness reads the last line of stdout. The child may have written
+    # there without a trailing newline, so start a fresh line first.
     sys.stdout = sys.__stdout__
-    print(json.dumps(verdict))
+    print("\n" + json.dumps(verdict), flush=True)
 
 
 if __name__ == "__main__":

--- a/src/olmo_eval/common/scorers/execution.py
+++ b/src/olmo_eval/common/scorers/execution.py
@@ -20,6 +20,16 @@ class SandboxRequiredError(RuntimeError):
     pass
 
 
+class ScoringIncompleteError(RuntimeError):
+    """Raised when a scorer could not reach a verdict for an output.
+
+    Distinguishes a score that was never produced, such as a grader that did
+    not run or a payload that could not be read, from a solution that was
+    graded and failed. The runner records these as lost scores rather than
+    folding them into the metric as zeros.
+    """
+
+
 @dataclass(frozen=True)
 class ContextScorer(Scorer):
     """Base class for scorers that require access to ScoringContext.

--- a/src/olmo_eval/evals/tasks/common/base.py
+++ b/src/olmo_eval/evals/tasks/common/base.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING, Any, NamedTuple
 from olmo_eval.common.formatters import Formatter
 from olmo_eval.common.metrics import Metric
 from olmo_eval.common.repr import hide_unset
-from olmo_eval.common.scorers import Scorer
+from olmo_eval.common.scorers import Scorer, ScoringIncompleteError
 from olmo_eval.common.types import (
     Instance,
     LMOutput,
@@ -44,13 +44,16 @@ def _format_scoring_error(exc: Exception, *, phase: str) -> dict[str, str]:
     message = str(exc).strip()
     if message:
         error["message"] = message
-    try:
-        from olmo_eval.harness.sandbox import SandboxInfrastructureError
+    if isinstance(exc, ScoringIncompleteError):
+        error["infrastructure"] = "true"
+    else:
+        try:
+            from olmo_eval.harness.sandbox import SandboxInfrastructureError
 
-        if isinstance(exc, SandboxInfrastructureError):
-            error["infrastructure"] = "true"
-    except ImportError:
-        pass
+            if isinstance(exc, SandboxInfrastructureError):
+                error["infrastructure"] = "true"
+        except ImportError:
+            pass
     return error
 
 

--- a/src/olmo_eval/evals/tasks/livecodebench.py
+++ b/src/olmo_eval/evals/tasks/livecodebench.py
@@ -1,0 +1,357 @@
+"""LiveCodeBench code generation task.
+
+LiveCodeBench collects programming contest problems tagged by contest date, so
+a model can be scored on problems published after its training data was
+collected. Solutions are graded by running them against the contest's own test
+cases inside a sandbox.
+
+Paper: https://arxiv.org/abs/2403.07974
+Dataset: livecodebench/code_generation_lite
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import shlex
+import uuid
+from collections.abc import Iterator
+from dataclasses import dataclass, replace
+from functools import lru_cache
+from typing import TYPE_CHECKING, Any
+
+from olmo_eval.common.execution.environment import StagingExecutionEnvironment
+from olmo_eval.common.formatters import ChatFormatter
+from olmo_eval.common.metrics import PassAtKMetric
+from olmo_eval.common.scorers import ExecutionScorer, SandboxRequiredError
+from olmo_eval.common.scorers.code_execution.scripts import get_script
+from olmo_eval.common.types import (
+    Instance,
+    LMOutput,
+    LMRequest,
+    SamplingParams,
+    Split,
+)
+from olmo_eval.data import DataSource
+from olmo_eval.evals.extract import extract_code
+from olmo_eval.evals.tasks.common import Task, register, register_variant
+
+if TYPE_CHECKING:
+    from olmo_eval.common.execution import ExecutionEnvironment
+
+logger = logging.getLogger(__name__)
+
+LIVECODEBENCH_REPO = "livecodebench/code_generation_lite"
+
+# Each release adds one data file; a window of files is one contest date range.
+RELEASE_V3_FILES: tuple[str, ...] = ("test.jsonl", "test2.jsonl", "test3.jsonl")
+RELEASE_V4_V6_FILES: tuple[str, ...] = ("test4.jsonl", "test5.jsonl", "test6.jsonl")
+
+SYSTEM_PROMPT = (
+    "You are an expert Python programmer. You will be given a question (problem "
+    "specification) and will generate a correct Python program that matches the "
+    "specification and passes all tests."
+)
+
+# The reasoning line sits between the problem statement and the per-problem
+# format instruction, so both parts are substituted here rather than folded
+# into the instance question.
+USER_TEMPLATE = (
+    "### Question:\n{question}\n\n"
+    "### Format:\n{reasoning_instruction}{format_instruction}\n\n"
+    "### Answer: (use the provided format with backticks)\n\n"
+)
+
+THINK_INSTRUCTION = (
+    "Provide CONCISE reasoning on how to arrive at the answer in the <think> </think> tag.\n"
+)
+
+STARTER_CODE_INSTRUCTION = (
+    "You will use the following starter code to write the solution to the problem "
+    "and enclose your code within delimiters."
+)
+
+STDIN_INSTRUCTION = (
+    "Read the inputs from stdin solve the problem and write the answer to stdout "
+    "(do not directly test on the sample inputs). Enclose your code within delimiters "
+    "as follows. Ensure that when the python program runs, it reads the inputs, runs "
+    "the algorithm and writes output to STDOUT.\n```python\n# YOUR CODE HERE\n```"
+)
+
+
+@lru_cache(maxsize=4)
+def _test_case_rows(repo: str, files: tuple[str, ...]) -> Any:
+    """Open a release's data files for random access by row.
+
+    Test payloads run to gigabytes per release, so they are read here when a
+    solution is graded rather than carried on every instance, which would put
+    them in the request records written for the run.
+    """
+    from datasets import load_dataset
+
+    return load_dataset(
+        "json",
+        data_files={"train": [f"hf://datasets/{repo}/{name}" for name in files]},
+        split="train",
+    )
+
+
+def _parse_verdict(output: str) -> dict[str, Any] | None:
+    """Read the grader's JSON verdict, which is the last line it prints."""
+    for line in reversed((output or "").strip().splitlines()):
+        line = line.strip()
+        if line.startswith("{") and line.endswith("}"):
+            try:
+                return json.loads(line)
+            except json.JSONDecodeError:
+                continue
+    return None
+
+
+@dataclass(slots=True)
+class LiveCodeBenchFormatter(ChatFormatter):
+    """Chat formatter that fills in each problem's answer format instruction.
+
+    Whether the model is asked to reason in ``<think>`` tags is part of the
+    prompt, so regimes that differ only in that line differ only by formatter.
+    """
+
+    reasoning_instruction: str = ""
+
+    def format(
+        self,
+        instance: Instance,
+        fewshot: list[Instance] | None = None,
+    ) -> LMRequest:
+        content = USER_TEMPLATE.format(
+            question=instance.question,
+            reasoning_instruction=self.reasoning_instruction,
+            format_instruction=instance.metadata.get("format_instruction", ""),
+        )
+        messages: list[dict[str, str]] = []
+        if self.system_prompt:
+            messages.append({"role": "system", "content": self.system_prompt})
+        messages.append({"role": "user", "content": content})
+        return LMRequest(
+            request_type=self.request_type,
+            messages=tuple(messages),
+            system_prompt=self.system_prompt or None,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class LiveCodeBenchScorer(ExecutionScorer):
+    """Run one solution against a problem's contest test cases in a sandbox.
+
+    The test cases are staged as a file rather than passed in the command,
+    because a single problem's cases can run to tens of megabytes and command
+    text is bounded by the operating system's argument size limit.
+    """
+
+    name: str = "code_exec"
+    #: Per test case, matching the reference harness.
+    timeout: float = 6.0
+    #: Ceiling for one solution across all of its test cases. Grading stops at
+    #: the first failure, so only a solution that passes runs the full set.
+    overall_timeout: float = 900.0
+    max_output_len: int = 4000
+
+    async def ascore(
+        self,
+        instance: Instance,
+        output: LMOutput,
+        execution_env: ExecutionEnvironment,
+    ) -> float:
+        if output.extracted_answer is None:
+            output.metadata["execution_result"] = {"success": False, "error": "No extracted answer"}
+            return 0.0
+
+        if not isinstance(execution_env, StagingExecutionEnvironment):
+            raise SandboxRequiredError(
+                f"{type(self).__name__} needs an execution environment that can stage "
+                "files; LiveCodeBench test cases are too large to pass as a command."
+            )
+
+        metadata = instance.metadata
+        row = _test_case_rows(metadata["test_repo"], tuple(metadata["test_files"]))[metadata["row"]]
+        if row["question_id"] != metadata["id"]:
+            # Grading against another problem's tests would score every
+            # solution wrong while still looking like a plausible result.
+            raise RuntimeError(
+                f"Test cases for problem {metadata['id']} are not at row "
+                f"{metadata['row']}; the dataset's row order changed."
+            )
+        problem = {
+            "public_test_cases": row["public_test_cases"],
+            "private_test_cases": row["private_test_cases"],
+            "fn_name": metadata.get("fn_name"),
+            "timeout": self.timeout,
+        }
+
+        work_dir = f"/tmp/lcb-{uuid.uuid4().hex}"
+        quoted = shlex.quote(work_dir)
+        result = await execution_env.execute_with_files(
+            f"cd {quoted} && python3 grade.py; status=$?; rm -rf {quoted}; exit $status",
+            {
+                f"{work_dir}/grade.py": get_script("livecodebench_grader"),
+                f"{work_dir}/problem.json": json.dumps(problem),
+                f"{work_dir}/solution.py": output.extracted_answer,
+            },
+            timeout=self.overall_timeout,
+        )
+
+        verdict = _parse_verdict(result.output)
+        passed = bool(verdict and verdict.get("passed"))
+        output.metadata["execution_result"] = {
+            "success": passed,
+            "exit_code": result.exit_code,
+            "error": result.error or (verdict or {}).get("error_message", ""),
+            "output": result.output[: self.max_output_len] if result.output else "",
+        }
+        if verdict is None:
+            logger.warning(
+                "No grader verdict for instance %s: %s",
+                metadata.get("id", "?"),
+                (result.error or result.output or "")[:200],
+            )
+        return 1.0 if passed else 0.0
+
+
+PASS_AT_KS = (1, 5, 10)
+METRICS = tuple(PassAtKMetric(k=k, scorer=LiveCodeBenchScorer) for k in PASS_AT_KS)
+PASS_AT_1 = PassAtKMetric(k=1, scorer=LiveCodeBenchScorer)
+
+THINK_FORMATTER = LiveCodeBenchFormatter(
+    system_prompt=SYSTEM_PROMPT,
+    reasoning_instruction=THINK_INSTRUCTION,
+)
+PLAIN_FORMATTER = LiveCodeBenchFormatter(system_prompt=SYSTEM_PROMPT)
+
+# Defaults mirror oe-eval's ``livecodebench_codegeneration::olmo3:adapt``, the
+# OLMo 3 post-training regime. max_tokens=None generates to the model's context
+# limit, matching the reference regime's effective behavior on any context size.
+ADAPT_SAMPLING = SamplingParams(
+    max_tokens=None,
+    temperature=0.6,
+    top_p=0.95,
+    num_samples=10,
+)
+
+
+@register("livecodebench")
+class LiveCodeBench(Task):
+    """LiveCodeBench release_v3: contests through the v3 cutoff (612 problems)."""
+
+    release_files: tuple[str, ...] = RELEASE_V3_FILES
+
+    data_source = DataSource(
+        path=LIVECODEBENCH_REPO,
+        data_files=RELEASE_V3_FILES,
+        split="train",
+    )
+    split = Split.TRAIN
+    formatter = THINK_FORMATTER
+    metrics = METRICS
+    primary_metric = PASS_AT_1
+    sampling_params = ADAPT_SAMPLING
+    # Test execution is slow and long-tailed; keep a share of shared sandbox
+    # pools comparable to the other heavyweight code tasks.
+    sandbox_allocation_weight = 6.0
+
+    @property
+    def instances(self) -> Iterator[Instance]:
+        yield from self._load_instances_cached()
+
+    def process_doc(self, doc: dict[str, Any], index: int = 0) -> Instance:
+        starter_code = (doc.get("starter_code") or "").strip()
+        if starter_code:
+            format_instruction = (
+                f"{STARTER_CODE_INSTRUCTION}\n```python\n{doc['starter_code']}\n```"
+            )
+        else:
+            format_instruction = STDIN_INSTRUCTION
+
+        problem_metadata = json.loads(doc["metadata"]) if doc.get("metadata") else {}
+        contest_date = doc.get("contest_date", "unknown")
+        if hasattr(contest_date, "isoformat"):
+            contest_date = contest_date.isoformat()
+
+        return Instance(
+            question=doc["question_content"],
+            metadata={
+                "id": doc["question_id"],
+                # Located by row so the scorer can read this problem's test
+                # cases without them travelling on the instance.
+                "row": index,
+                "test_repo": LIVECODEBENCH_REPO,
+                "test_files": self.release_files,
+                "format_instruction": format_instruction,
+                "fn_name": problem_metadata.get("func_name"),
+                "platform": doc.get("platform", "unknown"),
+                "difficulty": doc.get("difficulty", "unknown"),
+                "contest_date": contest_date,
+            },
+        )
+
+    def format_request(self, instance: Instance) -> LMRequest:
+        assert self.config.formatter is not None
+        return self.config.formatter.format(instance, self.get_fewshot())
+
+    def extract_answer(self, output: LMOutput) -> str | None:
+        return extract_code(output.text)
+
+
+@register("livecodebench_hidden")
+class LiveCodeBenchHidden(LiveCodeBench):
+    """LiveCodeBench v4-v6: contests after the v3 cutoff (443 problems).
+
+    Held out from the main task so that problems postdating a model's training
+    data can be scored separately.
+    """
+
+    release_files: tuple[str, ...] = RELEASE_V4_V6_FILES
+
+    data_source = DataSource(
+        path=LIVECODEBENCH_REPO,
+        data_files=RELEASE_V4_V6_FILES,
+        split="train",
+    )
+
+
+for _task_name in ("livecodebench", "livecodebench_hidden"):
+    # Mirrors oe-eval's ``::tulu``: no reasoning instruction, shorter budget.
+    register_variant(
+        _task_name,
+        "tulu",
+        formatter=PLAIN_FORMATTER,
+        sampling_params=SamplingParams(
+            max_tokens=2048,
+            temperature=0.2,
+            top_p=0.95,
+            num_samples=10,
+        ),
+    )
+
+    # Mirrors oe-eval's ``::tulu-thinker_deepseek_lite``: the default regime
+    # scored on a single sample, for cheaper iteration.
+    register_variant(
+        _task_name,
+        "lite",
+        metrics=(PASS_AT_1,),
+        primary_metric=PASS_AT_1,
+        sampling_params=replace(ADAPT_SAMPLING, num_samples=1),
+    )
+
+    # Mirrors oe-eval's ``:grpo::tulu-thinker``, used for RL runs.
+    register_variant(
+        _task_name,
+        "grpo",
+        metrics=tuple(PassAtKMetric(k=k, scorer=LiveCodeBenchScorer) for k in (1, 2, 4, 8, 10)),
+        primary_metric=PassAtKMetric(k=10, scorer=LiveCodeBenchScorer),
+        sampling_params=SamplingParams(
+            max_tokens=16384,
+            temperature=1.0,
+            top_p=1.0,
+            num_samples=10,
+        ),
+    )

--- a/src/olmo_eval/evals/tasks/livecodebench.py
+++ b/src/olmo_eval/evals/tasks/livecodebench.py
@@ -33,7 +33,6 @@ from olmo_eval.common.types import (
     Split,
 )
 from olmo_eval.data import DataSource
-from olmo_eval.evals.extract import extract_code
 from olmo_eval.evals.tasks.common import Task, register, register_variant
 
 if TYPE_CHECKING:
@@ -94,6 +93,22 @@ def _test_case_rows(repo: str, files: tuple[str, ...]) -> Any:
         data_files={"train": [f"hf://datasets/{repo}/{name}" for name in files]},
         split="train",
     )
+
+
+def _extract_last_code_block(text: str) -> str | None:
+    """Return the last fenced code block, as the reference implementation does.
+
+    The answer is the last block rather than the first. A reasoning model
+    drafts code while it thinks, so earlier blocks are usually attempts it
+    went on to discard, and its reply may open no ``<think>`` tag to strip
+    because the chat template already supplied one. Text holding fewer than
+    two fence markers has no complete block in it.
+    """
+    lines = (text or "").split("\n")
+    fences = [index for index, line in enumerate(lines) if "```" in line]
+    if len(fences) < 2:
+        return None
+    return "\n".join(lines[fences[-2] + 1 : fences[-1]])
 
 
 def _parse_verdict(output: str) -> dict[str, Any] | None:
@@ -298,7 +313,7 @@ class LiveCodeBench(Task):
         return self.config.formatter.format(instance, self.get_fewshot())
 
     def extract_answer(self, output: LMOutput) -> str | None:
-        return extract_code(output.text)
+        return _extract_last_code_block(output.text)
 
 
 @register("livecodebench_hidden")

--- a/src/olmo_eval/evals/tasks/livecodebench.py
+++ b/src/olmo_eval/evals/tasks/livecodebench.py
@@ -25,7 +25,11 @@ from typing import TYPE_CHECKING, Any
 from olmo_eval.common.execution.environment import StagingExecutionEnvironment
 from olmo_eval.common.formatters import ChatFormatter
 from olmo_eval.common.metrics import PassAtKMetric
-from olmo_eval.common.scorers import ExecutionScorer, SandboxRequiredError
+from olmo_eval.common.scorers import (
+    ExecutionScorer,
+    SandboxRequiredError,
+    ScoringIncompleteError,
+)
 from olmo_eval.common.scorers.code_execution.scripts import get_script
 from olmo_eval.common.types import (
     Instance,
@@ -36,7 +40,6 @@ from olmo_eval.common.types import (
 )
 from olmo_eval.data import DataSource
 from olmo_eval.evals.tasks.common import Task, register, register_variant
-from olmo_eval.harness.sandbox.errors import SandboxInfrastructureError
 
 if TYPE_CHECKING:
     from olmo_eval.common.execution import ExecutionEnvironment
@@ -116,7 +119,7 @@ def _stage_problem(metadata: dict[str, Any], timeout: float) -> str:
     if row["question_id"] != metadata["id"]:
         # Grading against another problem's tests would score every
         # solution wrong while still looking like a plausible result.
-        raise GradingFailedError(
+        raise ScoringIncompleteError(
             f"Test cases for problem {metadata['id']} are not at row "
             f"{metadata['row']}; the dataset's row order changed."
         )
@@ -146,13 +149,18 @@ def _extract_last_code_block(text: str) -> str | None:
     return "\n".join(lines[fences[-2] + 1 : fences[-1]])
 
 
+#: The grader marks its verdict line with this so that nothing a solution
+#: writes, on either stream, can be mistaken for it.
+VERDICT_PREFIX = "LCB_VERDICT "
+
+
 def _parse_verdict(output: str) -> dict[str, Any] | None:
-    """Read the grader's JSON verdict, which is the last line it prints."""
+    """Read the grader's JSON verdict from the command output."""
     for line in reversed((output or "").strip().splitlines()):
         line = line.strip()
-        if line.startswith("{") and line.endswith("}"):
+        if line.startswith(VERDICT_PREFIX):
             try:
-                return json.loads(line)
+                return json.loads(line[len(VERDICT_PREFIX) :])
             except json.JSONDecodeError:
                 continue
     return None
@@ -193,14 +201,6 @@ class LiveCodeBenchFormatter(ChatFormatter):
 GRADER_ERROR_CODE = -5
 
 
-class GradingFailedError(SandboxInfrastructureError):
-    """The grader produced no usable verdict, so the solution was never scored.
-
-    Raised as an infrastructure failure so that the task's result records the
-    lost scores instead of publishing them as zeros.
-    """
-
-
 @dataclass(frozen=True, slots=True)
 class LiveCodeBenchScorer(ExecutionScorer):
     """Run one solution against a problem's contest test cases in a sandbox.
@@ -220,8 +220,8 @@ class LiveCodeBenchScorer(ExecutionScorer):
     timeout: float = 6.0
     #: Ceiling for one grading run. The grader itself stops a solution at the
     #: reference harness's budget of ``(timeout + 1) * num_tests + 5`` seconds,
-    #: so this only needs to exceed that for the largest problem in a release:
-    #: 103 test cases, or 726 seconds, across the shipped releases.
+    #: so this only needs to exceed that budget for the problem with the most
+    #: test cases in a release.
     overall_timeout: float = 900.0
     max_output_len: int = 4000
 
@@ -260,6 +260,7 @@ class LiveCodeBenchScorer(ExecutionScorer):
         verdict = _parse_verdict(result.output)
         output.metadata["execution_result"] = {
             "success": bool(verdict and verdict.get("passed")),
+            "num_tests": (verdict or {}).get("num_tests"),
             "exit_code": result.exit_code,
             "error": result.error or (verdict or {}).get("error_message", ""),
             "output": result.output[: self.max_output_len] if result.output else "",
@@ -267,18 +268,18 @@ class LiveCodeBenchScorer(ExecutionScorer):
 
         problem_id = metadata.get("id", "?")
         if verdict is None:
-            raise GradingFailedError(
+            raise ScoringIncompleteError(
                 f"No grader verdict for problem {problem_id} "
                 f"(exit code {result.exit_code}): "
                 f"{(result.error or result.output or '')[:500]}"
             )
         if not verdict.get("num_tests"):
-            raise GradingFailedError(
+            raise ScoringIncompleteError(
                 f"No test cases were graded for problem {problem_id}: "
                 f"{verdict.get('error_message', 'the grader decoded an empty test set')}"
             )
         if verdict.get("error_code") == GRADER_ERROR_CODE:
-            raise GradingFailedError(
+            raise ScoringIncompleteError(
                 f"The grader failed on problem {problem_id}: {verdict.get('error_message', '')}"
             )
         return 1.0 if verdict.get("passed") else 0.0
@@ -325,7 +326,7 @@ ADAPT_SAMPLING = SamplingParams(
 
 @register("livecodebench")
 class LiveCodeBench(Task):
-    """LiveCodeBench release_v3: contests through the v3 cutoff (612 problems)."""
+    """LiveCodeBench release_v3: contests through the v3 cutoff."""
 
     release_files: tuple[str, ...] = RELEASE_V3_FILES
 
@@ -388,7 +389,7 @@ class LiveCodeBench(Task):
 
 @register("livecodebench_hidden")
 class LiveCodeBenchHidden(LiveCodeBench):
-    """LiveCodeBench v4-v6: contests after the v3 cutoff (443 problems).
+    """LiveCodeBench v4-v6: contests after the v3 cutoff.
 
     Held out from the main task so that problems postdating a model's training
     data can be scored separately.

--- a/src/olmo_eval/evals/tasks/livecodebench.py
+++ b/src/olmo_eval/evals/tasks/livecodebench.py
@@ -11,9 +11,11 @@ Dataset: livecodebench/code_generation_lite
 
 from __future__ import annotations
 
+import asyncio
 import json
-import logging
+import math
 import shlex
+import threading
 import uuid
 from collections.abc import Iterator
 from dataclasses import dataclass, replace
@@ -34,11 +36,10 @@ from olmo_eval.common.types import (
 )
 from olmo_eval.data import DataSource
 from olmo_eval.evals.tasks.common import Task, register, register_variant
+from olmo_eval.harness.sandbox.errors import SandboxInfrastructureError
 
 if TYPE_CHECKING:
     from olmo_eval.common.execution import ExecutionEnvironment
-
-logger = logging.getLogger(__name__)
 
 LIVECODEBENCH_REPO = "livecodebench/code_generation_lite"
 
@@ -78,20 +79,54 @@ STDIN_INSTRUCTION = (
 )
 
 
-@lru_cache(maxsize=4)
-def _test_case_rows(repo: str, files: tuple[str, ...]) -> Any:
-    """Open a release's data files for random access by row.
+_TEST_CASE_ROWS_LOCK = threading.Lock()
 
-    Test payloads run to gigabytes per release, so they are read here when a
-    solution is graded rather than carried on every instance, which would put
-    them in the request records written for the run.
-    """
+
+@lru_cache(maxsize=4)
+def _open_test_case_rows(repo: str, files: tuple[str, ...]) -> Any:
     from datasets import load_dataset
 
     return load_dataset(
         "json",
         data_files={"train": [f"hf://datasets/{repo}/{name}" for name in files]},
         split="train",
+    )
+
+
+def _test_case_rows(repo: str, files: tuple[str, ...]) -> Any:
+    """Open a release's data files for random access by row.
+
+    Test payloads run to gigabytes per release, so they are read here when a
+    solution is graded rather than carried on every instance, which would put
+    them in the request records written for the run. Scorers read from worker
+    threads, so the one-time load is serialized rather than repeated by each
+    thread that finds the cache empty.
+    """
+    with _TEST_CASE_ROWS_LOCK:
+        return _open_test_case_rows(repo, files)
+
+
+def _stage_problem(metadata: dict[str, Any], timeout: float) -> str:
+    """Serialize a problem's test cases for the grader.
+
+    Reading the row and encoding it can take most of a second for the largest
+    problems, so callers run this off the event loop.
+    """
+    row = _test_case_rows(metadata["test_repo"], tuple(metadata["test_files"]))[metadata["row"]]
+    if row["question_id"] != metadata["id"]:
+        # Grading against another problem's tests would score every
+        # solution wrong while still looking like a plausible result.
+        raise GradingFailedError(
+            f"Test cases for problem {metadata['id']} are not at row "
+            f"{metadata['row']}; the dataset's row order changed."
+        )
+    return json.dumps(
+        {
+            "public_test_cases": row["public_test_cases"],
+            "private_test_cases": row["private_test_cases"],
+            "fn_name": metadata.get("fn_name"),
+            "timeout": timeout,
+        }
     )
 
 
@@ -154,6 +189,18 @@ class LiveCodeBenchFormatter(ChatFormatter):
         )
 
 
+#: The grader reports this code when it, rather than the solution, failed.
+GRADER_ERROR_CODE = -5
+
+
+class GradingFailedError(SandboxInfrastructureError):
+    """The grader produced no usable verdict, so the solution was never scored.
+
+    Raised as an infrastructure failure so that the task's result records the
+    lost scores instead of publishing them as zeros.
+    """
+
+
 @dataclass(frozen=True, slots=True)
 class LiveCodeBenchScorer(ExecutionScorer):
     """Run one solution against a problem's contest test cases in a sandbox.
@@ -161,13 +208,20 @@ class LiveCodeBenchScorer(ExecutionScorer):
     The test cases are staged as a file rather than passed in the command,
     because a single problem's cases can run to tens of megabytes and command
     text is bounded by the operating system's argument size limit.
+
+    A solution that is wrong, crashes, or runs out of time scores zero. A
+    grading run that produced no verdict, found no test cases, or failed
+    inside the grader raises instead, so a broken image or payload is recorded
+    as an infrastructure failure on the task rather than as a plausible score.
     """
 
     name: str = "code_exec"
     #: Per test case, matching the reference harness.
     timeout: float = 6.0
-    #: Ceiling for one solution across all of its test cases. Grading stops at
-    #: the first failure, so only a solution that passes runs the full set.
+    #: Ceiling for one grading run. The grader itself stops a solution at the
+    #: reference harness's budget of ``(timeout + 1) * num_tests + 5`` seconds,
+    #: so this only needs to exceed that for the largest problem in a release:
+    #: 103 test cases, or 726 seconds, across the shipped releases.
     overall_timeout: float = 900.0
     max_output_len: int = 4000
 
@@ -188,48 +242,64 @@ class LiveCodeBenchScorer(ExecutionScorer):
             )
 
         metadata = instance.metadata
-        row = _test_case_rows(metadata["test_repo"], tuple(metadata["test_files"]))[metadata["row"]]
-        if row["question_id"] != metadata["id"]:
-            # Grading against another problem's tests would score every
-            # solution wrong while still looking like a plausible result.
-            raise RuntimeError(
-                f"Test cases for problem {metadata['id']} are not at row "
-                f"{metadata['row']}; the dataset's row order changed."
-            )
-        problem = {
-            "public_test_cases": row["public_test_cases"],
-            "private_test_cases": row["private_test_cases"],
-            "fn_name": metadata.get("fn_name"),
-            "timeout": self.timeout,
-        }
+        problem = await asyncio.to_thread(_stage_problem, metadata, self.timeout)
 
         work_dir = f"/tmp/lcb-{uuid.uuid4().hex}"
-        quoted = shlex.quote(work_dir)
         result = await execution_env.execute_with_files(
-            f"cd {quoted} && python3 grade.py; status=$?; rm -rf {quoted}; exit $status",
+            self._command(work_dir),
             {
                 f"{work_dir}/grade.py": get_script("livecodebench_grader"),
-                f"{work_dir}/problem.json": json.dumps(problem),
+                f"{work_dir}/problem.json": problem,
                 f"{work_dir}/solution.py": output.extracted_answer,
             },
-            timeout=self.overall_timeout,
+            # Leave the command time to remove the staged files once the
+            # grader has been stopped.
+            timeout=self.overall_timeout + 60.0,
         )
 
         verdict = _parse_verdict(result.output)
-        passed = bool(verdict and verdict.get("passed"))
         output.metadata["execution_result"] = {
-            "success": passed,
+            "success": bool(verdict and verdict.get("passed")),
             "exit_code": result.exit_code,
             "error": result.error or (verdict or {}).get("error_message", ""),
             "output": result.output[: self.max_output_len] if result.output else "",
         }
+
+        problem_id = metadata.get("id", "?")
         if verdict is None:
-            logger.warning(
-                "No grader verdict for instance %s: %s",
-                metadata.get("id", "?"),
-                (result.error or result.output or "")[:200],
+            raise GradingFailedError(
+                f"No grader verdict for problem {problem_id} "
+                f"(exit code {result.exit_code}): "
+                f"{(result.error or result.output or '')[:500]}"
             )
-        return 1.0 if passed else 0.0
+        if not verdict.get("num_tests"):
+            raise GradingFailedError(
+                f"No test cases were graded for problem {problem_id}: "
+                f"{verdict.get('error_message', 'the grader decoded an empty test set')}"
+            )
+        if verdict.get("error_code") == GRADER_ERROR_CODE:
+            raise GradingFailedError(
+                f"The grader failed on problem {problem_id}: {verdict.get('error_message', '')}"
+            )
+        return 1.0 if verdict.get("passed") else 0.0
+
+    def _command(self, work_dir: str) -> str:
+        """Shell command that grades the staged problem and removes it after.
+
+        The grader runs under ``timeout`` so that the shell survives to remove
+        the staged files when the grader is stopped. Directories left by runs
+        the sandbox itself had to kill are swept first; only ones older than
+        this scorer's ceiling can no longer belong to a run in flight.
+        """
+        quoted = shlex.quote(work_dir)
+        ceiling = math.ceil(self.overall_timeout)
+        stale_minutes = math.ceil((self.overall_timeout + 60.0) / 60.0) + 1
+        return (
+            f"find /tmp -maxdepth 1 -name 'lcb-*' -mmin +{stale_minutes} "
+            "-exec rm -rf {} + 2>/dev/null; "
+            f"cd {quoted} && timeout {ceiling} python3 grade.py; "
+            f"status=$?; rm -rf {quoted}; exit $status"
+        )
 
 
 PASS_AT_KS = (1, 5, 10)

--- a/src/olmo_eval/evals/tasks/livecodebench.py
+++ b/src/olmo_eval/evals/tasks/livecodebench.py
@@ -65,7 +65,9 @@ USER_TEMPLATE = (
     "### Answer: (use the provided format with backticks)\n\n"
 )
 
-THINK_INSTRUCTION = (
+REASONING_INSTRUCTION = "Provide CONCISE reasoning on how to arrive at the answer.\n"
+
+THINK_TAG_INSTRUCTION = (
     "Provide CONCISE reasoning on how to arrive at the answer in the <think> </think> tag.\n"
 )
 
@@ -307,13 +309,24 @@ PASS_AT_KS = (1, 5, 10)
 METRICS = tuple(PassAtKMetric(k=k, scorer=LiveCodeBenchScorer) for k in PASS_AT_KS)
 PASS_AT_1 = PassAtKMetric(k=1, scorer=LiveCodeBenchScorer)
 
-THINK_FORMATTER = LiveCodeBenchFormatter(
+# The default prompt is LiveCodeBench's own system prompt with a reasoning
+# line that names no tags. A model whose chat template opens a thinking block
+# reasons there, and one without such a template reasons inline, so the
+# instruction measures the same thing for both. Asking for literal <think>
+# tags, as the OLMo 3 post-training regime does, also measured how a model
+# copes with a tag its template may already have opened.
+DEFAULT_FORMATTER = LiveCodeBenchFormatter(
     system_prompt=SYSTEM_PROMPT,
-    reasoning_instruction=THINK_INSTRUCTION,
+    reasoning_instruction=REASONING_INSTRUCTION,
 )
+THINK_TAG_FORMATTER = LiveCodeBenchFormatter(
+    system_prompt=SYSTEM_PROMPT,
+    reasoning_instruction=THINK_TAG_INSTRUCTION,
+)
+NO_SYSTEM_FORMATTER = LiveCodeBenchFormatter(reasoning_instruction=REASONING_INSTRUCTION)
 PLAIN_FORMATTER = LiveCodeBenchFormatter(system_prompt=SYSTEM_PROMPT)
 
-# Defaults mirror oe-eval's ``livecodebench_codegeneration::olmo3:adapt``, the
+# Sampling mirrors oe-eval's ``livecodebench_codegeneration::olmo3:adapt``, the
 # OLMo 3 post-training regime. max_tokens=None generates to the model's context
 # limit, matching the reference regime's effective behavior on any context size.
 ADAPT_SAMPLING = SamplingParams(
@@ -336,7 +349,7 @@ class LiveCodeBench(Task):
         split="train",
     )
     split = Split.TRAIN
-    formatter = THINK_FORMATTER
+    formatter = DEFAULT_FORMATTER
     metrics = METRICS
     primary_metric = PASS_AT_1
     sampling_params = ADAPT_SAMPLING
@@ -405,6 +418,15 @@ class LiveCodeBenchHidden(LiveCodeBench):
 
 
 for _task_name in ("livecodebench", "livecodebench_hidden"):
+    # Mirrors oe-eval's ``::olmo3:adapt`` prompt, which asks for the reasoning
+    # inside literal <think> tags.
+    register_variant(_task_name, "think_tags", formatter=THINK_TAG_FORMATTER)
+
+    # Mirrors oe-eval-internal's ``::tulu-thinker_deepseek_no_think_tags``, the
+    # regime reported in the OLMo 3 paper: the default prompt with no system
+    # message.
+    register_variant(_task_name, "paper", formatter=NO_SYSTEM_FORMATTER)
+
     # Mirrors oe-eval's ``::tulu``: no reasoning instruction, shorter budget.
     register_variant(
         _task_name,

--- a/tests/evals/tasks/test_livecodebench.py
+++ b/tests/evals/tasks/test_livecodebench.py
@@ -105,11 +105,32 @@ def test_tulu_variant_drops_the_reasoning_line() -> None:
     )
 
 
-def test_answer_extraction_ignores_a_reasoning_block() -> None:
+def test_answer_extraction_takes_the_last_code_block() -> None:
+    # A reasoning model drafts code as it thinks; the answer is the last block.
     task = get_task("livecodebench")
-    output = LMOutput(text="<think>plan</think>\n```python\nprint(1)\n```")
+    output = LMOutput(
+        text=(
+            "Let me try:\n```python\nprint(0)  # draft\n```\n"
+            "That is wrong. Actually:\n```python\nprint(1)\n```"
+        )
+    )
 
-    assert task.extract_answer(output) == "print(1)\n"
+    assert task.extract_answer(output) == "print(1)"
+
+
+def test_answer_extraction_survives_an_unopened_think_tag() -> None:
+    # A chat template may supply the opening tag, so the reply closes one it
+    # never opened. Extraction must not depend on seeing a matched pair.
+    task = get_task("livecodebench")
+    output = LMOutput(text="reasoning...</think>\n```python\nprint(1)\n```")
+
+    assert task.extract_answer(output) == "print(1)"
+
+
+def test_answer_extraction_without_a_complete_block_yields_nothing() -> None:
+    task = get_task("livecodebench")
+    assert task.extract_answer(LMOutput(text="no code here at all")) is None
+    assert task.extract_answer(LMOutput(text="```python\nprint(1)")) is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/evals/tasks/test_livecodebench.py
+++ b/tests/evals/tasks/test_livecodebench.py
@@ -1,0 +1,475 @@
+"""Tests for the LiveCodeBench task, its prompts, and its grader."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from collections.abc import Mapping
+from typing import Any
+
+import pytest
+
+from olmo_eval.common.execution import ExecutionResult
+from olmo_eval.common.scorers import SandboxRequiredError
+from olmo_eval.common.scorers.code_execution.scripts import get_script
+from olmo_eval.common.types import Instance, LMOutput, RequestType
+from olmo_eval.evals.tasks.common import get_task
+from olmo_eval.evals.tasks.livecodebench import (
+    RELEASE_V3_FILES,
+    RELEASE_V4_V6_FILES,
+    SYSTEM_PROMPT,
+    LiveCodeBenchScorer,
+)
+
+STDIN_DOC = {
+    "question_id": "abc123_a",
+    "question_content": "Print the sum of two integers.",
+    "starter_code": "",
+    "metadata": "{}",
+    "platform": "atcoder",
+    "difficulty": "easy",
+    "contest_date": "2024-01-01T00:00:00",
+    "public_test_cases": "[]",
+    "private_test_cases": "[]",
+}
+
+STARTER_DOC = {
+    **STDIN_DOC,
+    "question_id": "2727",
+    "starter_code": (
+        "class Solution:\n    def countSeniors(self, details: List[str]) -> int:\n        "
+    ),
+    "metadata": json.dumps({"func_name": "countSeniors"}),
+    "platform": "leetcode",
+}
+
+
+# ---------------------------------------------------------------------------
+# Instances and prompts
+# ---------------------------------------------------------------------------
+
+
+def test_stdin_problem_asks_for_a_whole_program() -> None:
+    task = get_task("livecodebench")
+    instance = task.process_doc(STDIN_DOC, index=7)
+
+    assert instance.question == "Print the sum of two integers."
+    assert instance.metadata["id"] == "abc123_a"
+    assert instance.metadata["fn_name"] is None
+    assert "reads the inputs" in instance.metadata["format_instruction"]
+
+
+def test_starter_code_problem_carries_its_function_name() -> None:
+    task = get_task("livecodebench")
+    instance = task.process_doc(STARTER_DOC, index=0)
+
+    assert instance.metadata["fn_name"] == "countSeniors"
+    assert "starter code" in instance.metadata["format_instruction"]
+    assert "def countSeniors" in instance.metadata["format_instruction"]
+
+
+def test_test_cases_are_referenced_not_carried() -> None:
+    # Payloads reach tens of megabytes per problem, and instance metadata is
+    # written into the run's request records.
+    task = get_task("livecodebench")
+    instance = task.process_doc(STDIN_DOC, index=7)
+
+    assert instance.metadata["row"] == 7
+    assert instance.metadata["test_files"] == RELEASE_V3_FILES
+    assert "public_test_cases" not in instance.metadata
+    assert "private_test_cases" not in instance.metadata
+
+
+def test_default_prompt_requests_reasoning_in_think_tags() -> None:
+    task = get_task("livecodebench")
+    request = task.format_request(task.process_doc(STDIN_DOC))
+
+    assert request.request_type == RequestType.CHAT
+    assert request.messages[0] == {"role": "system", "content": SYSTEM_PROMPT}
+    user = request.messages[1]["content"]
+    assert user.startswith("### Question:\nPrint the sum of two integers.\n\n### Format:\n")
+    assert "<think> </think> tag" in user
+    assert user.endswith("### Answer: (use the provided format with backticks)\n\n")
+
+
+def test_tulu_variant_drops_the_reasoning_line() -> None:
+    task = get_task("livecodebench:tulu")
+    user = task.format_request(task.process_doc(STDIN_DOC)).messages[1]["content"]
+
+    assert "<think>" not in user
+    assert user.startswith(
+        "### Question:\nPrint the sum of two integers.\n\n### Format:\nRead the inputs from stdin"
+    )
+
+
+def test_answer_extraction_ignores_a_reasoning_block() -> None:
+    task = get_task("livecodebench")
+    output = LMOutput(text="<think>plan</think>\n```python\nprint(1)\n```")
+
+    assert task.extract_answer(output) == "print(1)\n"
+
+
+# ---------------------------------------------------------------------------
+# Releases and variants
+# ---------------------------------------------------------------------------
+
+
+def test_releases_select_different_contest_windows() -> None:
+    assert get_task("livecodebench").config.data_source.data_files == RELEASE_V3_FILES
+    assert get_task("livecodebench_hidden").config.data_source.data_files == RELEASE_V4_V6_FILES
+    assert not set(RELEASE_V3_FILES) & set(RELEASE_V4_V6_FILES)
+
+
+def test_default_regime_samples_ten_completions() -> None:
+    config = get_task("livecodebench").config
+
+    assert config.sampling_params is not None
+    assert config.sampling_params.num_samples == 10
+    assert config.sampling_params.temperature == pytest.approx(0.6)
+    assert config.sampling_params.top_p == pytest.approx(0.95)
+    # Generation is bounded by the model's context, not a fixed budget.
+    assert config.sampling_params.max_tokens is None
+    assert [metric.name for metric in config.metrics] == ["pass_at_1", "pass_at_5", "pass_at_10"]
+    assert config.primary_metric is not None
+    assert config.primary_metric.name == "pass_at_1"
+
+
+def test_lite_variant_scores_a_single_sample() -> None:
+    config = get_task("livecodebench:lite").config
+
+    assert config.sampling_params is not None
+    assert config.sampling_params.num_samples == 1
+    assert config.sampling_params.temperature == pytest.approx(0.6)
+    assert [metric.name for metric in config.metrics] == ["pass_at_1"]
+
+
+def test_grpo_variant_reports_pass_at_10() -> None:
+    config = get_task("livecodebench:grpo").config
+
+    assert config.sampling_params is not None
+    assert config.sampling_params.temperature == pytest.approx(1.0)
+    assert config.sampling_params.top_p == pytest.approx(1.0)
+    assert config.sampling_params.max_tokens == 16384
+    assert config.primary_metric is not None
+    assert config.primary_metric.name == "pass_at_10"
+
+
+def test_variants_are_registered_for_both_releases() -> None:
+    for variant in ("tulu", "lite", "grpo"):
+        assert get_task(f"livecodebench_hidden:{variant}") is not None
+
+
+# ---------------------------------------------------------------------------
+# Scorer
+# ---------------------------------------------------------------------------
+
+
+class _StubStagingEnv:
+    """Execution environment that records staged files and returns a verdict."""
+
+    def __init__(self, output: str = '{"passed": true}', success: bool = True) -> None:
+        self.output = output
+        self.success = success
+        self.staged: dict[str, str] = {}
+        self.commands: list[str] = []
+
+    @property
+    def is_running(self) -> bool:
+        return True
+
+    async def execute(self, command: str, timeout: float | None = None) -> str:
+        return ""
+
+    async def execute_command(self, command: str, timeout: float | None = None) -> ExecutionResult:
+        return ExecutionResult(success=self.success, output=self.output)
+
+    async def execute_code(
+        self, code: str, language: str = "python", timeout: float | None = None
+    ) -> ExecutionResult:
+        return ExecutionResult(success=self.success, output=self.output)
+
+    async def execute_with_files(
+        self, command: str, files: Mapping[str, str], timeout: float | None = None
+    ) -> ExecutionResult:
+        self.commands.append(command)
+        self.staged.update(files)
+        return ExecutionResult(success=self.success, output=self.output)
+
+
+class _NonStagingEnv:
+    """Execution environment that cannot stage files."""
+
+    @property
+    def is_running(self) -> bool:
+        return True
+
+    async def execute(self, command: str, timeout: float | None = None) -> str:
+        return ""
+
+    async def execute_command(self, command: str, timeout: float | None = None) -> ExecutionResult:
+        return ExecutionResult(success=True)
+
+    async def execute_code(
+        self, code: str, language: str = "python", timeout: float | None = None
+    ) -> ExecutionResult:
+        return ExecutionResult(success=True)
+
+
+def _instance() -> Instance:
+    return Instance(
+        question="Print the sum.",
+        metadata={
+            "id": "abc123_a",
+            "row": 3,
+            "test_repo": "org/repo",
+            "test_files": RELEASE_V3_FILES,
+            "fn_name": None,
+        },
+    )
+
+
+@pytest.fixture
+def stub_rows(monkeypatch: pytest.MonkeyPatch) -> None:
+    rows = [
+        {"question_id": f"q{index}", "public_test_cases": "[]", "private_test_cases": ""}
+        for index in range(4)
+    ]
+    rows[3] = {
+        "question_id": "abc123_a",
+        "public_test_cases": '[{"input": "1", "output": "1"}]',
+        "private_test_cases": "",
+    }
+
+    def fake_rows(repo: str, files: tuple[str, ...]) -> Any:
+        del repo, files
+        return rows
+
+    monkeypatch.setattr(
+        "olmo_eval.evals.tasks.livecodebench._test_case_rows",
+        fake_rows,
+    )
+
+
+@pytest.mark.anyio
+class TestLiveCodeBenchScorer:
+    async def test_stages_grader_problem_and_solution(self, stub_rows: None) -> None:
+        scorer = LiveCodeBenchScorer()
+        env = _StubStagingEnv()
+        output = LMOutput(text="unused")
+        output.extracted_answer = "print(1)"
+
+        score = await scorer.ascore(_instance(), output, env)
+
+        assert score == 1.0
+        staged = sorted(os.path.basename(path) for path in env.staged)
+        assert staged == ["grade.py", "problem.json", "solution.py"]
+
+        work_dirs = {os.path.dirname(path) for path in env.staged}
+        assert len(work_dirs) == 1, "all files belong to one working directory"
+        work_dir = work_dirs.pop()
+        assert work_dir in env.commands[0]
+
+        problem = json.loads(env.staged[f"{work_dir}/problem.json"])
+        assert problem["public_test_cases"] == '[{"input": "1", "output": "1"}]'
+        assert problem["timeout"] == scorer.timeout
+        assert env.staged[f"{work_dir}/solution.py"] == "print(1)"
+
+    async def test_working_directory_is_cleaned_up(self, stub_rows: None) -> None:
+        scorer = LiveCodeBenchScorer()
+        env = _StubStagingEnv()
+        output = LMOutput(text="unused")
+        output.extracted_answer = "print(1)"
+
+        await scorer.ascore(_instance(), output, env)
+
+        assert "rm -rf" in env.commands[0]
+
+    async def test_failing_verdict_scores_zero(self, stub_rows: None) -> None:
+        scorer = LiveCodeBenchScorer()
+        env = _StubStagingEnv(
+            output='{"passed": false, "error_code": -2, "error_message": "Wrong Answer"}'
+        )
+        output = LMOutput(text="unused")
+        output.extracted_answer = "print(2)"
+
+        score = await scorer.ascore(_instance(), output, env)
+
+        assert score == 0.0
+        assert output.metadata["execution_result"]["error"] == "Wrong Answer"
+
+    async def test_unparseable_output_scores_zero(self, stub_rows: None) -> None:
+        scorer = LiveCodeBenchScorer()
+        env = _StubStagingEnv(output="container died", success=False)
+        output = LMOutput(text="unused")
+        output.extracted_answer = "print(1)"
+
+        assert await scorer.ascore(_instance(), output, env) == 0.0
+        assert output.metadata["execution_result"]["success"] is False
+
+    async def test_missing_answer_scores_zero_without_executing(self) -> None:
+        scorer = LiveCodeBenchScorer()
+        env = _StubStagingEnv()
+        output = LMOutput(text="no code here")
+
+        assert await scorer.ascore(_instance(), output, env) == 0.0
+        assert env.commands == []
+
+    async def test_environment_without_staging_is_rejected(self, stub_rows: None) -> None:
+        scorer = LiveCodeBenchScorer()
+        output = LMOutput(text="unused")
+        output.extracted_answer = "print(1)"
+
+        with pytest.raises(SandboxRequiredError):
+            await scorer.ascore(_instance(), output, _NonStagingEnv())
+
+    async def test_row_pointing_at_another_problem_is_rejected(self, stub_rows: None) -> None:
+        # Silent misalignment would grade every solution against the wrong tests.
+        scorer = LiveCodeBenchScorer()
+        instance = _instance()
+        instance.metadata["row"] = 1
+        output = LMOutput(text="unused")
+        output.extracted_answer = "print(1)"
+
+        with pytest.raises(RuntimeError, match="row order changed"):
+            await scorer.ascore(instance, output, _StubStagingEnv())
+
+
+# ---------------------------------------------------------------------------
+# Grader
+# ---------------------------------------------------------------------------
+
+
+def _grade(
+    solution: str,
+    tests: list[dict[str, str]],
+    fn_name: str | None = None,
+    timeout: int = 5,
+) -> dict[str, Any]:
+    """Run the container-side grader the way the sandbox would."""
+    with tempfile.TemporaryDirectory() as work_dir:
+        with open(os.path.join(work_dir, "grade.py"), "w") as handle:
+            handle.write(get_script("livecodebench_grader"))
+        with open(os.path.join(work_dir, "problem.json"), "w") as handle:
+            json.dump(
+                {
+                    "public_test_cases": json.dumps(tests),
+                    "private_test_cases": "",
+                    "fn_name": fn_name,
+                    "timeout": timeout,
+                },
+                handle,
+            )
+        with open(os.path.join(work_dir, "solution.py"), "w") as handle:
+            handle.write(solution)
+
+        process = subprocess.run(
+            [sys.executable, "grade.py"],
+            cwd=work_dir,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+
+    verdicts = [line for line in process.stdout.strip().splitlines() if line.startswith("{")]
+    return json.loads(verdicts[-1])
+
+
+SUM_TESTS = [
+    {"input": "1 2\n", "output": "3\n"},
+    {"input": "10 20\n", "output": "30\n"},
+]
+
+
+class TestGraderStdinMode:
+    def test_correct_program_passes(self) -> None:
+        solution = "a, b = map(int, input().split())\nprint(a + b)\n"
+        assert _grade(solution, SUM_TESTS)["passed"] is True
+
+    def test_wrong_program_fails(self) -> None:
+        verdict = _grade("a, b = map(int, input().split())\nprint(a - b)\n", SUM_TESTS)
+        assert verdict["passed"] is False
+        assert verdict["error_code"] == -2
+
+    def test_main_guard_is_unwrapped(self) -> None:
+        solution = (
+            "def main():\n"
+            "    a, b = map(int, input().split())\n"
+            "    print(a + b)\n"
+            "if __name__ == '__main__':\n"
+            "    main()\n"
+        )
+        assert _grade(solution, SUM_TESTS)["passed"] is True
+
+    def test_extra_output_line_fails(self) -> None:
+        solution = "a, b = map(int, input().split())\nprint(a + b)\nprint('done')\n"
+        verdict = _grade(solution, SUM_TESTS)
+        assert verdict["passed"] is False
+        assert "length" in verdict["error_message"]
+
+    def test_numerically_equal_output_passes(self) -> None:
+        # Formatting differences must not fail an otherwise correct answer.
+        tests = [{"input": "1\n", "output": "1.50\n"}]
+        assert _grade("input()\nprint(1.5)\n", tests)["passed"] is True
+
+    def test_runtime_error_fails(self) -> None:
+        verdict = _grade("raise ValueError('boom')\n", SUM_TESTS)
+        assert verdict["passed"] is False
+        assert verdict["error_code"] == -4
+
+    def test_endless_loop_times_out(self) -> None:
+        verdict = _grade("while True:\n    pass\n", SUM_TESTS, timeout=2)
+        assert verdict["passed"] is False
+        assert verdict["error_code"] == -3
+
+    def test_syntax_error_is_reported_as_a_compilation_failure(self) -> None:
+        verdict = _grade("  this is not python\n", SUM_TESTS)
+        assert verdict["passed"] is False
+        assert verdict["error_code"] == -4
+        assert "Compilation error" in verdict["error_message"]
+
+
+DOUBLE_TESTS = [
+    {"input": "[1, 2, 3]", "output": "[2, 4, 6]"},
+    {"input": "[]", "output": "[]"},
+]
+
+
+class TestGraderCallMode:
+    def test_correct_solution_class_passes(self) -> None:
+        solution = (
+            "class Solution:\n"
+            "    def double(self, nums: List[int]) -> List[int]:\n"
+            "        return [n * 2 for n in nums]\n"
+        )
+        assert _grade(solution, DOUBLE_TESTS, fn_name="double")["passed"] is True
+
+    def test_wrong_solution_fails(self) -> None:
+        solution = (
+            "class Solution:\n"
+            "    def double(self, nums: List[int]) -> List[int]:\n"
+            "        return nums\n"
+        )
+        verdict = _grade(solution, DOUBLE_TESTS, fn_name="double")
+        assert verdict["passed"] is False
+        assert verdict["error_code"] == -2
+
+    def test_tuple_result_is_accepted(self) -> None:
+        # Ground truth is never a tuple, so a tuple answer is not a mismatch.
+        solution = (
+            "class Solution:\n"
+            "    def double(self, nums: List[int]) -> List[int]:\n"
+            "        return tuple(n * 2 for n in nums)\n"
+        )
+        assert _grade(solution, DOUBLE_TESTS, fn_name="double")["passed"] is True
+
+    def test_missing_function_fails(self) -> None:
+        verdict = _grade("class Solution:\n    pass\n", DOUBLE_TESTS, fn_name="double")
+        assert verdict["passed"] is False
+        assert verdict["error_code"] == -4
+
+    def test_module_level_function_is_found(self) -> None:
+        solution = "def double(nums):\n    return [n * 2 for n in nums]\n"
+        assert _grade(solution, DOUBLE_TESTS, fn_name="double")["passed"] is True

--- a/tests/evals/tasks/test_livecodebench.py
+++ b/tests/evals/tasks/test_livecodebench.py
@@ -84,16 +84,42 @@ def test_test_cases_are_referenced_not_carried() -> None:
     assert "private_test_cases" not in instance.metadata
 
 
-def test_default_prompt_requests_reasoning_in_think_tags() -> None:
+def test_default_prompt_asks_for_concise_reasoning_without_naming_tags() -> None:
+    # A template that opens a thinking block and one that does not both get
+    # the same instruction; literal tags would suit only one of them.
     task = get_task("livecodebench")
     request = task.format_request(task.process_doc(STDIN_DOC))
 
     assert request.request_type == RequestType.CHAT
     assert request.messages[0] == {"role": "system", "content": SYSTEM_PROMPT}
     user = request.messages[1]["content"]
-    assert user.startswith("### Question:\nPrint the sum of two integers.\n\n### Format:\n")
-    assert "<think> </think> tag" in user
+    assert user.startswith(
+        "### Question:\nPrint the sum of two integers.\n\n"
+        "### Format:\nProvide CONCISE reasoning on how to arrive at the answer.\n"
+    )
+    assert "<think>" not in user
     assert user.endswith("### Answer: (use the provided format with backticks)\n\n")
+
+
+def test_think_tags_variant_asks_for_reasoning_in_tags() -> None:
+    task = get_task("livecodebench:think_tags")
+    user = task.format_request(task.process_doc(STDIN_DOC)).messages[1]["content"]
+
+    assert (
+        "Provide CONCISE reasoning on how to arrive at the answer in the <think> </think> tag."
+        in user
+    )
+
+
+def test_paper_variant_sends_no_system_message() -> None:
+    task = get_task("livecodebench:paper")
+    request = task.format_request(task.process_doc(STDIN_DOC))
+
+    assert request.system_prompt is None
+    assert [message["role"] for message in request.messages] == ["user"]
+    user = request.messages[0]["content"]
+    assert "Provide CONCISE reasoning on how to arrive at the answer.\n" in user
+    assert "<think>" not in user
 
 
 def test_tulu_variant_drops_the_reasoning_line() -> None:
@@ -180,7 +206,7 @@ def test_grpo_variant_reports_pass_at_10() -> None:
 
 
 def test_variants_are_registered_for_both_releases() -> None:
-    for variant in ("tulu", "lite", "grpo"):
+    for variant in ("think_tags", "paper", "tulu", "lite", "grpo"):
         assert get_task(f"livecodebench_hidden:{variant}") is not None
 
 

--- a/tests/evals/tasks/test_livecodebench.py
+++ b/tests/evals/tasks/test_livecodebench.py
@@ -13,7 +13,7 @@ from typing import Any
 import pytest
 
 from olmo_eval.common.execution import ExecutionResult
-from olmo_eval.common.scorers import SandboxRequiredError
+from olmo_eval.common.scorers import SandboxRequiredError, ScoringIncompleteError
 from olmo_eval.common.scorers.code_execution.scripts import get_script
 from olmo_eval.common.types import Instance, LMOutput, RequestType
 from olmo_eval.evals.tasks.common import get_task
@@ -21,10 +21,9 @@ from olmo_eval.evals.tasks.livecodebench import (
     RELEASE_V3_FILES,
     RELEASE_V4_V6_FILES,
     SYSTEM_PROMPT,
-    GradingFailedError,
+    VERDICT_PREFIX,
     LiveCodeBenchScorer,
 )
-from olmo_eval.harness.sandbox.errors import SandboxInfrastructureError
 
 STDIN_DOC = {
     "question_id": "abc123_a",
@@ -196,7 +195,7 @@ class _StubStagingEnv:
     def __init__(
         self, output: str = '{"passed": true, "num_tests": 3}', success: bool = True
     ) -> None:
-        self.output = output
+        self.output = VERDICT_PREFIX + output if output.startswith("{") else output
         self.success = success
         self.staged: dict[str, str] = {}
         self.commands: list[str] = []
@@ -334,14 +333,21 @@ class TestLiveCodeBenchScorer:
         output = LMOutput(text="unused")
         output.extracted_answer = "print(1)"
 
-        with pytest.raises(GradingFailedError, match="No grader verdict"):
+        with pytest.raises(ScoringIncompleteError, match="No grader verdict"):
             await scorer.ascore(_instance(), output, env)
         assert output.metadata["execution_result"]["success"] is False
 
-    async def test_grading_failures_are_recorded_against_the_task(self) -> None:
-        # The runner only reports lost scores at the task level for
-        # infrastructure failures; anything else becomes a quiet zero.
-        assert issubclass(GradingFailedError, SandboxInfrastructureError)
+    async def test_verdict_is_found_among_solution_noise(self, stub_rows: None) -> None:
+        # The sandbox appends stderr after stdout, so a solution that prints a
+        # JSON object to stderr lands after the real verdict.
+        scorer = LiveCodeBenchScorer()
+        verdict = VERDICT_PREFIX + '{"passed": true, "num_tests": 3}'
+        env = _StubStagingEnv(output=f'debug\n{verdict}\n{{"passed": false}}\n')
+        output = LMOutput(text="unused")
+        output.extracted_answer = "print(1)"
+
+        assert await scorer.ascore(_instance(), output, env) == 1.0
+        assert output.metadata["execution_result"]["num_tests"] == 3
 
     async def test_verdict_with_no_tests_is_a_grading_failure(self, stub_rows: None) -> None:
         # Passing every test in an empty set is what an undecodable payload
@@ -351,7 +357,7 @@ class TestLiveCodeBenchScorer:
         output = LMOutput(text="unused")
         output.extracted_answer = "print(1)"
 
-        with pytest.raises(GradingFailedError, match="No test cases were graded"):
+        with pytest.raises(ScoringIncompleteError, match="No test cases were graded"):
             await scorer.ascore(_instance(), output, env)
 
     async def test_grader_error_is_a_grading_failure(self, stub_rows: None) -> None:
@@ -363,7 +369,7 @@ class TestLiveCodeBenchScorer:
         output = LMOutput(text="unused")
         output.extracted_answer = "print(1)"
 
-        with pytest.raises(GradingFailedError, match="KeyError"):
+        with pytest.raises(ScoringIncompleteError, match="KeyError"):
             await scorer.ascore(_instance(), output, env)
 
     async def test_grader_runs_under_a_time_limit_that_leaves_cleanup_to_the_shell(
@@ -407,7 +413,7 @@ class TestLiveCodeBenchScorer:
         output = LMOutput(text="unused")
         output.extracted_answer = "print(1)"
 
-        with pytest.raises(GradingFailedError, match="row order changed"):
+        with pytest.raises(ScoringIncompleteError, match="row order changed"):
             await scorer.ascore(instance, output, _StubStagingEnv())
 
 
@@ -447,8 +453,10 @@ def _grade(
             timeout=120,
         )
 
-    verdicts = [line for line in process.stdout.strip().splitlines() if line.startswith("{")]
-    return json.loads(verdicts[-1])
+    verdicts = [
+        line for line in process.stdout.strip().splitlines() if line.startswith(VERDICT_PREFIX)
+    ]
+    return json.loads(verdicts[-1][len(VERDICT_PREFIX) :])
 
 
 SUM_TESTS = [
@@ -514,6 +522,18 @@ class TestGraderStdinMode:
         assert verdict["passed"] is False
         assert verdict["error_code"] == -3
         assert "budget" in verdict["error_message"]
+
+    def test_closing_stdout_keeps_the_output(self) -> None:
+        solution = (
+            "a, b = map(int, input().split())\nprint(a + b)\nimport sys\nsys.stdout.close()\n"
+        )
+        assert _grade(solution, SUM_TESTS)["passed"] is True
+
+    def test_large_integers_convert_to_strings(self) -> None:
+        # The interpreter's default limit on int/str conversion is far below
+        # what contest answers reach; the reference harness raises it.
+        tests = [{"input": "5000\n", "output": "1" + "0" * 5000 + "\n"}]
+        assert _grade("n = int(input())\nprint(10 ** n)\n", tests)["passed"] is True
 
     def test_crashed_interpreter_is_a_failed_solution(self) -> None:
         # A crash takes down the process running the solution, not the grader.
@@ -589,7 +609,7 @@ class TestGraderCallMode:
 
 class TestGraderPayloads:
     def test_undecodable_test_cases_yield_no_tests_and_no_pass(self) -> None:
-        # Formerly an empty test set, which every solution passed.
+        # An empty test set is passed by every solution, so it must not be one.
         verdict = _grade("print(1)\n", "not json and not base64 pickle")
         assert verdict["passed"] is False
         assert verdict["num_tests"] == 0

--- a/tests/evals/tasks/test_livecodebench.py
+++ b/tests/evals/tasks/test_livecodebench.py
@@ -365,9 +365,9 @@ class TestLiveCodeBenchScorer:
 
 def _grade(
     solution: str,
-    tests: list[dict[str, str]],
+    tests: list[dict[str, str]] | str,
     fn_name: str | None = None,
-    timeout: int = 5,
+    timeout: float = 5,
 ) -> dict[str, Any]:
     """Run the container-side grader the way the sandbox would."""
     with tempfile.TemporaryDirectory() as work_dir:
@@ -376,7 +376,7 @@ def _grade(
         with open(os.path.join(work_dir, "problem.json"), "w") as handle:
             json.dump(
                 {
-                    "public_test_cases": json.dumps(tests),
+                    "public_test_cases": tests if isinstance(tests, str) else json.dumps(tests),
                     "private_test_cases": "",
                     "fn_name": fn_name,
                     "timeout": timeout,
@@ -445,6 +445,32 @@ class TestGraderStdinMode:
         assert verdict["passed"] is False
         assert verdict["error_code"] == -3
 
+    def test_sub_second_timeout_is_enforced(self) -> None:
+        # A whole-second alarm would round this down to no alarm at all.
+        verdict = _grade("while True:\n    pass\n", SUM_TESTS, timeout=0.5)
+        assert verdict["passed"] is False
+        assert verdict["error_code"] == -3
+
+    def test_solution_that_disarms_the_alarm_hits_the_overall_budget(self) -> None:
+        # The per-case alarm can be silenced from inside the solution; the
+        # budget for the whole run cannot, because another process keeps it.
+        solution = (
+            "import signal\nsignal.signal(signal.SIGALRM, signal.SIG_IGN)\nwhile True:\n    pass\n"
+        )
+        verdict = _grade(solution, SUM_TESTS[:1], timeout=0.1)
+        assert verdict["passed"] is False
+        assert verdict["error_code"] == -3
+        assert "budget" in verdict["error_message"]
+
+    def test_crashed_interpreter_is_a_failed_solution(self) -> None:
+        # A crash takes down the process running the solution, not the grader.
+        solution = "import ctypes\nctypes.string_at(0)\n"
+        verdict = _grade(solution, SUM_TESTS)
+        assert verdict["passed"] is False
+        assert verdict["error_code"] == -4
+        assert "signal" in verdict["error_message"]
+        assert verdict["num_tests"] == len(SUM_TESTS)
+
     def test_syntax_error_is_reported_as_a_compilation_failure(self) -> None:
         verdict = _grade("  this is not python\n", SUM_TESTS)
         assert verdict["passed"] is False
@@ -494,3 +520,29 @@ class TestGraderCallMode:
     def test_module_level_function_is_found(self) -> None:
         solution = "def double(nums):\n    return [n * 2 for n in nums]\n"
         assert _grade(solution, DOUBLE_TESTS, fn_name="double")["passed"] is True
+
+    def test_endless_module_body_is_a_timeout_not_a_compile_error(self) -> None:
+        solution = "while True:\n    pass\ndef double(nums):\n    return nums\n"
+        verdict = _grade(solution, DOUBLE_TESTS, fn_name="double", timeout=1)
+        assert verdict["passed"] is False
+        assert verdict["error_code"] == -3
+
+    def test_exiting_from_the_function_is_a_runtime_error(self) -> None:
+        solution = "def double(nums):\n    import sys\n    sys.exit(0)\n"
+        verdict = _grade(solution, DOUBLE_TESTS, fn_name="double")
+        assert verdict["passed"] is False
+        assert verdict["error_code"] == -4
+
+
+class TestGraderPayloads:
+    def test_undecodable_test_cases_yield_no_tests_and_no_pass(self) -> None:
+        # Formerly an empty test set, which every solution passed.
+        verdict = _grade("print(1)\n", "not json and not base64 pickle")
+        assert verdict["passed"] is False
+        assert verdict["num_tests"] == 0
+        assert verdict["error_code"] == -5
+        assert "neither JSON nor compressed pickle" in verdict["error_message"]
+
+    def test_case_count_is_reported(self) -> None:
+        solution = "a, b = map(int, input().split())\nprint(a + b)\n"
+        assert _grade(solution, SUM_TESTS)["num_tests"] == len(SUM_TESTS)

--- a/tests/evals/tasks/test_livecodebench.py
+++ b/tests/evals/tasks/test_livecodebench.py
@@ -21,8 +21,10 @@ from olmo_eval.evals.tasks.livecodebench import (
     RELEASE_V3_FILES,
     RELEASE_V4_V6_FILES,
     SYSTEM_PROMPT,
+    GradingFailedError,
     LiveCodeBenchScorer,
 )
+from olmo_eval.harness.sandbox.errors import SandboxInfrastructureError
 
 STDIN_DOC = {
     "question_id": "abc123_a",
@@ -191,7 +193,9 @@ def test_variants_are_registered_for_both_releases() -> None:
 class _StubStagingEnv:
     """Execution environment that records staged files and returns a verdict."""
 
-    def __init__(self, output: str = '{"passed": true}', success: bool = True) -> None:
+    def __init__(
+        self, output: str = '{"passed": true, "num_tests": 3}', success: bool = True
+    ) -> None:
         self.output = output
         self.success = success
         self.staged: dict[str, str] = {}
@@ -311,7 +315,8 @@ class TestLiveCodeBenchScorer:
     async def test_failing_verdict_scores_zero(self, stub_rows: None) -> None:
         scorer = LiveCodeBenchScorer()
         env = _StubStagingEnv(
-            output='{"passed": false, "error_code": -2, "error_message": "Wrong Answer"}'
+            output='{"passed": false, "num_tests": 3, "error_code": -2, '
+            '"error_message": "Wrong Answer"}'
         )
         output = LMOutput(text="unused")
         output.extracted_answer = "print(2)"
@@ -321,14 +326,62 @@ class TestLiveCodeBenchScorer:
         assert score == 0.0
         assert output.metadata["execution_result"]["error"] == "Wrong Answer"
 
-    async def test_unparseable_output_scores_zero(self, stub_rows: None) -> None:
+    async def test_missing_verdict_is_a_grading_failure(self, stub_rows: None) -> None:
+        # A grader that never reported (no python3, a killed container) must
+        # not turn into a plausible score of zero.
         scorer = LiveCodeBenchScorer()
-        env = _StubStagingEnv(output="container died", success=False)
+        env = _StubStagingEnv(output="bash: python3: command not found", success=False)
         output = LMOutput(text="unused")
         output.extracted_answer = "print(1)"
 
-        assert await scorer.ascore(_instance(), output, env) == 0.0
+        with pytest.raises(GradingFailedError, match="No grader verdict"):
+            await scorer.ascore(_instance(), output, env)
         assert output.metadata["execution_result"]["success"] is False
+
+    async def test_grading_failures_are_recorded_against_the_task(self) -> None:
+        # The runner only reports lost scores at the task level for
+        # infrastructure failures; anything else becomes a quiet zero.
+        assert issubclass(GradingFailedError, SandboxInfrastructureError)
+
+    async def test_verdict_with_no_tests_is_a_grading_failure(self, stub_rows: None) -> None:
+        # Passing every test in an empty set is what an undecodable payload
+        # looks like; it must not count as a pass.
+        scorer = LiveCodeBenchScorer()
+        env = _StubStagingEnv(output='{"passed": true, "num_tests": 0}')
+        output = LMOutput(text="unused")
+        output.extracted_answer = "print(1)"
+
+        with pytest.raises(GradingFailedError, match="No test cases were graded"):
+            await scorer.ascore(_instance(), output, env)
+
+    async def test_grader_error_is_a_grading_failure(self, stub_rows: None) -> None:
+        scorer = LiveCodeBenchScorer()
+        env = _StubStagingEnv(
+            output='{"passed": false, "num_tests": 3, "error_code": -5, '
+            '"error_message": "TestRunnerError: KeyError(\'input\')"}'
+        )
+        output = LMOutput(text="unused")
+        output.extracted_answer = "print(1)"
+
+        with pytest.raises(GradingFailedError, match="KeyError"):
+            await scorer.ascore(_instance(), output, env)
+
+    async def test_grader_runs_under_a_time_limit_that_leaves_cleanup_to_the_shell(
+        self, stub_rows: None
+    ) -> None:
+        scorer = LiveCodeBenchScorer(overall_timeout=120.0)
+        env = _StubStagingEnv()
+        output = LMOutput(text="unused")
+        output.extracted_answer = "print(1)"
+
+        await scorer.ascore(_instance(), output, env)
+
+        command = env.commands[0]
+        assert "timeout 120 python3 grade.py" in command
+        # Directories left by runs the sandbox had to kill are swept, but
+        # only ones too old to belong to a run still in flight.
+        assert command.index("find /tmp") < command.index("python3 grade.py")
+        assert "-name 'lcb-*' -mmin +4 " in command
 
     async def test_missing_answer_scores_zero_without_executing(self) -> None:
         scorer = LiveCodeBenchScorer()
@@ -354,7 +407,7 @@ class TestLiveCodeBenchScorer:
         output = LMOutput(text="unused")
         output.extracted_answer = "print(1)"
 
-        with pytest.raises(RuntimeError, match="row order changed"):
+        with pytest.raises(GradingFailedError, match="row order changed"):
             await scorer.ascore(instance, output, _StubStagingEnv())
 
 

--- a/tests/integration/test_livecodebench_sandbox.py
+++ b/tests/integration/test_livecodebench_sandbox.py
@@ -1,0 +1,180 @@
+"""Integration test for LiveCodeBench grading in a real sandbox.
+
+Requires Docker and the LiveCodeBench dataset. Test cases are staged into the
+container as files, which is the part that cannot be exercised with a stub:
+the payload is far too large to pass in a command, so nothing about this path
+is covered by the unit tests.
+
+    pytest tests/integration/test_livecodebench_sandbox.py -v
+"""
+
+from __future__ import annotations
+
+import subprocess
+from collections.abc import AsyncIterator
+
+import pytest
+
+from olmo_eval.common.types import Instance, LMOutput
+from olmo_eval.evals.tasks.common import get_task
+from olmo_eval.evals.tasks.livecodebench import RELEASE_V3_FILES, LiveCodeBenchScorer
+from olmo_eval.harness.sandbox import Capability, SandboxConfig, SandboxManager, SandboxMode
+
+pytestmark = pytest.mark.integration
+
+SANDBOX_IMAGE = "ghcr.io/astral-sh/uv:python3.12-bookworm-slim"
+
+# A whole-program problem: stdin in, stdout compared line by line.
+STDIN_PROBLEM_ID = "1873_B"
+STDIN_SOLUTION = """
+import sys
+
+def main():
+    data = sys.stdin.read().split()
+    t = int(data[0])
+    idx = 1
+    out = []
+    for _ in range(t):
+        n = int(data[idx])
+        idx += 1
+        digits = [int(x) for x in data[idx : idx + n]]
+        idx += n
+        best = 0
+        for i in range(n):
+            product = 1
+            for j in range(n):
+                product *= digits[j] + (1 if i == j else 0)
+            best = max(best, product)
+        out.append(str(best))
+    print("\\n".join(out))
+
+main()
+"""
+
+# A call-based problem: the named function is invoked with parsed arguments.
+CALL_PROBLEM_FN = "countSeniors"
+CALL_SOLUTION = """
+class Solution:
+    def countSeniors(self, details: List[str]) -> int:
+        return sum(1 for d in details if int(d[11:13]) > 60)
+"""
+
+
+def _docker_available() -> bool:
+    try:
+        result = subprocess.run(
+            ["docker", "version", "--format", "{{.Server.Version}}"],
+            capture_output=True,
+            timeout=15,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return result.returncode == 0
+
+
+@pytest.fixture(scope="module")
+def livecodebench_instances() -> dict[str, Instance]:
+    """Real instances, keyed by problem id."""
+    task = get_task("livecodebench")
+    return {instance.metadata["id"]: instance for instance in task.instances}
+
+
+@pytest.fixture
+async def sandbox() -> AsyncIterator[object]:
+    """A single running sandbox with swe-rex injected into the image."""
+    if not _docker_available():
+        pytest.skip("Docker is not available")
+
+    manager = SandboxManager(
+        [
+            SandboxConfig(
+                image=SANDBOX_IMAGE,
+                mode=SandboxMode.DOCKER,
+                container_runtime="docker",
+                instances=1,
+                startup_timeout=900.0,
+                command_timeout=900.0,
+                inject_swerex=True,
+            )
+        ],
+        owner="livecodebench-test",
+    )
+    await manager.start()
+    try:
+        yield manager.for_capabilities(Capability.DEFAULT)
+    finally:
+        await manager.stop()
+
+
+def _call_based_instance(instances: dict[str, Instance]) -> Instance:
+    for instance in instances.values():
+        if instance.metadata.get("fn_name") == CALL_PROBLEM_FN:
+            return instance
+    pytest.skip(f"No problem with function {CALL_PROBLEM_FN} in this release")
+
+
+async def _score(scorer: LiveCodeBenchScorer, instance: Instance, code: str, sandbox) -> float:
+    output = LMOutput(text="unused")
+    output.extracted_answer = code
+    return await scorer.ascore(instance, output, sandbox)
+
+
+@pytest.mark.anyio
+async def test_correct_stdin_solution_passes(
+    sandbox, livecodebench_instances: dict[str, Instance]
+) -> None:
+    instance = livecodebench_instances[STDIN_PROBLEM_ID]
+    assert instance.metadata["fn_name"] is None
+
+    score = await _score(LiveCodeBenchScorer(), instance, STDIN_SOLUTION, sandbox)
+
+    assert score == 1.0
+
+
+@pytest.mark.anyio
+async def test_wrong_stdin_solution_fails(
+    sandbox, livecodebench_instances: dict[str, Instance]
+) -> None:
+    instance = livecodebench_instances[STDIN_PROBLEM_ID]
+    wrong = STDIN_SOLUTION.replace("best = max(best, product)", "best = max(best, product + 1)")
+
+    score = await _score(LiveCodeBenchScorer(), instance, wrong, sandbox)
+
+    assert score == 0.0
+
+
+@pytest.mark.anyio
+async def test_correct_call_based_solution_passes(
+    sandbox, livecodebench_instances: dict[str, Instance]
+) -> None:
+    instance = _call_based_instance(livecodebench_instances)
+
+    score = await _score(LiveCodeBenchScorer(), instance, CALL_SOLUTION, sandbox)
+
+    assert score == 1.0
+
+
+@pytest.mark.anyio
+async def test_private_test_cases_reach_the_container(
+    sandbox, livecodebench_instances: dict[str, Instance]
+) -> None:
+    """The staged payload must be the problem's full case list, not just public ones."""
+    instance = livecodebench_instances[STDIN_PROBLEM_ID]
+    output = LMOutput(text="unused")
+    output.extracted_answer = STDIN_SOLUTION
+
+    await LiveCodeBenchScorer().ascore(instance, output, sandbox)
+
+    result = output.metadata["execution_result"]
+    assert result["success"] is True
+    # The grader reports how many cases it ran; public cases alone are few.
+    assert '"num_tests"' in result["output"]
+
+
+@pytest.mark.anyio
+async def test_release_files_are_the_v3_window(
+    livecodebench_instances: dict[str, Instance],
+) -> None:
+    assert len(livecodebench_instances) == 612
+    instance = next(iter(livecodebench_instances.values()))
+    assert tuple(instance.metadata["test_files"]) == RELEASE_V3_FILES

--- a/tests/integration/test_livecodebench_sandbox.py
+++ b/tests/integration/test_livecodebench_sandbox.py
@@ -22,7 +22,6 @@ from olmo_eval.evals.tasks.livecodebench import (
     LIVECODEBENCH_REPO,
     RELEASE_V3_FILES,
     LiveCodeBenchScorer,
-    _parse_verdict,
     _test_case_rows,
 )
 from olmo_eval.harness.sandbox import Capability, SandboxConfig, SandboxManager, SandboxMode
@@ -174,15 +173,13 @@ async def test_private_test_cases_reach_the_container(
 
     result = output.metadata["execution_result"]
     assert result["success"] is True
-    verdict = _parse_verdict(result["output"])
-    assert verdict is not None
 
     # Public cases are plain JSON on the row; the private ones are what the
     # grader had to decode in the container.
     row = _test_case_rows(LIVECODEBENCH_REPO, RELEASE_V3_FILES)[instance.metadata["row"]]
     public_count = len(json.loads(row["public_test_cases"]))
     assert public_count > 0
-    assert verdict["num_tests"] > public_count
+    assert result["num_tests"] > public_count
 
 
 @pytest.mark.anyio

--- a/tests/integration/test_livecodebench_sandbox.py
+++ b/tests/integration/test_livecodebench_sandbox.py
@@ -10,6 +10,7 @@ is covered by the unit tests.
 
 from __future__ import annotations
 
+import json
 import subprocess
 from collections.abc import AsyncIterator
 
@@ -17,7 +18,13 @@ import pytest
 
 from olmo_eval.common.types import Instance, LMOutput
 from olmo_eval.evals.tasks.common import get_task
-from olmo_eval.evals.tasks.livecodebench import RELEASE_V3_FILES, LiveCodeBenchScorer
+from olmo_eval.evals.tasks.livecodebench import (
+    LIVECODEBENCH_REPO,
+    RELEASE_V3_FILES,
+    LiveCodeBenchScorer,
+    _parse_verdict,
+    _test_case_rows,
+)
 from olmo_eval.harness.sandbox import Capability, SandboxConfig, SandboxManager, SandboxMode
 
 pytestmark = pytest.mark.integration
@@ -167,8 +174,15 @@ async def test_private_test_cases_reach_the_container(
 
     result = output.metadata["execution_result"]
     assert result["success"] is True
-    # The grader reports how many cases it ran; public cases alone are few.
-    assert '"num_tests"' in result["output"]
+    verdict = _parse_verdict(result["output"])
+    assert verdict is not None
+
+    # Public cases are plain JSON on the row; the private ones are what the
+    # grader had to decode in the container.
+    row = _test_case_rows(LIVECODEBENCH_REPO, RELEASE_V3_FILES)[instance.metadata["row"]]
+    public_count = len(json.loads(row["public_test_cases"]))
+    assert public_count > 0
+    assert verdict["num_tests"] > public_count
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
Ports LiveCodeBench from [oe-eval](https://github.com/allenai/oe-eval). Contest problems are tagged by contest date, so a model can be scored on problems published after its training data was collected, and solutions are graded by running them against the contest's own test cases.

Builds on #352 (sandbox file staging) and #353 (data file selection), both now merged; this branch is rebased on main and contains only the LiveCodeBench commits.

## Tasks and variants

| spec | prompt and sampling |
|---|---|
| `livecodebench` | LiveCodeBench's system prompt plus a reasoning line that names no tags ("Provide CONCISE reasoning on how to arrive at the answer."); sampling as oe-eval's `::olmo3:adapt`: temp 0.6, top_p 0.95, context-bounded generation, 10 samples, pass@1/5/10 |
| `livecodebench:think_tags` | oe-eval's `::olmo3:adapt` prompt, which asks for reasoning inside literal `<think> </think>` tags |
| `livecodebench:paper` | oe-eval-internal's `::tulu-thinker_deepseek_no_think_tags`, the regime reported in the OLMo 3 paper: the default prompt with no system message |
| `livecodebench:tulu` | oe-eval's `::tulu` — no reasoning instruction, temp 0.2, 2048 tokens |
| `livecodebench:lite` | oe-eval's `..._lite` — the default regime on a single sample, pass@1, for cheap iteration |
| `livecodebench:grpo` | oe-eval's `:grpo::tulu-thinker` — temp 1.0, top_p 1.0, 16384 tokens, primary pass@10 |

**Why the default prompt names no tags.** The `<think>`-tag instruction dates from models trained on literal tags whose chat template did not insert them. A template that already opens a thinking block gets asked for something it has done, and a model with no such training is asked to invent a format, so the instruction measured template compliance alongside coding ability. The tag-free line gives both kinds of model the same instruction. The system prompt is the benchmark's own and is kept; the paper regime dropped it, which is available as `:paper` for reproducing published numbers.

`livecodebench` is release_v3 (612 problems); `livecodebench_hidden` is the v4–v6 window after the v3 cutoff (443 problems), registered separately so problems postdating a model's training data can be scored on their own. Both carry all six variants.

Left out: `::tulu-thinker` (temp 0.8, superseded by the deepseek regime) and `::olmo3:midtrain` (the base regime plus stop sequences). Easy to add if wanted.

## What makes this task different

Its fixtures. HumanEval ships a few hundred bytes of assertions per problem; LiveCodeBench ships the contest's real input/output pairs. Measured across release_v3:

- median problem: tens of KB
- p90: **10–20MB**
- largest: **92MB** compressed, 199MB decoded
- release total: 2.6GB compressed

Neither oe-eval nor upstream caps them, and capping is not viable: even a 4MB budget truncates 26% of release_v3 problems, keeping a median of 43% of their tests, which would break comparability with published numbers.

Two consequences:

**They reach the container as staged files** rather than in the command string — the capability added in #352.

**They are kept off the instances.** `build_requests` splats `instance.metadata` into the run's request records, so carrying payloads there would write gigabytes per run. Instances carry a dataset row reference and the scorer reads the payload when it grades.

That row reference is an implicit coupling, so the scorer refuses to grade a row whose `question_id` does not match the instance. Grading against another problem's tests would score every solution wrong while still producing a plausible-looking number. Alignment was checked across both releases: 612 and 443 instances, all unique ids, zero mismatches.

## Grading

A port of the reference harness, staged into the container as a script, following the existing `harness/sandbox/scripts/` + `get_script()` pattern.

- **Call-based problems** (LeetCode) invoke a named function on a `Solution` instance and compare parsed values; a tuple result is not counted as a mismatch, since ground truth is never a tuple.
- **Whole-program problems** get stdin fed and stdout compared line by line, with a decimal fallback so numerically equal output is not failed over formatting. `if __name__ == '__main__'` guards are unwrapped so the program can be called per test case.
- Compile failures, missing entry points, wrong answers and timeouts are distinguished in the recorded error code. A solution that does not compile is a failed solution, not a failure of the grader.
- **The solution runs in a forked child**, as in the reference, under the reference's overall budget of `(timeout + 1) * num_tests + 5` seconds. A solution that segfaults, is OOM-killed, or silences the per-case alarm is a failed solution, not a missing verdict. Per-case timeouts use `setitimer`, so sub-second budgets are enforced rather than dropped.
- **A grading run that cannot be scored raises.** No verdict (no `python3` in the image, a killed container), a payload that decoded to zero test cases, or an error inside the grader itself raises a `SandboxInfrastructureError` subclass, which the runner records against the task as lost scores. Previously an undecodable payload scored 1.0 (every solution passes an empty test set) and a missing verdict scored 0.0 with a warning.
- **Answer extraction takes the last fenced block**, as the reference does. A reasoning model writes code while it thinks, so earlier blocks are attempts it discarded. The shared `extract_code` helper takes the first block and falls back to the whole reply, which reliably extracts a draft from such a model; it also cannot strip `<think>` blocks when a chat template supplied the opening tag and the reply only closes one. Taking the last block sidesteps both, which is why the reference strips no tags at all. This matches oe-eval's `extract_code` for this task, which also takes the last block, so it is a parity fix rather than a divergence. `extract_code` is unchanged, so `humaneval` and `mbpp` keep their behavior.

## Verification

- **Prompts byte-identical to oe-eval** across 61 real problems (52 starter-code, 9 stdin) for the `think_tags` and `tulu` regimes, checked against an independently constructed copy of oe-eval's template. The default and `paper` prompts differ from those only in the reasoning line and the presence of the system message, both covered by unit tests.
- **Grader correct on real dataset problems** in both modes: correct solutions pass, wrong answers and missing functions fail with the right codes, `__main__` guards unwrap, infinite loops time out.
- **End to end in Docker** (mock model, `release_v3`): the grader ran in the container, decoded the compressed blobs there — reporting 14, 14 and 15 cases for the three problems, the real per-problem counts — and returned verdicts the scorer turned into pass@1.
- **Integration test** (`tests/integration/test_livecodebench_sandbox.py`, skipped without Docker) covers what stubs cannot: correct solutions to a whole-program and a call-based problem both score 1.0 through the real staging path, a wrong one scores 0.0, and the grader in the container saw more test cases than the row's public ones.
- **A real model on GPU** (`Qwen/Qwen2.5-Coder-7B-Instruct`, vLLM on one L40, `livecodebench:lite`, 50 problems of release_v3): **pass@1 = 0.4200**, 50/50 instances scored in 51s.

  The verdict breakdown is what makes that number trustworthy rather than merely plausible:

  | outcome | count |
  |---|---|
  | passed | 21 |
  | wrong answer (-2) | 26 |
  | timeout (-3) | 2 |
  | compile error (-4) | 1 |

  Failures are overwhelmingly wrong answers, with a single compile error. A run whose failures are mostly compile errors means extraction is broken, not that the model is weak — which is exactly what an earlier run with a different model showed before the extraction fix above (37 compile errors, 13 with no verdict, pass@1 = 0.0). All 50 replies contained a fenced block and all 50 arrived as clean text.
- 44 unit tests for prompts, release selection, variants, extraction, the scorer, and the grader, including the zero-test, crashed-interpreter, disarmed-alarm and sub-second-timeout cases. Full suite: 2252 passed, 8 skipped.
- Test-case counts across both releases, from the decoded payloads: release_v3 has a median of 15 and a maximum of 103 cases per problem, v4–v6 a median of 42 and a maximum of 52. The reference budget for the largest problem is 726s, under the scorer's 900s ceiling.

## Still open

**Parity is not yet demonstrated.** The run above proves the pipeline is sound end to end, but I have no oe-eval number for this model on release_v3 to compare against. A true parity check needs the same model and regime through both harnesses; cheap to do now that the path works.

## Unrelated issues noticed while testing

None of these are caused by this PR, and all three cost a failed launch:

- `ai2/oe-base` is **deprecated**. It is the Beaker launcher's built-in default and appears in the README seven times, so launching from the documented example fails with `[code=422] deprecated budget`.
- `job_assembler.py:470` derives the vLLM venv layout from the **harness** provider kind while the runtime uses the **model preset's** kind. For a `kind: vllm` preset with a sandbox harness, vLLM is installed in an isolated venv the worker cannot import from, and the job dies at startup. This affects 10 of the 11 vLLM model presets and cannot be worked around from the CLI — a raw HuggingFace model id has to be passed instead of the preset, which is what this PR's testing did.
- The `codex_python` harness preset cannot start locally: its image has no `swerex-remote`, and the preset sets neither `inject_swerex` nor a startup timeout above 60s, so every instance fails. `codex_universal` sets both. Worked around with an inline sandbox override rather than changing the preset here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




