### PR TITLE
Add DeepSearchQA task (two grading implementations)

### DIFF
--- a/src/olmo_eval/evals/tasks/DEEPSEARCHQA.md
+++ b/src/olmo_eval/evals/tasks/DEEPSEARCHQA.md
@@ -12,14 +12,30 @@ question is either a **Single Answer** (one entity/value) or a **Set Answer**
 test whether an agent can plan and execute a search process that returns a
 *complete and precise* answer set, not just a single plausible fact.
 
+There are two registered tasks, sharing the same dataset and data-loading
+code (`DeepSearchQABase` in `deepsearchqa.py`) but with different generation
+prompts and grading mechanics — see "How grading works" below:
+
+- **`deepsearchqa`** — a discrete `FINAL ANSWER: ...` line, matched against
+  the gold item set by index. This is the default; it's easier to validate
+  programmatically (see below) but is a bigger departure from the official
+  methodology.
+- **`deepsearchqa_official_judge`** — mirrors the official paper prompt
+  (Appendix A): the judge grades the model's raw free-form response
+  directly, no special output format required.
+
 ## Files
 
-- [`deepsearchqa.py`](deepsearchqa.py) — the task implementation (this file's
-  companion module).
+- [`deepsearchqa.py`](deepsearchqa.py) — dataset loading (`DeepSearchQABase`)
+  and the `deepsearchqa` task implementation.
+- [`deepsearchqa_official_judge.py`](deepsearchqa_official_judge.py) — the
+  `deepsearchqa_official_judge` task implementation (imports `DeepSearchQABase`
+  from `deepsearchqa.py`).
 - [`../../../../tests/evals/tasks/test_deepsearchqa.py`](../../../../tests/evals/tasks/test_deepsearchqa.py)
-  — unit tests for parsing, scoring, and the registered task/variant.
+  and [`../../../../tests/evals/tasks/test_deepsearchqa_official_judge.py`](../../../../tests/evals/tasks/test_deepsearchqa_official_judge.py)
+  — unit tests for parsing, scoring, and the registered tasks/variants.
 
-No other files were modified; the task is picked up automatically by the
+No other files were modified; both tasks are picked up automatically by the
 package's task auto-discovery (`src/olmo_eval/evals/tasks/__init__.py`), the
 same mechanism every other task in this directory relies on.
 
@@ -43,6 +59,19 @@ same mechanism every other task in this directory relies on.
 
 ## How grading works
 
+**The official grader is published.** The technical report
+([PDF](https://storage.googleapis.com/deepmind-media/DeepSearchQA/DeepSearchQA_benchmark_paper.pdf))
+grades with Gemini 2.5 Flash, zero-shot, using the exact prompt printed in
+Appendix A — it is not an unpublished/proprietary prompt. `deepsearchqa_official_judge`
+uses that prompt verbatim; `deepsearchqa` uses a different, independently
+written mechanic (below). Both deviate from the official leaderboard in the
+same unavoidable way: olmo-eval's judge infrastructure (`build_openai_judge_fn`)
+is OpenAI-only, so both grade with an OpenAI model instead of Gemini (default
+`gpt-5.5:medium`, overridable — see below), so absolute numbers from either
+task are not directly comparable to the public Kaggle leaderboard.
+
+### `deepsearchqa`: discrete extraction + index matching
+
 The model is prompted to end its response with:
 
 ```
@@ -53,8 +82,9 @@ Only the text after the last `FINAL ANSWER` marker is graded (the rest of the
 response — search steps, reasoning, etc. — is not scored directly). That line
 is split into a predicted item set `S` and compared against the gold item set
 `G` with an LLM judge that decides semantic equivalence per item (so
-"NZ" ≟ "New Zealand" counts as a match). From the judge's matched indices the
-task computes, per instance:
+"NZ" ≟ "New Zealand" counts as a match), returning two lists of matched
+indices (one per side). From those matched counts the task computes, per
+instance:
 
 | Metric                    | Formula                    |
 |----------------------------|----------------------------|
@@ -63,13 +93,30 @@ task computes, per instance:
 | `deepsearchqa_f1`          | harmonic mean of precision/recall (**primary metric**) |
 | `deepsearchqa_exact_match` | `1.0` iff the item sets match exactly, else `0.0` |
 
-**Deviation from the official benchmark**: the paper/starter notebook grade
-with a Gemini 2.5 Flash autorater using an unpublished prompt. olmo-eval's
-judge infrastructure (`build_openai_judge_fn`) is OpenAI-only, so this task
-uses an independently written judge prompt against an OpenAI model instead
-(default `gpt-5.5:medium`, overridable — see below). The metric *definitions*
-(precision/recall/F1 over item sets) match the paper; absolute numbers are
-not directly comparable to the public Kaggle leaderboard.
+This mechanic is easier to validate programmatically than the official one:
+checking a judge-returned index is valid is just `0 <= i < N` for an `N` you
+already know, with no need to reconcile the judge's own text against your
+source data. The trade-off is that it requires the model to produce a
+specific output format, and it's a bigger departure from the paper's
+free-form grading than "different judge model" alone.
+
+### `deepsearchqa_official_judge`: free-form response, official prompt
+
+No special output format is required — the model just answers the question,
+and the judge grades the full raw response directly (verbatim Appendix A
+prompt). The judge returns, per gold item, a boolean ("was this item found in
+the response") plus a free list of "Excessive Answers" (items claimed that
+aren't part of the gold answer). The task counts how many gold items were
+marked found (capped at the gold count) and how many excessive answers were
+listed, then computes the same precision/recall/F1/exact-match formulas under
+the `deepsearchqa_official_*` metric names.
+
+Note this task does **not** attempt to reconcile the judge's per-item keys
+back to the exact `gold_items` strings (an LLM won't reliably echo them
+byte-for-byte) — it only counts `True` values, which is enough to compute the
+aggregate metrics without needing per-item traceability. If you need to know
+*which* specific gold item was missed, use `deepsearchqa`'s index-matching
+metadata instead.
 
 This benchmark is about live information-seeking rather than parametric
 knowledge, so it is intended to be evaluated with search tools attached via
@@ -90,6 +137,9 @@ uv run olmo-eval run -m llama3.1-8b -t deepsearchqa
 
 # Quick iteration on a 50-instance subset
 uv run olmo-eval run -m llama3.1-8b -t deepsearchqa:mini --harness dr_tulu
+
+# The official-prompt variant works the same way; swap the task name
+uv run olmo-eval run -m llama3.1-8b -t deepsearchqa_official_judge:mini --harness dr_tulu
 
 # Preview instances/prompts without calling a model or the judge
 uv run olmo-eval task inspect deepsearchqa -n 3 --request

--- a/src/olmo_eval/evals/tasks/DEEPSEARCHQA.md
+++ b/src/olmo_eval/evals/tasks/DEEPSEARCHQA.md
@@ -1,0 +1,103 @@
+# DeepSearchQA
+
+`deepsearchqa` implements [DeepSearchQA](https://huggingface.co/datasets/google/deepsearchqa)
+(Google DeepMind, [arXiv:2601.20975](https://arxiv.org/abs/2601.20975); Kaggle
+starter code: [deepsearchqa-starter-code](https://www.kaggle.com/code/andrewmingwang/deepsearchqa-starter-code),
+[leaderboard](https://www.kaggle.com/benchmarks/google/dsqa)) inside olmo-eval.
+
+900 hand-crafted, multi-step information-seeking questions across 17 domains
+(Politics, Finance, Science, Health, History, Geography, Media, ...). Each
+question is either a **Single Answer** (one entity/value) or a **Set Answer**
+(an enumeration or composite answer requiring multiple items); the goal is to
+test whether an agent can plan and execute a search process that returns a
+*complete and precise* answer set, not just a single plausible fact.
+
+## Files
+
+- [`deepsearchqa.py`](deepsearchqa.py) — the task implementation (this file's
+  companion module).
+- [`../../../../tests/evals/tasks/test_deepsearchqa.py`](../../../../tests/evals/tasks/test_deepsearchqa.py)
+  — unit tests for parsing, scoring, and the registered task/variant.
+
+No other files were modified; the task is picked up automatically by the
+package's task auto-discovery (`src/olmo_eval/evals/tasks/__init__.py`), the
+same mechanism every other task in this directory relies on.
+
+## Data
+
+- HuggingFace dataset: `google/deepsearchqa`, config `deepsearchqa`, split
+  `eval` (900 rows).
+- Columns: `problem` (question), `problem_category` (domain), `answer`
+  (ground truth, comma-joined for multi-item answers), `answer_type`
+  (`"Single Answer"` or `"Set Answer"`).
+- Both answer types are parsed the same way: the `answer` column is split on
+  `,` into a gold item set (a `"Single Answer"` becomes a one-item set), so
+  scoring treats every instance uniformly as set comparison.
+
+## How grading works
+
+The model is prompted to end its response with:
+
+```
+FINAL ANSWER: <item 1>, <item 2>, ...
+```
+
+Only the text after the last `FINAL ANSWER` marker is graded (the rest of the
+response — search steps, reasoning, etc. — is not scored directly). That line
+is split into a predicted item set `S` and compared against the gold item set
+`G` with an LLM judge that decides semantic equivalence per item (so
+"NZ" ≟ "New Zealand" counts as a match). From the judge's matched indices the
+task computes, per instance:
+
+| Metric                    | Formula                    |
+|----------------------------|----------------------------|
+| `deepsearchqa_precision`   | `\|S ∩ G\| / \|S\|`        |
+| `deepsearchqa_recall`      | `\|S ∩ G\| / \|G\|`        |
+| `deepsearchqa_f1`          | harmonic mean of precision/recall (**primary metric**) |
+| `deepsearchqa_exact_match` | `1.0` iff the item sets match exactly, else `0.0` |
+
+**Deviation from the official benchmark**: the paper/starter notebook grade
+with a Gemini 2.5 Flash autorater using an unpublished prompt. olmo-eval's
+judge infrastructure (`build_openai_judge_fn`) is OpenAI-only, so this task
+uses an independently written judge prompt against an OpenAI model instead
+(default `gpt-5.5:medium`, overridable — see below). The metric *definitions*
+(precision/recall/F1 over item sets) match the paper; absolute numbers are
+not directly comparable to the public Kaggle leaderboard.
+
+This benchmark is about live information-seeking rather than parametric
+knowledge, so it is intended to be evaluated with search tools attached via
+olmo-eval's Harness abstraction — running it without tools mostly measures
+how much of the answer the model already knows.
+
+## Running it
+
+```bash
+# Requires an OpenAI key for the LLM judge
+export OPENAI_API_KEY=...
+
+# Full 900-instance run with search tools (the intended way to run this eval)
+uv run olmo-eval run -m llama3.1-8b -t deepsearchqa --harness dr_tulu
+
+# Baseline, no search tools (parametric-knowledge reference point only)
+uv run olmo-eval run -m llama3.1-8b -t deepsearchqa
+
+# Quick iteration on a 50-instance subset
+uv run olmo-eval run -m llama3.1-8b -t deepsearchqa:mini --harness dr_tulu
+
+# Preview instances/prompts without calling a model or the judge
+uv run olmo-eval task inspect deepsearchqa -n 3 --request
+
+# Preview the run config without executing anything
+uv run olmo-eval run -m mock -t deepsearchqa --dry-run
+```
+
+Use a different judge model with `OLMO_EVAL_JUDGE`, e.g.:
+
+```bash
+OLMO_EVAL_JUDGE=gpt-5-mini uv run olmo-eval run -m llama3.1-8b -t deepsearchqa --harness dr_tulu
+```
+
+See the main [README's Harness section](../../../../README.md#harness) for
+configuring which search tools `--harness` attaches, and [Adding New
+Tasks](../../../../README.md#adding-new-tasks) for how this task fits the
+general task framework.

--- a/src/olmo_eval/evals/tasks/DEEPSEARCHQA.md
+++ b/src/olmo_eval/evals/tasks/DEEPSEARCHQA.md
@@ -126,8 +126,12 @@ how much of the answer the model already knows.
 ## Running it
 
 ```bash
-# Requires an OpenAI key for the LLM judge
+# Requires an OpenAI key for the LLM judge (always needed, regardless of harness)
 export OPENAI_API_KEY=...
+
+# --harness dr_tulu additionally requires its own search-tool keys
+export S2_API_KEY=...       # Semantic Scholar
+export SERPER_API_KEY=...   # Google web search
 
 # Full 900-instance run with search tools (the intended way to run this eval)
 uv run olmo-eval run -m llama3.1-8b -t deepsearchqa --harness dr_tulu

--- a/src/olmo_eval/evals/tasks/DEEPSEARCHQA.md
+++ b/src/olmo_eval/evals/tasks/DEEPSEARCHQA.md
@@ -33,6 +33,13 @@ same mechanism every other task in this directory relies on.
 - Both answer types are parsed the same way: the `answer` column is split on
   `,` into a gold item set (a `"Single Answer"` becomes a one-item set), so
   scoring treats every instance uniformly as set comparison.
+- 4 `Set Answer` rows encode "no items satisfy every constraint" as the
+  literal text `None` in the source CSV; HuggingFace's CSV loader coerces
+  that to a null value. These are treated as an empty gold answer set (not
+  dropped) — a correctly-empty model prediction scores full marks, and any
+  predicted item scores zero. A missing `answer` on a `Single Answer` row is
+  still treated as malformed and dropped, since that combination shouldn't
+  occur in valid data.
 
 ## How grading works
 

--- a/src/olmo_eval/evals/tasks/deepsearchqa.py
+++ b/src/olmo_eval/evals/tasks/deepsearchqa.py
@@ -1,0 +1,392 @@
+"""DeepSearchQA: deep-research agent evaluation (Google DeepMind, arXiv 2601.20975).
+
+DeepSearchQA is a 900-problem benchmark of hand-crafted, multi-step
+information-seeking questions spanning 17 domains (Politics, Finance, Science,
+Health, History, Geography, Media, ...). Each problem is either a
+``Single Answer`` (one entity/value) or a ``Set Answer`` (an enumeration or
+composite answer with multiple required items); on HuggingFace both are
+stored as one comma-joined ``answer`` string
+(``google/deepsearchqa``, config ``deepsearchqa``, split ``eval``).
+
+Grading follows the paper's outcome-based, set-comparison methodology: an
+LLM judge decides, per item, whether a submitted answer is semantically
+equivalent to a ground-truth answer (and vice versa), and the task reports
+Precision (``|S ∩ G| / |S|``), Recall (``|S ∩ G| / |G|``), their harmonic
+mean F1 (the primary metric), and an all-or-nothing Exact Match rate. Unlike
+the paper/starter-notebook's official grader (a Gemini 2.5 Flash autorater
+whose exact prompt is not published), this task uses olmo-eval's OpenAI-based
+judge infrastructure with an independently written judge prompt, so absolute
+numbers are not directly comparable to the public leaderboard. Set
+``OLMO_EVAL_JUDGE=<model>[:<effort>]`` to change the judge model.
+
+The task asks the model to end its response with a ``FINAL ANSWER: ...`` line
+listing every item in its answer set, comma-separated; this line (rather than
+the full response) is what gets judged. This benchmark is about finding
+information via search rather than about knowledge already in the model's
+parameters, so it is intended to be run with search tools attached via the
+Harness abstraction (e.g. ``--harness dr_tulu``); running without tools mostly
+measures parametric recall on questions designed to require live search.
+
+Usage:
+    # Tool-augmented (intended way to run this benchmark)
+    olmo-eval run -m llama3.1-8b -t deepsearchqa --harness dr_tulu
+
+    # Baseline, no search tools (for reference only)
+    olmo-eval run -m llama3.1-8b -t deepsearchqa
+
+    # Quick iteration on a 50-instance subset
+    olmo-eval run -m llama3.1-8b -t deepsearchqa:mini --harness dr_tulu
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import re
+from collections.abc import Iterator, Sequence
+from dataclasses import dataclass, field
+from typing import Any
+
+from olmo_eval.common.metrics import Metric
+from olmo_eval.common.scorers.base import Scorer
+from olmo_eval.common.scorers.llm_judge import JudgeFn, build_openai_judge_fn
+from olmo_eval.common.types import (
+    Instance,
+    LMOutput,
+    LMRequest,
+    RequestType,
+    Response,
+    SamplingParams,
+)
+from olmo_eval.data import DataSource
+from olmo_eval.evals.tasks.common import Task, register, register_variant
+
+logger = logging.getLogger(__name__)
+
+DEEPSEARCHQA_REPO = "google/deepsearchqa"
+DEEPSEARCHQA_CONFIG = "deepsearchqa"
+DEEPSEARCHQA_SPLIT = "eval"
+
+DEEPSEARCHQA_DEFAULT_JUDGE_SPEC = "gpt-5.5:medium"
+DEEPSEARCHQA_JUDGE_ATTEMPTS = 3
+
+DEEPSEARCHQA_GENERATION_PROMPT = """\
+Answer the following question. It may require an exhaustive search across \
+multiple sources rather than a single lookup. If you have access to search \
+tools, use them to find and verify each candidate answer instead of \
+answering from memory alone.
+
+The question may have exactly one correct answer, or it may require a \
+complete set of items that together satisfy every constraint it states \
+(watch for words like "all", "each", or "list"). Do not stop at the first \
+plausible answer if the question implies there may be more than one.
+
+Finish your response with a line of exactly this form:
+FINAL ANSWER: <item 1>, <item 2>, ...
+
+List every item belonging to your answer set on that line, separated by \
+commas, and put nothing else on it. If there is a single correct answer, \
+list just that one item.
+
+Question: {question}"""
+
+# Tolerates markdown emphasis and a missing/extra colon around the marker.
+_FINAL_ANSWER_MARKER = re.compile(r"\**\s*FINAL\s+ANSWER\s*\**\s*:?\s*", re.IGNORECASE)
+
+
+def extract_final_answer(text: str) -> str:
+    """Return the text after the last ``FINAL ANSWER`` marker.
+
+    Falls back to the full response when the marker is absent, so the judge
+    still sees the model's attempt.
+    """
+    matches = list(_FINAL_ANSWER_MARKER.finditer(text))
+    if not matches:
+        return text.strip()
+    return text[matches[-1].end() :].strip() or text.strip()
+
+
+def split_answer_set(text: str) -> list[str]:
+    """Split a comma-delimited answer string into non-empty, stripped items."""
+    return [item.strip() for item in text.split(",") if item.strip()]
+
+
+def _numbered_list(items: Sequence[str]) -> str:
+    return "\n".join(f"{index}. {item}" for index, item in enumerate(items))
+
+
+DEEPSEARCHQA_JUDGE_PROMPT = """\
+You are grading a submitted answer against a ground-truth answer for the \
+question below. The answer may be a single item or a set of items. Two \
+items are equivalent if they refer to the same real-world entity, value, or \
+fact, even when worded differently (abbreviations, alternate spellings, \
+reordering, or trivial formatting differences do not matter). Judge \
+semantic equivalence, not surface string similarity.
+
+Question: {question}
+
+Ground-truth answer set ({num_gold} item(s)):
+{gold_list}
+
+Submitted answer set ({num_pred} item(s)):
+{pred_list}
+
+For every ground-truth item, decide whether it is semantically covered by \
+at least one submitted item. Separately, for every submitted item, decide \
+whether it matches at least one ground-truth item.
+
+Respond with only a JSON object of exactly this form, and nothing else:
+{{"matched_gold_indices": [...], "matched_submitted_indices": [...]}}
+Both lists hold the 0-based indices (into the lists above) of the items \
+that were matched."""
+
+_JSON_OBJECT = re.compile(r"\{.*\}", re.DOTALL)
+
+
+def build_deepsearchqa_judge_fn() -> JudgeFn:
+    """Build the task's judge from ``$OLMO_EVAL_JUDGE`` or its own default."""
+    import os
+
+    spec = os.getenv("OLMO_EVAL_JUDGE", DEEPSEARCHQA_DEFAULT_JUDGE_SPEC)
+    model, separator, effort = spec.partition(":")
+    return build_openai_judge_fn(
+        model=model,
+        temperature=0.0,
+        max_tokens=1024,
+        scorer_name="DeepSearchQA",
+        reasoning_effort=(effort if separator else None),
+    )
+
+
+def build_deepsearchqa_judge_prompt(
+    question: str, gold_items: Sequence[str], pred_items: Sequence[str]
+) -> str:
+    """Format the item-matching judge prompt for one instance."""
+    return DEEPSEARCHQA_JUDGE_PROMPT.format(
+        question=question,
+        num_gold=len(gold_items),
+        gold_list=_numbered_list(gold_items),
+        num_pred=len(pred_items),
+        pred_list=_numbered_list(pred_items),
+    )
+
+
+def parse_deepsearchqa_judge_response(
+    raw: str, num_gold: int, num_pred: int
+) -> tuple[set[int], set[int]] | None:
+    """Parse the judge's matched-index JSON, or None if it is unparseable."""
+    match = _JSON_OBJECT.search(raw)
+    if match is None:
+        return None
+    try:
+        data = json.loads(match.group(0))
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(data, dict):
+        return None
+
+    gold_raw, pred_raw = data.get("matched_gold_indices"), data.get("matched_submitted_indices")
+    if not isinstance(gold_raw, list) or not isinstance(pred_raw, list):
+        return None
+
+    try:
+        matched_gold = {int(i) for i in gold_raw if 0 <= int(i) < num_gold}
+        matched_pred = {int(i) for i in pred_raw if 0 <= int(i) < num_pred}
+    except (TypeError, ValueError):
+        return None
+    return matched_gold, matched_pred
+
+
+def compute_deepsearchqa_scores(
+    num_gold: int, num_pred: int, num_matched_gold: int, num_matched_pred: int
+) -> dict[str, float]:
+    """Compute precision/recall/F1/exact-match from item-level match counts."""
+    recall = num_matched_gold / num_gold if num_gold else 1.0
+    precision = num_matched_pred / num_pred if num_pred else 0.0
+    f1 = 0.0 if precision + recall == 0 else 2 * precision * recall / (precision + recall)
+    exact_match = 1.0 if (num_pred > 0 and num_matched_pred == num_pred and recall == 1.0) else 0.0
+    return {
+        "deepsearchqa_precision": precision,
+        "deepsearchqa_recall": recall,
+        "deepsearchqa_f1": f1,
+        "deepsearchqa_exact_match": exact_match,
+    }
+
+
+@dataclass(frozen=True)
+class DeepSearchQAScorer(Scorer):
+    """Placeholder scorer; DeepSearchQA scores are computed in ``score_responses``."""
+
+    name: str = "deepsearchqa_f1"
+    score_key: str = "deepsearchqa_f1"
+
+    def score(self, instance: Instance, output: LMOutput) -> float:
+        return (output.metadata or {}).get(self.score_key, 0.0)
+
+
+@dataclass(frozen=True)
+class DeepSearchQAMetric(Metric):
+    """Mean of a precomputed DeepSearchQA score across responses."""
+
+    name: str = "deepsearchqa_f1"
+    scorer: type[Scorer] | Scorer = field(
+        default_factory=lambda: DeepSearchQAScorer(score_key="deepsearchqa_f1")
+    )
+
+    def compute(self, responses: Sequence[Response]) -> float:
+        if not responses:
+            return 0.0
+        return sum(response.scores.get(self.name, 0.0) for response in responses) / len(responses)
+
+    def pairwise_display_format(self) -> str:
+        return "percentage"
+
+    def pairwise_unit(self) -> str:
+        return "proportion"
+
+
+def _metric(name: str) -> DeepSearchQAMetric:
+    return DeepSearchQAMetric(name=name, scorer=DeepSearchQAScorer(score_key=name))
+
+
+F1_METRIC = _metric("deepsearchqa_f1")
+PRECISION_METRIC = _metric("deepsearchqa_precision")
+RECALL_METRIC = _metric("deepsearchqa_recall")
+EXACT_MATCH_METRIC = _metric("deepsearchqa_exact_match")
+DEEPSEARCHQA_METRICS = (F1_METRIC, PRECISION_METRIC, RECALL_METRIC, EXACT_MATCH_METRIC)
+
+
+@register("deepsearchqa")
+class DeepSearchQA(Task):
+    """DeepSearchQA multi-step search question answering, graded by item-set F1."""
+
+    data_source = DataSource(
+        path=DEEPSEARCHQA_REPO, subset=DEEPSEARCHQA_CONFIG, split=DEEPSEARCHQA_SPLIT
+    )
+    metrics = DEEPSEARCHQA_METRICS
+    primary_metric = F1_METRIC
+    sampling_params = SamplingParams(temperature=0.0, max_tokens=4096)
+    required_secrets = ("OPENAI_API_KEY",)
+
+    @property
+    def instances(self) -> Iterator[Instance]:
+        split = (
+            self.config.data_source.split
+            if isinstance(self.config.data_source, DataSource)
+            else None
+        )
+        yield from self._load_instances_cached(split=split)
+
+    def process_doc(self, doc: dict[str, Any], index: int = 0) -> Instance | None:
+        question = doc.get("problem")
+        answer = doc.get("answer")
+        if not question or not answer:
+            return None
+
+        gold_items = split_answer_set(answer)
+        if not gold_items:
+            return None
+
+        return Instance(
+            question=question,
+            gold_answer=answer,
+            metadata={
+                "id": f"deepsearchqa_{index}",
+                "index": index,
+                "problem_category": doc.get("problem_category", ""),
+                "answer_type": doc.get("answer_type", ""),
+                "gold_items": gold_items,
+            },
+        )
+
+    def format_request(self, instance: Instance) -> LMRequest:
+        prompt = DEEPSEARCHQA_GENERATION_PROMPT.format(question=instance.question)
+        return LMRequest(
+            request_type=RequestType.CHAT,
+            messages=({"role": "user", "content": prompt},),
+        )
+
+    def extract_answer(self, output: LMOutput) -> str:
+        """Keep only the comma-separated list after the ``FINAL ANSWER`` marker."""
+        return extract_final_answer(output.text)
+
+    async def score_responses(
+        self,
+        responses: Sequence[Response],
+        context: Any = None,
+    ) -> Sequence[Response]:
+        """Judge each response's answer set against the gold answer set."""
+        self._extract_answers(responses)
+        judge_fn = build_deepsearchqa_judge_fn()
+
+        failed_instances = 0
+        for response in responses:
+            scores, judge_metadata, judge_failed = await self._score_single(response, judge_fn)
+            response.scores.update(scores)
+            failed_instances += judge_failed
+
+            if response.outputs:
+                output = response.outputs[0]
+                output.metadata.update(judge_metadata)
+                for metric_name, score in scores.items():
+                    output.metadata[f"score:{metric_name}"] = score
+
+        if failed_instances:
+            logger.warning(
+                "DeepSearchQA judge returned no parseable verdict for %d instance(s) after "
+                "%d attempts; scored those 0.0 across all metrics.",
+                failed_instances,
+                DEEPSEARCHQA_JUDGE_ATTEMPTS,
+            )
+        return responses
+
+    async def _score_single(
+        self,
+        response: Response,
+        judge_fn: JudgeFn,
+    ) -> tuple[dict[str, float], dict[str, Any], int]:
+        """Score one response, returning metrics, judge details, and a failure count."""
+        gold_items = response.instance.metadata.get("gold_items", [])
+        output = response.outputs[0] if response.outputs else None
+
+        pred_text = ""
+        if output is not None:
+            extracted = output.extracted_answer
+            pred_text = extracted if isinstance(extracted, str) else output.text
+        pred_items = split_answer_set(pred_text)
+
+        base_metadata = {
+            "deepsearchqa_gold_items": gold_items,
+            "deepsearchqa_predicted_items": pred_items,
+        }
+
+        if not pred_items:
+            # Nothing to match against the gold set; skip the judge call.
+            scores = compute_deepsearchqa_scores(len(gold_items), 0, 0, 0)
+            return scores, base_metadata, 0
+
+        prompt = build_deepsearchqa_judge_prompt(response.instance.question, gold_items, pred_items)
+
+        parsed = None
+        for attempt in range(DEEPSEARCHQA_JUDGE_ATTEMPTS):
+            raw = await judge_fn(prompt)
+            parsed = parse_deepsearchqa_judge_response(raw, len(gold_items), len(pred_items))
+            if parsed is not None:
+                break
+            if attempt < DEEPSEARCHQA_JUDGE_ATTEMPTS - 1:
+                await asyncio.sleep(2**attempt)
+
+        matched_gold, matched_pred = parsed if parsed is not None else (set(), set())
+        scores = compute_deepsearchqa_scores(
+            len(gold_items), len(pred_items), len(matched_gold), len(matched_pred)
+        )
+        metadata = {
+            **base_metadata,
+            "deepsearchqa_matched_gold_indices": sorted(matched_gold),
+            "deepsearchqa_matched_submitted_indices": sorted(matched_pred),
+        }
+        return scores, metadata, 0 if parsed is not None else 1
+
+
+register_variant("deepsearchqa", "mini", limit=50)

--- a/src/olmo_eval/evals/tasks/deepsearchqa.py
+++ b/src/olmo_eval/evals/tasks/deepsearchqa.py
@@ -184,14 +184,17 @@ def parse_deepsearchqa_judge_response(
     raw: str, num_gold: int, num_pred: int
 ) -> tuple[set[int], set[int]] | None:
     """Parse the judge's matched-index JSON, or None if it is unparseable."""
-    match = _JSON_OBJECT.search(raw)
-    if match is None:
-        return None
-    try:
-        data = json.loads(match.group(0))
-    except json.JSONDecodeError:
-        return None
-    if not isinstance(data, dict):
+    decoder = json.JSONDecoder()
+    data: Any | None = None
+    for match in re.finditer(r"\{", raw):
+        try:
+            candidate, _end = decoder.raw_decode(raw[match.start() :])
+        except json.JSONDecodeError:
+            continue
+        if isinstance(candidate, dict):
+            data = candidate
+            break
+    if data is None:
         return None
 
     gold_raw, pred_raw = data.get("matched_gold_indices"), data.get("matched_submitted_indices")

--- a/src/olmo_eval/evals/tasks/deepsearchqa.py
+++ b/src/olmo_eval/evals/tasks/deepsearchqa.py
@@ -6,7 +6,10 @@ Health, History, Geography, Media, ...). Each problem is either a
 ``Single Answer`` (one entity/value) or a ``Set Answer`` (an enumeration or
 composite answer with multiple required items); on HuggingFace both are
 stored as one comma-joined ``answer`` string
-(``google/deepsearchqa``, config ``deepsearchqa``, split ``eval``).
+(``google/deepsearchqa``, config ``deepsearchqa``, split ``eval``). A handful
+of ``Set Answer`` rows encode "no items satisfy every constraint" as the
+literal text ``None``, which HuggingFace's CSV loader turns into a null; these
+are scored as an empty gold answer set rather than dropped.
 
 Grading follows the paper's outcome-based, set-comparison methodology: an
 LLM judge decides, per item, whether a submitted answer is semantically
@@ -202,7 +205,18 @@ def compute_deepsearchqa_scores(
     num_gold: int, num_pred: int, num_matched_gold: int, num_matched_pred: int
 ) -> dict[str, float]:
     """Compute precision/recall/F1/exact-match from item-level match counts."""
-    recall = num_matched_gold / num_gold if num_gold else 1.0
+    if num_gold == 0:
+        # Gold answer is the empty set: a correctly-empty prediction is a perfect score,
+        # any predicted item is an unwarranted hallucination.
+        is_correct = num_pred == 0
+        return {
+            "deepsearchqa_precision": 1.0 if is_correct else 0.0,
+            "deepsearchqa_recall": 1.0,
+            "deepsearchqa_f1": 1.0 if is_correct else 0.0,
+            "deepsearchqa_exact_match": 1.0 if is_correct else 0.0,
+        }
+
+    recall = num_matched_gold / num_gold
     precision = num_matched_pred / num_pred if num_pred else 0.0
     f1 = 0.0 if precision + recall == 0 else 2 * precision * recall / (precision + recall)
     exact_match = 1.0 if (num_pred > 0 and num_matched_pred == num_pred and recall == 1.0) else 0.0
@@ -281,21 +295,32 @@ class DeepSearchQA(Task):
     def process_doc(self, doc: dict[str, Any], index: int = 0) -> Instance | None:
         question = doc.get("problem")
         answer = doc.get("answer")
-        if not question or not answer:
+        answer_type = doc.get("answer_type", "")
+        if not question:
             return None
 
-        gold_items = split_answer_set(answer)
-        if not gold_items:
-            return None
+        if not answer:
+            # The source CSV encodes "no items satisfy every constraint" as the literal
+            # text "None" on Set Answer rows; the HF CSV loader coerces that string to a
+            # null, so it arrives here indistinguishable from a missing field. A missing
+            # answer only makes sense as an intentional empty answer set for Set Answer
+            # rows; treat anything else as a malformed row.
+            if answer_type != "Set Answer":
+                return None
+            gold_items: list[str] = []
+        else:
+            gold_items = split_answer_set(answer)
+            if not gold_items:
+                return None
 
         return Instance(
             question=question,
-            gold_answer=answer,
+            gold_answer=answer or "",
             metadata={
                 "id": f"deepsearchqa_{index}",
                 "index": index,
                 "problem_category": doc.get("problem_category", ""),
-                "answer_type": doc.get("answer_type", ""),
+                "answer_type": answer_type,
                 "gold_items": gold_items,
             },
         )
@@ -361,9 +386,10 @@ class DeepSearchQA(Task):
             "deepsearchqa_predicted_items": pred_items,
         }
 
-        if not pred_items:
-            # Nothing to match against the gold set; skip the judge call.
-            scores = compute_deepsearchqa_scores(len(gold_items), 0, 0, 0)
+        if not pred_items or not gold_items:
+            # Nothing to match on one side (an empty prediction, or a gold answer
+            # that is itself the empty set); the outcome is already determined.
+            scores = compute_deepsearchqa_scores(len(gold_items), len(pred_items), 0, 0)
             return scores, base_metadata, 0
 
         prompt = build_deepsearchqa_judge_prompt(response.instance.question, gold_items, pred_items)

--- a/src/olmo_eval/evals/tasks/deepsearchqa.py
+++ b/src/olmo_eval/evals/tasks/deepsearchqa.py
@@ -15,11 +15,16 @@ Grading follows the paper's outcome-based, set-comparison methodology: an
 LLM judge decides, per item, whether a submitted answer is semantically
 equivalent to a ground-truth answer (and vice versa), and the task reports
 Precision (``|S ∩ G| / |S|``), Recall (``|S ∩ G| / |G|``), their harmonic
-mean F1 (the primary metric), and an all-or-nothing Exact Match rate. Unlike
-the paper/starter-notebook's official grader (a Gemini 2.5 Flash autorater
-whose exact prompt is not published), this task uses olmo-eval's OpenAI-based
-judge infrastructure with an independently written judge prompt, so absolute
-numbers are not directly comparable to the public leaderboard. Set
+mean F1 (the primary metric), and an all-or-nothing Exact Match rate. The
+official grader (Gemini 2.5 Flash, zero-shot) and its exact prompt *are*
+published, in Appendix A of the technical report. This task nonetheless uses
+an independently written judge prompt against olmo-eval's OpenAI-based judge
+infrastructure (``build_openai_judge_fn`` is OpenAI-only), so absolute
+numbers are not directly comparable to the public leaderboard: the official
+prompt grades the model's raw free-form response directly, while this task
+requires a discrete ``FINAL ANSWER: ...`` line and matches two pre-extracted
+item lists by index. See ``deepsearchqa_official_judge`` for a second task
+that instead mirrors the official prompt and grading mechanic. Set
 ``OLMO_EVAL_JUDGE=<model>[:<effort>]`` to change the judge model.
 
 The task asks the model to end its response with a ``FINAL ANSWER: ...`` line
@@ -271,15 +276,16 @@ EXACT_MATCH_METRIC = _metric("deepsearchqa_exact_match")
 DEEPSEARCHQA_METRICS = (F1_METRIC, PRECISION_METRIC, RECALL_METRIC, EXACT_MATCH_METRIC)
 
 
-@register("deepsearchqa")
-class DeepSearchQA(Task):
-    """DeepSearchQA multi-step search question answering, graded by item-set F1."""
+class DeepSearchQABase(Task):
+    """Shared data loading for the DeepSearchQA task family.
+
+    Subclasses differ only in generation prompt and grading mechanic; the
+    dataset, schema, and empty-gold-set handling are identical across them.
+    """
 
     data_source = DataSource(
         path=DEEPSEARCHQA_REPO, subset=DEEPSEARCHQA_CONFIG, split=DEEPSEARCHQA_SPLIT
     )
-    metrics = DEEPSEARCHQA_METRICS
-    primary_metric = F1_METRIC
     sampling_params = SamplingParams(temperature=0.0, max_tokens=4096)
     required_secrets = ("OPENAI_API_KEY",)
 
@@ -324,6 +330,14 @@ class DeepSearchQA(Task):
                 "gold_items": gold_items,
             },
         )
+
+
+@register("deepsearchqa")
+class DeepSearchQA(DeepSearchQABase):
+    """DeepSearchQA multi-step search question answering, graded by item-set F1."""
+
+    metrics = DEEPSEARCHQA_METRICS
+    primary_metric = F1_METRIC
 
     def format_request(self, instance: Instance) -> LMRequest:
         prompt = DEEPSEARCHQA_GENERATION_PROMPT.format(question=instance.question)

--- a/src/olmo_eval/evals/tasks/deepsearchqa_official_judge.py
+++ b/src/olmo_eval/evals/tasks/deepsearchqa_official_judge.py
@@ -169,14 +169,17 @@ def parse_deepsearchqa_official_judge_response(raw: str, num_gold: int) -> tuple
     marked true, matching the official recall/precision formulas without
     needing per-item traceability.
     """
-    match = _JSON_OBJECT.search(raw)
-    if match is None:
-        return None
-    try:
-        data = json.loads(match.group(0))
-    except json.JSONDecodeError:
-        return None
-    if not isinstance(data, dict):
+    decoder = json.JSONDecoder()
+    data: Any | None = None
+    for match in re.finditer(r"\{", raw):
+        try:
+            candidate, _end = decoder.raw_decode(raw[match.start() :])
+        except json.JSONDecodeError:
+            continue
+        if isinstance(candidate, dict):
+            data = candidate
+            break
+    if data is None:
         return None
 
     correctness = data.get("Answer Correctness")

--- a/src/olmo_eval/evals/tasks/deepsearchqa_official_judge.py
+++ b/src/olmo_eval/evals/tasks/deepsearchqa_official_judge.py
@@ -1,0 +1,359 @@
+"""DeepSearchQA graded with the official paper prompt (Google DeepMind, arXiv 2601.20975).
+
+This is a second implementation of the ``deepsearchqa`` task (see
+``deepsearchqa.py`` for the dataset, taxonomy, and background) that instead
+mirrors the grading methodology published in Appendix A of the technical
+report: the judge grades the model's raw, free-form response directly rather
+than a discrete ``FINAL ANSWER: ...`` line, and reports per-gold-item
+"Correctness Details" plus a free-form "Excessive Answers" list rather than
+matching two pre-extracted item lists by index.
+
+Concretely, this changes two things relative to ``deepsearchqa``:
+  * The generation prompt does not ask for a ``FINAL ANSWER:`` line; the full
+    response is what gets judged.
+  * The judge prompt and parsing follow the official schema: a boolean per
+    expected gold item (did the response contain it), plus a free list of
+    excessive items the response claimed that are not part of the gold
+    answer. Precision/recall/F1/exact-match are derived from those counts
+    the same way the paper defines them.
+
+As with ``deepsearchqa``, the official grader is Gemini 2.5 Flash;
+``build_openai_judge_fn`` is OpenAI-only, so this task uses an OpenAI model
+against the official prompt text instead, and absolute numbers are still not
+directly comparable to the public Kaggle leaderboard.
+
+Usage:
+    olmo-eval run -m llama3.1-8b -t deepsearchqa_official_judge --harness dr_tulu
+    olmo-eval run -m llama3.1-8b -t deepsearchqa_official_judge:mini --harness dr_tulu
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import re
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from typing import Any
+
+from olmo_eval.common.metrics import Metric
+from olmo_eval.common.scorers.base import Scorer
+from olmo_eval.common.scorers.llm_judge import JudgeFn, build_openai_judge_fn
+from olmo_eval.common.types import Instance, LMOutput, LMRequest, RequestType, Response
+from olmo_eval.evals.tasks.common import register, register_variant
+from olmo_eval.evals.tasks.deepsearchqa import (
+    DEEPSEARCHQA_DEFAULT_JUDGE_SPEC,
+    DEEPSEARCHQA_JUDGE_ATTEMPTS,
+    DeepSearchQABase,
+)
+
+logger = logging.getLogger(__name__)
+
+DEEPSEARCHQA_OFFICIAL_GENERATION_PROMPT = """\
+Answer the following question. It may require an exhaustive search across \
+multiple sources rather than a single lookup. If you have access to search \
+tools, use them to find and verify each candidate answer instead of \
+answering from memory alone.
+
+The question may have exactly one correct answer, or it may require a \
+complete set of items that together satisfy every constraint it states. Do \
+not stop at the first plausible answer if the question implies there may be \
+more than one.
+
+Question: {question}"""
+
+# Verbatim from DeepSearchQA paper (arXiv 2601.20975), Appendix A: "Grader Prompt".
+DEEPSEARCHQA_OFFICIAL_JUDGE_PROMPT = """\
+Your task is to evaluate whether a given "AI Response" for a specific "User Prompt"
+arrived at the correct answer.
+
+**Answer Correctness Task**
+* **Purpose:** Assess whether the AI response provides the correct answer(s) based on
+the provided "Correct Answer" and "Prompt Type".
+* **Process:**
+    * Identify the "Prompt Type": "{prompt_type}".
+    * Refer to the "Correct Answer": "{answer}".
+    * Based on the "Prompt Type", determine if the "AI Response" contains the expected
+answer(s).
+        * **'Single Answer'**: Check if the response provides the answer that addresses
+the user's question. It does not have to match the exact wording of the provided
+answer.
+        * **'Set Answer'**: Check if the response includes *each* item from the provided
+ground truth answers. The order might not matter unless specified otherwise. The
+response might include more answers than the list. Determine the correctness *
+only* based on the list first and then check if the response includes answers not
+in the list.
+    * **Explanation:** Provide a brief explanation justifying your assessment of answer
+correctness, referencing specific parts of the AI response and the correct answer.
+    * **Correctness Details:** Provide a dictionary, one key for each expected answer
+part, and value is a boolean indicating whether each expected answer part was found.
+        * For 'Set Answer', this will be a list of attributes, one for each item/part in
+the "Correct Answer". Each key will be a string indicating the expected answer
+part, and the value will be a boolean indicating whether that part was found in
+the response.
+    * **Excessive Answers:** Provide a list of strings, each indicating an excessive
+answer part. If the response provides answers that are **not** in the "Correct Answer
+" list, add these answers as excessive answers. Return an empty list when there's no
+excessive answers in the response.
+
+**Output Format:**
+Your evaluation *must* be structured as a nested JSON dictionary with the following top-
+level keys: `"Answer Correctness"`. Please return NULL if any of "Prompt", "AI Response"
+or "Correct Answer" is empty.
+The value for `"Answer Correctness"` should be a dictionary containing `"Explanation"` (
+a string), `"Correctness Details"` (a dictionary where each key is the expected correct
+answer, and the value is a boolean indicating whether the response contains the correct
+answer), and `"Excessive Answers"` (a list of strings indicating the excessive answers).
+
+Make sure you return a valid JSON string. Pay special attention to quotes, commas and
+special characters in the JSON string. Make sure to escape all special characters and
+quotes in the JSON string.
+
+User Prompt (Wrapped in <prompt> and </prompt>):
+<prompt>
+{prompt}
+</prompt>
+--------------------
+Correct Answer (Wrapped in <answer> and </answer>):
+Prompt Type: {prompt_type}
+<answer>
+{answer}
+</answer>
+--------------------
+AI assistant response (Wrapped in <response> and </response>):
+<response>
+{response}
+</response>
+--------------------
+Rating:"""
+
+_JSON_OBJECT = re.compile(r"\{.*\}", re.DOTALL)
+
+
+def build_deepsearchqa_official_judge_fn() -> JudgeFn:
+    """Build the task's judge from ``$OLMO_EVAL_JUDGE`` or its own default."""
+    import os
+
+    spec = os.getenv("OLMO_EVAL_JUDGE", DEEPSEARCHQA_DEFAULT_JUDGE_SPEC)
+    model, separator, effort = spec.partition(":")
+    return build_openai_judge_fn(
+        model=model,
+        temperature=0.0,
+        max_tokens=1024,
+        scorer_name="DeepSearchQAOfficialJudge",
+        reasoning_effort=(effort if separator else None),
+    )
+
+
+def build_deepsearchqa_official_judge_prompt(
+    prompt: str, prompt_type: str, answer: str, response: str
+) -> str:
+    """Format the official Appendix A grader prompt for one instance."""
+    return DEEPSEARCHQA_OFFICIAL_JUDGE_PROMPT.format(
+        prompt=prompt,
+        prompt_type=prompt_type or "Set Answer",
+        answer=answer,
+        response=response,
+    )
+
+
+def parse_deepsearchqa_official_judge_response(raw: str, num_gold: int) -> tuple[int, int] | None:
+    """Parse the official schema's match/excessive counts, or None if unparseable.
+
+    The judge echoes gold items back as dictionary keys, which an LLM cannot
+    be relied on to reproduce verbatim (paraphrases, casing, punctuation).
+    Rather than reconciling those keys against ``gold_items`` by text — which
+    would reintroduce the same surface-matching problem the judge exists to
+    avoid — this counts how many of the (at most ``num_gold``) entries were
+    marked true, matching the official recall/precision formulas without
+    needing per-item traceability.
+    """
+    match = _JSON_OBJECT.search(raw)
+    if match is None:
+        return None
+    try:
+        data = json.loads(match.group(0))
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(data, dict):
+        return None
+
+    correctness = data.get("Answer Correctness")
+    if not isinstance(correctness, dict):
+        return None
+
+    details = correctness.get("Correctness Details")
+    excessive = correctness.get("Excessive Answers")
+    if not isinstance(details, dict) or not isinstance(excessive, list):
+        return None
+
+    num_matched = min(sum(1 for v in details.values() if v is True), num_gold)
+    return num_matched, len(excessive)
+
+
+def compute_deepsearchqa_official_scores(
+    num_gold: int, num_matched: int, num_excessive: int
+) -> dict[str, float]:
+    """Compute precision/recall/F1/exact-match from official match/excessive counts."""
+    if num_gold == 0:
+        is_correct = num_excessive == 0
+        return {
+            "deepsearchqa_official_precision": 1.0 if is_correct else 0.0,
+            "deepsearchqa_official_recall": 1.0,
+            "deepsearchqa_official_f1": 1.0 if is_correct else 0.0,
+            "deepsearchqa_official_exact_match": 1.0 if is_correct else 0.0,
+        }
+
+    recall = num_matched / num_gold
+    num_submitted = num_matched + num_excessive
+    precision = num_matched / num_submitted if num_submitted else 0.0
+    f1 = 0.0 if precision + recall == 0 else 2 * precision * recall / (precision + recall)
+    exact_match = 1.0 if (num_matched == num_gold and num_excessive == 0) else 0.0
+    return {
+        "deepsearchqa_official_precision": precision,
+        "deepsearchqa_official_recall": recall,
+        "deepsearchqa_official_f1": f1,
+        "deepsearchqa_official_exact_match": exact_match,
+    }
+
+
+@dataclass(frozen=True)
+class DeepSearchQAOfficialScorer(Scorer):
+    """Placeholder scorer; scores are computed in ``score_responses``."""
+
+    name: str = "deepsearchqa_official_f1"
+    score_key: str = "deepsearchqa_official_f1"
+
+    def score(self, instance: Instance, output: LMOutput) -> float:
+        return (output.metadata or {}).get(self.score_key, 0.0)
+
+
+@dataclass(frozen=True)
+class DeepSearchQAOfficialMetric(Metric):
+    """Mean of a precomputed DeepSearchQA-official score across responses."""
+
+    name: str = "deepsearchqa_official_f1"
+    scorer: type[Scorer] | Scorer = field(
+        default_factory=lambda: DeepSearchQAOfficialScorer(score_key="deepsearchqa_official_f1")
+    )
+
+    def compute(self, responses: Sequence[Response]) -> float:
+        if not responses:
+            return 0.0
+        return sum(response.scores.get(self.name, 0.0) for response in responses) / len(responses)
+
+    def pairwise_display_format(self) -> str:
+        return "percentage"
+
+    def pairwise_unit(self) -> str:
+        return "proportion"
+
+
+def _metric(name: str) -> DeepSearchQAOfficialMetric:
+    return DeepSearchQAOfficialMetric(name=name, scorer=DeepSearchQAOfficialScorer(score_key=name))
+
+
+F1_METRIC = _metric("deepsearchqa_official_f1")
+PRECISION_METRIC = _metric("deepsearchqa_official_precision")
+RECALL_METRIC = _metric("deepsearchqa_official_recall")
+EXACT_MATCH_METRIC = _metric("deepsearchqa_official_exact_match")
+DEEPSEARCHQA_OFFICIAL_METRICS = (F1_METRIC, PRECISION_METRIC, RECALL_METRIC, EXACT_MATCH_METRIC)
+
+
+@register("deepsearchqa_official_judge")
+class DeepSearchQAOfficialJudge(DeepSearchQABase):
+    """DeepSearchQA graded with the official paper prompt and free-form response."""
+
+    metrics = DEEPSEARCHQA_OFFICIAL_METRICS
+    primary_metric = F1_METRIC
+
+    def format_request(self, instance: Instance) -> LMRequest:
+        prompt = DEEPSEARCHQA_OFFICIAL_GENERATION_PROMPT.format(question=instance.question)
+        return LMRequest(
+            request_type=RequestType.CHAT,
+            messages=({"role": "user", "content": prompt},),
+        )
+
+    def extract_answer(self, output: LMOutput) -> str:
+        """No extraction: the official grader judges the full raw response."""
+        return output.text.strip()
+
+    async def score_responses(
+        self,
+        responses: Sequence[Response],
+        context: Any = None,
+    ) -> Sequence[Response]:
+        """Judge each response's raw text against the gold answer with the official prompt."""
+        self._extract_answers(responses)
+        judge_fn = build_deepsearchqa_official_judge_fn()
+
+        failed_instances = 0
+        for response in responses:
+            scores, judge_metadata, judge_failed = await self._score_single(response, judge_fn)
+            response.scores.update(scores)
+            failed_instances += judge_failed
+
+            if response.outputs:
+                output = response.outputs[0]
+                output.metadata.update(judge_metadata)
+                for metric_name, score in scores.items():
+                    output.metadata[f"score:{metric_name}"] = score
+
+        if failed_instances:
+            logger.warning(
+                "DeepSearchQAOfficialJudge judge returned no parseable verdict for %d "
+                "instance(s) after %d attempts; scored those 0.0 across all metrics.",
+                failed_instances,
+                DEEPSEARCHQA_JUDGE_ATTEMPTS,
+            )
+        return responses
+
+    async def _score_single(
+        self,
+        response: Response,
+        judge_fn: JudgeFn,
+    ) -> tuple[dict[str, float], dict[str, Any], int]:
+        """Score one response, returning metrics, judge details, and a failure count."""
+        gold_items = response.instance.metadata.get("gold_items", [])
+        answer_type = response.instance.metadata.get("answer_type", "")
+        output = response.outputs[0] if response.outputs else None
+
+        pred_text = ""
+        if output is not None:
+            extracted = output.extracted_answer
+            pred_text = extracted if isinstance(extracted, str) else output.text
+        pred_text = pred_text.strip()
+
+        base_metadata: dict[str, Any] = {"deepsearchqa_official_gold_items": gold_items}
+
+        if not pred_text:
+            # An empty response can't contain any gold item or excessive claim.
+            scores = compute_deepsearchqa_official_scores(len(gold_items), 0, 0)
+            return scores, base_metadata, 0
+
+        answer_text = ", ".join(gold_items) if gold_items else "None"
+        prompt = build_deepsearchqa_official_judge_prompt(
+            response.instance.question, answer_type, answer_text, pred_text
+        )
+
+        parsed = None
+        for attempt in range(DEEPSEARCHQA_JUDGE_ATTEMPTS):
+            raw = await judge_fn(prompt)
+            parsed = parse_deepsearchqa_official_judge_response(raw, len(gold_items))
+            if parsed is not None:
+                break
+            if attempt < DEEPSEARCHQA_JUDGE_ATTEMPTS - 1:
+                await asyncio.sleep(2**attempt)
+
+        num_matched, num_excessive = parsed if parsed is not None else (0, 0)
+        scores = compute_deepsearchqa_official_scores(len(gold_items), num_matched, num_excessive)
+        metadata = {
+            **base_metadata,
+            "deepsearchqa_official_num_matched": num_matched,
+            "deepsearchqa_official_num_excessive": num_excessive,
+        }
+        return scores, metadata, 0 if parsed is not None else 1
+
+
+register_variant("deepsearchqa_official_judge", "mini", limit=50)

--- a/tests/evals/tasks/test_deepsearchqa.py
+++ b/tests/evals/tasks/test_deepsearchqa.py
@@ -1,0 +1,262 @@
+"""Tests for the DeepSearchQA multi-step search question answering task."""
+
+import pytest
+
+from olmo_eval.common.types import Instance, LMOutput, LMRequest, RequestType, Response
+from olmo_eval.evals.tasks import deepsearchqa
+from olmo_eval.evals.tasks.common import get_task, task_exists
+from olmo_eval.evals.tasks.deepsearchqa import (
+    compute_deepsearchqa_scores,
+    extract_final_answer,
+    parse_deepsearchqa_judge_response,
+    split_answer_set,
+)
+
+
+@pytest.fixture
+def task():
+    return get_task("deepsearchqa")
+
+
+def _doc(
+    problem: str = "Which countries border Chad?",
+    problem_category: str = "Geography",
+    answer: str = "Libya, Sudan, Niger",
+    answer_type: str = "Set Answer",
+):
+    return {
+        "problem": problem,
+        "problem_category": problem_category,
+        "answer": answer,
+        "answer_type": answer_type,
+    }
+
+
+def _response(instance: Instance, text: str = "FINAL ANSWER: Libya, Sudan, Niger") -> Response:
+    return Response(
+        instance=instance,
+        request=LMRequest(request_type=RequestType.CHAT, messages=()),
+        outputs=[LMOutput(text=text)],
+        scores={},
+    )
+
+
+class TestRegistration:
+    def test_task_and_variant_are_registered(self):
+        assert task_exists("deepsearchqa")
+        assert task_exists("deepsearchqa:mini")
+
+        full = get_task("deepsearchqa")
+        mini = get_task("deepsearchqa:mini")
+        assert full.config.data_source.path == "google/deepsearchqa"
+        assert full.config.data_source.subset == "deepsearchqa"
+        assert full.config.data_source.split == "eval"
+        assert mini.config.limit == 50
+
+    def test_primary_and_secondary_metrics(self, task):
+        assert task.config.get_primary_metric().name == "deepsearchqa_f1"
+        assert {metric.name for metric in task.config.metrics} == {
+            "deepsearchqa_f1",
+            "deepsearchqa_precision",
+            "deepsearchqa_recall",
+            "deepsearchqa_exact_match",
+        }
+
+
+class TestProcessDoc:
+    def test_maps_real_schema_and_splits_answer_set(self, task):
+        instance = task.process_doc(_doc(), index=3)
+
+        assert instance is not None
+        assert instance.question == "Which countries border Chad?"
+        assert instance.gold_answer == "Libya, Sudan, Niger"
+        assert instance.metadata["id"] == "deepsearchqa_3"
+        assert instance.metadata["index"] == 3
+        assert instance.metadata["problem_category"] == "Geography"
+        assert instance.metadata["answer_type"] == "Set Answer"
+        assert instance.metadata["gold_items"] == ["Libya", "Sudan", "Niger"]
+
+    def test_single_answer_becomes_one_item_set(self, task):
+        instance = task.process_doc(_doc(answer="New Zealand", answer_type="Single Answer"))
+        assert instance is not None
+        assert instance.metadata["gold_items"] == ["New Zealand"]
+
+    def test_skips_missing_problem_or_answer(self, task):
+        assert task.process_doc(_doc(problem="")) is None
+        assert task.process_doc(_doc(answer="")) is None
+        assert task.process_doc(_doc(answer=" , ,")) is None
+
+
+class TestSplitAnswerSet:
+    def test_splits_and_strips_items(self):
+        assert split_answer_set("Libya, Sudan,Niger") == ["Libya", "Sudan", "Niger"]
+
+    def test_drops_empty_items(self):
+        assert split_answer_set(" New Zealand ,, ") == ["New Zealand"]
+
+    def test_empty_string_yields_empty_list(self):
+        assert split_answer_set("") == []
+
+
+class TestExtractFinalAnswer:
+    def test_extracts_text_after_marker(self):
+        text = "I searched several sources.\nFINAL ANSWER: Libya, Sudan, Niger"
+        assert extract_final_answer(text) == "Libya, Sudan, Niger"
+
+    def test_tolerates_markdown_emphasis_and_missing_colon(self):
+        text = "Reasoning...\n**FINAL ANSWER** Libya, Sudan, Niger"
+        assert extract_final_answer(text) == "Libya, Sudan, Niger"
+
+    def test_falls_back_to_full_text_when_marker_absent(self):
+        assert extract_final_answer(" Just an answer. ") == "Just an answer."
+
+    def test_uses_last_marker_when_repeated(self):
+        text = "FINAL ANSWER: draft\nMore thinking.\nFINAL ANSWER: Libya, Sudan, Niger"
+        assert extract_final_answer(text) == "Libya, Sudan, Niger"
+
+
+class TestParseJudgeResponse:
+    def test_parses_valid_json(self):
+        raw = '{"matched_gold_indices": [0, 1], "matched_submitted_indices": [0, 2]}'
+        parsed = parse_deepsearchqa_judge_response(raw, num_gold=2, num_pred=3)
+        assert parsed == ({0, 1}, {0, 2})
+
+    def test_tolerates_surrounding_prose(self):
+        raw = (
+            "Here is my judgment:\n"
+            '{"matched_gold_indices": [0], "matched_submitted_indices": [0]}\n'
+            "Done."
+        )
+        assert parse_deepsearchqa_judge_response(raw, num_gold=1, num_pred=1) == ({0}, {0})
+
+    def test_drops_out_of_range_indices(self):
+        raw = '{"matched_gold_indices": [0, 5], "matched_submitted_indices": [-1, 0]}'
+        assert parse_deepsearchqa_judge_response(raw, num_gold=2, num_pred=2) == ({0}, {0})
+
+    def test_returns_none_for_malformed_json(self):
+        assert parse_deepsearchqa_judge_response("not json", num_gold=1, num_pred=1) is None
+
+    def test_returns_none_when_fields_are_not_lists(self):
+        raw = '{"matched_gold_indices": "0", "matched_submitted_indices": [0]}'
+        assert parse_deepsearchqa_judge_response(raw, num_gold=1, num_pred=1) is None
+
+
+class TestComputeScores:
+    def test_perfect_match(self):
+        scores = compute_deepsearchqa_scores(
+            num_gold=2, num_pred=2, num_matched_gold=2, num_matched_pred=2
+        )
+        assert scores == {
+            "deepsearchqa_precision": 1.0,
+            "deepsearchqa_recall": 1.0,
+            "deepsearchqa_f1": 1.0,
+            "deepsearchqa_exact_match": 1.0,
+        }
+
+    def test_extra_predicted_item_hurts_precision_not_recall(self):
+        scores = compute_deepsearchqa_scores(
+            num_gold=2, num_pred=3, num_matched_gold=2, num_matched_pred=2
+        )
+        assert scores["deepsearchqa_recall"] == 1.0
+        assert scores["deepsearchqa_precision"] == pytest.approx(2 / 3)
+        assert scores["deepsearchqa_exact_match"] == 0.0
+
+    def test_missing_gold_item_hurts_recall_not_precision(self):
+        scores = compute_deepsearchqa_scores(
+            num_gold=3, num_pred=2, num_matched_gold=2, num_matched_pred=2
+        )
+        assert scores["deepsearchqa_precision"] == 1.0
+        assert scores["deepsearchqa_recall"] == pytest.approx(2 / 3)
+        assert scores["deepsearchqa_exact_match"] == 0.0
+
+    def test_no_predicted_items_scores_zero(self):
+        scores = compute_deepsearchqa_scores(
+            num_gold=2, num_pred=0, num_matched_gold=0, num_matched_pred=0
+        )
+        assert scores == {
+            "deepsearchqa_precision": 0.0,
+            "deepsearchqa_recall": 0.0,
+            "deepsearchqa_f1": 0.0,
+            "deepsearchqa_exact_match": 0.0,
+        }
+
+
+class TestScoreResponses:
+    @pytest.mark.anyio
+    async def test_scores_a_fully_correct_response(self, task, monkeypatch):
+        instance = task.process_doc(_doc())
+        response = _response(instance, text="FINAL ANSWER: Libya, Sudan, Niger")
+        calls = []
+
+        async def judge(prompt):
+            calls.append(prompt)
+            return '{"matched_gold_indices": [0, 1, 2], "matched_submitted_indices": [0, 1, 2]}'
+
+        monkeypatch.setattr(deepsearchqa, "build_deepsearchqa_judge_fn", lambda: judge)
+        await task.score_responses([response])
+
+        assert len(calls) == 1
+        assert response.scores["deepsearchqa_f1"] == 1.0
+        assert response.scores["deepsearchqa_exact_match"] == 1.0
+        assert response.outputs[0].metadata["deepsearchqa_predicted_items"] == [
+            "Libya",
+            "Sudan",
+            "Niger",
+        ]
+        assert response.outputs[0].metadata["score:deepsearchqa_f1"] == 1.0
+
+    @pytest.mark.anyio
+    async def test_empty_prediction_skips_the_judge_call(self, task, monkeypatch):
+        instance = task.process_doc(_doc())
+        response = _response(instance, text="")
+        calls = []
+
+        async def judge(prompt):
+            calls.append(prompt)
+            return '{"matched_gold_indices": [], "matched_submitted_indices": []}'
+
+        monkeypatch.setattr(deepsearchqa, "build_deepsearchqa_judge_fn", lambda: judge)
+        await task.score_responses([response])
+
+        assert calls == []
+        assert response.scores["deepsearchqa_f1"] == 0.0
+
+    @pytest.mark.anyio
+    async def test_retries_after_a_malformed_judge_reply(self, task, monkeypatch):
+        monkeypatch.setattr(deepsearchqa.asyncio, "sleep", lambda _seconds: _no_sleep())
+
+        instance = task.process_doc(_doc(answer="New Zealand", answer_type="Single Answer"))
+        response = _response(instance, text="FINAL ANSWER: New Zealand")
+        valid = '{"matched_gold_indices": [0], "matched_submitted_indices": [0]}'
+        outputs = iter(["not json", valid])
+        calls = []
+
+        async def judge(prompt):
+            calls.append(prompt)
+            return next(outputs)
+
+        monkeypatch.setattr(deepsearchqa, "build_deepsearchqa_judge_fn", lambda: judge)
+        await task.score_responses([response])
+
+        assert len(calls) == 2
+        assert response.scores["deepsearchqa_f1"] == 1.0
+
+    @pytest.mark.anyio
+    async def test_exhausted_retries_score_zero_without_raising(self, task, monkeypatch):
+        monkeypatch.setattr(deepsearchqa.asyncio, "sleep", lambda _seconds: _no_sleep())
+
+        instance = task.process_doc(_doc(answer="New Zealand", answer_type="Single Answer"))
+        response = _response(instance, text="FINAL ANSWER: New Zealand")
+
+        async def judge(_prompt):
+            return "not json"
+
+        monkeypatch.setattr(deepsearchqa, "build_deepsearchqa_judge_fn", lambda: judge)
+        await task.score_responses([response])
+
+        assert response.scores["deepsearchqa_f1"] == 0.0
+        assert response.scores["deepsearchqa_recall"] == 0.0
+
+
+async def _no_sleep() -> None:
+    return None

--- a/tests/evals/tasks/test_deepsearchqa.py
+++ b/tests/evals/tasks/test_deepsearchqa.py
@@ -81,10 +81,24 @@ class TestProcessDoc:
         assert instance is not None
         assert instance.metadata["gold_items"] == ["New Zealand"]
 
-    def test_skips_missing_problem_or_answer(self, task):
+    def test_skips_missing_problem(self, task):
         assert task.process_doc(_doc(problem="")) is None
-        assert task.process_doc(_doc(answer="")) is None
+
+    def test_skips_answer_that_is_only_junk_separators(self, task):
         assert task.process_doc(_doc(answer=" , ,")) is None
+
+    def test_missing_answer_on_single_answer_is_dropped_as_malformed(self, task):
+        assert task.process_doc(_doc(answer="", answer_type="Single Answer")) is None
+        assert task.process_doc(_doc(answer=None, answer_type="Single Answer")) is None
+
+    def test_missing_answer_on_set_answer_becomes_empty_gold_set(self, task):
+        # The source CSV spells "no items satisfy every constraint" as the literal
+        # text "None" on Set Answer rows; the CSV loader turns that into a null.
+        for missing in ("", None):
+            instance = task.process_doc(_doc(answer=missing, answer_type="Set Answer"))
+            assert instance is not None
+            assert instance.metadata["gold_items"] == []
+            assert instance.gold_answer == ""
 
 
 class TestSplitAnswerSet:
@@ -180,6 +194,28 @@ class TestComputeScores:
             "deepsearchqa_exact_match": 0.0,
         }
 
+    def test_empty_gold_set_and_empty_prediction_is_a_perfect_score(self):
+        scores = compute_deepsearchqa_scores(
+            num_gold=0, num_pred=0, num_matched_gold=0, num_matched_pred=0
+        )
+        assert scores == {
+            "deepsearchqa_precision": 1.0,
+            "deepsearchqa_recall": 1.0,
+            "deepsearchqa_f1": 1.0,
+            "deepsearchqa_exact_match": 1.0,
+        }
+
+    def test_empty_gold_set_with_hallucinated_prediction_scores_zero(self):
+        scores = compute_deepsearchqa_scores(
+            num_gold=0, num_pred=2, num_matched_gold=0, num_matched_pred=0
+        )
+        assert scores == {
+            "deepsearchqa_precision": 0.0,
+            "deepsearchqa_recall": 1.0,
+            "deepsearchqa_f1": 0.0,
+            "deepsearchqa_exact_match": 0.0,
+        }
+
 
 class TestScoreResponses:
     @pytest.mark.anyio
@@ -240,6 +276,43 @@ class TestScoreResponses:
 
         assert len(calls) == 2
         assert response.scores["deepsearchqa_f1"] == 1.0
+
+    @pytest.mark.anyio
+    async def test_empty_gold_set_with_correctly_empty_prediction_skips_judge(
+        self, task, monkeypatch
+    ):
+        instance = task.process_doc(_doc(answer="", answer_type="Set Answer"))
+        response = _response(instance, text="")
+        calls = []
+
+        async def judge(prompt):
+            calls.append(prompt)
+            return '{"matched_gold_indices": [], "matched_submitted_indices": []}'
+
+        monkeypatch.setattr(deepsearchqa, "build_deepsearchqa_judge_fn", lambda: judge)
+        await task.score_responses([response])
+
+        assert calls == []
+        assert response.scores["deepsearchqa_f1"] == 1.0
+        assert response.scores["deepsearchqa_exact_match"] == 1.0
+
+    @pytest.mark.anyio
+    async def test_empty_gold_set_with_hallucinated_prediction_skips_judge(self, task, monkeypatch):
+        instance = task.process_doc(_doc(answer="", answer_type="Set Answer"))
+        response = _response(instance, text="FINAL ANSWER: Some hallucinated item")
+        calls = []
+
+        async def judge(prompt):
+            calls.append(prompt)
+            return '{"matched_gold_indices": [], "matched_submitted_indices": []}'
+
+        monkeypatch.setattr(deepsearchqa, "build_deepsearchqa_judge_fn", lambda: judge)
+        await task.score_responses([response])
+
+        assert calls == []
+        assert response.scores["deepsearchqa_f1"] == 0.0
+        assert response.scores["deepsearchqa_recall"] == 1.0
+        assert response.scores["deepsearchqa_precision"] == 0.0
 
     @pytest.mark.anyio
     async def test_exhausted_retries_score_zero_without_raising(self, task, monkeypatch):

--- a/tests/evals/tasks/test_deepsearchqa_official_judge.py
+++ b/tests/evals/tasks/test_deepsearchqa_official_judge.py
@@ -1,0 +1,296 @@
+"""Tests for the DeepSearchQA task graded with the official Appendix A prompt."""
+
+import pytest
+
+from olmo_eval.common.types import Instance, LMOutput, LMRequest, RequestType, Response
+from olmo_eval.evals.tasks import deepsearchqa_official_judge
+from olmo_eval.evals.tasks.common import get_task, task_exists
+from olmo_eval.evals.tasks.deepsearchqa_official_judge import (
+    compute_deepsearchqa_official_scores,
+    parse_deepsearchqa_official_judge_response,
+)
+
+
+@pytest.fixture
+def task():
+    return get_task("deepsearchqa_official_judge")
+
+
+def _doc(
+    problem: str = "Which countries border Chad?",
+    problem_category: str = "Geography",
+    answer: str = "Libya, Sudan, Niger",
+    answer_type: str = "Set Answer",
+):
+    return {
+        "problem": problem,
+        "problem_category": problem_category,
+        "answer": answer,
+        "answer_type": answer_type,
+    }
+
+
+def _response(instance: Instance, text: str = "Libya, Sudan, and Niger border Chad.") -> Response:
+    return Response(
+        instance=instance,
+        request=LMRequest(request_type=RequestType.CHAT, messages=()),
+        outputs=[LMOutput(text=text)],
+        scores={},
+    )
+
+
+class TestRegistration:
+    def test_task_and_variant_are_registered(self):
+        assert task_exists("deepsearchqa_official_judge")
+        assert task_exists("deepsearchqa_official_judge:mini")
+
+        full = get_task("deepsearchqa_official_judge")
+        mini = get_task("deepsearchqa_official_judge:mini")
+        assert full.config.data_source.path == "google/deepsearchqa"
+        assert full.config.data_source.subset == "deepsearchqa"
+        assert full.config.data_source.split == "eval"
+        assert mini.config.limit == 50
+
+    def test_primary_and_secondary_metrics(self, task):
+        assert task.config.get_primary_metric().name == "deepsearchqa_official_f1"
+        assert {metric.name for metric in task.config.metrics} == {
+            "deepsearchqa_official_f1",
+            "deepsearchqa_official_precision",
+            "deepsearchqa_official_recall",
+            "deepsearchqa_official_exact_match",
+        }
+
+
+class TestProcessDoc:
+    """Data loading is inherited from DeepSearchQABase; spot-check it here too."""
+
+    def test_maps_real_schema(self, task):
+        instance = task.process_doc(_doc(), index=3)
+        assert instance is not None
+        assert instance.metadata["gold_items"] == ["Libya", "Sudan", "Niger"]
+
+    def test_missing_answer_on_set_answer_becomes_empty_gold_set(self, task):
+        instance = task.process_doc(_doc(answer="", answer_type="Set Answer"))
+        assert instance is not None
+        assert instance.metadata["gold_items"] == []
+
+
+class TestFormatRequest:
+    def test_prompt_has_no_final_answer_requirement(self, task):
+        instance = task.process_doc(_doc())
+        request = task.format_request(instance)
+        prompt = request.messages[0]["content"]
+        assert "FINAL ANSWER" not in prompt
+        assert "Which countries border Chad?" in prompt
+
+
+class TestExtractAnswer:
+    def test_returns_raw_stripped_text(self, task):
+        output = LMOutput(text="  Libya, Sudan, and Niger.  ")
+        assert task.extract_answer(output) == "Libya, Sudan, and Niger."
+
+
+class TestParseJudgeResponse:
+    def test_counts_true_correctness_details(self):
+        raw = (
+            '{"Answer Correctness": {"Explanation": "...", '
+            '"Correctness Details": {"Libya": true, "Sudan": true, "Niger": false}, '
+            '"Excessive Answers": []}}'
+        )
+        assert parse_deepsearchqa_official_judge_response(raw, num_gold=3) == (2, 0)
+
+    def test_counts_excessive_answers(self):
+        raw = (
+            '{"Answer Correctness": {"Explanation": "...", '
+            '"Correctness Details": {"Libya": true}, '
+            '"Excessive Answers": ["Egypt", "Nigeria"]}}'
+        )
+        assert parse_deepsearchqa_official_judge_response(raw, num_gold=1) == (1, 2)
+
+    def test_caps_matched_count_at_num_gold(self):
+        raw = (
+            '{"Answer Correctness": {"Correctness Details": '
+            '{"Libya": true, "Sudan": true, "Extra": true}, "Excessive Answers": []}}'
+        )
+        assert parse_deepsearchqa_official_judge_response(raw, num_gold=2) == (2, 0)
+
+    def test_tolerates_surrounding_prose(self):
+        raw = (
+            "Here is my rating:\n"
+            '{"Answer Correctness": {"Correctness Details": {"Libya": true}, '
+            '"Excessive Answers": []}}\nDone.'
+        )
+        assert parse_deepsearchqa_official_judge_response(raw, num_gold=1) == (1, 0)
+
+    def test_returns_none_for_malformed_json(self):
+        assert parse_deepsearchqa_official_judge_response("not json", num_gold=1) is None
+
+    def test_returns_none_when_answer_correctness_missing(self):
+        raw = '{"Correctness Details": {"Libya": true}, "Excessive Answers": []}'
+        assert parse_deepsearchqa_official_judge_response(raw, num_gold=1) is None
+
+    def test_returns_none_when_excessive_answers_is_not_a_list(self):
+        raw = (
+            '{"Answer Correctness": {"Correctness Details": {"Libya": true}, '
+            '"Excessive Answers": "none"}}'
+        )
+        assert parse_deepsearchqa_official_judge_response(raw, num_gold=1) is None
+
+
+class TestComputeScores:
+    def test_perfect_match(self):
+        scores = compute_deepsearchqa_official_scores(num_gold=3, num_matched=3, num_excessive=0)
+        assert scores == {
+            "deepsearchqa_official_precision": 1.0,
+            "deepsearchqa_official_recall": 1.0,
+            "deepsearchqa_official_f1": 1.0,
+            "deepsearchqa_official_exact_match": 1.0,
+        }
+
+    def test_excessive_answer_hurts_precision_not_recall(self):
+        scores = compute_deepsearchqa_official_scores(num_gold=2, num_matched=2, num_excessive=1)
+        assert scores["deepsearchqa_official_recall"] == 1.0
+        assert scores["deepsearchqa_official_precision"] == pytest.approx(2 / 3)
+        assert scores["deepsearchqa_official_exact_match"] == 0.0
+
+    def test_missing_gold_item_hurts_recall_not_precision(self):
+        scores = compute_deepsearchqa_official_scores(num_gold=3, num_matched=2, num_excessive=0)
+        assert scores["deepsearchqa_official_precision"] == 1.0
+        assert scores["deepsearchqa_official_recall"] == pytest.approx(2 / 3)
+        assert scores["deepsearchqa_official_exact_match"] == 0.0
+
+    def test_empty_gold_set_and_no_excessive_answers_is_perfect(self):
+        scores = compute_deepsearchqa_official_scores(num_gold=0, num_matched=0, num_excessive=0)
+        assert scores == {
+            "deepsearchqa_official_precision": 1.0,
+            "deepsearchqa_official_recall": 1.0,
+            "deepsearchqa_official_f1": 1.0,
+            "deepsearchqa_official_exact_match": 1.0,
+        }
+
+    def test_empty_gold_set_with_excessive_answers_scores_zero(self):
+        scores = compute_deepsearchqa_official_scores(num_gold=0, num_matched=0, num_excessive=2)
+        assert scores == {
+            "deepsearchqa_official_precision": 0.0,
+            "deepsearchqa_official_recall": 1.0,
+            "deepsearchqa_official_f1": 0.0,
+            "deepsearchqa_official_exact_match": 0.0,
+        }
+
+
+class TestScoreResponses:
+    @pytest.mark.anyio
+    async def test_scores_a_fully_correct_response(self, task, monkeypatch):
+        instance = task.process_doc(_doc())
+        response = _response(instance, text="Libya, Sudan, and Niger all border Chad.")
+        calls = []
+
+        async def judge(prompt):
+            calls.append(prompt)
+            return (
+                '{"Answer Correctness": {"Explanation": "...", "Correctness Details": '
+                '{"Libya": true, "Sudan": true, "Niger": true}, "Excessive Answers": []}}'
+            )
+
+        monkeypatch.setattr(
+            deepsearchqa_official_judge, "build_deepsearchqa_official_judge_fn", lambda: judge
+        )
+        await task.score_responses([response])
+
+        assert len(calls) == 1
+        assert "FINAL ANSWER" not in calls[0]
+        assert response.scores["deepsearchqa_official_f1"] == 1.0
+        assert response.outputs[0].metadata["deepsearchqa_official_num_matched"] == 3
+        assert response.outputs[0].metadata["score:deepsearchqa_official_f1"] == 1.0
+
+    @pytest.mark.anyio
+    async def test_empty_response_skips_the_judge_call(self, task, monkeypatch):
+        instance = task.process_doc(_doc())
+        response = _response(instance, text="")
+        calls = []
+
+        async def judge(prompt):
+            calls.append(prompt)
+            return '{"Answer Correctness": {"Correctness Details": {}, "Excessive Answers": []}}'
+
+        monkeypatch.setattr(
+            deepsearchqa_official_judge, "build_deepsearchqa_official_judge_fn", lambda: judge
+        )
+        await task.score_responses([response])
+
+        assert calls == []
+        assert response.scores["deepsearchqa_official_f1"] == 0.0
+
+    @pytest.mark.anyio
+    async def test_empty_gold_set_with_correct_abstention_skips_judge_call_is_not_required(
+        self, task, monkeypatch
+    ):
+        # Unlike the index-matching task, an empty gold set does NOT short-circuit here:
+        # only free text is available, so the judge must decide whether the model claimed
+        # any (excessive) items even though there is nothing to match against.
+        instance = task.process_doc(_doc(answer="", answer_type="Set Answer"))
+        response = _response(instance, text="I could not find any such country.")
+        calls = []
+
+        async def judge(prompt):
+            calls.append(prompt)
+            return '{"Answer Correctness": {"Correctness Details": {}, "Excessive Answers": []}}'
+
+        monkeypatch.setattr(
+            deepsearchqa_official_judge, "build_deepsearchqa_official_judge_fn", lambda: judge
+        )
+        await task.score_responses([response])
+
+        assert len(calls) == 1
+        assert response.scores["deepsearchqa_official_f1"] == 1.0
+
+    @pytest.mark.anyio
+    async def test_retries_after_a_malformed_judge_reply(self, task, monkeypatch):
+        monkeypatch.setattr(
+            deepsearchqa_official_judge.asyncio, "sleep", lambda _seconds: _no_sleep()
+        )
+
+        instance = task.process_doc(_doc(answer="New Zealand", answer_type="Single Answer"))
+        response = _response(instance, text="It's New Zealand.")
+        valid = (
+            '{"Answer Correctness": {"Correctness Details": {"New Zealand": true}, '
+            '"Excessive Answers": []}}'
+        )
+        outputs = iter(["not json", valid])
+        calls = []
+
+        async def judge(prompt):
+            calls.append(prompt)
+            return next(outputs)
+
+        monkeypatch.setattr(
+            deepsearchqa_official_judge, "build_deepsearchqa_official_judge_fn", lambda: judge
+        )
+        await task.score_responses([response])
+
+        assert len(calls) == 2
+        assert response.scores["deepsearchqa_official_f1"] == 1.0
+
+    @pytest.mark.anyio
+    async def test_exhausted_retries_score_zero_without_raising(self, task, monkeypatch):
+        monkeypatch.setattr(
+            deepsearchqa_official_judge.asyncio, "sleep", lambda _seconds: _no_sleep()
+        )
+
+        instance = task.process_doc(_doc(answer="New Zealand", answer_type="Single Answer"))
+        response = _response(instance, text="It's New Zealand.")
+
+        async def judge(_prompt):
+            return "not json"
+
+        monkeypatch.setattr(
+            deepsearchqa_official_judge, "build_deepsearchqa_official_judge_fn", lambda: judge
+        )
+        await task.score_responses([response])
+
+        assert response.scores["deepsearchqa_official_f1"] == 0.0
+        assert response.scores["deepsearchqa_official_recall"] == 0.0
+
+
+async def _no_sleep() -> None:
+    return None


### PR DESCRIPTION
## Summary

- Adds the [DeepSearchQA](https://huggingface.co/datasets/google/deepsearchqa) benchmark (Google DeepMind, arXiv:2601.20975) — 900 hand-crafted, multi-step information-seeking questions across 17 domains, each requiring either a single answer or a complete set of items, scored by item-set precision/recall/F1.
- Registers **two** tasks sharing the same dataset/loading code (`DeepSearchQABase`), differing only in generation prompt and grading mechanic:
  - `deepsearchqa` — model ends with a discrete `FINAL ANSWER: ...` line, judged by index-matching two extracted item lists.
  - `deepsearchqa_official_judge` — mirrors the official paper prompt (Appendix A) verbatim: the judge grades the model's raw free-form response directly, no special output format required.
  - Both grade with an OpenAI model via `build_openai_judge_fn` (the official grader is Gemini 2.5 Flash, which olmo-eval's judge infra doesn't support), so absolute numbers from either task aren't directly comparable to the public Kaggle leaderboard — see `DEEPSEARCHQA.md` for the full writeup of what each deviates from and why.
- Fixes a data-handling bug: 4 of the 900 rows encode "no items satisfy every constraint" as the literal text `None` in the source CSV, which the HF CSV loader silently coerces to a null; these were being dropped as malformed instead of scored as an empty gold-answer set. Both tasks now handle this correctly (900/900 instances load, not 896/900).
- `:mini` variants (50-instance subset) registered for both tasks for quick iteration.
- `DEEPSEARCHQA.md` documents both tasks, the data quirk above, and the secrets each requires (`OPENAI_API_KEY` always; `S2_API_KEY`/`SERPER_API_KEY` additionally for `--harness dr_tulu`).

## Test plan

- [x] `uv run ruff check src/ tests/` — passes
- [x] `uv run ruff format --check src/ tests/` — passes
- [x] `uv run ty check src/ alembic/` — passes (no new diagnostics)
- [x] `uv run pytest tests/ --ignore=tests/integration` — 2247 passed
- [x] Verified against the real `google/deepsearchqa` dataset end-to-end: all 900 rows load (including the 4 previously-dropped empty-answer-set rows), `task inspect` prompts render correctly for both tasks
- [x] Ran a live 5-instance smoke test with `Qwen/Qwen2.5-7B-Instruct` end-to-end (generation + judge scoring with `OPENAI_API_KEY` set)
- [ ] Not yet run with search-tool keys for the intended `--harness dr_tulu` setup