### PR TITLE
Add a strip_thinking task option that drops the reasoning trace before scoring

### DIFF
--- a/src/olmo_eval/cli/utils.py
+++ b/src/olmo_eval/cli/utils.py
@@ -127,6 +127,7 @@ TASK_CONFIG_FIELDS = frozenset(
         "sampling_params",
         "dependencies",
         "sandbox_allocation_weight",
+        "strip_thinking",
         "priority",  # Special: extracted for job priority, not a real TaskConfig field
     }
 )

--- a/src/olmo_eval/common/scorers/base.py
+++ b/src/olmo_eval/common/scorers/base.py
@@ -224,7 +224,10 @@ class BitsPerByteScorer(Scorer):
 
         total_logprob = sum(tok.get("logprob", 0.0) for tok in output.logprobs)
 
-        num_bytes = len(output.text.encode("utf-8")) if output.text else 0
+        # The logprobs cover the whole generation; if strip_thinking removed a
+        # reasoning trace from output.text, normalize by the original text.
+        text = (output.metadata or {}).get("original_text") or output.text
+        num_bytes = len(text.encode("utf-8")) if text else 0
 
         if num_bytes == 0:
             return 0.0

--- a/src/olmo_eval/evals/tasks/common/base.py
+++ b/src/olmo_eval/evals/tasks/common/base.py
@@ -161,14 +161,7 @@ class TaskConfig:
     max_length: int | None = None
     answer_extractor: Callable[[str], str] | None = None
 
-    #: Strip a ``<think>...</think>`` reasoning trace from each output before answer
-    #: extraction and scoring (mirrors oe-eval's ``r1_style`` output processor: everything
-    #: up to the last ``</think>`` is removed). The full text is kept in
-    #: ``output.metadata["original_text"]``, which logprob-normalized fields (bits per
-    #: byte, logits per char) keep using, since the logprobs cover the whole generation.
-    #: Outputs with no closing tag are scored as-is. The runner applies this via
-    #: :meth:`Task.strip_thinking_traces` before ``score_responses``, so tasks that
-    #: override ``score_responses`` are covered too.
+    #: Drop ``<think>...</think>`` traces before scoring; see :meth:`Task.strip_thinking_traces`.
     strip_thinking: bool = False
 
     #: Runtime dependencies to install for this task (package specs like "pkg==1.0" or git URLs)

--- a/src/olmo_eval/evals/tasks/common/base.py
+++ b/src/olmo_eval/evals/tasks/common/base.py
@@ -164,7 +164,11 @@ class TaskConfig:
     #: Strip a ``<think>...</think>`` reasoning trace from each output before answer
     #: extraction and scoring (mirrors oe-eval's ``r1_style`` output processor: everything
     #: up to the last ``</think>`` is removed). The full text is kept in
-    #: ``output.metadata["original_text"]``. Outputs with no closing tag are scored as-is.
+    #: ``output.metadata["original_text"]``, which logprob-normalized fields (bits per
+    #: byte, logits per char) keep using, since the logprobs cover the whole generation.
+    #: Outputs with no closing tag are scored as-is. The runner applies this via
+    #: :meth:`Task.strip_thinking_traces` before ``score_responses``, so tasks that
+    #: override ``score_responses`` are covered too.
     strip_thinking: bool = False
 
     #: Runtime dependencies to install for this task (package specs like "pkg==1.0" or git URLs)
@@ -561,8 +565,6 @@ class Task(ABC):
         Subclasses needing custom answer extraction should override
         `_extract_answers()` rather than this method.
         """
-        if self.config.strip_thinking:
-            self._strip_thinking(responses)
         self._extract_answers(responses)
 
         # Check if any scorers need async execution
@@ -605,8 +607,15 @@ class Task(ABC):
             )
         return self._has_async_cache
 
-    def _strip_thinking(self, responses: Sequence[Response]) -> None:
-        """Drop the reasoning trace so scorers see only the final answer."""
+    def strip_thinking_traces(self, responses: Sequence[Response]) -> None:
+        """Drop ``<think>...</think>`` traces so scorers see only the final answer.
+
+        No-op unless ``config.strip_thinking`` is set. Runners call this before
+        ``score_responses`` (which tasks may override). Idempotent: a stripped
+        output has no ``</think>`` left, so a second pass leaves it alone.
+        """
+        if not self.config.strip_thinking:
+            return
         for response in responses:
             for output in response.outputs:
                 text = output.text or ""
@@ -614,7 +623,7 @@ class Task(ABC):
                     continue
                 if output.metadata is None:
                     output.metadata = {}
-                output.metadata["original_text"] = text
+                output.metadata.setdefault("original_text", text)
                 output.text = re.sub(r"(?s).*</think>", "", text).lstrip()
 
     def _extract_answers(self, responses: Sequence[Response]) -> None:

--- a/src/olmo_eval/evals/tasks/common/base.py
+++ b/src/olmo_eval/evals/tasks/common/base.py
@@ -6,6 +6,7 @@ import asyncio
 import contextlib
 import logging
 import math
+import re
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterator, Sequence
 from dataclasses import dataclass
@@ -160,6 +161,12 @@ class TaskConfig:
     max_length: int | None = None
     answer_extractor: Callable[[str], str] | None = None
 
+    #: Strip a ``<think>...</think>`` reasoning trace from each output before answer
+    #: extraction and scoring (mirrors oe-eval's ``r1_style`` output processor: everything
+    #: up to the last ``</think>`` is removed). The full text is kept in
+    #: ``output.metadata["original_text"]``. Outputs with no closing tag are scored as-is.
+    strip_thinking: bool = False
+
     #: Runtime dependencies to install for this task (package specs like "pkg==1.0" or git URLs)
     dependencies: list[str] | None = None
 
@@ -289,6 +296,7 @@ class TaskConfig:
             "output_score_aggregation": self.output_score_aggregation.value,
             "max_length": self.max_length,
             "answer_extractor": getattr(self.answer_extractor, "__name__", None),
+            "strip_thinking": self.strip_thinking,
             "dependencies": self.dependencies,
         }
         if any(
@@ -553,6 +561,8 @@ class Task(ABC):
         Subclasses needing custom answer extraction should override
         `_extract_answers()` rather than this method.
         """
+        if self.config.strip_thinking:
+            self._strip_thinking(responses)
         self._extract_answers(responses)
 
         # Check if any scorers need async execution
@@ -594,6 +604,18 @@ class Task(ABC):
                 for s in self._get_scorers().values()
             )
         return self._has_async_cache
+
+    def _strip_thinking(self, responses: Sequence[Response]) -> None:
+        """Drop the reasoning trace so scorers see only the final answer."""
+        for response in responses:
+            for output in response.outputs:
+                text = output.text or ""
+                if "</think>" not in text:
+                    continue
+                if output.metadata is None:
+                    output.metadata = {}
+                output.metadata["original_text"] = text
+                output.text = re.sub(r"(?s).*</think>", "", text).lstrip()
 
     def _extract_answers(self, responses: Sequence[Response]) -> None:
         """Extract answers from outputs. Override for complex multi-output logic."""

--- a/src/olmo_eval/runners/asynq/preparation.py
+++ b/src/olmo_eval/runners/asynq/preparation.py
@@ -155,6 +155,7 @@ async def finalize_task(tracker: TaskTracker) -> TaskResult:
     responses = [tracker.responses[i] for i in sorted(tracker.responses.keys())]
 
     # Score and compute metrics
+    tracker.task.strip_thinking_traces(responses)
     scored = await tracker.task.score_responses(responses)
     metrics = tracker.task.compute_metrics(scored)
     infrastructure_failures = _count_infrastructure_scoring_errors(scored)

--- a/src/olmo_eval/runners/asynq/results.py
+++ b/src/olmo_eval/runners/asynq/results.py
@@ -221,6 +221,7 @@ async def process_results(
         """Score a single response and store the result."""
         async with scoring_semaphore:
             try:
+                task.strip_thinking_traces([response])
                 scored_list = await task.score_responses([response], context=scoring_context)
                 scored = scored_list[0] if scored_list else response
             except Exception as e:

--- a/src/olmo_eval/runners/io/builders.py
+++ b/src/olmo_eval/runners/io/builders.py
@@ -77,6 +77,11 @@ def build_predictions(scored: Sequence[Any], metrics: Sequence[Metric] = ()) -> 
             if sample_metrics:
                 out_data["sample_metrics"] = sample_metrics
 
+            # Full text before strip_thinking removed the reasoning trace, so the
+            # trace length and termination can be audited from the predictions file.
+            if "original_text" in meta:
+                out_data["original_text"] = meta["original_text"]
+
             # Include execution result if present
             if "execution_result" in meta:
                 out_data["execution_result"] = meta["execution_result"]

--- a/src/olmo_eval/runners/io/builders.py
+++ b/src/olmo_eval/runners/io/builders.py
@@ -28,8 +28,12 @@ def build_predictions(scored: Sequence[Any], metrics: Sequence[Metric] = ()) -> 
         for out in resp.outputs:
             # Get values from metadata (set by backend) or compute from logprobs
             meta = out.metadata or {}
-            num_bytes = len(out.text.encode("utf-8")) if out.text else 0
             num_chars = len(out.text) if out.text else 0
+            # Logprobs describe the whole generation. If strip_thinking removed a
+            # reasoning trace, normalize by the original text, not the stripped answer.
+            full_text = meta.get("original_text") or out.text or ""
+            num_bytes = len(full_text.encode("utf-8"))
+            num_chars_all = len(full_text)
 
             # Use metadata values if available (from vLLM provider), else compute
             sum_logits: float | None
@@ -62,12 +66,14 @@ def build_predictions(scored: Sequence[Any], metrics: Sequence[Metric] = ()) -> 
 
                 if num_tokens:
                     out_data["logits_per_token"] = sum_logits / num_tokens
-                if num_chars > 0:
-                    out_data["logits_per_char"] = sum_logits / num_chars
+                if num_chars_all > 0:
+                    out_data["logits_per_char"] = sum_logits / num_chars_all
                 if num_bytes > 0:
                     out_data["bits_per_byte"] = -sum_logits / (num_bytes * math.log(2))
 
             out_data["num_chars"] = num_chars
+            if "original_text" in meta:
+                out_data["num_chars_all"] = num_chars_all
 
             sample_metrics: dict[str, dict[str, float]] = {}
             for key, value in meta.items():

--- a/tests/common/test_bits_per_byte_scorer.py
+++ b/tests/common/test_bits_per_byte_scorer.py
@@ -1,0 +1,27 @@
+"""BitsPerByteScorer normalizes by the text the logprobs describe."""
+
+from __future__ import annotations
+
+import math
+
+from olmo_eval.common.scorers import BitsPerByteScorer
+from olmo_eval.common.types import Instance, LMOutput
+
+_LOGPROBS = [{"token": "x", "logprob": -1.0} for _ in range(5)]
+
+
+def test_bits_per_byte_uses_output_text() -> None:
+    output = LMOutput(text="abcd", logprobs=_LOGPROBS)
+
+    score = BitsPerByteScorer().score(Instance(question="Q", gold_answer="A"), output)
+
+    assert score == 5.0 / (4 * math.log(2))
+
+
+def test_bits_per_byte_uses_original_text_after_strip_thinking() -> None:
+    original = "<think>reasoning</think>abcd"
+    output = LMOutput(text="abcd", logprobs=_LOGPROBS, metadata={"original_text": original})
+
+    score = BitsPerByteScorer().score(Instance(question="Q", gold_answer="A"), output)
+
+    assert score == 5.0 / (len(original.encode("utf-8")) * math.log(2))

--- a/tests/evals/tasks/test_base.py
+++ b/tests/evals/tasks/test_base.py
@@ -298,6 +298,78 @@ class TestTaskScoring:
 
 
 @pytest.mark.anyio
+class TestStripThinking:
+    """Tests for TaskConfig.strip_thinking."""
+
+    def _make_response(self, texts: list[str]) -> Response:
+        return Response(
+            instance=Instance(question="What is 2+2?", gold_answer="4"),
+            request=LMRequest(request_type=RequestType.COMPLETION, prompt="What is 2+2?"),
+            outputs=[LMOutput(text=text) for text in texts],
+        )
+
+    async def test_strips_trace_before_extraction_and_scoring(self):
+        metric = AccuracyMetric(scorer=ExactMatchScorer)
+        config = TaskConfig(
+            name="test", data_source="test/dataset", metrics=(metric,), strip_thinking=True
+        )
+        task = ConcreteTask(config)
+        response = self._make_response(["<think>Maybe 5? No, 4.</think>\n\n4"])
+
+        scored = await task.score_responses([response])
+
+        output = scored[0].outputs[0]
+        assert output.text == "4"
+        assert output.extracted_answer == "4"
+        assert output.metadata["original_text"] == "<think>Maybe 5? No, 4.</think>\n\n4"
+        assert scored[0].scores["exact_match"] == 1.0
+
+    async def test_strips_up_to_last_closing_tag(self):
+        config = TaskConfig(name="test", data_source="test/dataset", strip_thinking=True)
+        task = ConcreteTask(config)
+        response = self._make_response(["<think>a</think> draft <think>b</think> 4"])
+
+        await task.score_responses([response])
+
+        assert response.outputs[0].text == "4"
+
+    async def test_unterminated_trace_is_scored_as_is(self):
+        config = TaskConfig(name="test", data_source="test/dataset", strip_thinking=True)
+        task = ConcreteTask(config)
+        response = self._make_response(["<think>still thinking about 4"])
+
+        await task.score_responses([response])
+
+        output = response.outputs[0]
+        assert output.text == "<think>still thinking about 4"
+        assert "original_text" not in output.metadata
+
+    async def test_output_without_trace_is_unchanged(self):
+        config = TaskConfig(name="test", data_source="test/dataset", strip_thinking=True)
+        task = ConcreteTask(config)
+        response = self._make_response(["4"])
+
+        await task.score_responses([response])
+
+        assert response.outputs[0].text == "4"
+        assert "original_text" not in response.outputs[0].metadata
+
+    async def test_disabled_by_default(self):
+        config = TaskConfig(name="test", data_source="test/dataset")
+        task = ConcreteTask(config)
+        response = self._make_response(["<think>reasoning</think>4"])
+
+        await task.score_responses([response])
+
+        assert response.outputs[0].text == "<think>reasoning</think>4"
+        assert response.outputs[0].extracted_answer == "<think>reasoning</think>4"
+
+    def test_to_dict_includes_strip_thinking(self):
+        config = TaskConfig(name="test", data_source="test/dataset", strip_thinking=True)
+        assert config.to_dict()["strip_thinking"] is True
+
+
+@pytest.mark.anyio
 class TestProcessScoring:
     """Tests for process-backed scorer execution."""
 

--- a/tests/evals/tasks/test_base.py
+++ b/tests/evals/tasks/test_base.py
@@ -299,7 +299,7 @@ class TestTaskScoring:
 
 @pytest.mark.anyio
 class TestStripThinking:
-    """Tests for TaskConfig.strip_thinking."""
+    """Tests for TaskConfig.strip_thinking (applied by the runner via strip_thinking_traces)."""
 
     def _make_response(self, texts: list[str]) -> Response:
         return Response(
@@ -316,6 +316,7 @@ class TestStripThinking:
         task = ConcreteTask(config)
         response = self._make_response(["<think>Maybe 5? No, 4.</think>\n\n4"])
 
+        task.strip_thinking_traces([response])
         scored = await task.score_responses([response])
 
         output = scored[0].outputs[0]
@@ -324,41 +325,53 @@ class TestStripThinking:
         assert output.metadata["original_text"] == "<think>Maybe 5? No, 4.</think>\n\n4"
         assert scored[0].scores["exact_match"] == 1.0
 
-    async def test_strips_up_to_last_closing_tag(self):
+    def test_strips_up_to_last_closing_tag(self):
         config = TaskConfig(name="test", data_source="test/dataset", strip_thinking=True)
         task = ConcreteTask(config)
         response = self._make_response(["<think>a</think> draft <think>b</think> 4"])
 
-        await task.score_responses([response])
+        task.strip_thinking_traces([response])
 
         assert response.outputs[0].text == "4"
 
-    async def test_unterminated_trace_is_scored_as_is(self):
+    def test_unterminated_trace_is_scored_as_is(self):
         config = TaskConfig(name="test", data_source="test/dataset", strip_thinking=True)
         task = ConcreteTask(config)
         response = self._make_response(["<think>still thinking about 4"])
 
-        await task.score_responses([response])
+        task.strip_thinking_traces([response])
 
         output = response.outputs[0]
         assert output.text == "<think>still thinking about 4"
         assert "original_text" not in output.metadata
 
-    async def test_output_without_trace_is_unchanged(self):
+    def test_output_without_trace_is_unchanged(self):
         config = TaskConfig(name="test", data_source="test/dataset", strip_thinking=True)
         task = ConcreteTask(config)
         response = self._make_response(["4"])
 
-        await task.score_responses([response])
+        task.strip_thinking_traces([response])
 
         assert response.outputs[0].text == "4"
         assert "original_text" not in response.outputs[0].metadata
+
+    def test_second_pass_is_a_no_op(self):
+        config = TaskConfig(name="test", data_source="test/dataset", strip_thinking=True)
+        task = ConcreteTask(config)
+        response = self._make_response(["<think>reasoning</think>4"])
+
+        task.strip_thinking_traces([response])
+        task.strip_thinking_traces([response])
+
+        assert response.outputs[0].text == "4"
+        assert response.outputs[0].metadata["original_text"] == "<think>reasoning</think>4"
 
     async def test_disabled_by_default(self):
         config = TaskConfig(name="test", data_source="test/dataset")
         task = ConcreteTask(config)
         response = self._make_response(["<think>reasoning</think>4"])
 
+        task.strip_thinking_traces([response])
         await task.score_responses([response])
 
         assert response.outputs[0].text == "<think>reasoning</think>4"

--- a/tests/runners/io/test_builders.py
+++ b/tests/runners/io/test_builders.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import math
+
 from olmo_eval.common.metrics import LogprobPerTokenMCAccuracyMetric
 from olmo_eval.common.types import Instance, LMOutput, LMRequest, RequestType, Response
 from olmo_eval.runners.io.builders import build_predictions
@@ -176,3 +178,26 @@ def test_build_predictions_includes_original_text_when_present() -> None:
     outputs = predictions[0]["model_output"]
     assert outputs[0]["original_text"] == "<think>reasoning</think>A"
     assert "original_text" not in outputs[1]
+
+
+def test_build_predictions_normalizes_logprobs_by_original_text() -> None:
+    original = "<think>reasoning</think>4"  # 25 chars, 25 bytes
+    response = Response(
+        instance=Instance(question="Q", gold_answer="4"),
+        request=LMRequest(request_type=RequestType.COMPLETION, prompt="Q"),
+        outputs=[
+            LMOutput(
+                text="4",
+                extracted_answer="4",
+                logprobs=[{"token": "x", "logprob": -1.0} for _ in range(5)],
+                metadata={"original_text": original},
+            )
+        ],
+    )
+
+    output = build_predictions([response])[0]["model_output"][0]
+
+    assert output["num_chars"] == 1
+    assert output["num_chars_all"] == len(original)
+    assert output["logits_per_char"] == -5.0 / len(original)
+    assert output["bits_per_byte"] == 5.0 / (len(original.encode("utf-8")) * math.log(2))

--- a/tests/runners/io/test_builders.py
+++ b/tests/runners/io/test_builders.py
@@ -155,3 +155,24 @@ def test_build_predictions_materializes_exact_mc_accuracy_metric_keys() -> None:
 
     assert predictions[0]["instance_metrics"]["logprob"]["logprob"] == -1.0
     assert predictions[0]["instance_metrics"]["accuracy"]["logprob"] == 1.0
+
+
+def test_build_predictions_includes_original_text_when_present() -> None:
+    response = Response(
+        instance=Instance(question="Q", gold_answer="A"),
+        request=LMRequest(request_type=RequestType.COMPLETION, prompt="Q"),
+        outputs=[
+            LMOutput(
+                text="A",
+                extracted_answer="A",
+                metadata={"original_text": "<think>reasoning</think>A"},
+            ),
+            LMOutput(text="B", extracted_answer="B"),
+        ],
+    )
+
+    predictions = build_predictions([response])
+
+    outputs = predictions[0]["model_output"]
+    assert outputs[0]["original_text"] == "<think>reasoning</think>A"
+    assert "original_text" not in outputs[1]

--- a/tests/runners/test_strip_thinking_runner.py
+++ b/tests/runners/test_strip_thinking_runner.py
@@ -1,0 +1,60 @@
+"""strip_thinking is applied by the runner, so tasks overriding score_responses are covered."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterator, Sequence
+
+from olmo_eval.common.execution.environment import ScoringContext
+from olmo_eval.common.types import Instance, LMOutput, LMRequest, RequestType, Response
+from olmo_eval.evals.tasks.common import Task, TaskConfig
+from olmo_eval.runners.asynq.preparation import finalize_task
+from olmo_eval.runners.asynq.types import TaskTracker
+
+
+class CustomScoringTask(Task):
+    """Scores output.text directly, bypassing the base class pipeline."""
+
+    @property
+    def instances(self) -> Iterator[Instance]:
+        yield Instance(question="Q", gold_answer="4")
+
+    def format_request(self, instance: Instance) -> LMRequest:
+        return LMRequest(request_type=RequestType.COMPLETION, prompt=instance.question)
+
+    async def score_responses(
+        self, responses: Sequence[Response], context: ScoringContext | None = None
+    ) -> Sequence[Response]:
+        for response in responses:
+            for output in response.outputs:
+                output.extracted_answer = output.text
+            response.scores["custom"] = float(
+                all(o.text == response.instance.gold_answer for o in response.outputs)
+            )
+        return responses
+
+
+def test_finalize_task_strips_before_custom_score_responses() -> None:
+    config = TaskConfig(name="custom", data_source="test/dataset", strip_thinking=True)
+    task = CustomScoringTask(config)
+    instance = Instance(question="Q", gold_answer="4")
+    response = Response(
+        instance=instance,
+        request=task.format_request(instance),
+        outputs=[LMOutput(text="<think>3? no, 4.</think>4")],
+    )
+    tracker = TaskTracker(
+        model_name="m",
+        spec="custom",
+        task=task,
+        total_instances=1,
+        completed_count=1,
+        responses={0: response},
+    )
+
+    result = asyncio.run(finalize_task(tracker))
+
+    assert result.error is None
+    assert response.outputs[0].text == "4"
+    assert response.scores["custom"] == 1.0
+    assert result.predictions[0]["model_output"][0]["original_text"] == "<think>3? no, 4.</think>4"


### PR DESCRIPTION
Claude Code · https://claude.ai/code/session_01RKJs8PPByCsRbgCucpXmLq — agent-written, Abhishek reviewed the request

## Problem

Reasoning models emit `<think>...</think>` before the answer. Scorers that read `output.text` directly (IFEval constraints, PopQA containment, LLM judges) score the trace along with the answer: IFEval's "no commas" / word-count / keyword checks fail on the reasoning, and containment scorers credit entity names mentioned while thinking. oe-eval handles this with the `r1_style` output processor (`oe_eval/models/output_processors.py`); olmo-eval has no equivalent outside the safety tasks' `answer_extractor`, which `output.text`-based scorers never see.

## Change

- `TaskConfig.strip_thinking: bool = False`. When set, `Task.strip_thinking_traces` removes everything up to the **last** `</think>` (same regex as oe-eval). The runner calls it before `score_responses` in both scoring paths, so tasks that override `score_responses` (AstaBench SQA, ExpertQA, FrontierScience, LitSearch, ResearchQA, SAGE) are covered. Outputs with no closing tag are scored as-is, also matching oe-eval.
- The pre-strip text is kept in `output.metadata["original_text"]` and written to the prediction row, so trace length and termination rate can be audited from the artifact (metadata is otherwise not serialized). Logprobs describe the whole generation, so `BitsPerByteScorer` and the prediction row's `logits_per_char` / `bits_per_byte` normalize by `original_text` when present; the row also carries `num_chars_all` next to `num_chars`.
- `strip_thinking` is accepted as a `-o` task override; it can also be baked into a variant via `register_variant(..., strip_thinking=True)`.

## Usage

```bash
olmo-eval beaker launch ... -t ifeval -o max_tokens=32768 -o temperature=0.6 -o top_p=0.95 -o do_sample=true -o strip_thinking=true
```

## Verification

- `ruff check` / `ruff format --check` / `ty check` clean on the touched files; `tests/evals/tasks/test_base.py`, `tests/cli/test_utils.py`, `tests/runners` pass (103 tests).
- Exercised on Beaker against an OLMoE3 latent-KDA Dolci-Think SFT checkpoint (smoke [01M21JA557YTZJJFPA897DXP2J](https://beaker.org/ex/01M21JA557YTZJJFPA897DXP2J)): IFEval and a MATH chat variant scored only the post-`</think>` text (e.g. 1300 generated tokens, 915 visible characters), extracted answers came from the answer rather than the trace.
- Tests: `TestStripThinking` in `tests/evals/tasks/test_base.py` (closed tag, last-tag-wins, unterminated, no tag, idempotence, default off, `to_dict`); `tests/runners/test_strip_thinking_runner.py` (a task overriding `score_responses` still sees stripped text through `finalize_task`); `tests/runners/io/test_builders.py` (`original_text`, `num_chars_all`, logprob normalization); `tests/common/test_bits_per_byte_scorer.py`. 154 tests pass across the touched areas.

Not included here: the `olmo3adapt` MATH/AIME chat variants that reproduce oe-eval's `olmo3:adapt` configs. They sit on `abhishekr/paper-protocol` and can follow as a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RKJs8PPByCsRbgCucpXmLq


