### PR TITLE
Keep provider settings a dict round trip cannot name

### DIFF
--- a/src/olmo_eval/inference/providers/config.py
+++ b/src/olmo_eval/inference/providers/config.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import os
 from collections.abc import Mapping
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, fields
 from typing import TYPE_CHECKING, Any, ClassVar
 
 from olmo_eval.common.repr import hide_unset
@@ -199,6 +199,8 @@ class ProviderConfig:
             d["package"] = self.package
         if self.dependencies:
             d["dependencies"] = list(self.dependencies)
+        if self.alias is not None:
+            d["alias"] = self.alias
         if self.kwargs:
             d["kwargs"] = dict(self.kwargs)
         return d
@@ -222,6 +224,13 @@ class ProviderConfig:
                 f"provider.dependencies must be a list, not a string: {deps!r}. "
                 "Use provider.dependencies=[url1,url2] syntax."
             )
+
+        # A key that names no field is a provider argument, the same reading
+        # with_overrides gives it. Dropping it instead would discard a
+        # caller's setting without saying so.
+        known = {spec.name for spec in fields(cls)} | {"model_name"}
+        kwargs = {**data.get("kwargs", {}), **{k: v for k, v in data.items() if k not in known}}
+
         return cls(
             kind=data.get("kind", ProviderKind.VLLM),
             model=data.get("model", data.get("model_name", "")),
@@ -238,7 +247,8 @@ class ProviderConfig:
             required_secrets=tuple(data.get("required_secrets", [])),
             package=data.get("package"),
             dependencies=tuple(deps),
-            kwargs=data.get("kwargs", {}),
+            alias=data.get("alias"),
+            kwargs=kwargs,
         )
 
     def with_overrides(self, **overrides: Any) -> ProviderConfig:

--- a/tests/core/test_configs.py
+++ b/tests/core/test_configs.py
@@ -151,3 +151,75 @@ class TestGetProviderConfig:
 
         # llama3.1 doesn't have a preset tokenizer - defaults to None
         assert config.tokenizer is None
+
+
+class TestProviderConfigRoundTrip:
+    """Tests for provider settings surviving a dict round trip.
+
+    CLI overrides reach a provider by round tripping the harness config
+    through a dict, so a setting lost in `from_dict` is lost silently.
+    """
+
+    def test_unknown_key_becomes_a_provider_argument(self):
+        # `with_overrides` reads an unknown name as a provider argument;
+        # the dict path has to agree with it.
+        config = ProviderConfig.from_dict(
+            {"kind": "vllm_server", "model": "org/model", "startup_timeout": 1500}
+        )
+
+        assert config.kwargs == {"startup_timeout": 1500}
+
+    def test_unknown_key_matches_with_overrides(self):
+        from_dict = ProviderConfig.from_dict(
+            {"kind": "vllm_server", "model": "org/model", "startup_timeout": 1500}
+        )
+        with_overrides = ProviderConfig(kind="vllm_server", model="org/model").with_overrides(
+            startup_timeout=1500
+        )
+
+        assert from_dict.kwargs == with_overrides.kwargs
+
+    def test_unknown_key_merges_with_declared_kwargs(self):
+        config = ProviderConfig.from_dict(
+            {
+                "kind": "vllm_server",
+                "model": "org/model",
+                "kwargs": {"gpu_memory_utilization": 0.7},
+                "startup_timeout": 1500,
+            }
+        )
+
+        assert config.kwargs == {"gpu_memory_utilization": 0.7, "startup_timeout": 1500}
+
+    def test_known_fields_still_bind_directly(self):
+        config = ProviderConfig.from_dict(
+            {"kind": "vllm_server", "model": "org/model", "max_model_len": 32768}
+        )
+
+        assert config.max_model_len == 32768
+        assert config.kwargs == {}
+
+    def test_model_name_alias_is_not_a_provider_argument(self):
+        config = ProviderConfig.from_dict({"kind": "vllm_server", "model_name": "org/model"})
+
+        assert config.model == "org/model"
+        assert config.kwargs == {}
+
+    def test_alias_survives_as_a_field(self):
+        original = ProviderConfig(kind="vllm_server", model="org/model", alias="short-name")
+
+        restored = ProviderConfig.from_dict(original.to_dict())
+
+        assert restored.alias == "short-name"
+        assert "alias" not in restored.kwargs
+
+    def test_declared_kwargs_survive(self):
+        original = ProviderConfig(
+            kind="vllm_server",
+            model="org/model",
+            kwargs={"enable_expert_parallel": True, "tool_call_parser": "qwen3_coder"},
+        )
+
+        restored = ProviderConfig.from_dict(original.to_dict())
+
+        assert restored.kwargs == original.kwargs


### PR DESCRIPTION
## The bug

`-o provider.startup_timeout=1500` is accepted, does nothing, and says nothing.

CLI overrides reach a provider by round tripping the harness config through a dict — `to_dict`, then `_apply_dotlist_overrides`, then `from_dict`. The dotlist step writes `startup_timeout` as a top-level key in the provider dict. `from_dict` (`providers/config.py:225`) then builds the config from an explicit list of keys and reads `kwargs` only from a literal `"kwargs"` key, so anything it does not recognize is discarded silently.

Reproduced:

```python
d = _apply_dotlist_overrides(get_harness_preset("codex_python").to_dict(),
                             ["provider.startup_timeout=1500",
                              "provider.max_model_len=32768"])
p = HarnessConfig.from_dict(d).provider

p.max_model_len   # 32768   -- a declared field survives
p.kwargs          # {}      -- the rest is gone
```

This bit for real. A vLLM server kept waiting on the `DEFAULT_STARTUP_TIMEOUT` of 300s while the logs counted `.../300s`, and a Beaker job whose model was not yet in the shared HuggingFace cache failed at startup — for the exact reason the command line appeared to have addressed. It affects local runs too: `cli/run/config.py:452-454` performs the same round trip.

## The fix

`ProviderConfig.with_overrides` already treats an unknown name as a provider argument, and documents it:

> Known field names are set directly on the config. Unknown names are merged into kwargs.

`from_dict` now agrees. Keys naming no field are merged into `kwargs` behind any the caller declared, and flow on through `create_provider` to the provider constructor. Known fields keep binding directly, and `model_name` stays an alias for `model` rather than becoming an argument.

**`alias` was lost the same way.** It is a declared field that neither `to_dict` nor `from_dict` touched, so it vanished on every round trip. Both now carry it — which also keeps it out of `kwargs`, where the merge above would otherwise have sent it to a provider that accepts no such argument.

## Scope and a deliberate non-fix

Four lines of behavior change, confined to `ProviderConfig`. Nothing that worked before changes: declared `kwargs` already round-tripped correctly (verified — presets like `qwen3-coder-30b` that depend on them were never affected), and every existing field keeps its binding.

A **typo in a known field name** is still accepted rather than rejected: `provider.max_model_lenn=4096` now becomes a provider argument and surfaces as an error from the provider, instead of being silently ignored. Rejecting unknown keys outright would catch typos at the source, but would also refuse configs that legitimately carry extra keys, so this follows the reading `with_overrides` already established. Worth revisiting if the stricter behavior is wanted.

## Tests

Seven tests in `tests/core/test_configs.py::TestProviderConfigRoundTrip`. **Four fail without the fix** (verified by stashing it), covering the unknown-key path, agreement with `with_overrides`, merging with declared kwargs, and `alias`. The other three guard what must not change: known fields binding directly, `model_name` staying an alias, and declared kwargs surviving.

Full suite: 2158 passed, 8 skipped.

Found while getting a first real LiveCodeBench run through Beaker (#354); independent of that work and of #352/#353.

🤖 Generated with [Claude Code](https://claude.com/claude-code)