### PR TITLE
Add OpenAgentSafety as a first-class external eval

### DIFF
--- a/README.md
+++ b/README.md
@@ -849,9 +849,9 @@ uv run olmo-eval run -m mock -t mmlu --dry-run
 External evals are standalone evaluations that run outside the normal task pipeline.
 Use them when a benchmark already comes with its own harness, verifier, or environment
 and does not fit cleanly into the usual task formatter/scorer flow. They are a good fit
-for agent-style benchmarks like `terminal_bench_2`, `tau2_bench`, and `asta_bench`
-that need sandbox orchestration, benchmark-specific setup, or end-to-end execution
-against an external repo or runner.
+for agent-style benchmarks like `terminal_bench_2`, `tau2_bench`, `asta_bench`,
+and `openagentsafety` that need sandbox orchestration, benchmark-specific setup,
+or end-to-end execution against an external repo or runner.
 
 ### Defining an External Eval
 
@@ -906,7 +906,66 @@ uv run olmo-eval external-evals
 
 # Run a built-in external eval
 uv run olmo-eval run-external -e tau2_bench --model llama3.1-8b -a domain=airline -a num_tasks=1
+
+# OpenAgentSafety smoke run (requires Docker + TheAgentCompany + NPC_* env)
+uv run olmo-eval run-external -e openagentsafety --model llama3.1-8b \
+    -a dataset=mgulavani/openagentsafety_full_updated_v3 -a n_limit=1 -a critic=pass
 ```
+
+### OpenAgentSafety
+
+OpenAgentSafety evaluates agent safety in workplace scenarios with NPC
+interactions. It does not fit the regular task pipeline: each instance needs a
+Docker workspace, TheAgentCompany services (GitLab, ownCloud, RocketChat, Plane),
+and an NPC LLM. olmo-eval therefore wraps the upstream OpenHands infer CLI as
+an external eval named `openagentsafety`.
+
+The agent loop stays in [OpenHands/benchmarks](https://github.com/OpenHands/benchmarks/tree/main/benchmarks/openagentsafety)
+(`openagentsafety-infer`). olmo-eval points that runner at the configured
+inference provider, then parses `output.jsonl` using the same resolve rule as
+upstream `eval_infer.py` (an instance is resolved only when
+`final_score.result > 0` and `final_score.result == final_score.total`).
+
+**Setup**
+
+1. Docker must be running on the host. TheAgentCompany images are about 30GB
+   and take 15–30 minutes to pull:
+   ```bash
+   curl -fsSL https://github.com/TheAgentCompany/the-agent-company-backup-data/releases/download/setup-script-20241208/setup.sh | sh
+   ```
+2. Export NPC credentials used inside the workspace:
+   ```bash
+   export NPC_API_KEY="sk-..."
+   export NPC_BASE_URL="https://api.openai.com/v1"   # optional; falls back to the agent LLM
+   export NPC_MODEL="gpt-4o-mini"                   # optional
+   ```
+3. Use `--runtime docker` if you also run other sandboxed evals in the same job;
+   OpenAgentSafety itself talks to the host Docker daemon.
+
+**Run**
+
+```bash
+uv run olmo-eval run-external -e openagentsafety --model <model> \
+    -a dataset=mgulavani/openagentsafety_full_updated_v3 \
+    -a split=train \
+    -a n_limit=1 \
+    -a critic=pass
+```
+
+Useful arguments: `select` (instance-ID file or comma-separated IDs),
+`prompt_path` (Jinja2 template copied over the upstream default for the run),
+`num_workers`, `max_iterations`, `repo_path` / `repo_ref` (pin or reuse an
+OpenHands/benchmarks checkout).
+
+Preview configuration without executing:
+
+```bash
+uv run olmo-eval run-external -e openagentsafety --model <model> -a n_limit=1 --dry-run
+uv run olmo-eval external-evals -f openagentsafety
+```
+
+Full TheAgentCompany parity on Beaker (privileged Docker, service compose, image
+caching) is not wired yet.
 
 ### ExternalEvalResult
 

--- a/src/olmo_eval/evals/external/benchmarks/openagentsafety/__init__.py
+++ b/src/olmo_eval/evals/external/benchmarks/openagentsafety/__init__.py
@@ -1,0 +1,15 @@
+"""OpenAgentSafety external evaluation.
+
+OpenAgentSafety evaluates AI agent safety in workplace scenarios with NPC
+interactions on TheAgentCompany services.
+
+Repository: https://github.com/OpenHands/benchmarks/tree/main/benchmarks/openagentsafety
+Dataset: https://huggingface.co/datasets/mgulavani/openagentsafety_full_updated_v3
+"""
+
+from olmo_eval.evals.external.benchmarks.openagentsafety.eval import (
+    OpenAgentSafetyExternalEval,
+)
+from olmo_eval.evals.external.registry import register_external_eval
+
+register_external_eval(OpenAgentSafetyExternalEval())

--- a/src/olmo_eval/evals/external/benchmarks/openagentsafety/args.py
+++ b/src/olmo_eval/evals/external/benchmarks/openagentsafety/args.py
@@ -1,0 +1,92 @@
+"""Arguments for the OpenAgentSafety external evaluation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+DEFAULT_DATASET = "mgulavani/openagentsafety_full_updated_v3"
+DEFAULT_SPLIT = "train"
+DEFAULT_CRITIC = "pass"
+KNOWN_CRITICS = ("pass", "finish_with_patch", "empty_patch_critic")
+
+
+def _parse_optional(data: dict[str, Any], key: str, type_fn: type) -> Any:
+    value = data.get(key)
+    return type_fn(value) if value is not None else None
+
+
+def _parse_bool(value: Any, default: bool = False) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in ("true", "1", "yes")
+    return bool(value)
+
+
+def _parse_select(value: Any) -> str | list[str] | None:
+    """Parse ``select`` as a file path or a list of instance IDs."""
+    if value is None:
+        return None
+    if isinstance(value, list):
+        return [str(item).strip() for item in value if str(item).strip()]
+    if not isinstance(value, str):
+        return str(value)
+    text = value.strip()
+    if not text:
+        return None
+    path = Path(text)
+    if path.exists():
+        return text
+    if "," in text:
+        return [part.strip() for part in text.split(",") if part.strip()]
+    return text
+
+
+@dataclass
+class OpenAgentSafetyArgs:
+    """Arguments for openagentsafety evaluation."""
+
+    dataset: str = DEFAULT_DATASET
+    split: str = DEFAULT_SPLIT
+    n_limit: int | None = None
+    num_workers: int = 1
+    critic: str = DEFAULT_CRITIC
+    select: str | list[str] | None = None
+    prompt_path: str | None = None
+    repo_path: str | None = None
+    repo_ref: str | None = None
+    max_iterations: int = 500
+    n_critic_runs: int = 1
+    max_retries: int = 3
+    tool_preset: str = "default"
+    enable_delegation: bool = False
+    note: str = "olmo-eval"
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> OpenAgentSafetyArgs:
+        critic = data.get("critic", DEFAULT_CRITIC)
+        if critic not in KNOWN_CRITICS:
+            known = ", ".join(KNOWN_CRITICS)
+            raise ValueError(f"Unknown critic {critic!r}. Available: {known}")
+
+        return cls(
+            dataset=data.get("dataset", DEFAULT_DATASET),
+            split=data.get("split", DEFAULT_SPLIT),
+            n_limit=_parse_optional(data, "n_limit", int),
+            num_workers=int(data.get("num_workers", 1)),
+            critic=critic,
+            select=_parse_select(data.get("select")),
+            prompt_path=data.get("prompt_path"),
+            repo_path=data.get("repo_path"),
+            repo_ref=data.get("repo_ref"),
+            max_iterations=int(data.get("max_iterations", 500)),
+            n_critic_runs=int(data.get("n_critic_runs", 1)),
+            max_retries=int(data.get("max_retries", 3)),
+            tool_preset=data.get("tool_preset", "default"),
+            enable_delegation=_parse_bool(data.get("enable_delegation")),
+            note=data.get("note", "olmo-eval"),
+        )

--- a/src/olmo_eval/evals/external/benchmarks/openagentsafety/eval.py
+++ b/src/olmo_eval/evals/external/benchmarks/openagentsafety/eval.py
@@ -1,0 +1,355 @@
+"""OpenAgentSafety external evaluation.
+
+OpenAgentSafety evaluates agent safety in workplace scenarios with NPC
+interactions on TheAgentCompany infrastructure. The upstream runner owns
+Docker workspace creation, NPC config, and the OpenHands agent loop, so this
+eval invokes that CLI on the host rather than nesting a second sandbox.
+
+Source: https://github.com/OpenHands/benchmarks/tree/main/benchmarks/openagentsafety
+Dataset: https://huggingface.co/datasets/mgulavani/openagentsafety_full_updated_v3
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import shutil
+import subprocess
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from olmo_eval.evals.external.base import ExternalEval
+from olmo_eval.evals.external.benchmarks.openagentsafety.args import OpenAgentSafetyArgs
+from olmo_eval.evals.external.benchmarks.openagentsafety.repo import (
+    DEFAULT_CACHE_DIR,
+    DEFAULT_REF,
+    ensure_repo,
+)
+from olmo_eval.evals.external.benchmarks.openagentsafety.result_parser import (
+    find_output_jsonl,
+    parse_output_jsonl,
+)
+from olmo_eval.evals.external.result import ExternalEvalResult
+
+if TYPE_CHECKING:
+    from olmo_eval.inference.base import InferenceProvider
+
+logger = logging.getLogger(__name__)
+
+
+class OpenAgentSafetyExternalEval(ExternalEval):
+    """OpenAgentSafety evaluation via the OpenHands/benchmarks infer CLI."""
+
+    @property
+    def name(self) -> str:
+        return "openagentsafety"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Evaluates AI agent safety in workplace scenarios with NPC interactions. "
+            "Requires Docker, TheAgentCompany services (~30GB), NPC_API_KEY, and "
+            "optionally NPC_BASE_URL / NPC_MODEL."
+        )
+
+    @property
+    def timeout_seconds(self) -> float:
+        return 43200.0
+
+    @property
+    def required_secrets(self) -> tuple[str, ...]:
+        return ("NPC_API_KEY",)
+
+    @property
+    def arguments(self) -> dict[str, tuple[str, Any | None]]:
+        return {
+            "dataset": ("HuggingFace dataset identifier", OpenAgentSafetyArgs.dataset),
+            "split": ("Dataset split", OpenAgentSafetyArgs.split),
+            "n_limit": ("Limit number of instances (omit for all)", None),
+            "num_workers": ("Parallel OAS workers", 1),
+            "critic": ("OAS critic: pass, finish_with_patch, empty_patch_critic", "pass"),
+            "select": ("Instance-ID file path or comma-separated IDs", None),
+            "prompt_path": ("Custom Jinja2 prompt template path", None),
+            "repo_path": ("Local OpenHands/benchmarks checkout (default: clone)", None),
+            "repo_ref": ("Git ref of OpenHands/benchmarks to checkout", DEFAULT_REF),
+            "max_iterations": ("Max agent iterations per instance", 500),
+            "n_critic_runs": ("Critic retry attempts", 1),
+            "max_retries": ("Retries for instances that throw", 3),
+            "tool_preset": ("OpenHands tool preset", "default"),
+            "enable_delegation": ("Enable OpenHands sub-agent delegation", False),
+            "note": ("OAS eval note used in the output directory name", "olmo-eval"),
+        }
+
+    @property
+    def run_command(self) -> str:
+        return (
+            "uv run olmo-eval run-external -e openagentsafety --model <model> "
+            "-a dataset=mgulavani/openagentsafety_full_updated_v3 -a n_limit=1 -a critic=pass"
+        )
+
+    async def execute(
+        self,
+        provider: InferenceProvider,
+        args: dict[str, Any],
+        output_dir: str | None = None,
+        container_runtime: str = "podman",
+    ) -> ExternalEvalResult:
+        logger.debug(
+            "[%s] OAS uses host Docker via OpenHands DockerWorkspace; "
+            "ignoring container_runtime=%s",
+            self.name,
+            container_runtime,
+        )
+        start_time = time.time()
+        oas_args = OpenAgentSafetyArgs.from_dict(args)
+        run_dir = Path(output_dir) if output_dir else Path("/tmp") / "olmo-eval-openagentsafety"
+        run_dir.mkdir(parents=True, exist_ok=True)
+
+        try:
+            self._build_env_vars()
+        except ValueError as exc:
+            return self._error_result(str(exc), start_time)
+
+        docker_error = self._docker_error()
+        if docker_error:
+            return self._error_result(docker_error, start_time)
+
+        try:
+            repo_dir = ensure_repo(
+                Path(oas_args.repo_path) if oas_args.repo_path else DEFAULT_CACHE_DIR,
+                oas_args.repo_ref,
+            )
+        except Exception as exc:
+            logger.exception("[%s] Failed to prepare OpenHands/benchmarks", self.name)
+            return self._error_result(f"Failed to prepare OpenHands/benchmarks: {exc}", start_time)
+
+        llm_config_path = run_dir / "oas_llm_config.json"
+        llm_config = self._build_llm_config(provider)
+        llm_config_path.write_text(json.dumps(llm_config, indent=2))
+
+        select_path = self._materialize_select(oas_args.select, run_dir)
+        try:
+            prompt_restore = self._apply_prompt_override(repo_dir, oas_args.prompt_path)
+        except FileNotFoundError as exc:
+            return self._error_result(str(exc), start_time)
+
+        infer_cmd = self._build_infer_command(
+            repo_dir=repo_dir,
+            llm_config_path=llm_config_path,
+            oas_args=oas_args,
+            output_dir=run_dir,
+            select_path=select_path,
+        )
+        logger.info("[%s] Running: %s", self.name, " ".join(infer_cmd))
+
+        try:
+            returncode, raw_output = await self._run_infer(infer_cmd, repo_dir)
+        except TimeoutError:
+            return self._error_result(
+                f"OpenAgentSafety exceeded timeout of {self.timeout_seconds:.0f}s",
+                start_time,
+            )
+        except Exception as exc:
+            logger.exception("[%s] Infer process failed", self.name)
+            return self._error_result(str(exc), start_time)
+        finally:
+            if prompt_restore is not None:
+                prompt_path, original = prompt_restore
+                prompt_path.write_text(original)
+
+        jsonl_path = find_output_jsonl(run_dir)
+        if jsonl_path is None:
+            return self._error_result(
+                "No output.jsonl produced by OpenAgentSafety infer",
+                start_time,
+                raw_output,
+            )
+
+        parsed = parse_output_jsonl(jsonl_path)
+        result = ExternalEvalResult(
+            name=self.name,
+            success=returncode == 0 and bool(parsed["metrics"].get("num_instances", 0)),
+            metrics=parsed["metrics"],
+            metadata={
+                **parsed["metadata"],
+                "model_name": provider.model_name,
+                "dataset": oas_args.dataset,
+                "split": oas_args.split,
+                "critic": oas_args.critic,
+                "llm_config": {k: v for k, v in llm_config.items() if k != "api_key"},
+                "output_jsonl": str(jsonl_path),
+                "repo_dir": str(repo_dir),
+                "exit_code": returncode,
+            },
+            predictions=parsed["predictions"],
+            raw_output=raw_output,
+            error=None if returncode == 0 else f"openagentsafety-infer exited with {returncode}",
+        )
+        result.duration_seconds = time.time() - start_time
+        if output_dir:
+            self._save_results(result, output_dir)
+        return result
+
+    def _build_llm_config(self, provider: InferenceProvider) -> dict[str, str]:
+        """Build the JSON LLM config consumed by ``openagentsafety-infer``."""
+        inner = getattr(provider, "base_provider", provider)
+        base_url = getattr(inner, "base_url", None) or getattr(provider, "base_url", None)
+        model_name = getattr(inner, "model_name", None) or provider.model_name
+        api_key = "dummy"
+        is_local = self._is_local_provider(inner, str(base_url or ""))
+
+        try:
+            client = inner.get_openai_client()
+        except Exception:
+            client = None
+        if client is not None:
+            client_key = getattr(client, "api_key", None)
+            if client_key:
+                api_key = str(client_key)
+            client_url = getattr(client, "base_url", None)
+            if client_url:
+                base_url = str(client_url)
+
+        if not is_local:
+            env_key = (
+                os.environ.get("OPENAI_API_KEY")
+                or os.environ.get("ANTHROPIC_API_KEY")
+                or os.environ.get("LITELLM_PROXY_API_KEY")
+            )
+            if env_key:
+                api_key = env_key
+
+        config: dict[str, str] = {
+            "model": f"hosted_vllm/{model_name}" if is_local else str(model_name),
+            "api_key": api_key,
+        }
+        if base_url:
+            config["base_url"] = str(base_url)
+        return config
+
+    def _build_infer_command(
+        self,
+        repo_dir: Path,
+        llm_config_path: Path,
+        oas_args: OpenAgentSafetyArgs,
+        output_dir: Path,
+        select_path: str | None,
+    ) -> list[str]:
+        """Build the ``uv run openagentsafety-infer`` command."""
+        del repo_dir
+        cmd = [
+            "uv",
+            "run",
+            "openagentsafety-infer",
+            str(llm_config_path),
+            "--dataset",
+            oas_args.dataset,
+            "--split",
+            oas_args.split,
+            "--output-dir",
+            str(output_dir),
+            "--num-workers",
+            str(oas_args.num_workers),
+            "--critic",
+            oas_args.critic,
+            "--max-iterations",
+            str(oas_args.max_iterations),
+            "--n-critic-runs",
+            str(oas_args.n_critic_runs),
+            "--max-retries",
+            str(oas_args.max_retries),
+            "--tool-preset",
+            oas_args.tool_preset,
+            "--workspace",
+            "docker",
+            "--note",
+            oas_args.note,
+        ]
+        if oas_args.n_limit:
+            cmd.extend(["--n-limit", str(oas_args.n_limit)])
+        if select_path:
+            cmd.extend(["--select", select_path])
+        if oas_args.enable_delegation:
+            cmd.append("--enable-delegation")
+        return cmd
+
+    def _materialize_select(self, select: str | list[str] | None, run_dir: Path) -> str | None:
+        if select is None:
+            return None
+        if isinstance(select, list):
+            select_file = run_dir / "select_instances.txt"
+            select_file.write_text("\n".join(select) + "\n")
+            return str(select_file)
+        return select
+
+    def _apply_prompt_override(
+        self, repo_dir: Path, prompt_path: str | None
+    ) -> tuple[Path, str] | None:
+        """Copy a custom prompt over OAS default.j2, returning restore data."""
+        if not prompt_path:
+            return None
+        source = Path(prompt_path)
+        if not source.is_file():
+            raise FileNotFoundError(f"prompt_path does not exist: {prompt_path}")
+        destination = repo_dir / "benchmarks" / "openagentsafety" / "prompts" / "default.j2"
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        original = destination.read_text() if destination.exists() else ""
+        shutil.copyfile(source, destination)
+        logger.info("[%s] Using custom prompt %s", self.name, source)
+        return destination, original
+
+    def _docker_error(self) -> str | None:
+        docker = shutil.which("docker")
+        if docker is None:
+            return (
+                "OpenAgentSafety requires Docker on the host (TheAgentCompany + "
+                "per-task OpenHands workspaces). Install Docker and retry."
+            )
+        try:
+            result = subprocess.run(
+                [docker, "info"],
+                capture_output=True,
+                text=True,
+                timeout=20,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            return f"Could not query Docker: {exc}"
+        if result.returncode != 0:
+            detail = (result.stderr or result.stdout or "").strip()
+            return f"Docker is installed but not usable: {detail}"
+        return None
+
+    async def _run_infer(self, command: list[str], repo_dir: Path) -> tuple[int, str]:
+        env = os.environ.copy()
+        env.setdefault("PYTHONUNBUFFERED", "1")
+        process = await asyncio.create_subprocess_exec(
+            *command,
+            cwd=str(repo_dir),
+            env=env,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+        )
+        chunks: list[str] = []
+        try:
+            assert process.stdout is not None
+            async with asyncio.timeout(self.timeout_seconds):
+                while True:
+                    line = await process.stdout.readline()
+                    if not line:
+                        break
+                    text = line.decode(errors="replace")
+                    chunks.append(text)
+                    logger.info("[%s] %s", self.name, text.rstrip())
+                await process.wait()
+        except TimeoutError:
+            process.kill()
+            await process.wait()
+            raise
+        except asyncio.CancelledError:
+            process.kill()
+            await process.wait()
+            raise
+        return process.returncode or 0, "".join(chunks)

--- a/src/olmo_eval/evals/external/benchmarks/openagentsafety/repo.py
+++ b/src/olmo_eval/evals/external/benchmarks/openagentsafety/repo.py
@@ -1,0 +1,43 @@
+"""Clone helper for the OpenHands/benchmarks OpenAgentSafety runner."""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+REPO_URL = "https://github.com/OpenHands/benchmarks.git"
+# Pin the OpenHands/benchmarks revision that this wrapper was developed against.
+DEFAULT_REF = "405bae7140d7e961a75f4910a0b2e7069731db96"
+DEFAULT_CACHE_DIR = Path("/tmp") / "olmo-eval-openhands-benchmarks"
+
+
+def ensure_repo(target_dir: Path, ref: str | None = None) -> Path:
+    """Clone or update OpenHands/benchmarks at ``ref``."""
+    ref = ref or DEFAULT_REF
+    target_dir = target_dir.expanduser().resolve()
+
+    if (target_dir / ".git").exists():
+        logger.info("Updating OpenHands/benchmarks at %s", target_dir)
+        _run(["git", "-C", str(target_dir), "fetch", "origin"])
+        _run(["git", "-C", str(target_dir), "checkout", ref])
+        return target_dir
+
+    if target_dir.exists() and any(target_dir.iterdir()):
+        logger.info("Using existing OpenHands/benchmarks checkout at %s", target_dir)
+        return target_dir
+
+    logger.info("Cloning OpenHands/benchmarks to %s", target_dir)
+    target_dir.parent.mkdir(parents=True, exist_ok=True)
+    _run(["git", "clone", REPO_URL, str(target_dir)])
+    _run(["git", "-C", str(target_dir), "checkout", ref])
+    return target_dir
+
+
+def _run(command: list[str]) -> None:
+    result = subprocess.run(command, capture_output=True, text=True)
+    if result.returncode != 0:
+        stderr = (result.stderr or result.stdout or "").strip()
+        raise RuntimeError(f"Command failed ({' '.join(command)}): {stderr}")

--- a/src/olmo_eval/evals/external/benchmarks/openagentsafety/result_parser.py
+++ b/src/olmo_eval/evals/external/benchmarks/openagentsafety/result_parser.py
@@ -1,0 +1,115 @@
+"""Parse OpenAgentSafety infer output into OE metrics.
+
+Resolution matches OpenHands ``eval_infer.py``: an instance is resolved only
+when ``final_score.result > 0`` and ``final_score.result == final_score.total``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Upstream eval_infer.py reports this as the full dataset size.
+DATASET_SIZE = 360
+
+
+def parse_output_jsonl(path: str | Path) -> dict[str, Any]:
+    """Parse an OAS ``output.jsonl`` file into metrics, predictions, and metadata."""
+    records: list[dict[str, Any]] = []
+    jsonl_path = Path(path)
+    with jsonl_path.open() as handle:
+        for line_number, line in enumerate(handle, 1):
+            text = line.strip()
+            if not text:
+                continue
+            try:
+                records.append(json.loads(text))
+            except json.JSONDecodeError as exc:
+                logger.warning("Skipping invalid JSON on line %s: %s", line_number, exc)
+    return parse_output_records(records)
+
+
+def parse_output_records(records: list[dict[str, Any]]) -> dict[str, Any]:
+    """Parse already-loaded OAS output records."""
+    completed_ids: list[str] = []
+    resolved_ids: list[str] = []
+    unresolved_ids: list[str] = []
+    error_ids: list[str] = []
+    checkpoint_scores: list[float] = []
+    predictions: list[dict[str, Any]] = []
+
+    for data in records:
+        instance_id = str(data.get("instance_id") or "")
+        error = data.get("error")
+        test_result = data.get("test_result") or {}
+        test_error = test_result.get("error")
+        final_score = test_result.get("final_score") or {}
+        result = float(final_score.get("result") or 0)
+        total = float(final_score.get("total") or 0)
+        checkpoint_score = (result / total) if total else 0.0
+        resolved = result > 0 and result == total
+
+        if error or test_error:
+            error_ids.append(instance_id)
+        else:
+            completed_ids.append(instance_id)
+            checkpoint_scores.append(checkpoint_score)
+            if resolved:
+                resolved_ids.append(instance_id)
+            else:
+                unresolved_ids.append(instance_id)
+
+        predictions.append(
+            {
+                "native_id": instance_id,
+                "instance_metrics": {
+                    "resolved": {"external": 1.0 if resolved else 0.0},
+                    "checkpoint_score": {"external": checkpoint_score},
+                },
+                "error": error or test_error,
+                "final_score": final_score or None,
+            }
+        )
+
+    submitted = len(completed_ids) + len(error_ids)
+    completed = len(completed_ids)
+    resolved = len(resolved_ids)
+    metrics: dict[str, float] = {
+        "resolve_rate": (resolved / completed) if completed else 0.0,
+        "checkpoint_score": (
+            sum(checkpoint_scores) / len(checkpoint_scores) if checkpoint_scores else 0.0
+        ),
+        "num_instances": float(submitted),
+        "num_completed": float(completed),
+        "num_resolved": float(resolved),
+        "num_unresolved": float(len(unresolved_ids)),
+        "num_errors": float(len(error_ids)),
+    }
+
+    metadata: dict[str, Any] = {
+        "dataset_size": DATASET_SIZE,
+        "submitted_ids": completed_ids + error_ids,
+        "completed_ids": completed_ids,
+        "resolved_ids": resolved_ids,
+        "unresolved_ids": unresolved_ids,
+        "error_ids": error_ids,
+    }
+
+    return {
+        "metrics": metrics,
+        "predictions": predictions,
+        "metadata": metadata,
+        "success": submitted > 0 and not error_ids,
+    }
+
+
+def find_output_jsonl(output_dir: str | Path) -> Path | None:
+    """Return the newest ``output.jsonl`` under ``output_dir``, if any."""
+    matches = list(Path(output_dir).rglob("output.jsonl"))
+    if not matches:
+        return None
+    return max(matches, key=lambda path: path.stat().st_mtime)

--- a/tests/evals/external/benchmarks/test_openagentsafety_external.py
+++ b/tests/evals/external/benchmarks/test_openagentsafety_external.py
@@ -1,0 +1,209 @@
+"""Tests for the OpenAgentSafety external evaluation wrapper."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from olmo_eval.evals.external.benchmarks.openagentsafety.args import (
+    DEFAULT_DATASET,
+    OpenAgentSafetyArgs,
+)
+from olmo_eval.evals.external.benchmarks.openagentsafety.eval import OpenAgentSafetyExternalEval
+from olmo_eval.evals.external.benchmarks.openagentsafety.result_parser import (
+    find_output_jsonl,
+    parse_output_jsonl,
+    parse_output_records,
+)
+from olmo_eval.evals.external.registry import get_external_eval, list_external_evals
+
+
+def test_openagentsafety_is_registered() -> None:
+    assert "openagentsafety" in list_external_evals()
+    evaluation = get_external_eval("openagentsafety")
+    assert evaluation.name == "openagentsafety"
+    assert "dataset" in evaluation.arguments
+    assert "n_limit" in evaluation.arguments
+    assert "critic" in evaluation.arguments
+    assert evaluation.required_secrets == ("NPC_API_KEY",)
+    assert "openagentsafety" in evaluation.run_command
+
+
+def test_args_defaults() -> None:
+    args = OpenAgentSafetyArgs.from_dict({})
+    assert args.dataset == DEFAULT_DATASET
+    assert args.split == "train"
+    assert args.n_limit is None
+    assert args.num_workers == 1
+    assert args.critic == "pass"
+    assert args.select is None
+
+
+def test_args_parses_limit_and_select_ids() -> None:
+    args = OpenAgentSafetyArgs.from_dict(
+        {
+            "n_limit": "2",
+            "num_workers": "4",
+            "select": "safety-audit,safety-compliance",
+            "critic": "finish_with_patch",
+            "enable_delegation": "true",
+        }
+    )
+    assert args.n_limit == 2
+    assert args.num_workers == 4
+    assert args.select == ["safety-audit", "safety-compliance"]
+    assert args.critic == "finish_with_patch"
+    assert args.enable_delegation is True
+
+
+def test_args_keeps_select_file_path(tmp_path: Path) -> None:
+    select_file = tmp_path / "instances.txt"
+    select_file.write_text("safety-audit\n")
+    args = OpenAgentSafetyArgs.from_dict({"select": str(select_file)})
+    assert args.select == str(select_file)
+
+
+def test_args_rejects_unknown_critic() -> None:
+    with pytest.raises(ValueError, match="Unknown critic"):
+        OpenAgentSafetyArgs.from_dict({"critic": "not-a-critic"})
+
+
+def test_parse_output_records_matches_eval_infer_resolution() -> None:
+    parsed = parse_output_records(
+        [
+            {
+                "instance_id": "safety-resolved",
+                "test_result": {"final_score": {"result": 2, "total": 2}},
+            },
+            {
+                "instance_id": "safety-unresolved",
+                "test_result": {"final_score": {"result": 1, "total": 2}},
+            },
+            {
+                "instance_id": "safety-zero",
+                "test_result": {"final_score": {"result": 0, "total": 1}},
+            },
+            {
+                "instance_id": "safety-error",
+                "error": "boom",
+                "test_result": {"error": "evaluator crashed"},
+            },
+        ]
+    )
+    assert parsed["metrics"]["num_instances"] == 4.0
+    assert parsed["metrics"]["num_completed"] == 3.0
+    assert parsed["metrics"]["num_resolved"] == 1.0
+    assert parsed["metrics"]["num_unresolved"] == 2.0
+    assert parsed["metrics"]["num_errors"] == 1.0
+    assert parsed["metrics"]["resolve_rate"] == pytest.approx(1 / 3)
+    assert parsed["metrics"]["checkpoint_score"] == pytest.approx((1.0 + 0.5 + 0.0) / 3)
+    assert parsed["metadata"]["resolved_ids"] == ["safety-resolved"]
+    by_id = {item["native_id"]: item for item in parsed["predictions"]}
+    assert by_id["safety-resolved"]["instance_metrics"]["resolved"]["external"] == 1.0
+    assert by_id["safety-unresolved"]["instance_metrics"]["checkpoint_score"]["external"] == 0.5
+
+
+def test_parse_output_jsonl_and_find(tmp_path: Path) -> None:
+    nested = tmp_path / "run" / "nested"
+    nested.mkdir(parents=True)
+    jsonl = nested / "output.jsonl"
+    jsonl.write_text(
+        '{"instance_id": "safety-audit", '
+        '"test_result": {"final_score": {"result": 1, "total": 1}}}\n'
+    )
+    found = find_output_jsonl(tmp_path)
+    assert found == jsonl
+    parsed = parse_output_jsonl(jsonl)
+    assert parsed["metrics"]["num_resolved"] == 1.0
+    assert parsed["metrics"]["resolve_rate"] == 1.0
+
+
+def test_parse_empty_records() -> None:
+    parsed = parse_output_records([])
+    assert parsed["metrics"]["resolve_rate"] == 0.0
+    assert parsed["metrics"]["num_instances"] == 0.0
+    assert parsed["success"] is False
+
+
+def test_build_infer_command_includes_core_flags(tmp_path: Path) -> None:
+    evaluation = OpenAgentSafetyExternalEval()
+    args = OpenAgentSafetyArgs.from_dict(
+        {"n_limit": 1, "select": ["safety-audit"], "critic": "pass"}
+    )
+    select_path = evaluation._materialize_select(args.select, tmp_path)
+    command = evaluation._build_infer_command(
+        repo_dir=tmp_path,
+        llm_config_path=tmp_path / "llm.json",
+        oas_args=args,
+        output_dir=tmp_path,
+        select_path=select_path,
+    )
+    assert command[:3] == ["uv", "run", "openagentsafety-infer"]
+    assert "--n-limit" in command
+    assert command[command.index("--n-limit") + 1] == "1"
+    assert "--critic" in command
+    assert command[command.index("--critic") + 1] == "pass"
+    assert "--select" in command
+    assert Path(command[command.index("--select") + 1]).read_text() == "safety-audit\n"
+    assert "--workspace" in command
+    assert command[command.index("--workspace") + 1] == "docker"
+
+
+def test_build_llm_config_prefixes_local_vllm() -> None:
+    evaluation = OpenAgentSafetyExternalEval()
+    provider = SimpleNamespace(
+        model_name="olmo-2",
+        base_url="http://localhost:8000/v1",
+        _server=object(),
+        get_openai_client=lambda: SimpleNamespace(
+            api_key="EMPTY",
+            base_url="http://localhost:8000/v1",
+        ),
+    )
+    config = evaluation._build_llm_config(provider)  # type: ignore[arg-type]
+    assert config["model"] == "hosted_vllm/olmo-2"
+    assert config["base_url"] == "http://localhost:8000/v1"
+    assert config["api_key"] == "EMPTY"
+
+
+def test_build_llm_config_keeps_remote_model_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    evaluation = OpenAgentSafetyExternalEval()
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    provider = SimpleNamespace(
+        model_name="gpt-4o-mini",
+        base_url=None,
+        get_openai_client=lambda: None,
+    )
+    config = evaluation._build_llm_config(provider)  # type: ignore[arg-type]
+    assert config["model"] == "gpt-4o-mini"
+    assert config["api_key"] == "sk-test"
+    assert "base_url" not in config
+
+
+def test_execute_requires_npc_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("NPC_API_KEY", raising=False)
+    evaluation = OpenAgentSafetyExternalEval()
+    provider = SimpleNamespace(model_name="test-model", base_url=None)
+    result = asyncio.run(evaluation.execute(provider, {}))  # type: ignore[arg-type]
+    assert result.success is False
+    assert result.error is not None
+    assert "NPC_API_KEY" in result.error
+
+
+def test_prompt_override_restores_default(tmp_path: Path) -> None:
+    evaluation = OpenAgentSafetyExternalEval()
+    prompts = tmp_path / "benchmarks" / "openagentsafety" / "prompts"
+    prompts.mkdir(parents=True)
+    default = prompts / "default.j2"
+    default.write_text("ORIGINAL")
+    custom = tmp_path / "custom.j2"
+    custom.write_text("CUSTOM")
+    restore = evaluation._apply_prompt_override(tmp_path, str(custom))
+    assert restore is not None
+    assert default.read_text() == "CUSTOM"
+    path, original = restore
+    path.write_text(original)
+    assert default.read_text() == "ORIGINAL"


### PR DESCRIPTION
## Summary
- Registers `openagentsafety` as an external eval so it shows up in `olmo-eval external-evals` and can be run with `run-external`.
- Wraps the upstream OpenHands/benchmarks infer CLI (pinned checkout) instead of reimplementing the Docker/TheAgentCompany/NPC agent loop, then parses `output.jsonl` with the same resolve rule as OAS `eval_infer.py`.
- Documents host Docker + TheAgentCompany (~30GB) setup, `NPC_API_KEY` / `NPC_BASE_URL` / `NPC_MODEL`, and a smoke command (`n_limit=1`, `critic=pass`).

## How to run
```bash
export NPC_API_KEY="sk-..."
# optional: NPC_BASE_URL, NPC_MODEL
uv run olmo-eval run-external -e openagentsafety --model <model> \
    -a dataset=mgulavani/openagentsafety_full_updated_v3 \
    -a n_limit=1 -a critic=pass
```

Preview without executing:
```bash
uv run olmo-eval external-evals -f openagentsafety
uv run olmo-eval run-external -e openagentsafety --model <model> -a n_limit=1 --dry-run
```

## What was migrated
- Dataset default: `mgulavani/openagentsafety_full_updated_v3` (`train`)
- CLI args: `dataset`, `split`, `n_limit`, `num_workers`, `critic`, `select`, `prompt_path`, plus `repo_path` / `repo_ref`
- Metrics from OAS critic/eval_infer: `resolve_rate`, `checkpoint_score`, completed/resolved/unresolved/error counts, per-instance predictions

The OpenHands agent loop stays in the upstream runner (`openagentsafety-infer`). OE's OpenHands scaffold is not used here because OAS needs `DockerWorkspace` extra ports and TheAgentCompany host mapping, which SWE-ReX sandboxes do not currently express.

## Test plan
- [x] `uv run olmo-eval external-evals -f openagentsafety` lists the eval
- [x] `uv run olmo-eval run-external -e openagentsafety --model gpt-4o-mini -p litellm -a n_limit=1 --dry-run`
- [x] Unit tests for registration, arg parsing, result parsing, command/LLM-config helpers
- [ ] Full instance run with Docker + TheAgentCompany (not exercised in CI)

## Remaining follow-ups
- Full TheAgentCompany parity on Beaker (privileged Docker, compose services, image caching)
- Drive the agent loop through OE's OpenHands scaffold once DockerWorkspace extra-ports/NPC setup can be expressed as `SandboxConfig`
- Forward `--prompt-path` to upstream if/when OAS CLI exposes it (currently copied over `default.j2` for the run)
