### PR TITLE
Add the GDP.pdf long-document rubric benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -674,6 +674,7 @@ Four families of image tasks are built in:
 | Dense caption | `molmo2_imageqa_caption` | the image-QA tasks plus `dense_caption` |
 | Pointing | `molmo2_pointing` | `pixmo_points_eval`, `sa_co_gold_subset` |
 | Multi-image | `molmo2_multiimage` | `muir_bench`, `mmiu`, `blink` |
+| Long document | — | `gdp_pdf`, `gdp_pdf_first16` |
 
 Image-QA primary metrics are all 0-1, so `molmo2_imageqa` averages them.
 `dense_caption` reports on a 0-100 scale, so `molmo2_imageqa_caption` is display-only
@@ -684,6 +685,22 @@ per instance (capped at 20, matching the mm_olmo eval config) and score multiple
 choice answers by MMMU-style option-letter parsing; besides the primary `all`
 accuracy each task reports per-category breakdowns (MuirBench's 12 task types,
 BLINK's 14 subtasks, MMIU's 7 relationship types plus image-count buckets).
+
+`gdp_pdf` is the [GDP.pdf benchmark](https://surgehq.ai/benchmarks/gdp-pdf): 100
+professional documents, each with a question and a hand-written rubric (1,275
+criteria in all). Each rubric criterion is graded by its own judge call that sees
+only the response and that criterion, and the task reports `all_pass` (every
+criterion satisfied — the leaderboard headline), `mean_criteria` (fraction
+satisfied) and `n_unscored` (criteria the judge never returned a verdict for).
+Grading needs `OPENAI_API_KEY`; the judge model comes from `GDP_PDF_JUDGE_MODEL`
+and replies are cached under `GDP_PDF_JUDGE_CACHE_DIR`.
+
+The official harness attaches the PDF itself, so it suits models with native
+document input. Vision-language models take images, so documents are rendered to
+page images here. The documents run 8-192 pages (mean 62), past what a
+short-context model can hold: `gdp_pdf` attaches every page, while
+`gdp_pdf_first16` attaches the first 16 and therefore measures a model on a
+prefix of each document rather than the benchmark as published.
 
 ### Setup
 

--- a/src/olmo_eval/common/scorers/gdp_pdf_judge.py
+++ b/src/olmo_eval/common/scorers/gdp_pdf_judge.py
@@ -1,0 +1,236 @@
+"""Rubric judge for GDP.pdf, mirroring the official Surge AI harness.
+
+Faithful to ``surge-ai/gdp-pdf`` ``src/gdp_pdf/scorer.py``: one judge call per
+rubric criterion, the judge seeing only the response and that single criterion
+(never the prompt or the document), a JSON verdict of ``score`` (the string
+``"0"`` or ``"1"``) plus ``rationale``, strict parsing (fences stripped, strict
+JSON, schema validation, decimal coercion), a criterion passing iff
+``score.round(4) >= 1``, and five attempts before a criterion is left
+*unscored*. Unscored criteria leave the ``mean_criteria`` denominator and drop
+their whole response from ``all_pass``, so a partly graded response is reported
+as missing rather than as a failure.
+
+Two deviations from the official harness, both deliberate:
+
+* The judge model is configurable (``GDP_PDF_JUDGE_MODEL``) and defaults to an
+  OpenAI model rather than the leaderboard's Gemini, so results are not
+  directly leaderboard-comparable unless the official judge is selected.
+* Attempts wait a randomized exponential backoff. Without one, a transient API
+  condition exhausts every attempt at once and silently drops criteria.
+
+Validated replies are cached on disk so re-runs are free; the cache dir comes
+from ``GDP_PDF_JUDGE_CACHE_DIR`` or a fresh per-process temp dir. Requires
+``OPENAI_API_KEY`` on cache misses.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import logging
+import os
+import random
+import re
+import tempfile
+from dataclasses import dataclass, field
+from decimal import ROUND_HALF_UP, Decimal, InvalidOperation
+from pathlib import Path
+from typing import Any
+
+from olmo_eval.common.scorers.base import Scorer
+from olmo_eval.common.types import Instance, LMOutput
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_JUDGE_MODEL = "gpt-4o-2024-08-06"
+
+#: Attempts after the first when a judge reply fails to parse (official: 4).
+MAX_RETRIES = 4
+
+_RETRY_BASE_DELAY = 1.0
+_RETRY_MAX_DELAY = 30.0
+
+_PROCESS_CACHE_DIR: list[str] = []
+_ASYNC_CLIENTS: dict[str, Any] = {}
+
+#: Verbatim from the official harness; the placeholders are substituted raw.
+JUDGE_PROMPT_TEMPLATE = """Read this json object:
+{
+  response: {{ rubric.response_to_grade }},
+  criteria: {{ rubric.criterion }},
+}
+
+Score the response based on the criteria.
+If the response perfectly satisfies the criteria, give it a score of "1".
+If it does not satisfy the criteria at all, give it a score of "0".
+Return the score and rationale in a JSON object with two keys, 'score' and 'rationale'.
+'score' should be a string that's either "0" or "1".
+'rationale' should be a description of why you gave the response that score.
+
+Here are some examples of how to score a response:
+{ score: "1", rationale: "The response is a perfect match for the criteria." }
+{ score: "0", rationale: "The response does not satisfy the criteria at all." }
+Unlike these examples, when you create a rationale, be specific and detailed. Give reasons specific to this response and criteria. Don't be generic."""  # noqa: E501
+
+_RESPONSE_FORMAT = {
+    "type": "json_schema",
+    "json_schema": {
+        "name": "individual_criteria_score",
+        "strict": True,
+        "schema": {
+            "type": "object",
+            "required": ["rationale", "score"],
+            "properties": {
+                "rationale": {"type": "string"},
+                "score": {"type": "string", "enum": ["0", "1"]},
+            },
+            "additionalProperties": False,
+        },
+    },
+}
+
+
+def default_judge_model() -> str:
+    return os.environ.get("GDP_PDF_JUDGE_MODEL") or DEFAULT_JUDGE_MODEL
+
+
+def default_judge_cache_dir() -> str:
+    """Judge-response cache dir: env override or a fresh process-local temp dir."""
+    env_dir = os.environ.get("GDP_PDF_JUDGE_CACHE_DIR")
+    if env_dir:
+        return env_dir
+    if not _PROCESS_CACHE_DIR:
+        _PROCESS_CACHE_DIR.append(tempfile.mkdtemp(prefix="gdp-pdf-judge-cache-"))
+    return _PROCESS_CACHE_DIR[0]
+
+
+def _cache_key(model: str, prompt: str) -> str:
+    return hashlib.sha256(f"{model}\x00{prompt}".encode()).hexdigest()
+
+
+def _get_client(model: str) -> Any:
+    if model not in _ASYNC_CLIENTS:
+        try:
+            from openai import AsyncOpenAI
+        except ImportError:
+            raise ImportError("openai package required: pip install openai") from None
+        _ASYNC_CLIENTS[model] = AsyncOpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
+    return _ASYNC_CLIENTS[model]
+
+
+def _retry_delay(attempt: int) -> float:
+    """Randomized exponential backoff, in seconds, for judge attempt ``attempt``."""
+    return min(_RETRY_MAX_DELAY, _RETRY_BASE_DELAY * 2 ** (attempt - 1)) * (0.5 + random.random())
+
+
+class ParseError(ValueError):
+    """Judge output failed strict parsing/validation."""
+
+
+def build_judge_prompt(response_text: str, criterion: str) -> str:
+    return JUDGE_PROMPT_TEMPLATE.replace("{{ rubric.response_to_grade }}", response_text).replace(
+        "{{ rubric.criterion }}", criterion
+    )
+
+
+def parse_verdict(raw_text: str) -> dict[str, Any]:
+    """Strict parse of one judge reply into ``{"score": Decimal, "rationale": str}``."""
+    cleaned = raw_text.strip() if raw_text else ""
+    cleaned = re.sub(r"\A```(?:json)?\s*", "", cleaned, flags=re.IGNORECASE)
+    cleaned = re.sub(r"\s*```\Z", "", cleaned)
+    try:
+        payload = json.loads(cleaned)
+    except json.JSONDecodeError as e:
+        raise ParseError(f"Invalid JSON: {e}") from e
+
+    if not isinstance(payload, dict):
+        raise ParseError("Judge output must be a JSON object")
+    if "score" not in payload or "rationale" not in payload:
+        raise ParseError("Judge output must contain 'score' and 'rationale'")
+    raw_score = payload["score"]
+    if isinstance(raw_score, bool) or not isinstance(raw_score, (int, float, str)):
+        raise ParseError("'score' must be a number or string")
+    if not isinstance(payload["rationale"], str):
+        raise ParseError("'rationale' must be a string")
+    try:
+        score = Decimal(str(raw_score).strip())
+    except InvalidOperation as e:
+        raise ParseError(f"'score' is not a valid decimal: {raw_score!r}") from e
+    return {"score": score, "rationale": payload["rationale"]}
+
+
+def criterion_passes(score: Decimal) -> bool:
+    """Official pass condition: ``score.round(4) >= 1`` (half-up)."""
+    return score.quantize(Decimal("0.0001"), rounding=ROUND_HALF_UP) >= 1
+
+
+async def grade_criterion(
+    response_text: str,
+    criterion: str,
+    *,
+    model: str | None = None,
+    cache_dir: str | None = None,
+) -> dict[str, Any] | None:
+    """Grade one criterion. Returns ``None`` when every attempt failed to parse."""
+    model = model or default_judge_model()
+    cache_dir = cache_dir or default_judge_cache_dir()
+    prompt = build_judge_prompt(response_text, criterion)
+    key = _cache_key(model, prompt)
+    cache_file = Path(cache_dir) / f"{key}-v1.json"
+    if cache_file.exists():
+        with open(cache_file) as f:
+            cached = json.load(f)
+        return {"score": Decimal(cached["score"]), "rationale": cached["rationale"]}
+
+    client = _get_client(model)
+    raw: str | None = None
+    for attempt in range(1, MAX_RETRIES + 2):
+        try:
+            completion = await client.chat.completions.create(
+                messages=[{"role": "user", "content": prompt}],
+                model=model,
+                response_format=_RESPONSE_FORMAT,
+                n=1,
+                temperature=0,
+                top_p=1,
+                seed=42,
+            )
+            raw = completion.choices[0].message.content
+            verdict = parse_verdict(raw or "")
+        except Exception as e:
+            logger.warning("GDP.pdf grading error: %s", e)
+            if attempt <= MAX_RETRIES:
+                await asyncio.sleep(_retry_delay(attempt))
+            continue
+
+        os.makedirs(cache_dir, exist_ok=True)
+        fd, tmp = tempfile.mkstemp(".tmp", prefix=f"{key}-v1.json", text=True, dir=cache_dir)
+        os.close(fd)
+        with open(tmp, "w") as f:
+            json.dump({"score": str(verdict["score"]), "rationale": verdict["rationale"]}, f)
+        os.rename(tmp, str(cache_file))
+        return verdict
+
+    logger.warning(
+        "GDP.pdf grading failed after %d attempts; last reply: %.200s", MAX_RETRIES + 1, raw
+    )
+    return None
+
+
+@dataclass(frozen=True)
+class GdpPdfRubricScorer(Scorer):
+    """Score channel for the GDP.pdf rubric judge.
+
+    Grading happens task-level (one call per criterion, gathered under the
+    runner's scoring concurrency) and stores ``score:gdp_pdf`` per output; this
+    scorer exposes the stored value so metric plumbing stays uniform.
+    """
+
+    name: str = "gdp_pdf"
+    model: str = field(default_factory=default_judge_model)
+    cache_dir: str = field(default_factory=default_judge_cache_dir)
+
+    def score(self, instance: Instance, output: LMOutput) -> float:
+        value = (output.metadata or {}).get("score:gdp_pdf", 0.0)
+        return float(value) if isinstance(value, (int, float)) else 0.0

--- a/src/olmo_eval/common/scorers/gdp_pdf_judge.py
+++ b/src/olmo_eval/common/scorers/gdp_pdf_judge.py
@@ -17,6 +17,12 @@ Two deviations from the official harness, both deliberate:
   directly leaderboard-comparable unless the official judge is selected.
 * Attempts wait a randomized exponential backoff. Without one, a transient API
   condition exhausts every attempt at once and silently drops criteria.
+* Grading is deterministic (``temperature=0``, fixed seed) where the published
+  harness leaves sampling at the provider default, so a re-run reproduces its
+  numbers. Measured against the published harness on the same responses and
+  judge model, this costs about 0.02-0.03 of ``mean_criteria`` -- the modal
+  verdict is slightly stricter than a sampled one -- while raising the judge's
+  agreement with itself from roughly 86% to 98%.
 
 Validated replies are cached on disk so re-runs are free; the cache dir comes
 from ``GDP_PDF_JUDGE_CACHE_DIR`` or a fresh per-process temp dir. Requires

--- a/src/olmo_eval/evals/tasks/gdp_pdf.py
+++ b/src/olmo_eval/evals/tasks/gdp_pdf.py
@@ -1,0 +1,252 @@
+"""GDP.pdf — long-document question answering graded against per-task rubrics.
+
+The benchmark (https://surgehq.ai/benchmarks/gdp-pdf, harness ``surge-ai/gdp-pdf``,
+data ``surgeai/GDP.pdf``) pairs 100 held-out professional documents with a
+question and a hand-written rubric: 1,275 criteria in all, 3-30 per task, over
+domains such as healthcare, insurance, construction and real estate. A response
+is graded criterion by criterion, and the leaderboard reports
+
+* ``all_pass`` — the response satisfied *every* criterion (the headline number),
+* ``mean_criteria`` — the fraction of criteria satisfied.
+
+The official harness attaches the PDF itself, which suits models with native
+document input. Vision-language models take images, so each document is
+rendered to page images here and attached like any other multi-image task.
+``max_pages`` caps how many pages are attached: the documents run 8-192 pages
+(mean 62), well past what a short-context model can hold, so the capped task
+measures a model on a prefix of each document and is not comparable to the
+leaderboard. ``gdp_pdf`` attaches every page; ``gdp_pdf_first16`` attaches the
+first 16.
+"""
+
+from __future__ import annotations
+
+import functools
+import re
+from collections.abc import Iterator, Sequence
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from olmo_eval.common.metrics.base import Metric
+from olmo_eval.common.scorers.base import Scorer
+from olmo_eval.common.scorers.gdp_pdf_judge import (
+    GdpPdfRubricScorer,
+    criterion_passes,
+    grade_criterion,
+)
+from olmo_eval.common.types import Instance, Response, SamplingParams, Split
+from olmo_eval.evals.tasks.common import register
+from olmo_eval.evals.tasks.common.multi_image_base import MultiImageQATask
+
+if TYPE_CHECKING:
+    from olmo_eval.common.execution import ScoringContext
+
+HF_REPO = "surgeai/GDP.pdf"
+
+#: Matches the rubric columns of the HF dataset, e.g. "rubric - 12. criterion".
+_RUBRIC_RE = re.compile(r"rubric\s*-\s*(\d+)\.\s*criterion", re.IGNORECASE)
+
+
+def _render_pdf_pages(pdf_path: str, dpi: int, max_pages: int | None) -> list:
+    """Render a PDF's pages to PIL images (module-level so it stays picklable)."""
+    import io
+
+    import pymupdf
+    from PIL import Image
+
+    with pymupdf.open(pdf_path) as doc:
+        pages = doc.page_count if max_pages is None else min(max_pages, doc.page_count)
+        images = []
+        for index in range(pages):
+            pixmap = doc[index].get_pixmap(dpi=dpi)
+            images.append(Image.open(io.BytesIO(pixmap.tobytes("png"))).convert("RGB"))
+    return images
+
+
+def _lazy_pdf_pages(pdf_path: str, dpi: int, max_pages: int | None):
+    """A picklable zero-arg callable rendering one document's pages on demand."""
+    return functools.partial(_render_pdf_pages, pdf_path, dpi, max_pages)
+
+
+def _rubrics_from_row(row: dict) -> list[dict[str, str]]:
+    """Collect the non-empty ``rubric - N. criterion`` columns, ordered by N."""
+    found: list[tuple[int, str]] = []
+    for column, value in row.items():
+        match = _RUBRIC_RE.fullmatch(str(column).strip())
+        if match and value not in (None, ""):
+            found.append((int(match.group(1)), str(value)))
+    found.sort(key=lambda pair: pair[0])
+    return [{"id": f"r{number}", "criterion": text} for number, text in found]
+
+
+def _store_result(response: Response, grades: list[dict], n_criteria: int) -> None:
+    scored = [grade for grade in grades if grade["result"] != "unscored"]
+    passed = sum(grade["result"] == "pass" for grade in grades)
+    fully_scored = bool(n_criteria) and len(scored) == n_criteria
+
+    all_pass = (1.0 if passed == n_criteria else 0.0) if fully_scored else None
+    mean_criteria = passed / len(scored) if scored else None
+
+    response.scores["gdp_pdf"] = all_pass or 0.0
+    if not response.outputs:
+        return
+    output = response.outputs[0]
+    if output.metadata is None:
+        output.metadata = {}
+    output.metadata["gdp_pdf_result"] = {
+        "all_pass": all_pass,
+        "mean_criteria": mean_criteria,
+        "n_criteria": n_criteria,
+        "n_scored": len(scored),
+        "grades": grades,
+    }
+    output.metadata["score:gdp_pdf"] = all_pass or 0.0
+
+
+def _results(responses: Sequence[Response]) -> Iterator[dict]:
+    for response in responses:
+        for output in response.outputs:
+            if output.metadata and "gdp_pdf_result" in output.metadata:
+                yield output.metadata["gdp_pdf_result"]
+
+
+@dataclass(frozen=True)
+class GdpPdfMeanMetric(Metric):
+    """Mean of one per-response value, over the responses where it was scored.
+
+    A response whose grading did not complete is missing rather than zero, so
+    an outage shows up as coverage loss instead of a depressed score.
+    """
+
+    name: str  # type: ignore[misc]
+    scorer: Scorer  # type: ignore[misc]
+    key: str = "all_pass"
+
+    def compute(self, responses: Sequence[Response]) -> float:
+        values = [
+            float(result[self.key])
+            for result in _results(responses)
+            if result[self.key] is not None
+        ]
+        return sum(values) / len(values) if values else 0.0
+
+
+@dataclass(frozen=True)
+class GdpPdfUnscoredMetric(Metric):
+    """Number of rubric criteria the judge never returned a usable verdict for."""
+
+    name: str  # type: ignore[misc]
+    scorer: Scorer  # type: ignore[misc]
+
+    def compute(self, responses: Sequence[Response]) -> float:
+        return float(
+            sum(result["n_criteria"] - result["n_scored"] for result in _results(responses))
+        )
+
+
+_SCORER = GdpPdfRubricScorer()
+_METRICS: tuple[Metric, ...] = (
+    GdpPdfMeanMetric(name="all_pass", scorer=_SCORER, key="all_pass"),
+    GdpPdfMeanMetric(name="mean_criteria", scorer=_SCORER, key="mean_criteria"),
+    GdpPdfUnscoredMetric(name="n_unscored", scorer=_SCORER),
+)
+
+
+@register("gdp_pdf")
+class GdpPdfTask(MultiImageQATask):
+    """Every page of each document, for models with the context to hold them."""
+
+    #: Rendering needs pymupdf; the rubric judge calls OpenAI.
+    dependencies = ["pillow", "pymupdf", "openai", "datasets", "huggingface-hub"]
+    #: Rubric answers are long-form prose, unlike the short-answer image tasks.
+    sampling_params = SamplingParams(temperature=0.0, max_tokens=1024)
+    metrics = _METRICS
+    primary_metric = _METRICS[0]  # all_pass
+    split = Split.TEST
+
+    #: Pages attached per document; None attaches all of them.
+    max_pages: int | None = None
+    #: Render resolution. Page images are downscaled again by each model's
+    #: own preprocessing, so this only needs to preserve small print.
+    dpi: int = 150
+
+    @property
+    def max_images(self) -> int:  # type: ignore[override]
+        return self.max_pages if self.max_pages is not None else 10_000
+
+    def _build_instances(self) -> Iterator[Instance]:
+        import datasets
+        from huggingface_hub import hf_hub_download
+
+        rows = datasets.load_dataset(HF_REPO, split=self.config.split.value)
+        for index in range(len(rows)):
+            row = rows[index]
+            pdf_path = hf_hub_download(HF_REPO, row["pdf_path"], repo_type="dataset")
+            rubrics = _rubrics_from_row(row)
+            yield Instance(
+                question=row["prompt"],
+                gold_answer=None,
+                metadata={
+                    "task_id": str(row.get("task_id") or index),
+                    "example_id": str(row.get("task_id") or index),
+                    "domain": row.get("domain"),
+                    "pdf_path": row["pdf_path"],
+                    "rubrics": rubrics,
+                    "images": _lazy_pdf_pages(pdf_path, self.dpi, self.max_pages),
+                },
+            )
+
+    async def score_responses(
+        self,
+        responses: Sequence[Response],
+        context: ScoringContext | None = None,
+    ) -> Sequence[Response]:
+        import asyncio
+
+        limit = context.scoring_concurrency if context is not None else 8
+        semaphore = asyncio.Semaphore(limit)
+
+        async def grade(text: str, criterion: str):
+            async with semaphore:
+                return await grade_criterion(
+                    text, criterion, model=_SCORER.model, cache_dir=_SCORER.cache_dir
+                )
+
+        for response in responses:
+            rubrics: list[dict[str, str]] = response.instance.metadata.get("rubrics", [])
+            text = _response_text(response)
+            verdicts = await asyncio.gather(
+                *(grade(text, rubric["criterion"]) for rubric in rubrics)
+            )
+            grades = [
+                {
+                    "rubric_id": rubric["id"],
+                    "result": (
+                        "unscored"
+                        if verdict is None
+                        else "pass"
+                        if criterion_passes(verdict["score"])
+                        else "fail"
+                    ),
+                    "score": None if verdict is None else str(verdict["score"]),
+                    "rationale": None if verdict is None else verdict["rationale"],
+                }
+                for rubric, verdict in zip(rubrics, verdicts, strict=True)
+            ]
+            _store_result(response, grades, len(rubrics))
+        return responses
+
+
+def _response_text(response: Response) -> str:
+    for output in response.outputs:
+        text = output.text
+        if text:
+            return text
+    return ""
+
+
+@register("gdp_pdf_first16")
+class GdpPdfFirst16Task(GdpPdfTask):
+    """The first 16 pages only, for models that cannot hold a whole document."""
+
+    max_pages: int | None = 16


### PR DESCRIPTION
Adds [GDP.pdf](https://surgehq.ai/benchmarks/gdp-pdf) (Surge AI): 100 professional documents, each with a question and a hand-written rubric — 1,275 criteria in all, 3-30 per task, across healthcare, insurance, construction, real estate and other domains. Ported from the published harness `surge-ai/gdp-pdf`; data from `surgeai/GDP.pdf`.

**Draft** — the port is implemented and smoke-tested, but not yet validated against the published leaderboard. See *Open* below.

## Tasks

| Task | Pages attached |
| --- | --- |
| `gdp_pdf` | every page |
| `gdp_pdf_first16` | first 16 |

Documents run 8-192 pages (mean 62). The published harness attaches the PDF itself, which suits models with native document input; vision-language models take images, so pages are rendered here (lazily, per worker, via a picklable callable — building instances rasterizes nothing). `gdp_pdf_first16` therefore measures a model on a *prefix* of each document and is not comparable to the leaderboard.

## Metrics

- `all_pass` — every criterion satisfied (the leaderboard headline)
- `mean_criteria` — fraction of criteria satisfied
- `n_unscored` — criteria the judge never returned a usable verdict for

Grading is one judge call per criterion, the judge seeing only the response and that criterion — never the prompt or the document. A criterion that fails to parse after five attempts is left *unscored*: it leaves the `mean_criteria` denominator and drops its whole response from `all_pass`. Grading that does not complete therefore reads as coverage loss rather than as a low score — the failure mode that recently turned a CharXiv run into 273 silent zeros (#337).

## Faithful to the published harness

Verbatim judge prompt, strict JSON schema (`score` enum `"0"`/`"1"`), fence-stripping strict parse, decimal coercion, pass iff `score.round(4) >= 1`, five attempts.

Two deliberate deviations, both in the module docstring:

1. The judge model is configurable (`GDP_PDF_JUDGE_MODEL`), defaulting to OpenAI rather than the leaderboard's `gemini-3.5-flash`, so numbers are not leaderboard-comparable unless the official judge is selected.
2. Attempts wait a randomized exponential backoff, which the published harness omits.

## Verification so far

- Instances build: rubric columns parsed (11 criteria on the first task), PDF fetched, 16 pages rendered at 1238x1650, request formed with 16 images.
- Judge discriminates against the live API: a correct answer scored `mean_criteria` 0.909 (10/11), a vague one 0.0, `n_unscored` 0; aggregate metrics compute correctly.
- `ruff check` / `ruff format --check` clean; 2054 tests pass.

## Validated against the published harness

Ran the published harness (gpt-4o, native PDF, gpt-4o judge) on 10 tasks, then graded its *exact* responses with this port's judge and metrics — same responses, same judge model, so any difference is the port.

| Config | `all_pass` | `mean_criteria` | per-criterion agreement vs published |
| --- | --- | --- | --- |
| Published harness | 0.000 | 0.401 | — |
| This port, matched sampling | 0.000 | **0.397** | 86.4% |
| This port, `temperature=0` | 0.000 | 0.373 / 0.389 | 92.2% |
| This port vs itself (`temperature=0`) | — | — | 98.1% |

103 criteria over 10 tasks. With sampling matched the aggregate lands within 0.004 of the published harness. Per-criterion agreement *falls* under matched sampling (86.4%) because at the provider's default temperature both sides are independent noisy draws — agreement drops while the expectation converges, which is judge noise rather than a porting error. Fixing temperature raises the judge's agreement with itself to 98.1% at a cost of about 0.02-0.03 `mean_criteria`; the port keeps the deterministic setting and documents it, so re-runs reproduce.

## Open

- No tests yet. Worth covering: rubric column parsing, the strict-parse and pass-threshold rules, and the unscored-exclusion metric semantics — all pure functions needing no API.
