### PR TITLE
Fix(Strip):  think traces before GPQA CoT, PopQA, and OMEGA extraction.

### DIFF
--- a/src/olmo_eval/evals/tasks/gpqa.py
+++ b/src/olmo_eval/evals/tasks/gpqa.py
@@ -39,6 +39,7 @@ from olmo_eval.evals.extract import (
     OLMO_3_ANSWER_REGEX_TEMPLATES,
     ExtractedAnswer,
     extract_answer_with_format,
+    extract_think_answer,
 )
 from olmo_eval.evals.tasks.common import Task, register, register_variant
 
@@ -264,8 +265,14 @@ _COT_SAMPLING = SamplingParams(
 
 
 def _extract_cot_answer(text: str) -> ExtractedAnswer:
+    """Extract the answer letter from a CoT continuation.
+
+    Reasoning enclosed in ``<think>`` tags is dropped first, as the reference
+    harness does for reasoning models, so letters mentioned while thinking
+    cannot be mistaken for the final answer.
+    """
     extracted = extract_answer_with_format(
-        text,
+        extract_think_answer(text) or "",
         answer_format_regex=_COT_ANSWER_FORMAT_REGEX,
         answer_regexes=_COT_ANSWER_REGEXES,
         answer_regexes_templates=OLMO_3_ANSWER_REGEX_TEMPLATES,

--- a/src/olmo_eval/evals/tasks/omega_500.py
+++ b/src/olmo_eval/evals/tasks/omega_500.py
@@ -26,7 +26,11 @@ from olmo_eval.common.types import (
     Split,
 )
 from olmo_eval.data import DataSource
-from olmo_eval.evals.extract import ExtractedAnswer, extract_answer_with_format
+from olmo_eval.evals.extract import (
+    ExtractedAnswer,
+    extract_answer_with_format,
+    extract_think_answer,
+)
 from olmo_eval.evals.tasks.common import Task, register
 
 _BOXED_SUFFIX = "\n\nPresent the answer in LaTex format: \\boxed{Your answer}"
@@ -73,7 +77,13 @@ _DELIMITERS_TO_STRIP = (
 
 
 def _extract(continuation: str) -> ExtractedAnswer:
-    """Normalize a continuation and extract the final answer."""
+    """Normalize a continuation and extract the final answer.
+
+    Reasoning enclosed in ``<think>`` tags is dropped first, as the reference
+    harness does for reasoning models, so boxed or prefixed answers mentioned
+    while thinking cannot be mistaken for the final answer.
+    """
+    continuation = extract_think_answer(continuation) or ""
     output = re.sub(r"(\d),(\d)", r"\1\2", continuation)
     res = re.sub(r"\.\s*$", "", output).strip()
     for left, right in _DELIMITERS_TO_STRIP:

--- a/src/olmo_eval/evals/tasks/popqa.py
+++ b/src/olmo_eval/evals/tasks/popqa.py
@@ -25,6 +25,7 @@ from olmo_eval.common.types import (
     Split,
 )
 from olmo_eval.data import DataSource
+from olmo_eval.evals.extract import extract_think_answer
 from olmo_eval.evals.tasks.common import Task, register, register_variant
 from olmo_eval.evals.tasks.constants.popqa import POPQA_FIXED_FEWSHOT
 
@@ -39,19 +40,21 @@ class PopQAContainsScorer(Scorer):
 
     A response is correct if any accepted alias appears in it verbatim,
     lowercased, or capitalized — the matching rule used by the reference
-    implementation. With ``first_line`` set, only text up to the first
-    newline is searched: models that ramble past their answer invent
-    follow-up Q/A pairs full of plausible entity names, and whole-output
-    containment credits those accidental hits.
+    implementation. Reasoning enclosed in ``<think>`` tags is dropped first,
+    as the reference harness does for reasoning models. With ``first_line``
+    set, only text up to the first newline of the remaining answer is
+    searched: models that ramble past their answer invent follow-up Q/A
+    pairs full of plausible entity names, and whole-output containment
+    credits those accidental hits.
     """
 
     name: str = "popqa_contains"
     first_line: bool = False
 
     def score(self, instance: Instance, output: LMOutput) -> float:
-        response = output.text or ""
+        response = extract_think_answer(output.text or "") or ""
         if self.first_line:
-            response = response.split("\n")[0]
+            response = response.lstrip().split("\n")[0]
         aliases = instance.metadata.get("aliases") or []
         if not aliases and instance.gold_answer:
             aliases = [instance.gold_answer]

--- a/tests/evals/tasks/test_gpqa.py
+++ b/tests/evals/tasks/test_gpqa.py
@@ -411,3 +411,12 @@ class TestCoTVariant:
     def test_extract_answer_strips_parens(self, task):
         output = LMOutput(text="Reasoning. Therefore, the answer is (D)")
         assert task.extract_answer(output) == "D"
+
+    def test_scorer_strips_think_block(self, task):
+        from olmo_eval.evals.tasks.gpqa import GPQACoTExactMatchScorer
+
+        scorer = GPQACoTExactMatchScorer()
+        instance = Instance(question="q", gold_answer="B", metadata={})
+        visible = "Therefore, the answer is (B)"
+        assert scorer.score(instance, LMOutput(text=f"<think>Could be D.</think>{visible}")) == 1.0
+        assert scorer.score(instance, LMOutput(text=f"<think>{visible}</think>")) == 0.0

--- a/tests/evals/tasks/test_omega_500.py
+++ b/tests/evals/tasks/test_omega_500.py
@@ -103,6 +103,17 @@ class TestOmegaScorers(unittest.TestCase):
     def test_empty_response(self) -> None:
         self.assertEqual(self._scores("42", ""), (0.0, 0.0))
 
+    def test_strips_think_block(self) -> None:
+        text = (
+            "<think>Could be 41, or \\boxed{41}.</think>\n\n"
+            "Therefore, the final answer is \\boxed{42}."
+        )
+        self.assertEqual(self._scores("42", text), (1.0, 1.0))
+        self.assertEqual(
+            self._scores("42", "<think>Therefore, the final answer is \\boxed{42}.</think>"),
+            (0.0, 0.0),
+        )
+
     def test_format_correct_recorded_in_metadata(self) -> None:
         output = LMOutput(text="Therefore, the final answer is \\boxed{42}.")
         _STRICT.score(_make_instance("42"), output)

--- a/tests/evals/tasks/test_popqa.py
+++ b/tests/evals/tasks/test_popqa.py
@@ -132,6 +132,14 @@ class TestPopQAContainsScorer(unittest.TestCase):
     def test_empty_response(self) -> None:
         self.assertEqual(self._score(""), 0.0)
 
+    def test_strips_think_block(self) -> None:
+        think_wrong = "<think>USA is a candidate</think>\nFrance"
+        self.assertEqual(self._score(think_wrong), 0.0)
+        self.assertEqual(self.first_line.score(self.instance, LMOutput(text=think_wrong)), 0.0)
+
+        think_right = "<think>maybe Canada</think>\nThe USA, of course.\nSome elaboration"
+        self.assertEqual(self.first_line.score(self.instance, LMOutput(text=think_right)), 1.0)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Reasoning models emit <think> blocks that the remaining post-training extractors scored as if they were the final answer. Apply the same extract_think_answer pre-step already used by mmlu:cot so Think-model numbers stay comparable to oe-eval.

## Description

<!-- Describe your changes in detail -->

## Type of Change

<!-- Put an `x` in all the boxes that apply -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Testing

<!-- Describe how you tested your changes -->

- [ ] Unit tests pass locally (`pytest tests/ --ignore=tests/integration/`)
- [ ] Integration tests pass (if applicable)
- [ ] New tests added for new functionality

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added/updated documentation as needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published
